### PR TITLE
chore(gitignore): Hides tmp-gen folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ opentdf.yaml
 .idea/
 
 # Generated files
+tmp-gen/
 /examples/examples
 /go.work.sum
 /go.work


### PR DESCRIPTION
- these are used by some build scripts to temporarily build gencode, then move it