### PR TITLE
fix(core): Fix several misspellings 

### DIFF
--- a/README-hsm.md
+++ b/README-hsm.md
@@ -3,7 +3,7 @@
 The `opentdf` services can use hardware security modules (HSMs)
 to protect access to high value private key data,
 notably KAS private keys used for long lived identity of the server.
-The servcies can use PKCS #11 bindings to communicate with a system or network HSM.
+The services can use PKCS #11 bindings to communicate with a system or network HSM.
 To configure a development environment,
 we use [softHSM](https://github.com/opendnssec/SoftHSMv2).
 

--- a/examples/cmd/encrypt.go
+++ b/examples/cmd/encrypt.go
@@ -49,7 +49,7 @@ func encrypt(cmd *cobra.Command, args []string) error {
 		//sdk.WithDataAttributes("https://example.com/attr/attr1/value/value1"),
 		sdk.WithKasInformation(
 			sdk.KASInfo{
-				// examples assume unsecure http
+				// examples assume insecure http
 				URL:       fmt.Sprintf("http://%s", cmd.Flag("platformEndpoint").Value.String()),
 				PublicKey: "",
 			}))

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -2,7 +2,7 @@ logger:
   level: debug
   type: text
   output: stdout
-# DB and Server confgurations are defaulted for local development
+# DB and Server configurations are defaulted for local development
 # db:
 #   host: localhost
 #   port: 5432

--- a/opentdf-example-no-kas.yaml
+++ b/opentdf-example-no-kas.yaml
@@ -2,7 +2,7 @@ logger:
   level: debug
   type: text
   output: stdout
-# DB and Server confgurations are defaulted for local development
+# DB and Server configurations are defaulted for local development
 # db:
 #   host: localhost
 #   port: 5432

--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -2,7 +2,7 @@ logger:
   level: debug
   type: text
   output: stdout
-# DB and Server confgurations are defaulted for local development
+# DB and Server configurations are defaulted for local development
 db:
   host: opentdfdb
 #   port: 5432

--- a/opentdf-with-hsm.yaml
+++ b/opentdf-with-hsm.yaml
@@ -2,7 +2,7 @@ logger:
   level: debug
   type: text
   output: stdout
-# DB and Server confgurations are defaulted for local development
+# DB and Server configurations are defaulted for local development
 # db:
 #   host: localhost
 #   port: 5432

--- a/sdk/auth_config.go
+++ b/sdk/auth_config.go
@@ -61,7 +61,7 @@ func NewOIDCAuthConfig(ctx context.Context, client *http.Client, host, realm, cl
 
 	authConfig.accessToken, err = authConfig.fetchOIDCAccessToken(ctx, host, realm, clientID, clientSecret, subjectToken)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch acces token: %w", err)
+		return nil, fmt.Errorf("failed to fetch access token: %w", err)
 	}
 	return authConfig, nil
 }

--- a/sdk/auth_config_test.go
+++ b/sdk/auth_config_test.go
@@ -41,6 +41,6 @@ func TestNewOIDCAuthConfig(t *testing.T) {
 	}
 
 	if authConfig.accessToken != expectedAccessToken {
-		t.Fatalf("Auth token expected %s recived %s", expectedAccessToken, authConfig.accessToken)
+		t.Fatalf("Auth token expected %s received %s", expectedAccessToken, authConfig.accessToken)
 	}
 }

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -146,7 +146,7 @@ func (s SDK) CreateTDF(writer io.Writer, reader io.ReadSeeker, opts ...TDFOption
 		}
 
 		if int64(n) != readSize {
-			return nil, fmt.Errorf("io.ReadSeeker.Read size missmatch")
+			return nil, fmt.Errorf("io.ReadSeeker.Read size mismatch")
 		}
 
 		cipherData, err := tdfObject.aesGcm.Encrypt(readBuf.Bytes()[:readSize])

--- a/service/authorization/authorization.go
+++ b/service/authorization/authorization.go
@@ -95,7 +95,7 @@ func (as AuthorizationService) GetDecisions(ctx context.Context, req *authorizat
 				return nil, err
 			}
 
-			// get the relevent resource attribute fqns
+			// get the relevant resource attribute fqns
 			allPertinentFqnsRA := authorization.ResourceAttribute{
 				AttributeValueFqns: ra.GetAttributeValueFqns(),
 			}
@@ -122,7 +122,7 @@ func (as AuthorizationService) GetDecisions(ctx context.Context, req *authorizat
 					return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("getEntitlements request failed ", req.String()))
 				}
 
