### PR TITLE
docs: removes advice to use go install for prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@
 On macOS, these can be installed with [brew](https://docs.brew.sh/Installation)
 
 ```sh
-brew install buf golangci-lint goose grpcurl openssl
-
+brew install buf go golangci-lint goose grpcurl openssl
 ```
 
 ### Run


### PR DESCRIPTION
- Instead, follow the advice at the given links
- brew still works on macs, though