### PR TITLE
ci: Fix hsm panics in unit tests

### DIFF
--- a/service/internal/security/hsm.go
+++ b/service/internal/security/hsm.go
@@ -677,6 +677,9 @@ func (h *HSMSession) RSAPublicKeyAsJSON(keyID string) (string, error) {
 	// TODO: For now ignore the key id
 	slog.Info("⚠️ Ignoring the", slog.String("key id", keyID))
 
+	if h.RSA == nil || h.RSA.PublicKey == nil {
+		return "", ErrCertNotFound
+	}
 	rsaPublicKeyJwk, err := jwk.FromRaw(h.RSA.PublicKey)
 	if err != nil {
 		return "", fmt.Errorf("jwk.FromRaw: %w", err)
@@ -691,6 +694,9 @@ func (h *HSMSession) RSAPublicKeyAsJSON(keyID string) (string, error) {
 }
 
 func (h *HSMSession) ECPublicKey(string) (string, error) {
+	if h.EC == nil || h.EC.PublicKey == nil {
+		return "", ErrCertNotFound
+	}
 	pubkeyBytes, err := x509.MarshalPKIXPublicKey(h.EC.PublicKey)
 	if err != nil {
 		return "", errors.Join(ErrPublicKeyMarshal, err)

--- a/service/internal/security/standard_crypto.go
+++ b/service/internal/security/standard_crypto.go
@@ -80,7 +80,7 @@ func NewStandardCrypto(cfg StandardConfig) (*StandardCrypto, error) {
 
 func (s StandardCrypto) RSAPublicKey(keyID string) (string, error) {
 	if len(s.rsaKeys) == 0 {
-		return "", errStandardCryptoObjIsInvalid
+		return "", ErrCertNotFound
 	}
 
 	// TODO: For now ignore the key id
@@ -95,7 +95,7 @@ func (s StandardCrypto) RSAPublicKey(keyID string) (string, error) {
 }
 
 func (s StandardCrypto) ECPublicKey(string) (string, error) {
-	return "", nil
+	return "", ErrCertNotFound
 }
 
 func (s StandardCrypto) RSADecrypt(_ crypto.Hash, keyID string, _ string, ciphertext []byte) ([]byte, error) {

--- a/service/kas/access/publicKey.go
+++ b/service/kas/access/publicKey.go
@@ -25,6 +25,9 @@ func (p *Provider) LegacyPublicKey(ctx context.Context, in *kaspb.LegacyPublicKe
 	algorithm := in.GetAlgorithm()
 	var pem string
 	var err error
+	if p.CryptoProvider == nil {
+		return nil, errors.Join(ErrConfig, status.Error(codes.Internal, "configuration error"))
+	}
 	if algorithm == algorithmEc256 {
 		pem, err = p.CryptoProvider.ECPublicKey("unknown")
 		if err != nil {

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -197,7 +197,7 @@ func TestCertificateHandlerEmpty(t *testing.T) {
 	}
 	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI := mustParseURI(t, "https://"+hostname+":5000")
+	kasURI := urlHost(t)
 
 	kas := Provider{
 		URI:            *kasURI,
@@ -217,10 +217,10 @@ func mustNewCryptoProvider(t *testing.T, config security.Config) security.Crypto
 	return hsmSession
 }
 
-func mustParseURI(t *testing.T, hostname string) *url.URL {
-	uri, err := url.Parse("https://" + hostname + ":5000")
+func urlHost(t *testing.T) *url.URL {
+	url, err := url.Parse("https://" + hostname + ":5000")
 	require.NoError(t, err)
-	return uri
+	return url
 }
 
 func TestCertificateHandlerWithEc256(t *testing.T) {
@@ -236,7 +236,7 @@ func TestCertificateHandlerWithEc256(t *testing.T) {
 	}
 	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI := mustParseURI(t, "https://"+hostname+":5000")
+	kasURI := urlHost(t)
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,
@@ -265,7 +265,7 @@ func TestPublicKeyHandlerWithEc256(t *testing.T) {
 	}
 	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI := mustParseURI(t, "https://"+hostname+":5000")
+	kasURI := urlHost(t)
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,
@@ -294,7 +294,7 @@ func TestPublicKeyHandlerV2(t *testing.T) {
 	}
 	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI := mustParseURI(t, "https://"+hostname+":5000")
+	kasURI := urlHost(t)
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,
@@ -317,7 +317,7 @@ func TestPublicKeyHandlerV2Failure(t *testing.T) {
 	}
 	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI := mustParseURI(t, "https://"+hostname+":5000")
+	kasURI := urlHost(t)
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,
@@ -343,7 +343,7 @@ func TestPublicKeyHandlerV2WithEc256(t *testing.T) {
 	}
 	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI := mustParseURI(t, "https://"+hostname+":5000")
+	kasURI := urlHost(t)
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,
@@ -373,7 +373,7 @@ func TestPublicKeyHandlerV2WithJwk(t *testing.T) {
 	}
 	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI := mustParseURI(t, "https://"+hostname+":5000")
+	kasURI := urlHost(t)
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -214,6 +214,7 @@ func mustNewCryptoProvider(t *testing.T, config security.Config) security.Crypto
 	hsmSession, err := security.NewCryptoProvider(config)
 	maybeSkip(t, err)
 	require.NoError(t, err)
+	require.NotNil(t, hsmSession)
 	return hsmSession
 }
 

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -177,9 +177,9 @@ func TestCertificateHandlerEmpty(t *testing.T) {
 		"rsa": {},
 		"ec":  {},
 	}
-	hsmSession, _ := security.NewCryptoProvider(config)
+	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI, _ := url.Parse("https://" + hostname + ":5000")
+	kasURI := mustParseURI(t, "https://"+hostname+":5000")
 
 	kas := Provider{
 		URI:            *kasURI,
@@ -190,6 +190,18 @@ func TestCertificateHandlerEmpty(t *testing.T) {
 	result, err := kas.PublicKey(context.Background(), &kaspb.PublicKeyRequest{Fmt: "pkcs8"})
 	require.Error(t, err, "not found")
 	assert.Nil(t, result)
+}
+
+func mustNewCryptoProvider(t *testing.T, config security.Config) security.CryptoProvider {
+	hsmSession, err := security.NewCryptoProvider(config)
+	require.NoError(t, err)
+	return hsmSession
+}
+
+func mustParseURI(t *testing.T, hostname string) *url.URL {
+	uri, err := url.Parse("https://" + hostname + ":5000")
+	require.NoError(t, err)
+	return uri
 }
 
 func TestCertificateHandlerWithEc256(t *testing.T) {
@@ -203,9 +215,9 @@ func TestCertificateHandlerWithEc256(t *testing.T) {
 			Label: "development-ec-kas",
 		},
 	}
-	hsmSession, _ := security.NewCryptoProvider(config)
+	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI, _ := url.Parse("https://" + hostname + ":5000")
+	kasURI := mustParseURI(t, "https://"+hostname+":5000")
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,
@@ -232,9 +244,9 @@ func TestPublicKeyHandlerWithEc256(t *testing.T) {
 			Label: "development-ec-kas",
 		},
 	}
-	hsmSession, _ := security.NewCryptoProvider(config)
+	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI, _ := url.Parse("https://" + hostname + ":5000")
+	kasURI := mustParseURI(t, "https://"+hostname+":5000")
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,
@@ -261,9 +273,9 @@ func TestPublicKeyHandlerV2(t *testing.T) {
 			Label: "development-ec-kas",
 		},
 	}
-	hsmSession, _ := security.NewCryptoProvider(config)
+	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI, _ := url.Parse("https://" + hostname + ":5000")
+	kasURI := mustParseURI(t, "https://"+hostname+":5000")
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,
@@ -284,9 +296,9 @@ func TestPublicKeyHandlerV2Failure(t *testing.T) {
 		"rsa": {},
 		"ec":  {},
 	}
-	hsmSession, _ := security.NewCryptoProvider(config)
+	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI, _ := url.Parse("https://" + hostname + ":5000")
+	kasURI := mustParseURI(t, "https://"+hostname+":5000")
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,
@@ -310,9 +322,9 @@ func TestPublicKeyHandlerV2WithEc256(t *testing.T) {
 			Label: "development-ec-kas",
 		},
 	}
-	hsmSession, _ := security.NewCryptoProvider(config)
+	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI, _ := url.Parse("https://" + hostname + ":5000")
+	kasURI := mustParseURI(t, "https://"+hostname+":5000")
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,
@@ -340,9 +352,9 @@ func TestPublicKeyHandlerV2WithJwk(t *testing.T) {
 			Label: "development-ec-kas",
 		},
 	}
-	hsmSession, _ := security.NewCryptoProvider(config)
+	hsmSession := mustNewCryptoProvider(t, config)
 	defer hsmSession.Close()
-	kasURI, _ := url.Parse("https://" + hostname + ":5000")
+	kasURI := mustParseURI(t, "https://"+hostname+":5000")
 	kas := Provider{
 		URI:            *kasURI,
 		CryptoProvider: hsmSession,


### PR DESCRIPTION
- Adds more checks to make sure the keys are non-nil when loading them
- Updates all asserts to use testify to hopefully get more detailed info on the errors, but we'll also need to update where they are created