### PR TITLE
chore: version pin buf plugins

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -13,11 +13,11 @@ plugins:
     opt:
       - paths=source_relative
   # dependencies
-  - plugin: buf.build/protocolbuffers/go
+  - plugin: buf.build/protocolbuffers/go:v1.31.0
     out: gen
     opt:
       - paths=source_relative
-  - plugin: buf.build/grpc/go
+  - plugin: buf.build/grpc/go:v1.3.0
     out: gen
     opt:
       - paths=source_relative


### PR DESCRIPTION
This version pins the buf plugins we are currently leveraging. 
