### PR TITLE
docs: remove red chiclets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # OpenTDF
 
-![CI](https://github.com/opentdf/platform/actions/workflows/checks.yaml/badge.svg?branch=main)
-
-![lint](https://github.com/opentdf/platform/actions/workflows/lint-all.yaml/badge.svg?branch=main)
-
 ![Vulnerability Check](https://github.com/opentdf/platform/actions/workflows/vulnerability-check.yaml/badge.svg?branch=main)
 
 ## Documentation


### PR DESCRIPTION
CI and lint workflows will fail until linter is passing.  Removing the chiclets for now.