### PR TITLE
fix(authorization): (temp) Update keycloak rego to use dot notation to assign subject mappings from entity repr

### DIFF
--- a/services/policies/entitlements/entitlements-keycloak.rego
+++ b/services/policies/entitlements/entitlements-keycloak.rego
@@ -10,11 +10,19 @@ import rego.v1
  	"legacykeycloak": input.idp.legacy,
  }}
 
+# proto oneof only allows for one of the fields in the entity struct
 idp_request := {"entities": [{
 	"id": input.entity.id,
-	"emailAddress": input.entity.email_address,
 	"clientId": input.entity.client_id,
-}]}
+}]} if { input.entity.client_id }
+else := {"entities": [{
+	"id": input.entity.id,
+	"emailAddress": input.entity.email_address,
+}]} if { input.entity.email_address }
+else := {"entities": [{
+	"id": input.entity.id,
+	"userName": input.entity.username,
+}]} if { input.entity.username }
 
 attributes := [attribute |
 	# external entity
@@ -34,14 +42,28 @@ condition_group_evaluate(payload, boolean_operator, conditions) if {
 	# AND
 	boolean_operator == 1
 	some condition in conditions
-	condition_evaluate(payload[condition.subject_external_field], condition.operator, condition.subject_external_values)
+	# TODO: additional_props is a list of entity representations
+	# (for when an email provided is for a group)
+	# how do we handle the situation when multiple entities returned
+	# add to the list for each entity?
+	# or do they all have to have the attribtue for it to be returned?
+	condition_evaluate(
+        make_array(object.get(payload[0], split(condition.subject_external_field, "."), [])),
+         condition.operator, condition.subject_external_values
+    )
 } else if {
 	# OR
 	boolean_operator == 2
 	payload[key]
 	some condition in conditions
-	condition_evaluate(payload[condition.subject_external_field], condition.operator, condition.subject_external_values)
+	condition_evaluate(
+        make_array(object.get(payload[0], split(condition.subject_external_field, "."), [])),
+         condition.operator, condition.subject_external_values
+    )
 }
+
+# In case the value retrieved from the entity representation is singular
+make_array(x) := x if { is_array(x) } else := [x]
 
 # condition
 condition_evaluate(property_values, operator, values) if {


### PR DESCRIPTION
expects subject_external_field to be the location of the value in the entity representation, ex "attributes.myattribute" or "emailAddress"

temporarily unblocking development while adr around subject_external_field is discussed https://github.com/opentdf/platform/issues/470

expected long term solution -- create another custom plugin that handles the path notation so we can customize it to something non-rego supported like json-path