### PR TITLE
chore(lint): Cleanup staticcheck errs

### DIFF
--- a/.golangci-ratchet.yaml
+++ b/.golangci-ratchet.yaml
@@ -12,6 +12,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    # - staticcheck
+    - staticcheck
     - typecheck
     - unused

--- a/sdk/auth_config_test.go
+++ b/sdk/auth_config_test.go
@@ -28,7 +28,6 @@ func TestNewOIDCAuthConfig(t *testing.T) {
 			}
 
 			_, _ = w.Write([]byte("{\"access_token\": \"fail\", \"token_type\": \"ok\"}"))
-			w.WriteHeader(200)
 		}),
 	)
 	defer s.Close()

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy/resourcemapping"
 	"github.com/opentdf/platform/protocol/go/policy/subjectmapping"
 	"github.com/opentdf/platform/sdk"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -24,18 +25,15 @@ func GetMethods(i interface{}) (m []string) {
 	return m
 }
 
-func Test_ShouldCreateNewSDK(t *testing.T) {
-	// When
+func TestNew_ShouldCreateSDK(t *testing.T) {
 	sdk, err := sdk.New(goodPlatformEndpoint,
 		sdk.WithClientCredentials("myid", "mysecret", nil),
 		sdk.WithTokenEndpoint("https://example.org/token"),
 	)
-	// Then
-	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
-	}
-	if sdk == nil {
-		t.Errorf("Expected sdk, got nil")
+	assert.NoError(t, err)
+	assert.NotNil(t, sdk)
+	if t.Failed() {
+		return
 	}
 
 	// check if the clients are available
@@ -53,25 +51,18 @@ func Test_ShouldCreateNewSDK(t *testing.T) {
 	}
 }
 
-func Test_ShouldCloseSDKConnection(t *testing.T) {
-	t.Skip("Skipping test since close is broken")
-	// Given
+func TestNew_ShouldCloseConnections(t *testing.T) {
 	sdk, err := sdk.New(goodPlatformEndpoint,
 		sdk.WithClientCredentials("myid", "mysecret", nil),
 		sdk.WithTokenEndpoint("https://example.org/token"),
 	)
-	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
-	}
-	// When
-	err = sdk.Close()
-	// Then
-	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
+	assert.NoError(t, err)
+	if !t.Failed() {
+		assert.NoError(t, sdk.Close())
 	}
 }
 
-func Test_ShouldHaveSameMethods(t *testing.T) {
+func TestNew_ShouldHaveSameMethods(t *testing.T) {
 	sdk, err := sdk.New(goodPlatformEndpoint,
 		sdk.WithClientCredentials("myid", "mysecret", nil),
 		sdk.WithTokenEndpoint("https://example.org/token"),

--- a/services/kas/archive/manifest/validator_test.go
+++ b/services/kas/archive/manifest/validator_test.go
@@ -1,12 +1,12 @@
 package manifest
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func TestValid(t *testing.T) {
-	f, err := ioutil.ReadFile("testdata/manifest.json")
+	f, err := os.ReadFile("testdata/manifest.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/services/kas/archive/validator_test.go
+++ b/services/kas/archive/validator_test.go
@@ -2,13 +2,13 @@ package archive
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 )
 
 func TestValid(t *testing.T) {
-	f, err := ioutil.ReadFile("testdata/envoy.yaml.tdf")
+	f, err := os.ReadFile("testdata/envoy.yaml.tdf")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- enables staticcheck linter on merge queue events
- fixes 'nil' escapes due to me not understanding how `t` errors works
- removes default http response header
- removes deprecated package, `io/ioutil`