### PR TITLE
ci: Fixes golangci-lint on merge_group events

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -58,7 +58,6 @@ jobs:
       - name: golangci-lint on merge_group
         if: github.event_name == 'merge_group'
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
-        continue-on-error: false
         with:
           version: v1.55
           working-directory: ${{ matrix.directory }}


### PR DESCRIPTION
Workaround for #281 