### PR TITLE
chore(restore): fix lint output

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -58,6 +58,7 @@ jobs:
           working-directory: ${{ matrix.directory }}
           skip-cache: true
           only-new-issues: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
+          args: --out-format=colored-line-number
       - name: Install softHSM
         if: matrix.directory == '.'
         run: |-

--- a/.github/workflows/lint-all.yaml
+++ b/.github/workflows/lint-all.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           version: v1.56
           working-directory: ${{ matrix.directory }}
+          args: --out-format=colored-line-number
 
   buf:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Restore missing argument to lint that displays filenames and line numbers for all output.