### PR TITLE
fix(kas): oidc issuer from config

### DIFF
--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -11,6 +11,7 @@ logger:
 services:
   kas:
     enabled: true
+    issuer: http://localhost:8888/auth/realms/opentdf
   policy:
     enabled: true
   authorization:

--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -12,6 +12,7 @@ services:
   kas:
     enabled: true
     issuer: http://localhost:8888/auth/realms/opentdf
+    discovery: http://localhost:8888/auth/realms/opentdf
   policy:
     enabled: true
   authorization:

--- a/opentdf-with-hsm.yaml
+++ b/opentdf-with-hsm.yaml
@@ -11,6 +11,7 @@ logger:
 services:
   kas:
     enabled: true
+    issuer: http://localhost:8888/auth/realms/opentdf
   policy:
     enabled: true
   authorization:

--- a/opentdf-with-hsm.yaml
+++ b/opentdf-with-hsm.yaml
@@ -12,6 +12,7 @@ services:
   kas:
     enabled: true
     issuer: http://localhost:8888/auth/realms/opentdf
+    discovery: http://localhost:8888/auth/realms/opentdf
   policy:
     enabled: true
   authorization:

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -15,9 +15,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func loadIdentityProvider() *oidc.IDTokenVerifier {
-	oidcIssuerURL := "http://localhost:8888/auth/realms/opentdf"
-	discoveryBaseURL := "http://localhost:8888/auth/realms/opentdf"
+func loadIdentityProvider(cfg serviceregistry.ServiceConfig) *oidc.IDTokenVerifier {
+	oidcIssuerURL := cfg.ExtraProps["issuer"].(string)
+	discoveryBaseURL := cfg.ExtraProps["issuer"].(string)
 	ctx := context.Background()
 	if discoveryBaseURL != "" {
 		ctx = oidc.InsecureIssuerURLContext(ctx, oidcIssuerURL)
@@ -68,7 +68,7 @@ func NewRegistration() serviceregistry.Registration {
 				URI:            *kasURI,
 				AttributeSvc:   nil,
 				CryptoProvider: srp.OTDF.CryptoProvider,
-				OIDCVerifier:   loadIdentityProvider(),
+				OIDCVerifier:   loadIdentityProvider(srp.Config),
 			}
 			return &p, func(ctx context.Context, mux *runtime.ServeMux, server any) error {
 				kas, ok := server.(*access.Provider)

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -16,7 +16,7 @@ import (
 )
 
 func loadIdentityProvider(cfg serviceregistry.ServiceConfig) *oidc.IDTokenVerifier {
-	if cfg.ExtraProps != nil && cfg.ExtraProps["issuer"] == nil {
+	if cfg.ExtraProps == nil || cfg.ExtraProps["issuer"] == nil {
 		panic(errors.New("services.kas.issuer is required"))
 	}
 	oidcIssuerURL := cfg.ExtraProps["issuer"].(string)

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -2,10 +2,10 @@ package kas
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
-	"os"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -16,17 +16,14 @@ import (
 )
 
 func loadIdentityProvider(cfg serviceregistry.ServiceConfig) *oidc.IDTokenVerifier {
-	oidcIssuerURL := cfg.ExtraProps["issuer"].(string)
-	discoveryBaseURL := cfg.ExtraProps["issuer"].(string)
-	ctx := context.Background()
-	if discoveryBaseURL != "" {
-		ctx = oidc.InsecureIssuerURLContext(ctx, oidcIssuerURL)
-	} else {
-		discoveryBaseURL = oidcIssuerURL
+	if cfg.ExtraProps["issuer"] == nil {
+		panic(errors.New("services.kas.issuer is required"))
 	}
-	provider, err := oidc.NewProvider(ctx, discoveryBaseURL)
+	oidcIssuerURL := cfg.ExtraProps["issuer"].(string)
+	ctx := context.Background()
+	ctx = oidc.InsecureIssuerURLContext(ctx, oidcIssuerURL)
+	provider, err := oidc.NewProvider(ctx, oidcIssuerURL)
 	if err != nil {
-		slog.Error("OIDC_ISSUER_URL provider fail", "err", err, "OIDC_ISSUER_URL", oidcIssuerURL, "OIDC_DISCOVERY_BASE_URL", os.Getenv("OIDC_DISCOVERY_BASE_URL"))
 		panic(err)
 	}
 	// Configure an OpenID Connect aware OAuth2 client.

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"net/url"
+
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	kaspb "github.com/opentdf/platform/protocol/go/kas"
 	"github.com/opentdf/platform/service/kas/access"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
 	"golang.org/x/oauth2"
-	"log/slog"
-	"net/url"
 )
 
 func loadIdentityProvider(cfg serviceregistry.ServiceConfig) *oidc.IDTokenVerifier {

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -16,7 +16,7 @@ import (
 )
 
 func loadIdentityProvider(cfg serviceregistry.ServiceConfig) *oidc.IDTokenVerifier {
-	if cfg.ExtraProps["issuer"] == nil {
+	if cfg.ExtraProps != nil && cfg.ExtraProps["issuer"] == nil {
 		panic(errors.New("services.kas.issuer is required"))
 	}
 	oidcIssuerURL := cfg.ExtraProps["issuer"].(string)

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -24,12 +24,12 @@ func loadIdentityProvider(cfg serviceregistry.ServiceConfig) *oidc.IDTokenVerifi
 	if !ok {
 		panic(errors.New("services.kas.issuer must be a string"))
 	}
-	if cfg.ExtraProps == nil || cfg.ExtraProps["discovery"] == nil {
-		panic(errors.New("services.kas.discovery is required"))
-	}
-	discoveryBaseURL, ok := cfg.ExtraProps["discovery"].(string)
-	if !ok {
-		panic(errors.New("services.kas.discovery must be a string"))
+	discoveryBaseURL := ""
+	if cfg.ExtraProps != nil && cfg.ExtraProps["discovery"] != nil {
+		db, ok := cfg.ExtraProps["discovery"].(string)
+		if ok {
+			discoveryBaseURL = db
+		}
 	}
 	if discoveryBaseURL != "" {
 		ctx = oidc.InsecureIssuerURLContext(ctx, oidcIssuerURL)

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -19,7 +19,10 @@ func loadIdentityProvider(cfg serviceregistry.ServiceConfig) *oidc.IDTokenVerifi
 	if cfg.ExtraProps == nil || cfg.ExtraProps["issuer"] == nil {
 		panic(errors.New("services.kas.issuer is required"))
 	}
-	oidcIssuerURL := cfg.ExtraProps["issuer"].(string)
+	oidcIssuerURL, ok := cfg.ExtraProps["issuer"].(string)
+	if !ok {
+		panic(errors.New("services.kas.issuer must be a string"))
+	}
 	ctx := context.Background()
 	ctx = oidc.InsecureIssuerURLContext(ctx, oidcIssuerURL)
 	provider, err := oidc.NewProvider(ctx, oidcIssuerURL)


### PR DESCRIPTION
For KAS, load the OIDC issuer from the `opentdf.yaml` config.

- Added `issuer` and `discovery` 
```yaml
  kas:
    enabled: true
    issuer: http://localhost:8888/auth/realms/opentdf
    discovery: http://127.0.0.1:4444
```