### PR TITLE
ci: add `--recursive` to cosign command

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -62,4 +62,4 @@ jobs:
           for tag in ${TAGS}; do
             images+="${tag}@${DIGEST} "
           done
-          cosign sign --yes ${images}
+          cosign sign --yes --recursive ${images}


### PR DESCRIPTION
I think we want the `--recursive` flag here to sign all multi-arch images as well within the manifest. 

```
-r, --recursive=false:
	if a multi-arch image is specified, additionally sign each discrete image
```