### PR TITLE
chore(ci): Validates internal deps are up-to-date

### DIFF
--- a/.github/scripts/work-init.sh
+++ b/.github/scripts/work-init.sh
@@ -31,27 +31,26 @@ if ! cd "$ROOT_DIR"; then
   echo "[ERROR] unable to find project directory; expected it to be in [${ROOT_DIR}]"
 fi
 
-
-
 echo "[INFO] Rebuilding partial go.work for [${component}]"
 case $component in
-lib/ocrypto | lib/fixtures | protocol/go)
-  echo "[INFO] skipping for leaf package"
-  ;;
-sdk)
-  rm go.work go.work.sum
-  go work init
-  go work add ./service
-  go work add ./examples
-  ;;
-service)
-  rm go.work go.work.sum
-  go work init
-  go work add ./examples
-  ;;
-examples)
-  rm go.work go.work.sum
-  ;;
-*)
-  echo "[ERROR] unknown component [${component}]"
+  lib/ocrypto | lib/fixtures | protocol/go)
+    echo "[INFO] skipping for leaf package"
+    ;;
+  sdk)
+    rm go.work go.work.sum
+    go work init
+    go work add ./service
+    go work add ./examples
+    ;;
+  service)
+    rm go.work go.work.sum
+    go work init
+    go work add ./examples
+    ;;
+  examples)
+    rm go.work go.work.sum
+    ;;
+  *)
+    echo "[ERROR] unknown component [${component}]"
+    ;;
 esac

--- a/.github/scripts/work-init.sh
+++ b/.github/scripts/work-init.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Generates a partial go.work for service X that only includes X and downstream
+# items
+#
+#    Usage: work-init (component path)
+#
+# If component is unspecfied it will look for it in the GITHUB_HEAD_REF.
+# This is intended to be used as part of a release please to validate the
+# internal go.mod deps are up to date and accurate.
+#
+#  examples -> protocol/go, sdk
+#  lib/crypto -> ∅
+#  lib/fixtures -> ∅
+#  protocol/go -> ∅
+#  sdk -> lib/fixtures, lib/ocrypto, protocol/go
+#  services -> lib/fixtures, lib/ocrypto, protocol/go, sdk
+
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+ROOT_DIR="$(cd "${APP_DIR}/../.." >/dev/null && pwd)"
+
+if [ -n "$1" ]; then
+  component="$1"
+else
+  branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+  component=${branch#release-please--branches--main--components--}
+fi
+
+if ! cd "$ROOT_DIR"; then
+  echo "[ERROR] unable to find project directory; expected it to be in [${ROOT_DIR}]"
+fi
+
+
+
+echo "[INFO] Rebuilding partial go.work for [${component}]"
+case $component in
+lib/ocrypto | lib/fixtures | protocol/go)
+  echo "[INFO] skipping for leaf package"
+  ;;
+sdk)
+  rm go.work go.work.sum
+  go work init
+  go work add ./service
+  go work add ./examples
+  ;;
+service)
+  rm go.work go.work.sum
+  go work init
+  go work add ./examples
+  ;;
+examples)
+  rm go.work go.work.sum
+  ;;
+*)
+  echo "[ERROR] unknown component [${component}]"
+esac

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
-          fetch-depth: 0      
+          fetch-depth: 0
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: "1.22.2"
@@ -81,6 +81,8 @@ jobs:
             protocol/go/go.sum
             sdk/go.sum
             service/go.sum
+      - if: startsWith(github.head_ref, 'release-please-')
+        run: ./.github/scripts/work-init.sh
       - run: go mod download
       - run: go mod verify
       - name: golangci-lint
@@ -126,6 +128,8 @@ jobs:
             examples/go.sum
             protocol/go/go.sum
             sdk/go.sum
+      - if: startsWith(github.head_ref, 'release-please-')
+        run: ./.github/scripts/work-init.sh
       - run: go mod download
       - run: go mod verify
       - name: Install softHSM


### PR DESCRIPTION
Most of our tests currently use the go workspaces feature, which allows us to test with internal 'head' (unreleased) versions of the code in sync. However. our current build infra generates per-module tags and releases, which means we need to make sure that downstream users get a coherent set of modules.

To validate a release, this removes the 'upstream' deps from the go.work before running any test. This only happens on release branches