-				// currently just adding each entity retuned to same list
+				// currently just adding each entity returned to same list
 				entityAttrValues := make(map[string][]string)
 				for _, e := range ecEntitlements.GetEntitlements() {
 					entityAttrValues[e.GetEntityId()] = e.GetAttributeValueFqns()

--- a/service/internal/access/pdp.go
+++ b/service/internal/access/pdp.go
@@ -225,7 +225,7 @@ func (pdp *Pdp) anyOfRule(ctx context.Context, dataAttrValuesOfOneDefinition []*
 		}
 
 		// AnyOf - IF there were fewer value failures for this entity, for this Attribute Value FQN,
-		// then there are distict data values, for this Attribute Value FQN, THEN this entity must
+		// then there are distinct data values, for this Attribute Value FQN, THEN this entity must
 		// possess AT LEAST ONE of the values in its entity Attribute Value group,
 		// and we have satisfied AnyOf
 		if len(valueFailures) < len(dataAttrValuesOfOneDefinition) {
@@ -345,7 +345,7 @@ func (pdp *Pdp) getHighestRankedInstanceFromDataAttributes(ctx context.Context, 
 		if foundRank == -1 {
 			msg := fmt.Sprintf("Data value %s is not in %s and is not a valid value for this attribute - ignoring this invalid value and continuing to look for a valid one...", dataAttr.GetValue(), order)
 			slog.WarnContext(ctx, msg)
-			// If this isnt a valid data value, skip this iteration and look at the next one - maybe it is?
+			// If this isn't a valid data value, skip this iteration and look at the next one - maybe it is?
 			// If none of them are valid, we should return a nil instance
 			continue
 		}

--- a/service/internal/security/standard_crypto.go
+++ b/service/internal/security/standard_crypto.go
@@ -88,7 +88,7 @@ func (s StandardCrypto) RSAPublicKey(keyID string) (string, error) {
 
 	pem, err := s.rsaKeys[0].asymEncryption.PublicKeyInPemFormat()
 	if err != nil {
-		return "", fmt.Errorf("failed to retrive rsa public key file: %w", err)
+		return "", fmt.Errorf("failed to retrieve rsa public key file: %w", err)
 	}
 
 	return pem, nil

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -214,7 +214,7 @@ func newGrpcServer(c Config, a *auth.Authentication) (*grpc.Server, error) {
 	var i []grpc.UnaryServerInterceptor
 	var o []grpc.ServerOption
 
-	// Enbale proto validation
+	// Enable proto validation
 	validator, err := protovalidate.New()
 	if err != nil {
 		slog.Warn("failed to create proto validator", slog.String("error", err.Error()))

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -295,7 +295,7 @@ func TestParseAndVerifyRequest(t *testing.T) {
 					SignedRequestToken: string(tt.body),
 				},
 			)
-			slog.Info("verifiy repspponse", "v", verified, "e", err)
+			slog.Info("verify repspponse", "v", verified, "e", err)
 			if tt.bearish {
 				require.NoError(t, err, "failed to parse srt=[%s], tok=[%s]", tt.body, tt.bearer)
 				require.NotNil(t, verified.ClientPublicKey, "unable to load public key")

--- a/service/policy/db/migrations/20240213000000_create_attribute_fqn.md
+++ b/service/policy/db/migrations/20240213000000_create_attribute_fqn.md
@@ -14,7 +14,7 @@ notes: |
   used with systems like KAS to look up the data and make a decision.
 
   It is alright if this data is eventually consistent as the data can be reindexed as needed. There
-  might be a future when we support multiple datastores and utilize an auxillary database to support
+  might be a future when we support multiple datastores and utilize an auxiliary database to support
   faster lookups.
 ---
 


### PR DESCRIPTION
This PR fixes several misspellings.

Since doing this work manually seems like a waste of time, you might consider introducing automation to prevent spelling errors (I make them constantly).
 
One automatic spell-checker is https://github.com/codespell-project/codespell .  It's very easy to run both locally and in CI, using pre-commit, e.g. the following will lint Go, Markdown, and YAML:

```yaml
# To learn about "pre-commit", see:
#   https://github.com/pre-commit/pre-commit

repos:
-   repo: https://github.com/codespell-project/codespell
    rev: v2.2.6
    hooks:
    - id: codespell
      files: ^.*\.(go|md|yaml)$
      args: ["--write-changes", "--ignore-words-list", "MYCOOLWORD,ANOTHAONE"]
```