### PR TITLE
chore: rewrap fixes for client-web

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -25,12 +25,16 @@ import (
 )
 
 const (
-	dpopJWKContextKey        = authContextKey("dpop-jwk")
-	accessTokenContextKey    = authContextKey("access-token")
-	rawAccessTokenContextKey = authContextKey("raw-access-token")
+	authnContextKey = authContextKey("dpop-jwk")
 )
 
 type authContextKey string
+
+type authContext struct {
+	key         jwk.Key
+	accessToken jwt.Token
+	rawToken    string
+}
 
 var (
 	// Set of allowed public endpoints that do not require authentication
@@ -333,52 +337,49 @@ func (a Authentication) checkToken(ctx context.Context, authHeader []string, dpo
 	if err != nil {
 		return nil, nil, err
 	}
-	ctx = ContextWithJWK(ctx, key)
-	ctx = context.WithValue(ctx, accessTokenContextKey, accessToken)
-	ctx = context.WithValue(ctx, rawAccessTokenContextKey, tokenRaw)
+	ctx = ContextWithJWK(ctx, key, accessToken, tokenRaw)
 	return accessToken, ctx, nil
 }
 
-func ContextWithJWK(ctx context.Context, key jwk.Key) context.Context {
-	return context.WithValue(ctx, dpopJWKContextKey, key)
+func ContextWithJWK(ctx context.Context, key jwk.Key, accessToken jwt.Token, raw string) context.Context {
+	return context.WithValue(ctx, authnContextKey, &authContext{
+		key,
+		accessToken,
+		raw,
+	})
 }
 
-func GetJWKFromContext(ctx context.Context) jwk.Key {
-	key := ctx.Value(dpopJWKContextKey)
+func getContextDetails(ctx context.Context) *authContext {
+	key := ctx.Value(authnContextKey)
 	if key == nil {
 		return nil
 	}
-	if jwk, ok := key.(jwk.Key); ok {
-		return jwk
+	if c, ok := key.(*authContext); ok {
+		return c
 	}
 
-	slog.ErrorContext(ctx, "got something that is not a jwk.Key from the JWK context")
+	slog.ErrorContext(ctx, "invalid authContext")
+	return nil
+}
+
+func GetJWKFromContext(ctx context.Context) jwk.Key {
+	if c := getContextDetails(ctx); c != nil {
+		return c.key
+	}
 	return nil
 }
 
 func GetAccessTokenFromContext(ctx context.Context) jwt.Token {
-	v := ctx.Value(accessTokenContextKey)
-	if v == nil {
-		return nil
+	if c := getContextDetails(ctx); c != nil {
+		return c.accessToken
 	}
-	if jwt, ok := v.(jwt.Token); ok {
-		return jwt
-	}
-
-	slog.ErrorContext(ctx, "got something that is not a jwt.Token from the access token context")
 	return nil
 }
 
 func GetRawAccessTokenFromContext(ctx context.Context) string {
-	v := ctx.Value(rawAccessTokenContextKey)
-	if v == nil {
-		return ""
+	if c := getContextDetails(ctx); c != nil {
+		return c.rawToken
 	}
-	if jwt, ok := v.(string); ok {
-		return jwt
-	}
-
-	slog.ErrorContext(ctx, "got something that is not a string from the access token context")
 	return ""
 }
 

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -352,7 +352,8 @@ func GetJWKFromContext(ctx context.Context) jwk.Key {
 		return jwk
 	}
 
-	panic("got something that is not a jwk.Key from the JWK context")
+	slog.ErrorContext(ctx, "got something that is not a jwk.Key from the JWK context")
+	return nil
 }
 
 func GetAccessTokenFromContext(ctx context.Context) jwt.Token {
@@ -364,7 +365,8 @@ func GetAccessTokenFromContext(ctx context.Context) jwt.Token {
 		return jwt
 	}
 
-	panic("got something that is not a jwt.Token from the access token context")
+	slog.ErrorContext(ctx, "got something that is not a jwt.Token from the access token context")
+	return nil
 }
 
 func GetRawAccessTokenFromContext(ctx context.Context) string {
@@ -376,7 +378,8 @@ func GetRawAccessTokenFromContext(ctx context.Context) string {
 		return jwt
 	}
 
-	panic("got something that is not a string from the access token context")
+	slog.ErrorContext(ctx, "got something that is not a string from the access token context")
+	return ""
 }
 
 func validateDPoP(accessToken jwt.Token, acessTokenRaw string, dpopInfo receiverInfo, headers []string) (jwk.Key, error) {

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -72,10 +72,6 @@ func err403(s string) error {
 	return errors.Join(ErrUser, status.Error(codes.PermissionDenied, s))
 }
 
-func err500(s string) error {
-	return errors.Join(ErrInternal, status.Error(codes.Unknown, s))
-}
-
 func generateHMACDigest(ctx context.Context, msg, key []byte) ([]byte, error) {
 	mac := hmac.New(sha256.New, key)
 	_, err := mac.Write(msg)
@@ -98,7 +94,7 @@ func verifySRT(ctx context.Context, srt string, dpopJWK jwk.Key) (string, error)
 }
 
 func noverify(ctx context.Context, srt string) (string, error) {
-	token, err := jwt.Parse([]byte(srt), jwt.WithVerify(false), jwt.WithAcceptableSkew(30*time.Second))
+	token, err := jwt.Parse([]byte(srt), jwt.WithVerify(false), jwt.WithAcceptableSkew(acceptableSkew))
 	if err != nil {
 		slog.WarnContext(ctx, "unable to validate or parse token", "err", err)
 		return "", err401("could not parse token")

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -137,7 +137,7 @@ func extractSRTBody(ctx context.Context, in *kaspb.RewrapRequest) (*RequestBody,
 	} else {
 		// verify and validate the request token
 		var err error
-		rbString, err = verifySRT(ctx, srt, dpopJWK, rbString)
+		rbString, err = verifySRT(ctx, srt, dpopJWK)
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +177,7 @@ func extractSRTBody(ctx context.Context, in *kaspb.RewrapRequest) (*RequestBody,
 	}
 }
 
-func verifySRT(ctx context.Context, srt string, dpopJWK jwk.Key, rbString string) (string, error) {
+func verifySRT(ctx context.Context, srt string, dpopJWK jwk.Key) (string, error) {
 	v, err := jws.NewVerifier(jwa.RS256)
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to load RSA verifier", "err", err)
@@ -213,8 +213,7 @@ func verifySRT(ctx context.Context, srt string, dpopJWK jwk.Key, rbString string
 		slog.WarnContext(ctx, "unable to unmarshall srt", "err", err, "srt", srt, "jwk", dpopJWK)
 		return "", err400("signed content failure")
 	}
-	rbString = srtDecoded.RequestBody
-	return rbString, nil
+	return srtDecoded.RequestBody, nil
 }
 
 func verifyAndParsePolicy(ctx context.Context, requestBody *RequestBody, k []byte) (*Policy, error) {

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -287,9 +287,7 @@ func TestParseAndVerifyRequest(t *testing.T) {
 				require.NoError(t, err, "couldn't get JWK from key")
 				err = key.Set(jwk.AlgorithmKey, jwa.RS256) // Check the error return value
 				require.NoError(t, err, "failed to set algorithm key")
-				ctx = auth.ContextWithJWK(ctx, key)
-				ctx = context.WithValue(ctx, "access-token", mockJWT(t))
-				ctx = context.WithValue(ctx, "raw-access-token", bearer)
+				ctx = auth.ContextWithJWK(ctx, key, mockJWT(t), bearer)
 			}
 
 			md := metadata.New(map[string]string{"token": bearer})
@@ -328,7 +326,7 @@ func Test_SignedRequestBody_When_Bad_Signature_Expect_Failure(t *testing.T) {
 
 	err = key.Set(jwk.AlgorithmKey, jwa.NoSignature)
 	require.NoError(t, err, "failed to set algorithm key")
-	ctx = auth.ContextWithJWK(ctx, key)
+	ctx = auth.ContextWithJWK(ctx, key, mockJWT(t), string(jwtStandard(t)))
 
 	md := metadata.New(map[string]string{"token": string(jwtWrongKey(t))})
 	ctx = metadata.NewIncomingContext(ctx, md)


### PR DESCRIPTION
- Fixes several issues surfaced while fixing up client web, notably:
- work with empty attribute lists (for both subjects and objects). evaluates to 'permit' when both are empty
- remove duplicate dpop analysis code
- adds more stuff to dpop/auth context to make up for the missing re-parsing code
- implement SRT parsing correctly using dpop jwk if present and requested