### PR TITLE
chore(ci): Fixes issue with lint in releases

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -84,14 +84,14 @@ jobs:
             protocol/go/go.sum
             sdk/go.sum
             service/go.sum
-      - if: env.IS_RELEASE_BRANCH
+      - if: env.IS_RELEASE_BRANCH == 'true'
         run: ./.github/scripts/work-init.sh
       - run: go mod download
         working-directory: ${{ matrix.directory }}
       - run: go mod verify
         working-directory: ${{ matrix.directory }}
       - run: go work use .
-        if: env.IS_RELEASE_BRANCH
+        if: env.IS_RELEASE_BRANCH == 'true'
         working-directory: ${{ matrix.directory }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@9d1e0624a798bb64f6c3cea93db47765312263dc
@@ -126,8 +126,7 @@ jobs:
       - run: git diff-files --ignore-submodules
       - name: Check that files have been formatted before PR submission; see above for error details
         run: git diff-files --quiet --ignore-submodules
-        if: >-
-          !env.IS_RELEASE_BRANCH
+        if: env.IS_RELEASE_BRANCH == 'false'
 
   integration:
     name: integration tests
@@ -148,7 +147,7 @@ jobs:
             examples/go.sum
             protocol/go/go.sum
             sdk/go.sum
-      - if: env.IS_RELEASE_BRANCH
+      - if: env.IS_RELEASE_BRANCH == 'true'
         run: ./.github/scripts/work-init.sh
       - run: go mod download
       - run: go mod verify

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,5 +1,8 @@
 name: "Checks"
 
+env:
+  IS_RELEASE_BRANCH: ${{ startsWith(github.head_ref, 'release-please-') }}
+
 on:
   pull_request:
     branches:
@@ -81,11 +84,14 @@ jobs:
             protocol/go/go.sum
             sdk/go.sum
             service/go.sum
-      - if: startsWith(github.head_ref, 'release-please-')
+      - if: env.IS_RELEASE_BRANCH
         run: ./.github/scripts/work-init.sh
       - run: go mod download
         working-directory: ${{ matrix.directory }}
       - run: go mod verify
+        working-directory: ${{ matrix.directory }}
+      - run: go work use .
+        if: env.IS_RELEASE_BRANCH
         working-directory: ${{ matrix.directory }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@9d1e0624a798bb64f6c3cea93db47765312263dc
@@ -120,6 +126,8 @@ jobs:
       - run: git diff-files --ignore-submodules
       - name: Check that files have been formatted before PR submission; see above for error details
         run: git diff-files --quiet --ignore-submodules
+        if: >-
+          !env.IS_RELEASE_BRANCH
 
   integration:
     name: integration tests
@@ -140,7 +148,7 @@ jobs:
             examples/go.sum
             protocol/go/go.sum
             sdk/go.sum
-      - if: startsWith(github.head_ref, 'release-please-')
+      - if: env.IS_RELEASE_BRANCH
         run: ./.github/scripts/work-init.sh
       - run: go mod download
       - run: go mod verify


### PR DESCRIPTION
- Lets the 'current' module be added for linting and unit tests only.
- Tests of other modules still use the reduced go.work
- Disables the fmt and mod tidy up to date checks on release branches