### PR TITLE
ci(conventional): Blocks unconventional messages

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   pr:
     name: Validate PR title
-    if: ${{ github.event_name != 'merge_group' }}
+    if: contains(fromJSON('["pull_request", "pull_request_target"]'), github.event_name)
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: read
@@ -148,6 +148,7 @@ jobs:
       - integration
       - image
       - buflint
+      - pr
     runs-on: ubuntu-latest
     if: always()
     steps:


### PR DESCRIPTION
- Lets PR validation only run before Queuing the PR for submission
- Let `ci` block on conventional commit validation job (Validate PR title)
- Since the merge queue automatically uses the PR title and description as the commit message, we do not need to check the commit message content itself