### PR TITLE
fix: install instructions for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ pre-build:
 	@echo "Checking for required tools..."
 	@which buf > /dev/null || (echo "buf not found, please install it from https://docs.buf.build/installation" && exit 1)
 	@which golangci-lint > /dev/null || (echo "golangci-lint not found, please install it from https://golangci-lint.run/usage/install/" && exit 1)
-	@which protoc-gen-doc > /dev/null || (echo "protoc-gen-doc not found, please 'go install' it https://github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc" && exit 1)
+	@which protoc-gen-doc > /dev/null || (echo "protoc-gen-doc not found, run 'go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1'" && exit 1)
 	@golangci-lint --version | grep "version 1.55" > /dev/null || (echo "golangci-lint version must be v1.55" && exit 1)
 
 go.work go.work.sum:


### PR DESCRIPTION
Install instructions on https://github.com/pseudomuto/protoc-gen-doc are deprecated, and the library is relatively unmaintained.

No great alternatives exist for generating proto documentation.