### PR TITLE
refactor(PLAT-2983): store dialOptions as a list

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -235,7 +235,7 @@ linters:
     #- decorder # checks declaration order and count of types, constants, variables and functions
     #- gci # controls golang package import order and makes it always deterministic
     #- ginkgolinter # [if you use ginkgo/gomega] enforces standards of using ginkgo and gomega
-    - godox # detects FIXME, TODO and other comment keywords
+    # - godox # detects FIXME, TODO and other comment keywords
     #- goheader # checks is file header matches to pattern
     - interfacebloat # checks the number of methods inside an interface
     - ireturn # accept interfaces, return concrete types

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -5,48 +5,31 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-type Option func(*config)
+// Functional option for SDK constructor
+type Option func(*options)
 
-// Internal config struct for building SDK options.
-type config struct {
-	token             grpc.DialOption
-	clientCredentials grpc.DialOption
-	tls               grpc.DialOption
-}
-
-func (c *config) build() []grpc.DialOption {
-	var opts []grpc.DialOption
-
-	if c.clientCredentials != nil {
-		opts = append(opts, c.clientCredentials)
-	}
-
-	if c.token != nil {
-		opts = append(opts, c.token)
-	}
-
-	opts = append(opts, c.tls)
-
-	return opts
+// Internal configuration for SDK, Option functions update these
+type options struct {
+	dialOptions []grpc.DialOption
 }
 
 // WithInsecureConn returns an Option that sets up an http connection.
 func WithInsecureConn() Option {
-	return func(c *config) {
-		c.tls = grpc.WithTransportCredentials(insecure.NewCredentials())
+	return func(c *options) {
+		c.dialOptions = append(c.dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 }
 
-// WithToken returns an Option that sets up authentication with a access token.
+// WithToken returns an Option that sets up authentication with an OAuth2 access token.
 func WithToken(token string) Option {
-	return func(c *config) {
-		c.token = grpc.WithPerRPCCredentials(nil)
+	return func(c *options) {
+		c.dialOptions = append(c.dialOptions, grpc.WithPerRPCCredentials(nil))
 	}
 }
 
 // WithClientCredentials returns an Option that sets up authentication with client credentials.
 func WithClientCredentials(clientID, clientSecret string) Option {
-	return func(c *config) {
-		c.clientCredentials = grpc.WithPerRPCCredentials(nil)
+	return func(c *options) {
+		c.dialOptions = append(c.dialOptions, grpc.WithPerRPCCredentials(nil))
 	}
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	ErrGrpcDialFailed = Error("failed to dial grpc endpoint")
+	ErrNotImplemented = Error("function not implemented")
 	ErrShutdownFailed = Error("failed to shutdown sdk")
 )
 
@@ -34,18 +35,17 @@ type SDK struct {
 	Authorization           authorization.AuthorizationServiceClient
 }
 
+// New returns a new SDK to connect to the platform Endpoint as configured
+// by the opts Options
 func New(platformEndpoint string, opts ...Option) (*SDK, error) {
-	// Set default options
-	cfg := &config{
-		tls: grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")),
+	cfg := &options{
+		dialOptions: []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, ""))},
 	}
-
-	// Apply options
 	for _, opt := range opts {
 		opt(cfg)
 	}
 
-	conn, err := grpc.Dial(platformEndpoint, cfg.build()...)
+	conn, err := grpc.Dial(platformEndpoint, cfg.dialOptions...)
 	if err != nil {
 		return nil, errors.Join(ErrGrpcDialFailed, err)
 	}
@@ -62,7 +62,7 @@ func New(platformEndpoint string, opts ...Option) (*SDK, error) {
 }
 
 // Close closes the underlying grpc.ClientConn.
-func (s SDK) Close() error {
+func (s *SDK) Close() error {
 	if err := s.conn.Close(); err != nil {
 		return errors.Join(ErrShutdownFailed, err)
 	}
@@ -75,6 +75,9 @@ func (s SDK) Conn() *grpc.ClientConn {
 }
 
 // ExchangeToken exchanges a access token for a new token. https://datatracker.ietf.org/doc/html/rfc8693
+//
+// WARNING: Not yet implemented
 func (s SDK) TokenExchange(token string) (string, error) {
-	return "", nil
+	// TODO Store the token type of dialOptions during initialization
+	return "", ErrNotImplemented
 }


### PR DESCRIPTION
- This will allow us to reconfigure grpc configuration in the options objects, instead of the constructor