### PR TITLE
refactor: Simplifies loading kas grpc service

### DIFF
--- a/examples/go.sum
+++ b/examples/go.sum
@@ -223,5 +223,3 @@ gopkg.in/go-jose/go-jose.v2 v2.6.2/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEI
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
-gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/valyala/fasthttp v1.52.0
 	github.com/virtru/access-pdp v1.11.0
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
-	golang.org/x/oauth2 v0.18.0
 	google.golang.org/grpc v1.62.1
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/go-jose/go-jose.v2 v2.6.3
@@ -140,6 +139,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/mod v0.15.0 // indirect
+	golang.org/x/oauth2 v0.18.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.18.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
@@ -157,7 +157,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.21.0
-	golang.org/x/net v0.22.0 // indirect
+	golang.org/x/net v0.22.0
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/testcontainers/testcontainers-go v0.28.0
 	golang.org/x/oauth2 v0.16.0
 	google.golang.org/grpc v1.61.0
-	gotest.tools/v3 v3.5.0
 )
 
 replace github.com/opentdf/platform/protocol/go => ../protocol/go
@@ -42,7 +41,6 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
 	github.com/klauspost/compress v1.16.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect

--- a/services/kas/access/provider.go
+++ b/services/kas/access/provider.go
@@ -1,8 +1,9 @@
 package access
 
 import (
-	"github.com/opentdf/platform/internal/security"
 	"net/url"
+
+	"github.com/opentdf/platform/internal/security"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	kaspb "github.com/opentdf/platform/protocol/go/kas"

--- a/services/kas/kas.go
+++ b/services/kas/kas.go
@@ -7,58 +7,35 @@ import (
 	"net/url"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/opentdf/platform/internal/server"
 	"github.com/opentdf/platform/pkg/serviceregistry"
 	kaspb "github.com/opentdf/platform/protocol/go/kas"
 	"github.com/opentdf/platform/services/kas/access"
 )
-
-type KasService struct {
-	kaspb.UnimplementedAccessServiceServer
-	o *server.OpenTDFServer
-	p *access.Provider
-}
-
-func (s *KasService) initProvider() error {
-	if s.p != nil {
-		slog.Info("KAS already initialized")
-		return nil
-	}
-	if s.o.HSM == nil {
-		slog.Error("hsm not enabled")
-		return fmt.Errorf("hsm not enabled")
-	}
-	kasURLString := "https://" + s.o.HTTPServer.Addr
-	kasURI, err := url.Parse(kasURLString)
-	if err != nil {
-		return fmt.Errorf("invalid kas address [%s] %w", kasURLString, err)
-	}
-
-	s.p = &access.Provider{
-		URI:          *kasURI,
-		AttributeSvc: nil,
-		Session:      *s.o.HSM,
-		OIDCVerifier: nil,
-	}
-
-	// TODO: Add Authorization or Attribute service??
-	// TODO: Add OIDC Verifier
-
-	return nil
-}
 
 func NewRegistration() serviceregistry.Registration {
 	return serviceregistry.Registration{
 		Namespace:   "kas",
 		ServiceDesc: &kaspb.AccessService_ServiceDesc,
 		RegisterFunc: func(srp serviceregistry.RegistrationParams) (any, serviceregistry.HandlerServer) {
-			k := KasService{o: srp.OTDF}
-			err := k.initProvider()
-			if err != nil {
-				panic(err)
+			hsm := srp.OTDF.HSM
+			if hsm == nil {
+				slog.Error("hsm not enabled")
+				panic(fmt.Errorf("hsm not enabled"))
 			}
-			return &k, func(ctx context.Context, mux *runtime.ServeMux, server any) error {
-				kas, ok := server.(kaspb.AccessServiceServer)
+			kasURLString := "https://" + srp.OTDF.HTTPServer.Addr
+			kasURI, err := url.Parse(kasURLString)
+			if err != nil {
+				panic(fmt.Errorf("invalid kas address [%s] %w", kasURLString, err))
+			}
+
+			p := access.Provider{
+				URI:          *kasURI,
+				AttributeSvc: nil,
+				Session:      *hsm,
+				OIDCVerifier: nil,
+			}
+			return &p, func(ctx context.Context, mux *runtime.ServeMux, server any) error {
+				kas, ok := server.(*access.Provider)
 				if !ok {
 					panic("invalid kas server object")
 				}
@@ -66,30 +43,4 @@ func NewRegistration() serviceregistry.Registration {
 			}
 		},
 	}
-}
-
-func (s *KasService) Info(ctx context.Context, req *kaspb.InfoRequest) (*kaspb.InfoResponse, error) {
-	return &kaspb.InfoResponse{
-		Version: "1.0.0",
-	}, nil
-}
-
-func (s *KasService) PublicKey(ctx context.Context, req *kaspb.PublicKeyRequest) (*kaspb.PublicKeyResponse, error) {
-	resp, err := s.p.PublicKey(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return &kaspb.PublicKeyResponse{
-		PublicKey: resp.PublicKey,
-	}, nil
-}
-
-func (s KasService) Rewrap(ctx context.Context, req *kaspb.RewrapRequest) (*kaspb.RewrapResponse, error) {
-	resp, err := s.p.Rewrap(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return &kaspb.RewrapResponse{
-		EntityWrappedKey: resp.EntityWrappedKey,
-	}, nil
 }


### PR DESCRIPTION
- Removed layer of indirection leftover from when we had both access.proto and kas.proto