### PR TITLE
fix(sdk): handle err

### DIFF
--- a/sdk/auth_config.go
+++ b/sdk/auth_config.go
@@ -259,6 +259,10 @@ func (*AuthConfig) getPublicKey(kasInfo KASInfo) (string, error) {
 			slog.Error("Fail to close HTTP response")
 		}
 	}()
+	if err != nil {
+		slog.Error("failed http request")
+		return "", fmt.Errorf("client.Do error: %w", err)
+	}
 	if response.StatusCode != kHTTPOk {
 		return "", fmt.Errorf("client.Do failed: %w", err)
 	}


### PR DESCRIPTION
Fixes error ignored, followed by a panic.  This happens making a call to KAS public key.
