### PR TITLE
fix(docs): air install correction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 
 [Air](https://github.com/cosmtrek/air)
 
-`brew install air`
+With go 1.18 or higher:
+
+`go install github.com/cosmtrek/air@v1.49.0`
 
 [Buf](https://buf.build/docs/ecosystem/cli-overview)
 


### PR DESCRIPTION
It doesn't look like `air` is installable via Homebrew, but the `air` docs recommend Go install. The README now reflects install via `Go` with recommended Go version requirements and a pinned `air` version rather than `latest` to avoid trouble down the line.