### PR TITLE
ci(fix): Another attempt to fix lint in MQ

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -39,6 +39,8 @@ jobs:
           - examples
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: ${{github.event_name != 'merge_group' && 1 || 0}}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: "1.21"


### PR DESCRIPTION
Notably, this checks out the whole git tree to work around not finding the ‘patch’ folder used to run lint twice to get the ‘new lint error’ list