### PR TITLE
fix(fqn namespaces): fixes LIST query for namespaces so only the single namespace fqn is returned

### DIFF
--- a/services/policy/db/namespaces.go
+++ b/services/policy/db/namespaces.go
@@ -122,7 +122,8 @@ func listNamespacesSql(opts namespaceSelectOptions) (string, []interface{}, erro
 		From(t.Name())
 
 	if opts.withFqn {
-		sb = sb.LeftJoin(fqnT.Name() + " ON " + fqnT.Field("namespace_id") + " = " + t.Field("id"))
+		sb = sb.LeftJoin(fqnT.Name() + " ON " + fqnT.Field("namespace_id") + " = " + t.Field("id") +
+		" AND " + fqnT.Field("attribute_id") + " IS NULL")
 	}
 
 	if opts.state != "" && opts.state != StateAny {


### PR DESCRIPTION
Fixes behavior where a namespace was returned per namespace, attribute definition, and attribute value because they all contained an fqn. The expected behavior is that LIST returns each namespace once and contains an `fqn` without any reference to attributes/values beyond it.