### PR TITLE
refactor(tdf): return []byte for decrypted metadata

### DIFF
--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -59,7 +59,7 @@ const (
 
 type Reader struct {
 	manifest            Manifest
-	unencryptedMetadata string
+	unencryptedMetadata []byte
 	tdfReader           archive.TDFReader
 	unwrapper           Unwrapper
 	cursor              int64
@@ -559,11 +559,11 @@ func (r *Reader) ReadAt(buf []byte, offset int64) (int, error) { //nolint:funlen
 }
 
 // UnencryptedMetadata return decrypted metadata in manifest.
-func (r *Reader) UnencryptedMetadata() (string, error) {
+func (r *Reader) UnencryptedMetadata() ([]byte, error) {
 	if r.payloadKey == nil {
 		err := r.doPayloadKeyUnwrap()
 		if err != nil {
-			return "", fmt.Errorf("reader.doPayloadKeyUnwrap failed: %w", err)
+			return nil, fmt.Errorf("reader.doPayloadKeyUnwrap failed: %w", err)
 		}
 	}
 
@@ -611,7 +611,7 @@ func (r *Reader) DataAttributes() ([]string, error) {
 
 // Unwraps the payload key, if possible, using the access service
 func (r *Reader) doPayloadKeyUnwrap() error { //nolint:gocognit
-	var unencryptedMetadata string
+	var unencryptedMetadata []byte
 	var payloadKey [kKeySize]byte
 	for _, keyAccessObj := range r.manifest.EncryptionInformation.KeyAccessObjs {
 		wrappedKey, err := r.unwrapper.unwrap(keyAccessObj, r.manifest.EncryptionInformation.Policy)
@@ -647,7 +647,7 @@ func (r *Reader) doPayloadKeyUnwrap() error { //nolint:gocognit
 				return fmt.Errorf("crypto.AesGcm.encrypt failed:%w", err)
 			}
 
-			unencryptedMetadata = string(metaData)
+			unencryptedMetadata = metaData
 		}
 	}
 

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/golang-jwt/jwt/v4"
+	"gotest.tools/v3/assert"
 
 	"github.com/opentdf/platform/sdk/internal/crypto"
 )
@@ -283,7 +284,7 @@ func TestSimpleTDF(t *testing.T) {
 	serverURL, closer, sdk := runKas()
 	defer closer()
 
-	metaDataStr := `{"displayName" : "openTDF go sdk"}`
+	metaData := []byte(`{"displayName" : "openTDF go sdk"}`)
 
 	attributes := []string{
 		"https://example.com/attr/Classification/value/S",
@@ -317,7 +318,7 @@ func TestSimpleTDF(t *testing.T) {
 
 		tdfObj, err := sdk.CreateTDF(fileWriter, bufReader,
 			WithKasInformation(kasURLs...),
-			WithMetaData(metaDataStr),
+			WithMetaData(string(metaData)),
 			WithDataAttributes(attributes...))
 		if err != nil {
 			t.Fatalf("tdf.CreateTDF failed: %v", err)
@@ -352,9 +353,7 @@ func TestSimpleTDF(t *testing.T) {
 			t.Fatalf("Fail to get meta data from tdf:%v", err)
 		}
 
-		if metaDataStr != unencryptedMetaData {
-			t.Errorf("meta data test failed expected %v, got %v", metaDataStr, unencryptedMetaData)
-		}
+		assert.DeepEqual(t, metaData, unencryptedMetaData)
 
 		dataAttributes, err := r.DataAttributes()
 		if err != nil {


### PR DESCRIPTION
Because the structure is unknown at this time we should return encrypted metadata as a ` []byte`. This will allow the user to cast it to a `string` or umarshall into a struct type of their choice. 