### PR TITLE
fix: update dockerfile to leverage `ENTRYPOINT` instead of `CMD`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ FROM cgr.dev/chainguard/glibc-dynamic
 
 COPY --from=builder /app/opentdf /usr/bin/
 
-CMD ["/usr/bin/opentdf"]
+ENTRYPOINT ["/usr/bin/opentdf"]


### PR DESCRIPTION
We want the `opentdf` application to be the entrypoint. This will allow to do things like 

`docker run registry.opentdf.io/platform:nightly provision keycloak`

instead of having to do 

`docker run -it registry.opentdf.io/platform:nightly opentdf  provision`