### PR TITLE
ci: fix license check job to split evaluating sdk and platform

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -212,8 +212,23 @@ jobs:
       - name: install go-licenses
         run: go install github.com/google/go-licenses@5348b744d0983d85713295ea08a20cca1654a45e
       - name: check platform licenses
-        if: steps.sdk-changed.outputs.src == 'false'
-        run: go-licenses check --disallowed_types=forbidden --include_tests  --ignore github.com/opentdf/platform/sdk --ignore github.com/opentdf/platform/protocol  ./...
+        if: steps.deps-changed.outputs.platform == 'true'
+        run: >-
+          go-licenses check --disallowed_types=forbidden --include_tests  
+              --ignore github.com/opentdf/platform/sdk
+              --ignore github.com/opentdf/platform/protocol
+              .
       - name: check sdk licenses
-        if: steps.sdk-changed.outputs.src == 'true'
-        run: go-licenses check --disallowed_types=forbidden --include_tests --ignore github.com/opentdf/platform/protocol ./sdk
+        if: steps.deps-changed.outputs.sdk == 'true'
+        run: >-
+          go-licenses check --disallowed_types=forbidden --include_tests  
+              --ignore github.com/opentdf/platform/sdk
+              --ignore github.com/opentdf/platform/protocol
+              ./sdk
+      - name: check examples licenses
+        if: steps.deps-changed.outputs.examples == 'true'
+        run: >-
+          go-licenses check --disallowed_types=forbidden --include_tests  
+              --ignore github.com/opentdf/platform/sdk
+              --ignore github.com/opentdf/platform/protocol
+              ./examples


### PR DESCRIPTION
This pr and #374 hopefully cleanup the license check job. I wasn't sure the best way to do this but when checking the root go.mod file it looks in `sdk` and `protocol/go` for a license. This splits the job into evaluating sdk and root platform separately with each ignoring `protocol/go`. 