### PR TITLE
fix(sdk): this (`enforceDPoP`) flag needs to be flipped

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -312,7 +312,7 @@ func (a Authentication) checkToken(ctx context.Context, authHeader []string, dpo
 	}
 
 	_, tokenHasCNF := accessToken.Get("cnf")
-	if !tokenHasCNF && a.enforceDPoP {
+	if !tokenHasCNF && !a.enforceDPoP {
 		// this condition is not quite tight because it's possible that the `cnf` claim may
 		// come from token introspection
 		return accessToken, ctx, nil

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -144,7 +144,7 @@ func (s *AuthSuite) SetupTest() {
 		context.Background(),
 		Config{
 			AuthNConfig: AuthNConfig{
-				EnforceDPoP: false,
+				EnforceDPoP: true,
 				Issuer:      s.server.URL,
 				Audience:    "test",
 			},
@@ -548,7 +548,7 @@ func makeDPoPToken(t *testing.T, tc dpopTestCase) string {
 
 func (s *AuthSuite) Test_Allowing_Auth_With_No_DPoP() {
 	authnConfig := AuthNConfig{
-		EnforceDPoP: true,
+		EnforceDPoP: false,
 		Issuer:      s.server.URL,
 		Audience:    "test",
 	}


### PR DESCRIPTION
the flag was inverted incorrectly