### PR TITLE
chore: cleanup lint errors in subject_mapping tests

### DIFF
--- a/service/integration/config.go
+++ b/service/integration/config.go
@@ -2,6 +2,10 @@ package integration
 
 import "github.com/opentdf/platform/service/internal/config"
 
+const (
+	nonExistentAttributeValueUUID = "78909865-8888-9999-9999-000000000000"
+)
+
 var Config *config.Config
 
 func init() {


### PR DESCRIPTION
Cleaned up 
- `testifylint` 
- `containedctx` in suite struct.
-  `revive` using the `new` keyword as a var name