### PR TITLE
fix: pull postgresql from dockerhub in integration tests

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -69,7 +69,7 @@ func TestMain(m *testing.M) {
 	req := tc.GenericContainerRequest{
 		ProviderType: providerType,
 		ContainerRequest: tc.ContainerRequest{
-			Image:        "public.ecr.aws/docker/library/postgres:15-alpine",
+			Image:        "postgres:15-alpine",
 			Name:         "testcontainer-postgres",
 			ExposedPorts: []string{"5432/tcp"},
 


### PR DESCRIPTION
I think it will be better to try and pull postgres from docker hub. I don't think public images are rate limited from github actions according to this comment. 

https://github.com/actions/runner-images/issues/1445#issuecomment-713861495

fixes #343 