### PR TITLE
fix(authz): Adds jwt to context when verified

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -331,17 +331,18 @@ func (a Authentication) checkToken(ctx context.Context, authHeader []string, dpo
 	if !tokenHasCNF && !a.enforceDPoP {
 		// this condition is not quite tight because it's possible that the `cnf` claim may
 		// come from token introspection
+		ctx = ContextWithAuthNInfo(ctx, nil, accessToken, tokenRaw)
 		return accessToken, ctx, nil
 	}
 	key, err := validateDPoP(accessToken, tokenRaw, dpopInfo, dpopHeader)
 	if err != nil {
 		return nil, nil, err
 	}
-	ctx = ContextWithJWK(ctx, key, accessToken, tokenRaw)
+	ctx = ContextWithAuthNInfo(ctx, key, accessToken, tokenRaw)
 	return accessToken, ctx, nil
 }
 
-func ContextWithJWK(ctx context.Context, key jwk.Key, accessToken jwt.Token, raw string) context.Context {
+func ContextWithAuthNInfo(ctx context.Context, key jwk.Key, accessToken jwt.Token, raw string) context.Context {
 	return context.WithValue(ctx, authnContextKey, &authContext{
 		key,
 		accessToken,

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -308,7 +308,7 @@ func TestParseAndVerifyRequest(t *testing.T) {
 				require.NoError(t, err, "couldn't get JWK from key")
 				err = key.Set(jwk.AlgorithmKey, jwa.RS256) // Check the error return value
 				require.NoError(t, err, "failed to set algorithm key")
-				ctx = auth.ContextWithJWK(ctx, key, mockJWT(t), bearer)
+				ctx = auth.ContextWithAuthNInfo(ctx, key, mockJWT(t), bearer)
 			}
 
 			md := metadata.New(map[string]string{"token": bearer})
@@ -347,7 +347,7 @@ func Test_SignedRequestBody_When_Bad_Signature_Expect_Failure(t *testing.T) {
 
 	err = key.Set(jwk.AlgorithmKey, jwa.NoSignature)
 	require.NoError(t, err, "failed to set algorithm key")
-	ctx = auth.ContextWithJWK(ctx, key, mockJWT(t), string(jwtStandard(t)))
+	ctx = auth.ContextWithAuthNInfo(ctx, key, mockJWT(t), string(jwtStandard(t)))
 
 	md := metadata.New(map[string]string{"token": string(jwtWrongKey(t))})
 	ctx = metadata.NewIncomingContext(ctx, md)


### PR DESCRIPTION
This would otherwise only be added if DPoP passes. However, DPoP is not required, so this would break some rewrap flows (and other services that need to inspect the JWT) when DPoP is disabled.