### PR TITLE
fix(sdk): make KasInfo fields public

### DIFF
--- a/sdk/auth_config.go
+++ b/sdk/auth_config.go
@@ -230,7 +230,7 @@ func getWrappedKey(rewrapResponseBody []byte, clientPrivateKey string) ([]byte, 
 }
 
 func (*AuthConfig) getPublicKey(kasInfo KASInfo) (string, error) {
-	kasPubKeyURL, err := url.JoinPath(kasInfo.url, kasPublicKeyPath)
+	kasPubKeyURL, err := url.JoinPath(kasInfo.URL, kasPublicKeyPath)
 	if err != nil {
 		return "", fmt.Errorf("url.Parse failed: %w", err)
 	}

--- a/sdk/kas_client.go
+++ b/sdk/kas_client.go
@@ -158,13 +158,13 @@ func (k *KASClient) getRewrapRequest(keyAccess KeyAccess, policy string) (*kas.R
 
 func (k *KASClient) getPublicKey(kasInfo KASInfo) (string, error) {
 	req := kas.PublicKeyRequest{}
-	grpcAddress, err := getGRPCAddress(kasInfo.url)
+	grpcAddress, err := getGRPCAddress(kasInfo.URL)
 	if err != nil {
 		return "", err
 	}
 	conn, err := grpc.Dial(grpcAddress, k.dialOptions...)
 	if err != nil {
-		return "", fmt.Errorf("error connecting to grpc service at %s: %w", kasInfo.url, err)
+		return "", fmt.Errorf("error connecting to grpc service at %s: %w", kasInfo.URL, err)
 	}
 	defer conn.Close()
 

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -259,7 +259,7 @@ func (t *TDFObject) prepareManifest(tdfConfig TDFConfig) error { //nolint:funlen
 	base64PolicyObject := crypto.Base64Encode(policyObjectAsStr)
 	symKeys := make([][]byte, 0, len(tdfConfig.kasInfoList))
 	for _, kasInfo := range tdfConfig.kasInfoList {
-		if len(kasInfo.publicKey) == 0 {
+		if len(kasInfo.PublicKey) == 0 {
 			return errKasPubKeyMissing
 		}
 
@@ -270,7 +270,7 @@ func (t *TDFObject) prepareManifest(tdfConfig TDFConfig) error { //nolint:funlen
 
 		keyAccess := KeyAccess{}
 		keyAccess.KeyType = kWrapped
-		keyAccess.KasURL = kasInfo.url
+		keyAccess.KasURL = kasInfo.URL
 		keyAccess.Protocol = kKasProtocol
 
 		// add policyBinding
@@ -278,7 +278,7 @@ func (t *TDFObject) prepareManifest(tdfConfig TDFConfig) error { //nolint:funlen
 		keyAccess.PolicyBinding = string(crypto.Base64Encode([]byte(policyBinding)))
 
 		// wrap the key with kas public key
-		asymEncrypt, err := crypto.NewAsymEncryption(kasInfo.publicKey)
+		asymEncrypt, err := crypto.NewAsymEncryption(kasInfo.PublicKey)
 		if err != nil {
 			return fmt.Errorf("crypto.NewAsymEncryption failed:%w", err)
 		}
@@ -732,16 +732,16 @@ func validateRootSignature(manifest Manifest, secret []byte) (bool, error) {
 
 func fillInPublicKeys(unwrapper Unwrapper, kasInfos []KASInfo) error {
 	for idx, kasInfo := range kasInfos {
-		if kasInfo.publicKey != "" {
+		if kasInfo.PublicKey != "" {
 			continue
 		}
 
 		publicKey, err := unwrapper.getPublicKey(kasInfo)
 		if err != nil {
-			return fmt.Errorf("unable to retrieve public key from KAS at [%s]: %w", kasInfo.url, err)
+			return fmt.Errorf("unable to retrieve public key from KAS at [%s]: %w", kasInfo.URL, err)
 		}
 
-		kasInfos[idx].publicKey = publicKey
+		kasInfos[idx].PublicKey = publicKey
 	}
 	return nil
 }

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -28,13 +28,12 @@ const (
 
 const kHTTPOk = 200
 
+// KASInfo contains Key Access Server information.
 type KASInfo struct {
-	url       string
-	publicKey string // Public key can be empty.
-}
-
-func NewKasInfo(url string) KASInfo {
-	return KASInfo{url: url}
+	// URL of the KAS server``
+	URL string
+	// Public key can be empty. If it is empty, the public key will be fetched from the KAS server.
+	PublicKey string
 }
 
 type TDFOption func(*TDFConfig) error

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -98,8 +98,8 @@ var testHarnesses = []tdfTest{ //nolint:gochecknoglobals // requires for testing
 		checksum:    "ed968e840d10d2d313a870bc131a4e2c311d7ad09bdf32b3418147221f51a6e2",
 		kasInfoList: []KASInfo{
 			{
-				url:       "http://localhost:65432/api/kas",
-				publicKey: "",
+				URL:       "http://localhost:65432/api/kas",
+				PublicKey: "",
 			},
 		},
 	},
@@ -109,8 +109,8 @@ var testHarnesses = []tdfTest{ //nolint:gochecknoglobals // requires for testing
 		checksum:    "2edc986847e209b4016e141a6dc8716d3207350f416969382d431539bf292e4a",
 		kasInfoList: []KASInfo{
 			{
-				url:       "http://localhost:65432/api/kas",
-				publicKey: "",
+				URL:       "http://localhost:65432/api/kas",
+				PublicKey: "",
 			},
 		},
 	},
@@ -120,12 +120,12 @@ var testHarnesses = []tdfTest{ //nolint:gochecknoglobals // requires for testing
 		checksum:    "cee41e98d0a6ad65cc0ec77a2ba50bf26d64dc9007f7f1c7d7df68b8b71291a6",
 		kasInfoList: []KASInfo{
 			{
-				url:       "http://localhost:65432/api/kas",
-				publicKey: mockKasPublicKey,
+				URL:       "http://localhost:65432/api/kas",
+				PublicKey: mockKasPublicKey,
 			},
 			{
-				url:       "http://localhost:65432/api/kas",
-				publicKey: mockKasPublicKey,
+				URL:       "http://localhost:65432/api/kas",
+				PublicKey: mockKasPublicKey,
 			},
 		},
 	},
@@ -135,12 +135,12 @@ var testHarnesses = []tdfTest{ //nolint:gochecknoglobals // requires for testing
 		checksum:    "d2fb707e70a804cf2ea770c9229295689831b4c88879c62bdb966e77e7336f18",
 		kasInfoList: []KASInfo{
 			{
-				url:       "http://localhost:65432/api/kas",
-				publicKey: mockKasPublicKey,
+				URL:       "http://localhost:65432/api/kas",
+				PublicKey: mockKasPublicKey,
 			},
 			{
-				url:       "http://localhost:65432/api/kas",
-				publicKey: mockKasPublicKey,
+				URL:       "http://localhost:65432/api/kas",
+				PublicKey: mockKasPublicKey,
 			},
 		},
 	},
@@ -226,12 +226,12 @@ var partialTDFTestHarnesses = []partialReadTdfTest{ //nolint:gochecknoglobals //
 		payload: payload, // len: 62
 		kasInfoList: []KASInfo{
 			{
-				url:       "http://localhost:65432/api/kas",
-				publicKey: mockKasPublicKey,
+				URL:       "http://localhost:65432/api/kas",
+				PublicKey: mockKasPublicKey,
 			},
 			{
-				url:       "http://localhost:65432/api/kas",
-				publicKey: mockKasPublicKey,
+				URL:       "http://localhost:65432/api/kas",
+				PublicKey: mockKasPublicKey,
 			},
 		},
 		readAtTests: []TestReadAt{
@@ -296,8 +296,8 @@ func TestSimpleTDF(t *testing.T) {
 	{
 		kasURLs := []KASInfo{
 			{
-				url:       serverURL,
-				publicKey: "",
+				URL:       serverURL,
+				PublicKey: "",
 			},
 		}
 
@@ -409,8 +409,8 @@ func TestTDFReader(t *testing.T) { //nolint:gocognit
 	for _, test := range partialTDFTestHarnesses { // create .txt file
 		kasInfoList := test.kasInfoList
 		for index := range kasInfoList {
-			kasInfoList[index].url = serverURL
-			kasInfoList[index].publicKey = ""
+			kasInfoList[index].URL = serverURL
+			kasInfoList[index].PublicKey = ""
 		}
 
 		for _, readAtTest := range test.readAtTests {
@@ -494,8 +494,8 @@ func TestTDF(t *testing.T) {
 
 		kasInfoList := test.kasInfoList
 		for index := range kasInfoList {
-			kasInfoList[index].url = serverURL
-			kasInfoList[index].publicKey = ""
+			kasInfoList[index].URL = serverURL
+			kasInfoList[index].PublicKey = ""
 		}
 
 		// test encrypt
@@ -515,8 +515,8 @@ func BenchmarkReader(b *testing.B) {
 		fileSize: 10 * oneMB,
 		kasInfoList: []KASInfo{
 			{
-				url:       "http://localhost:65432/api/kas",
-				publicKey: mockKasPublicKey,
+				URL:       "http://localhost:65432/api/kas",
+				PublicKey: mockKasPublicKey,
 			},
 		},
 	}
@@ -526,8 +526,8 @@ func BenchmarkReader(b *testing.B) {
 
 	kasInfoList := test.kasInfoList
 	for index := range kasInfoList {
-		kasInfoList[index].url = serverURL
-		kasInfoList[index].publicKey = ""
+		kasInfoList[index].URL = serverURL
+		kasInfoList[index].PublicKey = ""
 	}
 
 	// encrypt


### PR DESCRIPTION
When I was building out an encrypt example I was not able to set the PublicKey on `KASInfo` configuration. This makes the fields public and removes the `NewKasInfo(url string) KASInfo` function to allow other packages access to those fields. 

What lead to this is the following example

```go
client.CreateTDF(tdfFile,strReader,
		sdk.WithDataAttributes("https://example.com/attributes/1","https://example.com/attributes/2"),
		sdk.WithKasInformation(
			sdk.KASInfo{
				URL: "https://example.com/kas",
				PublicKey: "--- RSA PUBLIC KEY---"
			},
	))
```