### PR TITLE
fix(keycloak-port): move keycloak to 8888

### DIFF
--- a/opentdf-compose.yaml
+++ b/opentdf-compose.yaml
@@ -12,15 +12,17 @@ services:
       KC_DB_URL_DATABASE: keycloak
       KC_DB_USERNAME: keycloak
       KC_DB_PASSWORD: changeme
+      KC_HOSTNAME_PORT: "8888"
       KC_HOSTNAME_STRICT: "false"
       KC_HOSTNAME_STRICT_BACKCHANNEL: "false"
       KC_HOSTNAME_STRICT_HTTPS: "false"
       KC_HTTP_ENABLED: "true"
+      KC_HTTP_PORT: "8888"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: changeme
       KC_FEATURES: "preview,token-exchange"
     ports:
-      - "8080:8080"
+      - "8888:8888"
   keycloakdb:
     image: postgres
     restart: always


### PR DESCRIPTION
- resolves port conflict with keycloak in docker-compose listening on 8080 and main http server listening on 8080