### PR TITLE
build(go version): Updates to go 1.21.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ toolcheck:
 
 go.work go.work.sum:
 	go work init . examples protocol/go sdk
-	go work edit --go=1.21.7
+	go work edit --go=1.21.8
 
 fix:
 	for m in $(MODS); do (cd $$m && go mod tidy && go fmt ./...) || exit 1; done

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentdf/platform/examples
 
-go 1.21.7
+go 1.21.8
 
 require (
 	github.com/opentdf/platform/protocol/go v0.0.0-00010101000000-000000000000

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentdf/platform
 
-go 1.21.7
+go 1.21.8
 
 require (
 	github.com/Masterminds/squirrel v1.5.4

--- a/protocol/go/go.mod
+++ b/protocol/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentdf/platform/protocol/go
 
-go 1.21.7
+go 1.21.8
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.32.0-20231115204500-e097f827e652.1

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentdf/platform/sdk
 
-go 1.21.7
+go 1.21.8
 
 require (
 	github.com/docker/go-connections v0.5.0


### PR DESCRIPTION
- This should fix several vulnerabilities