### PR TITLE
ci: introduce release-please

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
+        with:
+          app-id: '${{ secrets.APP_ID }}'
+          private-key: '${{ secrets.AUTOMATION_KEY }}'
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          token: '${{ steps.generate_token.outputs.token }}'
+          config-file: release-please.json
+          manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,10 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
         with:
-          app-id: '${{ secrets.APP_ID }}'
-          private-key: '${{ secrets.AUTOMATION_KEY }}'
+          app-id: "${{ secrets.APP_ID }}"
+          private-key: "${{ secrets.AUTOMATION_KEY }}"
       - uses: google-github-actions/release-please-action@v4
         with:
-          token: '${{ steps.generate_token.outputs.token }}'
+          token: "${{ steps.generate_token.outputs.token }}"
           config-file: release-please.json
           manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,8 +1,10 @@
 {
-  ".": "2.0.0",
-  ".+FILLER": "0.0.0",
+  "service": "2.0.0",
+  "service+FILLER": "0.0.0",
   "sdk": "0.1.0",
   "sdk+FILLER": "0.0.0",
   "protocol": "0.1.0",
-  "protocol+FILLER": "0.0.0"
+  "protocol+FILLER": "0.0.0",
+  "lib": "0.1.0",
+  "lib+FILLER": "0.0.0"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,8 @@
+{
+  ".": "2.0.0",
+  ".+FILLER": "0.0.0",
+  "sdk": "0.1.0",
+  "sdk+FILLER": "0.0.0",
+  "protocol": "0.1.0",
+  "protocol+FILLER": "0.0.0"
+}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,10 +1,10 @@
 {
-  "service": "2.0.0",
+  "service": "0.2.0",
   "service+FILLER": "0.0.0",
-  "sdk": "0.1.0",
+  "sdk": "0.2.0",
   "sdk+FILLER": "0.0.0",
-  "protocol": "0.1.0",
+  "protocol": "0.2.0",
   "protocol+FILLER": "0.0.0",
-  "lib": "0.1.0",
+  "lib": "0.2.0",
   "lib+FILLER": "0.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "go",
+  "separate-pull-requests": true,
+  "include-component-in-tag": true,
+  "tag-separator": "/",
+  "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
+  "packages": {
+    ".":{
+      "exclude-paths": [
+        "sdk",
+        "protocol"
+      ]
+    },
+    "sdk":{
+      "component": "sdk",
+      "separate-pull-requests": true,
+      "include-component-in-tag": true
+    },
+    "protocol":{
+      "component": "protocol",
+      "separate-pull-requests": true,
+      "include-component-in-tag": true
+    }
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,19 +6,23 @@
   "tag-separator": "/",
   "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
   "packages": {
-    ".":{
-      "exclude-paths": [
-        "sdk",
-        "protocol"
-      ]
+    "service": {
+      "component": "service",
+      "separate-pull-requests": true,
+      "include-component-in-tag": true
     },
-    "sdk":{
+    "sdk": {
       "component": "sdk",
       "separate-pull-requests": true,
       "include-component-in-tag": true
     },
-    "protocol":{
+    "protocol": {
       "component": "protocol",
+      "separate-pull-requests": true,
+      "include-component-in-tag": true
+    },
+    "lib": {
+      "component": "lib",
       "separate-pull-requests": true,
       "include-component-in-tag": true
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,8 +6,18 @@
   "tag-separator": "/",
   "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
   "packages": {
-    "service": {
-      "component": "service",
+    "lib/fixtures": {
+      "component": "lib/fixtures",
+      "separate-pull-requests": true,
+      "include-component-in-tag": true
+    },
+    "lib/ocrypto": {
+      "component": "lib/ocrypto",
+      "separate-pull-requests": true,
+      "include-component-in-tag": true
+    },
+    "protocol/go": {
+      "component": "protocol/go",
       "separate-pull-requests": true,
       "include-component-in-tag": true
     },
@@ -16,13 +26,8 @@
       "separate-pull-requests": true,
       "include-component-in-tag": true
     },
-    "protocol": {
-      "component": "protocol",
-      "separate-pull-requests": true,
-      "include-component-in-tag": true
-    },
-    "lib": {
-      "component": "lib",
+    "service": {
+      "component": "service",
       "separate-pull-requests": true,
       "include-component-in-tag": true
     }


### PR DESCRIPTION
This change introduces a new workflow for release-please. 

Release Please will open a release pull request for the **platform**, **sdk** and **protocol**. Basically each component with a `go.mod` file. Once we are ready all we have to do is merge in those release pr's and a new tag/gh release will be created. 

If its a submodule like sdk the tag will look like `sdk/v0.1.0`.


To learn more about release-please: https://github.com/googleapis/release-please 
