### PR TITLE
ci: nightly ocrypto

### DIFF
--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -14,7 +14,7 @@ jobs:
           - examples
           - sdk
           - service
-          - lib/crypto
+          - lib/ocrypto
     steps:
       - name: govluncheck
         uses: golang/govulncheck-action@3a32958c2706f7048305d5a2e53633d7e37e97d0


### PR DESCRIPTION
Fix path to `lib/ocrypto` in nightly build