### PR TITLE
chore(docs): fix nonexistent makefile script in readme, pre-build -> toolcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ toolcheck:
 	@which buf > /dev/null || (echo "buf not found, please install it from https://docs.buf.build/installation" && exit 1)
 	@which golangci-lint > /dev/null || (echo "golangci-lint not found, run  'go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2'" && exit 1)
 	@which protoc-gen-doc > /dev/null || (echo "protoc-gen-doc not found, run 'go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1'" && exit 1)
-	@golangci-lint --version | grep "version 1.5[67]" > /dev/null || (echo "golangci-lint version must be v1.55 [$$(golangci-lint --version)]" && exit 1)
+	@golangci-lint --version | grep "version v1.5[67]" > /dev/null || (echo "golangci-lint version must be v1.55 [$$(golangci-lint --version)]" && exit 1)
 
 go.work go.work.sum:
 	go work init $(MODS)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Our native gRPC service functions are generated from `proto` definitions using [
 The `Makefile` provides command scripts to invoke `Buf` with the `buf.gen.yaml` config, including OpenAPI docs, grpc docs, and the
 generated code.
 
-For convenience, the `make pre-build` script checks if you have the necessary dependencies for `proto -> gRPC` generation.
+For convenience, the `make toolcheck` script checks if you have the necessary dependencies for `proto -> gRPC` generation.
 
 ## Services
 


### PR DESCRIPTION
Closes https://github.com/opentdf/platform/issues/157
Also fixes grep's missing `v` in the version output for `golangci-lint` check in `make toolcheck`