### PR TITLE
docs: how to run platform locally

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -116,7 +116,7 @@ jobs:
         if: matrix.crypto == 'hsm'
       - run: |
           .github/scripts/init-temp-keys.sh
-          cp opentdf-example.yaml opentdf.yaml
+          cp opentdf-dev.yaml opentdf.yaml
         if: matrix.crypto == 'standard'
       - run: go run ./service provision keycloak
       - uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@
    ```sh
       docker run --network opentdf_platform \
          -v ./opentdf.yaml:/home/nonroot/.opentdf/opentdf.yaml \
-         -it registry.opentdf.io/platform:nightly \ 
-         provision keycloak -e http://keycloak:8888/auth
+         -it registry.opentdf.io/platform:nightly provision keycloak -e http://keycloak:8888/auth
    ```
 
 4. Initialize KAS Keys ```.github/scripts/init-temp-keys.sh -o kas-keys```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@
 - [Policy Config Schema](./service/migrations/20240212000000_schema_erd.md)
 - [Policy Config Testing Diagram](./service/integration/testing_diagram.png)
 
+## Running the Platform Locally
+
+### Setting up pre-requisites
+
+1. Stand up the local Postgres database and Keycloak instances using `docker-compose up -d --wait`.
+2. Bootstrap Keycloak
+
+   ```sh
+      docker run --network opentdf-v2-poc_default \
+         -v ./opentdf.yaml:/home/nonroot/.opentdf/opentdf.yaml \
+         -it us-docker.pkg.dev/prj-sb-engineering-nerq/sean-test/opentdf:v2 \ 
+         provision keycloak -e http://keycloak:8888/auth
+   ```
+
 ## Development
 
 ### Prerequisites
@@ -98,7 +112,7 @@ In this folder, create your go code as usual.
 #### Add a README.md and a LICENSE File
 
 A README is recommended to assist with orientation to use of your package.
-Remember, this will be published to https://pkg.go.dev/ as part of the module documentation.
+Remember, this will be published to <https://pkg.go.dev/> as part of the module documentation.
 
 Make sure to add a LICENSE file to your module to support automated license checks.
 Feel free to copy the existing (BSD-clear) LICENSE file for most new modules.
@@ -128,7 +142,7 @@ Feel free to copy the existing (BSD-clear) LICENSE file for most new modules.
 
    ```Makefile
    lib/foo/foo: $(shell find lib/foo)
-   	(cd lib/foo && go build ./...)
+    (cd lib/foo && go build ./...)
    ```
 
 #### Updating the Docker Images

--- a/README.md
+++ b/README.md
@@ -14,13 +14,24 @@
 ### Setting up pre-requisites
 
 1. Stand up the local Postgres database and Keycloak instances using `docker-compose up -d --wait`.
-2. Bootstrap Keycloak
+2. Copy the `opentdf-example.yaml` file to `opentdf.yaml` and update the [configuration](./docs/configuration.md) as needed.
+3. Bootstrap Keycloak
 
    ```sh
-      docker run --network opentdf-v2-poc_default \
+      docker run --network opentdf_platform \
          -v ./opentdf.yaml:/home/nonroot/.opentdf/opentdf.yaml \
-         -it us-docker.pkg.dev/prj-sb-engineering-nerq/sean-test/opentdf:v2 \ 
+         -it registry.opentdf.io/platform:nightly \ 
          provision keycloak -e http://keycloak:8888/auth
+   ```
+
+4. Initialize KAS Keys ```.github/scripts/init-temp-keys.sh -o kas-keys```
+5. Start the platform
+
+   ```sh
+   docker run --network opentdf_platform \
+      -v ./kas-keys/:/keys/ \
+      -v ./opentdf.yaml:/home/nonroot/.opentdf/opentdf.yaml \
+      -it registry.opentdf.io/platform:nightly start
    ```
 
 ## Development
@@ -56,7 +67,7 @@ brew install buf go golangci-lint goose grpcurl openssl
 
 1. `docker-compose up`. Starts both the local Postgres database (contains the ABAC policy configuration data) and Keycloak (the local IdP).
 2. Create an OpenTDF config file: `opentdf.yaml`
-   1. The `opentdf-example.yaml` file is the more secure starting point, but you will likely need to modify it to match your environment. This configuration is recommended as it is more secure but it does require valid development keypairs.
+   1. The `opentdf-dev.yaml` file is the more secure starting point, but you will likely need to modify it to match your environment. This configuration is recommended as it is more secure but it does require valid development keypairs.
    2. The `opentdf-example-no-kas.yaml` file is simpler to run but less secure. This file configures the platform to startup without a KAS instances and without endpoint authentication.
 3. Provision keycloak: `go run github.com/opentdf/platform/service provision keycloak`. Updates the local Keycloak configuration for local testing and development by creating a realm, roles, a client, and users.
 4. Configure KAS keys: `.github/scripts/init-temp-keys.sh`. Creates temporary keys for the local KAS. This step can be ignored if you are running the 'opentdf-example-no-kas' configuration in step 2.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,6 @@
+networks:
+  default:
+    name: opentdf_platform
 services:
   keycloak:
     # This is kc 24.0.1 with opentdf protocol mapper on board

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -3,8 +3,8 @@ logger:
   type: text
   output: stdout
 # DB and Server confgurations are defaulted for local development
-db:
-  host: opentdfdb
+# db:
+#   host: localhost
 #   port: 5432
 #   user: postgres
 #   password: changeme
@@ -15,7 +15,7 @@ services:
     enabled: true
   authorization:
     enabled: true
-    url: http://keycloak:8888
+    url: http://localhost:8888
     client: "tdf-entity-resolution"
     secret: "secret"
     realm: "opentdf"
@@ -24,7 +24,7 @@ server:
   auth:
     enabled: true
     audience: "http://localhost:8080"
-    issuer: http://keycloak:8888/auth/realms/opentdf
+    issuer: http://localhost:8888/auth/realms/opentdf
     policy:
       ## Default policy for all requests
       default: #"role:readonly"
@@ -69,15 +69,15 @@ server:
     standard:
       rsa:
         123:
-          privateKeyPath: /keys/kas-private.pem
-          publicKeyPath: /keys/kas-cert.pem
+          privateKeyPath: kas-private.pem
+          publicKeyPath: kas-cert.pem
         456:
-          privateKeyPath: /keys/kas-private.pem
-          publicKeyPath: /keys/kas-cert.pem
+          privateKeyPath: kas-private.pem
+          publicKeyPath: kas-cert.pem
       ec:
         123:
-          privateKeyPath: /keys/kas-ec-private.pem
-          publicKeyPath: /keys/kas-ec-cert.pem
+          privateKeyPath: kas-ec-private.pem
+          publicKeyPath: kas-ec-cert.pem
   port: 8080
 opa:
   embedded: true # Only for local development


### PR DESCRIPTION
Updates readme with instructions on how to run the platform locally without having to worry about setting up a go development environment. 