### PR TITLE
feat: ability to set config key or config file from root cmd

### DIFF
--- a/service/cmd/migrate.go
+++ b/service/cmd/migrate.go
@@ -19,7 +19,14 @@ var (
 		Use:   "down",
 		Short: "Run database migration down one version",
 		Run: func(cmd *cobra.Command, args []string) {
-			dbClient, err := migrateDBClient()
+			configFile, _ := cmd.Flags().GetString(configFileFlag)
+			configKey, _ := cmd.Flags().GetString(configKeyFlag)
+			cfg, err := config.LoadConfig(configKey, configFile)
+			if err != nil {
+				panic(fmt.Errorf("could not load config: %w", err))
+			}
+
+			dbClient, err := migrateDbClient(cfg)
 			if err != nil {
 				panic(fmt.Errorf("could not load config: %w", err))
 			}
@@ -34,8 +41,14 @@ var (
 	migrateUpCmd = &cobra.Command{
 		Use:   "up",
 		Short: "Run database migrations up to the latest version",
-		Run: func(cmd *cobra.Command, _ []string) {
-			dbClient, err := migrateDBClient()
+		Run: func(cmd *cobra.Command, args []string) {
+			configFile, _ := cmd.Flags().GetString(configFileFlag)
+			configKey, _ := cmd.Flags().GetString(configKeyFlag)
+			cfg, err := config.LoadConfig(configKey, configFile)
+			if err != nil {
+				panic(fmt.Errorf("could not load config: %w", err))
+			}
+			dbClient, err := migrateDbClient(cfg)
 			if err != nil {
 				panic(fmt.Errorf("could not load config: %w", err))
 			}
@@ -52,7 +65,13 @@ var (
 		Use:   "status",
 		Short: "Show the status of the database migrations",
 		Run: func(cmd *cobra.Command, args []string) {
-			dbClient, err := migrateDBClient()
+			configFile, _ := cmd.Flags().GetString(configFileFlag)
+			configKey, _ := cmd.Flags().GetString(configKeyFlag)
+			cfg, err := config.LoadConfig(configKey, configFile)
+			if err != nil {
+				panic(fmt.Errorf("could not load config: %w", err))
+			}
+			dbClient, err := migrateDbClient(cfg)
 			if err != nil {
 				panic(fmt.Errorf("could not load config: %w", err))
 			}
@@ -68,13 +87,7 @@ var (
 	}
 )
 
-func migrateDBClient() (*db.Client, error) {
-	// Load the config
-	conf, err := config.LoadConfig("opentdf")
-	if err != nil {
-		return nil, err
-	}
-
+func migrateDbClient(conf *config.Config) (*db.Client, error) {
 	slog.Info("creating database client")
 	dbClient, err := db.NewClient(conf.DB)
 	if err != nil {

--- a/service/cmd/migrate.go
+++ b/service/cmd/migrate.go
@@ -26,7 +26,7 @@ var (
 				panic(fmt.Errorf("could not load config: %w", err))
 			}
 
-			dbClient, err := migrateDbClient(cfg)
+			dbClient, err := migrateDBClient(cfg)
 			if err != nil {
 				panic(fmt.Errorf("could not load config: %w", err))
 			}
@@ -41,14 +41,14 @@ var (
 	migrateUpCmd = &cobra.Command{
 		Use:   "up",
 		Short: "Run database migrations up to the latest version",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			configFile, _ := cmd.Flags().GetString(configFileFlag)
 			configKey, _ := cmd.Flags().GetString(configKeyFlag)
 			cfg, err := config.LoadConfig(configKey, configFile)
 			if err != nil {
 				panic(fmt.Errorf("could not load config: %w", err))
 			}
-			dbClient, err := migrateDbClient(cfg)
+			dbClient, err := migrateDBClient(cfg)
 			if err != nil {
 				panic(fmt.Errorf("could not load config: %w", err))
 			}
@@ -71,7 +71,7 @@ var (
 			if err != nil {
 				panic(fmt.Errorf("could not load config: %w", err))
 			}
-			dbClient, err := migrateDbClient(cfg)
+			dbClient, err := migrateDBClient(cfg)
 			if err != nil {
 				panic(fmt.Errorf("could not load config: %w", err))
 			}
@@ -87,7 +87,7 @@ var (
 	}
 )
 
-func migrateDbClient(conf *config.Config) (*db.Client, error) {
+func migrateDBClient(conf *config.Config) (*db.Client, error) {
 	slog.Info("creating database client")
 	dbClient, err := db.NewClient(conf.DB)
 	if err != nil {

--- a/service/cmd/policy.go
+++ b/service/cmd/policy.go
@@ -29,7 +29,13 @@ var (
 		Long:  policyFqnReindexCmdLong,
 
 		Run: func(cmd *cobra.Command, args []string) {
-			dbClient, err := policyDBClient()
+			configFile, _ := cmd.Flags().GetString(configFileFlag)
+			configKey, _ := cmd.Flags().GetString(configKeyFlag)
+			cfg, err := config.LoadConfig(configKey, configFile)
+			if err != nil {
+				panic(fmt.Errorf("could not load config: %w", err))
+			}
+			dbClient, err := policyDBClient(cfg)
 			if err != nil {
 				panic(fmt.Errorf("could not load config: %w", err))
 			}
@@ -53,13 +59,7 @@ var (
 	}
 )
 
-func policyDBClient() (*policydb.PolicyDBClient, error) {
-	// Load the config
-	conf, err := config.LoadConfig("opentdf")
-	if err != nil {
-		return nil, err
-	}
-
+func policyDBClient(conf *config.Config) (*policydb.PolicyDBClient, error) {
 	slog.Info("creating database client")
 	dbClient, err := db.NewClient(conf.DB)
 	if err != nil {

--- a/service/cmd/provisionFixtures.go
+++ b/service/cmd/provisionFixtures.go
@@ -35,7 +35,9 @@ to run this command in a clean database. This command is intended for local deve
 ** Teardown or Issues **
 You can clear/recycle your database with 'docker-compose down' and 'docker-compose up' to start fresh.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			cfg, err := config.LoadConfig("opentdf")
+			configFile, _ := cmd.Flags().GetString(configFileFlag)
+			configKey, _ := cmd.Flags().GetString(configKeyFlag)
+			cfg, err := config.LoadConfig(configKey, configFile)
 			if err != nil {
 				panic(fmt.Errorf("could not load config: %w", err))
 			}

--- a/service/cmd/provisionKeyloak.go
+++ b/service/cmd/provisionKeyloak.go
@@ -67,6 +67,8 @@ var (
 			realmName, _ := cmd.Flags().GetString(provKcRealm)
 			kcUsername, _ := cmd.Flags().GetString(provKcUsername)
 			kcPassword, _ := cmd.Flags().GetString(provKcPassword)
+			configFile, _ := cmd.Flags().GetString(configFileFlag)
+			configKey, _ := cmd.Flags().GetString(configKeyFlag)
 
 			kcConnectParams := keycloakConnectParams{
 				BasePath:         kcEndpoint,
@@ -76,7 +78,7 @@ var (
 				AllowInsecureTLS: true,
 			}
 
-			config, err := config.LoadConfig("")
+			config, err := config.LoadConfig(configKey, configFile)
 			if err != nil {
 				return err
 			}

--- a/service/cmd/root.go
+++ b/service/cmd/root.go
@@ -19,6 +19,16 @@ user authorization, and performing access checks. Use this tool to start, stop,
 manage, configure, or upgrade one or more of the OpenTDF Platform services.`,
 }
 
+var (
+	configFileFlag = "config-file"
+	configKeyFlag  = "config-key"
+)
+
+func init() {
+	rootCmd.PersistentFlags().StringP(configFileFlag, "", "", "custom configuration file location")
+	rootCmd.PersistentFlags().StringP(configKeyFlag, "", "opentdf", "the key is the name of the configuration file without the extension")
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {

--- a/service/cmd/start.go
+++ b/service/cmd/start.go
@@ -15,6 +15,13 @@ func init() {
 	rootCmd.AddCommand(&startCmd)
 }
 
-func start(_ *cobra.Command, _ []string) error {
-	return server.Start(server.WithWaitForShutdownSignal())
+func start(cmd *cobra.Command, _ []string) error {
+	configFile, _ := cmd.Flags().GetString(configFileFlag)
+	configKey, _ := cmd.Flags().GetString(configKeyFlag)
+
+	return server.Start(
+		server.WithWaitForShutdownSignal(),
+		server.WithConfigFile(configFile),
+		server.WithConfigKey(configKey),
+	)
 }

--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 
@@ -35,14 +34,7 @@ const (
 )
 
 // Load config with viper.
-func LoadConfig(key string) (*Config, error) {
-	if key == "" {
-		key = "opentdf"
-		slog.Info("LoadConfig: key not provided, using default", "config", key)
-	} else {
-		slog.Info("LoadConfig", "config", key)
-	}
-
+func LoadConfig(key string, file string) (*Config, error) {
 	config := &Config{}
 	homedir, err := os.UserHomeDir()
 	if err != nil {
@@ -57,6 +49,12 @@ func LoadConfig(key string) (*Config, error) {
 	viper.SetEnvPrefix(key)
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
+
+	// Allow for a custom config file to be passed in
+	// This takes precedence over the AddConfigPath/SetConfigName
+	if file != "" {
+		viper.SetConfigFile(file)
+	}
 
 	if err := viper.ReadInConfig(); err != nil {
 		return nil, errors.Join(err, ErrLoadingConfig)

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -20,9 +20,24 @@ import (
 
 type StartOptions func(StartConfig) StartConfig
 
+// Deprecated: Use WithConfigKey
 func WithConfigName(name string) StartOptions {
 	return func(c StartConfig) StartConfig {
-		c.ConfigName = name
+		c.ConfigKey = name
+		return c
+	}
+}
+
+func WithConfigFile(file string) StartOptions {
+	return func(c StartConfig) StartConfig {
+		c.ConfigFile = file
+		return c
+	}
+}
+
+func WithConfigKey(key string) StartOptions {
+	return func(c StartConfig) StartConfig {
+		c.ConfigKey = key
 		return c
 	}
 }
@@ -35,7 +50,8 @@ func WithWaitForShutdownSignal() StartOptions {
 }
 
 type StartConfig struct {
-	ConfigName            string
+	ConfigKey             string
+	ConfigFile            string
 	WaitForShutdownSignal bool
 }
 
@@ -50,7 +66,7 @@ func Start(f ...StartOptions) error {
 	slog.Info("starting opentdf services")
 
 	slog.Info("loading configuration")
-	conf, err := config.LoadConfig(startConfig.ConfigName)
+	conf, err := config.LoadConfig(startConfig.ConfigKey, startConfig.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("could not load config: %w", err)
 	}


### PR DESCRIPTION
This change introduces the ability to set the `config-key` or `config-file` as a flag when running any of the commands that require loading the config.