### PR TITLE
chore: replace go-jose with lestrrat/jwx

### DIFF
--- a/service/go.mod
+++ b/service/go.mod
@@ -33,7 +33,6 @@ require (
 	golang.org/x/oauth2 v0.18.0
 	google.golang.org/grpc v1.62.1
 	google.golang.org/protobuf v1.33.0
-	gopkg.in/go-jose/go-jose.v2 v2.6.3
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/service/go.sum
+++ b/service/go.sum
@@ -517,8 +517,6 @@ google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHh
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/go-jose/go-jose.v2 v2.6.3 h1:nt80fvSDlhKWQgSWyHyy5CfmlQr+asih51R8PTWNKKs=
-gopkg.in/go-jose/go-jose.v2 v2.6.3/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEIoEdZlFBI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -159,7 +159,12 @@ func (p *Provider) verifyBearerAndParseRequestBody(ctx context.Context, in *kasp
 	}
 
 	slog.DebugContext(ctx, "okay now we can check", "bodyClaims.requestBody", eb)
-	decoder := json.NewDecoder(strings.NewReader(eb.(string)))
+	sb, ok := eb.(string)
+	if !ok {
+		return nil, err400("bad request")
+	}
+	decoder := json.NewDecoder(strings.NewReader(sb))
+
 	var requestBody RequestBody
 	err = decoder.Decode(&requestBody)
 	if err != nil {

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -19,6 +19,8 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/authorization"
 	kaspb "github.com/opentdf/platform/protocol/go/kas"
@@ -28,7 +30,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"gopkg.in/go-jose/go-jose.v2/jwt"
 )
 
 type RequestBody struct {
@@ -138,37 +139,27 @@ func (p *Provider) verifyBearerAndParseRequestBody(ctx context.Context, in *kasp
 	}
 	slog.DebugContext(ctx, "verified", "claims", cl)
 
-	requestToken, err := jwt.ParseSigned(in.GetSignedRequestToken())
+	dpopJWK := auth.GetJWKFromContext(ctx)
+
+	var requestToken jwt.Token
+	if dpopJWK == nil {
+		slog.ErrorContext(ctx, "allowing rewrap without authentication. the authn middleware is not in use")
+		requestToken, err = jwt.Parse([]byte(in.GetSignedRequestToken()), jwt.WithVerify(false))
+	} else {
+		requestToken, err = jwt.Parse([]byte(in.GetSignedRequestToken()), jwt.WithKey(jwa.RS256, dpopJWK))
+	}
 	if err != nil {
 		slog.WarnContext(ctx, "unable parse request", "err", err)
 		return nil, err400("bad request")
 	}
 
-	dpopJWK := auth.GetJWKFromContext(ctx)
-
-	var bodyClaims customClaimsBody
-	if dpopJWK == nil {
-		slog.ErrorContext(ctx, "allowing rewrap without authentication. the authn middleware is not in use")
-		err = requestToken.UnsafeClaimsWithoutVerification(&bodyClaims)
-		if err != nil {
-			return nil, err403("unable to parse unverified claims from body")
-		}
-	} else {
-		var verificationKey interface{}
-		err = dpopJWK.Raw(&verificationKey)
-		if err != nil {
-			slog.WarnContext(ctx, "error getting underlying key to verify signature", "key", dpopJWK, "err", err)
-			return nil, err503("error parsing DPoP key")
-		}
-		err = requestToken.Claims(verificationKey, &bodyClaims)
-		if err != nil {
-			slog.WarnContext(ctx, "invalid signature on body claims", "err", err)
-			return nil, err403("signature on body was invalid")
-		}
+	eb, ok := requestToken.Get("requestBody")
+	if !ok {
+		return nil, err400("bad request")
 	}
 
-	slog.DebugContext(ctx, "okay now we can check", "bodyClaims.RequestBody", bodyClaims.RequestBody)
-	decoder := json.NewDecoder(strings.NewReader(bodyClaims.RequestBody))
+	slog.DebugContext(ctx, "okay now we can check", "bodyClaims.requestBody", eb)
+	decoder := json.NewDecoder(strings.NewReader(eb.(string)))
 	var requestBody RequestBody
 	err = decoder.Decode(&requestBody)
 	if err != nil {

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -10,12 +10,16 @@ import (
 	"encoding/pem"
 	"log/slog"
 	"net/url"
-	"strings"
 	"testing"
 
+	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/opentdf/platform/service/internal/auth"
 	"github.com/opentdf/platform/service/internal/security"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/google/uuid"
@@ -24,8 +28,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"gopkg.in/go-jose/go-jose.v2"
-	"gopkg.in/go-jose/go-jose.v2/jwt"
 )
 
 const (
@@ -137,80 +139,66 @@ func emptyPolicyBytes() []byte {
 	return dst
 }
 
-func fauxPolicyBytes() []byte {
+func fauxPolicyBytes(t *testing.T) []byte {
 	data, err := json.Marshal(fauxPolicy())
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	dst := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
 	base64.StdEncoding.Encode(dst, data)
 	return dst
 }
 
-func privateKey() *rsa.PrivateKey {
+func privateKey(t *testing.T) *rsa.PrivateKey {
 	b, rest := pem.Decode([]byte(rsaPrivate))
-	if b == nil || len(rest) > 0 {
-		slog.Error("failed private key", "bytes", b, "rest", rest)
-		panic(len(rest))
-	}
+	require.NotNil(t, b)
+	assert.Empty(t, rest)
+
 	k, err := x509.ParsePKCS1PrivateKey(b.Bytes)
-	if k == nil || err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, k)
 	return k
 }
 
-func publicKey() *rsa.PublicKey {
+func publicKey(t *testing.T) *rsa.PublicKey {
 	b, rest := pem.Decode([]byte(rsaPublic))
-	if b == nil || len(rest) > 0 {
-		slog.Error("failed public key", "bytes", b, "rest", rest)
-		panic(len(rest))
-	}
+	require.NotNil(t, b)
+	assert.Empty(t, rest)
+
 	pub, err := x509.ParsePKIXPublicKey(b.Bytes)
-	if pub == nil || err != nil {
-		panic(err)
-	}
+	require.NotNil(t, pub)
+	require.NoError(t, err)
 	return pub.(*rsa.PublicKey)
 }
 
-func entityPrivateKey() *rsa.PrivateKey {
+func entityPrivateKey(t *testing.T) *rsa.PrivateKey {
 	b, rest := pem.Decode([]byte(rsaPrivateAlt))
-	if b == nil || len(rest) > 0 {
-		slog.Error("failed entity private key", "bytes", b, "rest", rest)
-		panic(len(rest))
-	}
+	require.NotNil(t, b)
+	assert.Empty(t, rest)
+
 	k, err := x509.ParsePKCS1PrivateKey(b.Bytes)
-	if k == nil || err != nil {
-		panic(err)
-	}
+	require.NotNil(t, k)
+	require.NoError(t, err)
 	return k
 }
 
-func entityPublicKey() *rsa.PublicKey {
+func entityPublicKey(t *testing.T) *rsa.PublicKey {
 	b, rest := pem.Decode([]byte(rsaPublicAlt))
-	if b == nil || len(rest) > 0 {
-		slog.Error("failed entity public key", "bytes", b, "rest", rest)
-		panic(len(rest))
-	}
+	require.NotNil(t, b)
+	assert.Empty(t, rest)
+
 	pub, err := x509.ParsePKIXPublicKey(b.Bytes)
-	if pub == nil || err != nil {
-		panic(err)
-	}
+	require.NotNil(t, pub)
+	require.NoError(t, err)
 	return pub.(*rsa.PublicKey)
 }
 
-func keyAccessWrappedRaw() tdf3.KeyAccess {
-	policyBytes := fauxPolicyBytes()
+func keyAccessWrappedRaw(t *testing.T) tdf3.KeyAccess {
+	policyBytes := fauxPolicyBytes(t)
 
-	wrappedKey, err := tdf3.EncryptWithPublicKey([]byte(plainKey), entityPublicKey())
-	if err != nil {
-		slog.Warn("rewrap: encryptWithPublicKey failed", "err", err, "clientPublicKey", rsaPublicAlt)
-		panic(err)
-	}
+	wrappedKey, err := tdf3.EncryptWithPublicKey([]byte(plainKey), entityPublicKey(t))
+	require.NoError(t, err, "rewrap: encryptWithPublicKey failed")
+
 	bindingBytes, err := generateHMACDigest(context.Background(), policyBytes, []byte(plainKey))
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	dst := make([]byte, hex.EncodedLen(len(bindingBytes)))
 	hex.Encode(dst, bindingBytes)
@@ -230,23 +218,12 @@ type RSAPublicKey rsa.PublicKey
 
 func (publicKey *RSAPublicKey) VerifySignature(ctx context.Context, raw string) (payload []byte, err error) {
 	slog.Debug("Verifying key")
-	tok, err := jwt.ParseSigned(raw)
+	tok, err := jws.Verify([]byte(raw), jws.WithKey(jwa.RS256, rsa.PublicKey(*publicKey)))
 	if err != nil {
-		slog.Error("jwt parse fail", "raw", raw)
+		slog.Error("jws.Verify fail", "raw", raw)
 		return nil, err
 	}
-
-	out := make(map[string]interface{})
-	if err := tok.Claims((*rsa.PublicKey)(publicKey), &out); err != nil {
-		slog.Error("claim fail")
-		return nil, err
-	}
-	jsonString, err := json.Marshal(out)
-	if err != nil {
-		slog.Error("marshal fail")
-		return nil, err
-	}
-	return []byte(jsonString), nil
+	return tok, nil
 }
 
 func standardClaims() ClaimsObject {
@@ -283,122 +260,87 @@ func standardClaims() ClaimsObject {
 	}
 }
 
-func signedMockJWT(signer *rsa.PrivateKey) string {
-	sig, err := jose.NewSigner(
-		jose.SigningKey{
-			Algorithm: jose.RS256,
-			Key:       signer,
-		},
-		(&jose.SignerOptions{}).WithType("JWT"),
-	)
-	if err != nil {
-		panic(err)
-	}
-	cl := customClaimsHeader{
-		Subject:   "testuser1",
-		ClientID:  "testonly",
-		TDFClaims: standardClaims(),
-	}
+func signedMockJWT(t *testing.T, signer *rsa.PrivateKey) []byte {
+	tok := jwt.New()
+	tok.Set(jwt.IssuerKey, mockIdPOrigin)
+	tok.Set(jwt.AudienceKey, `testonly`)
+	tok.Set(jwt.SubjectKey, `testuser1`)
+	tok.Set("tdf_claims", standardClaims())
 
-	raw, err := jwt.Signed(sig).Claims(jwt.Claims{Issuer: mockIdPOrigin, Audience: jwt.Audience{"testonly"}}).Claims(cl).CompactSerialize()
-	if err != nil {
-		panic(err)
-	}
+	raw, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, signer))
+	require.NoError(t, err)
 	return raw
 }
 
-func jwtStandard() string {
-	return signedMockJWT(privateKey())
+func jwtStandard(t *testing.T) []byte {
+	j := signedMockJWT(t, privateKey(t))
+	jwt.Parse(j, jwt.WithKey(jwa.RS256, publicKey(t)))
+	return j
 }
 
-func jwtWrongIssuer() string {
-	sig, err := jose.NewSigner(
-		jose.SigningKey{
-			Algorithm: jose.RS256,
-			Key:       privateKey(),
-		},
-		(&jose.SignerOptions{}).WithType("JWT"),
-	)
-	if err != nil {
-		panic(err)
-	}
-	cl := customClaimsHeader{
-		Subject:   "testuser1",
-		ClientID:  "testonly",
-		TDFClaims: standardClaims(),
-	}
+func jwtWrongIssuer(t *testing.T) []byte {
+	tok := jwt.New()
+	tok.Set(jwt.IssuerKey, "https://someone.else/")
+	tok.Set(jwt.AudienceKey, `testonly`)
+	tok.Set(jwt.SubjectKey, `testuser1`)
+	tok.Set("tdf_claims", standardClaims())
 
-	raw, err := jwt.Signed(sig).Claims(jwt.Claims{Issuer: "https://someone.else/", Audience: jwt.Audience{"testonly"}}).Claims(cl).CompactSerialize()
-	if err != nil {
-		panic(err)
-	}
+	raw, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, privateKey(t)))
+	require.NoError(t, err)
 	return raw
 }
 
-func jwtWrongKey() string {
-	return signedMockJWT(entityPrivateKey())
+func jwtWrongKey(t *testing.T) []byte {
+	return signedMockJWT(t, entityPrivateKey(t))
 }
 
-func mockVerifier() *oidc.IDTokenVerifier {
+func mockVerifier(t *testing.T) *oidc.IDTokenVerifier {
 	return oidc.NewVerifier(
 		mockIdPOrigin,
-		(*RSAPublicKey)(publicKey()),
+		(*RSAPublicKey)(publicKey(t)),
 		&oidc.Config{SkipExpiryCheck: true, ClientID: "testonly"},
 	)
 }
 
-func makeRewrapBody(_ *testing.T, policy []byte) (string, error) {
+func makeRewrapBody(t *testing.T, policy []byte) ([]byte, error) {
 	mockBody := RequestBody{
-		KeyAccess:       keyAccessWrappedRaw(),
+		KeyAccess:       keyAccessWrappedRaw(t),
 		Policy:          string(policy),
 		ClientPublicKey: rsaPublicAlt,
 	}
 	bodyData, err := json.Marshal(mockBody)
-	if err != nil {
-		panic(err)
-	}
-	cl := customClaimsBody{
-		RequestBody: string(bodyData),
-	}
-	signer, err := jose.NewSigner(
-		jose.SigningKey{
-			Algorithm: jose.RS256,
-			Key:       entityPrivateKey(),
-		},
-		(&jose.SignerOptions{}).WithType("JWT"),
-	)
-	if err != nil {
-		return "", err
-	}
-	return jwt.Signed(signer).Claims(cl).CompactSerialize()
+	require.NoError(t, err)
+	tok := jwt.New()
+	tok.Set("requestBody", string(bodyData))
+
+	s, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, entityPrivateKey(t)))
+	require.NoError(t, err)
+	return s, nil
 }
 
 func TestParseAndVerifyRequest(t *testing.T) {
-	srt, err := makeRewrapBody(t, fauxPolicyBytes())
-	if err != nil {
-		t.Errorf("failed to generate srt=[%s], err=[%v]", srt, err)
-	}
+	srt, err := makeRewrapBody(t, fauxPolicyBytes(t))
+	require.NoError(t, err, "failed to generate srt=[%s]", srt)
+
 	badPolicySrt, err := makeRewrapBody(t, emptyPolicyBytes())
-	if err != nil {
-		t.Errorf("failed to generate badPolicySrt=[%s], err=[%v]", badPolicySrt, err)
-	}
+	require.NoError(t, err, "failed to generate badPolicySrt=[%s]", badPolicySrt)
 
 	p := &Provider{
-		OIDCVerifier: mockVerifier(),
+		OIDCVerifier: mockVerifier(t),
 	}
 
 	var tests = []struct {
 		name    string
-		tok     string
-		body    string
+		bearer  []byte
+		body    []byte
 		bearish bool
 		polite  bool
 		addDPoP bool
 	}{
-		{"good", jwtStandard(), srt, true, true, true},
-		{"bad bearer wrong issuer", jwtWrongIssuer(), srt, false, true, true},
-		{"bad bearer signature", jwtWrongKey(), srt, false, true, true},
-		{"different policy", jwtStandard(), badPolicySrt, true, false, true},
+		{"good", jwtStandard(t), srt, true, true, true},
+		{"bad bearer wrong issuer", jwtWrongIssuer(t), srt, false, true, true},
+		{"bad bearer signature", jwtWrongKey(t), srt, false, true, true},
+		{"different policy", jwtStandard(t), badPolicySrt, true, false, true},
 		// once we start always requiring auth then add this test back {"no dpop token included", jwtStandard(), srt, false, true, false},
 	}
 	// The execution loop
@@ -406,44 +348,34 @@ func TestParseAndVerifyRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			if tt.addDPoP {
-				key, err := jwk.FromRaw(entityPublicKey())
-				if err != nil {
-					t.Fatalf("couldn't get JWK from key")
-				}
+				key, err := jwk.FromRaw(entityPublicKey(t))
+				require.NoError(t, err, "couldn't get JWK from key")
+
 				ctx = auth.ContextWithJWK(ctx, key)
 			}
 
 			verified, err := p.verifyBearerAndParseRequestBody(
 				ctx,
 				&kaspb.RewrapRequest{
-					Bearer:             tt.tok,
-					SignedRequestToken: tt.body,
+					Bearer:             string(tt.bearer),
+					SignedRequestToken: string(tt.body),
 				},
 			)
+			slog.Info("verifiy repspponse", "v", verified, "e", err)
 			if tt.bearish {
-				if err != nil {
-					t.Errorf("failed to parse srt=[%s], tok=[%s], err=[%v]", tt.body, tt.tok, err)
-				}
-				if verified.publicKey == nil {
-					t.Error("unable to load public key")
-				}
-				if verified.requestBody == nil {
-					t.Error("unable to load request body")
-				}
+				require.NoError(t, err, "failed to parse srt=[%s], tok=[%s]", tt.body, tt.bearer)
+				require.NotNil(t, verified.publicKey, "unable to load public key")
+				require.NotNil(t, verified.requestBody, "unable to load request body")
+
 				policy, err := p.verifyAndParsePolicy(context.Background(), verified.requestBody, []byte(plainKey))
 				if tt.polite {
-					if err != nil || len(policy.Body.DataAttributes) != 2 {
-						t.Errorf("failed to verify policy body=[%v], err=[%v]", tt.body, err)
-					}
+					assert.NoError(t, err, "failed to verify policy body=[%v]", tt.body)
+					assert.Len(t, policy.Body.DataAttributes, 2, "incorrect policy body=[%v]", policy.Body)
 				} else {
-					if err == nil {
-						t.Errorf("failed to fail policy body=[%v], err=[%v]", tt.body, err)
-					}
+					assert.Error(t, err, "failed to fail policy body=[%v]", tt.body)
 				}
 			} else {
-				if err == nil {
-					t.Errorf("failed to fail srt=[%s], tok=[%s]", tt.body, tt.tok)
-				}
+				assert.Error(t, err, "failed to fail srt=[%s], tok=[%s]", tt.body, tt.bearer)
 			}
 		})
 	}
@@ -464,33 +396,27 @@ func TestLegacyBearerTokenFails(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(tt.metadata...))
 			p, err := legacyBearerToken(ctx, "")
-			if p != "" || err == nil || !strings.Contains(err.Error(), tt.msg) {
-				t.Errorf("should fail p=[%s], err=[%s], expected [%s]", p, err, tt.msg)
-			}
+			assert.Empty(t, p)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.msg)
 		})
 	}
 }
 
-func TestSignedRequestTokenVerification(t *testing.T) {
-
-}
-
 func TestLegacyBearerTokenEtc(t *testing.T) {
 	p, err := legacyBearerToken(context.Background(), "")
-	if p != "" || err == nil || !strings.Contains(err.Error(), "no auth token") {
-		t.Errorf("should fail p=[%s], err=[%s], expected 'no auth token'", p, err)
-	}
+	assert.Empty(t, p)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no auth token")
 
 	p, err = legacyBearerToken(context.Background(), "something")
-	if p != "something" || err != nil {
-		t.Errorf("should succeed p=[%s], err=[%s], expected 'something' in p", p, err)
-	}
+	assert.Equal(t, "something", p)
+	assert.NoError(t, err)
 
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("Authorization", "Bearer TOKEN"))
 	p, err = legacyBearerToken(ctx, "")
-	if p != "TOKEN" || err != nil {
-		t.Errorf("should succeed p=[%s], err=[%s], expected p='TOKEN'", p, err)
-	}
+	assert.Equal(t, "TOKEN", p)
+	assert.NoError(t, err)
 }
 
 func TestHandlerAuthFailure0(t *testing.T) {
@@ -505,9 +431,8 @@ func TestHandlerAuthFailure0(t *testing.T) {
 	body := `{"mock": "value"}`
 	_, err := kas.Rewrap(context.Background(), &kaspb.RewrapRequest{SignedRequestToken: body})
 	status, ok := status.FromError(err)
-	if !ok || status.Code() != codes.Unauthenticated {
-		t.Errorf("got [%s], but should return expected error, status.message: [%s], status.code: [%s]", err, status.Message(), status.Code())
-	}
+	assert.True(t, ok)
+	assert.Equal(t, status.Code(), codes.Unauthenticated)
 }
 
 func TestHandlerAuthFailure1(t *testing.T) {
@@ -526,9 +451,8 @@ func TestHandlerAuthFailure1(t *testing.T) {
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	_, err := kas.Rewrap(ctx, &kaspb.RewrapRequest{SignedRequestToken: body})
 	status, ok := status.FromError(err)
-	if !ok || status.Code() != codes.PermissionDenied {
-		t.Errorf("got [%s], but should return expected error, status.message: [%s], status.code: [%s]", err, status.Message(), status.Code())
-	}
+	assert.True(t, ok)
+	assert.Equal(t, status.Code(), codes.PermissionDenied)
 }
 
 func TestHandlerAuthFailure2(t *testing.T) {
@@ -543,7 +467,6 @@ func TestHandlerAuthFailure2(t *testing.T) {
 	body := `{"mock": "value"}`
 	_, err := kas.Rewrap(context.Background(), &kaspb.RewrapRequest{SignedRequestToken: body, Bearer: "invalidToken"})
 	status, ok := status.FromError(err)
-	if !ok || status.Code() != codes.PermissionDenied {
-		t.Errorf("got [%s], but should return expected error, status.message: [%s], status.code: [%s]", err, status.Message(), status.Code())
-	}
+	assert.True(t, ok)
+	assert.Equal(t, status.Code(), codes.PermissionDenied)
 }


### PR DESCRIPTION
go-jose is still pulled in by our oidc/oauth libraries, but at least we can reduce its usage in direct deps