### PR TITLE
feat(PLAT-3112): Initial consumption of ec_key_pair functions by nanotdf

### DIFF
--- a/lib/ocrypto/go.mod
+++ b/lib/ocrypto/go.mod
@@ -1,3 +1,11 @@
 module github.com/opentdf/platform/lib/ocrypto
 
 go 1.21.9
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/lib/ocrypto/go.sum
+++ b/lib/ocrypto/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -100,8 +100,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/opentdf/platform/lib/ocrypto v0.0.0-20240409133529-9d7b951a26c6 h1:WP4SvDBCOANBYNEGcYE694/Dm//Ei6XPHZ0CSiuq8Mc=
-github.com/opentdf/platform/lib/ocrypto v0.0.0-20240409133529-9d7b951a26c6/go.mod h1:LFw5zaMH/d/cbWabcpY7nA0BVYdWYDfpS31Xem6p/D4=
 github.com/opentdf/platform/protocol/go v0.0.0-20240409133529-9d7b951a26c6 h1:dCkzhFss6IeOr/CYnEFjH/ZYewwWviu1B1Tnicbbwd0=
 github.com/opentdf/platform/protocol/go v0.0.0-20240409133529-9d7b951a26c6/go.mod h1:QcLUArzpnfaLehOin8EBM77dCyyUwlRg/kH6uhy+HVE=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/sdk/nanotdf.go
+++ b/sdk/nanotdf.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+
+	"github.com/opentdf/platform/lib/ocrypto"
 )
 
 const (
@@ -31,12 +33,12 @@ func (resourceLocator) isPolicyBody() {}
 type bindingCfg struct {
 	useEcdsaBinding bool
 	padding         uint8
-	bindingBody     eccMode
+	bindingBody     ocrypto.ECCMode
 }
 
 type signatureConfig struct {
 	hasSignature  bool
-	signatureMode eccMode
+	signatureMode ocrypto.ECCMode
 	cipher        cipherMode
 }
 
@@ -79,15 +81,6 @@ const (
 	urlProtocolShared urlProtocol = 255
 )
 
-type eccMode uint8
-
-const (
-	eccModeSecp256r1 eccMode = 0
-	eccModeSecp384r1 eccMode = 1
-	eccModeSecp521r1 eccMode = 2
-	eccModeSecp256k1 eccMode = 3
-)
-
 type cipherMode int
 
 const (
@@ -112,7 +105,7 @@ func deserializeBindingCfg(b byte) *bindingCfg {
 	cfg := bindingCfg{}
 	cfg.useEcdsaBinding = (b >> 7 & 0x01) == 1
 	cfg.padding = 0
-	cfg.bindingBody = eccMode((b >> 4) & 0x07)
+	cfg.bindingBody = ocrypto.ECCMode((b >> 4) & 0x07)
 
 	return &cfg
 }
@@ -120,7 +113,7 @@ func deserializeBindingCfg(b byte) *bindingCfg {
 func deserializeSignatureCfg(b byte) *signatureConfig {
 	cfg := signatureConfig{}
 	cfg.hasSignature = (b >> 7 & 0x01) == 1
-	cfg.signatureMode = eccMode((b >> 4) & 0x07)
+	cfg.signatureMode = ocrypto.ECCMode((b >> 4) & 0x07)
 	cfg.cipher = cipherMode(b & 0x0F)
 
 	return &cfg
@@ -156,14 +149,14 @@ func readPolicyBody(reader io.Reader, mode uint8) (PolicyBody, error) {
 	}
 }
 
-func readEphemeralPublicKey(reader io.Reader, curve eccMode) (*eccKey, error) {
+func readEphemeralPublicKey(reader io.Reader, curve ocrypto.ECCMode) (*eccKey, error) {
 	var numberOfBytes uint8
 	switch curve {
-	case eccModeSecp256r1:
+	case ocrypto.ECCModeSecp256r1:
 		numberOfBytes = 33
-	case eccModeSecp384r1:
+	case ocrypto.ECCModeSecp384r1:
 		numberOfBytes = 49
-	case eccModeSecp521r1:
+	case ocrypto.ECCModeSecp521r1:
 		numberOfBytes = 67
 	}
 	buffer := make([]byte, numberOfBytes)

--- a/sdk/nanotdf_test.go
+++ b/sdk/nanotdf_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/gob"
 	"os"
 	"testing"
+
+	"github.com/opentdf/platform/lib/ocrypto"
 )
 
 // nanotdfEqual compares two nanoTdf structures for equality.
@@ -103,11 +105,11 @@ func TestReadNanoTDFHeader(t *testing.T) {
 		binding: &bindingCfg{
 			useEcdsaBinding: true,
 			padding:         0,
-			bindingBody:     eccModeSecp256r1,
+			bindingBody:     ocrypto.ECCModeSecp256r1,
 		},
 		sigCfg: &signatureConfig{
 			hasSignature:  true,
-			signatureMode: eccModeSecp256r1,
+			signatureMode: ocrypto.ECCModeSecp256r1,
 			cipher:        cipherModeAes256gcm64Bit,
 		},
 		policy: &policyInfo{


### PR DESCRIPTION
Now that ec_key_pair is available, add references to that functionality in nanotdf.

[PLAT-3112]

[PLAT-3112]: https://virtru.atlassian.net/browse/PLAT-3112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Not the end of the nanotdf support work by a longshot, but it gets the nanotdf header code that Misha wrote working and using the ec_key_pair code.