### PR TITLE
chore(docs): improve developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ![Vulnerability Check](https://github.com/opentdf/platform/actions/workflows/vulnerability-check.yaml/badge.svg?branch=main)
 
+> [!NOTE]
+> It is advised to familiarize yourself with the [terms and concepts](../README.md#terms-and-concepts) used in the
+> OpenTDF platform.
+
 ## Documentation
 
 - [Configuration](./docs/configuration.md)
@@ -20,18 +24,26 @@
   - [Podman Compose](https://github.com/containers/podman-compose)
 - [Buf](https://buf.build/docs/ecosystem/cli-overview) is used for managing protobuf files.
   Required for developing services.
-- _Optional_ [Air](https://github.com/cosmtrek/air) is used for hot-reload development
-- _Optional_ [golangci-lint](https://golangci-lint.run/) is used for ensuring good coding practices
-  - install with `brew install golangci-lint`
-- _Optional_ [grpcurl](https://github.com/fullstorydev/grpcurl) is used for testing gRPC services
 
 On macOS, these can be installed with [brew](https://docs.brew.sh/Installation)
 
 ```sh
-brew install buf go golangci-lint goose grpcurl openssl
+brew install buf go
 ```
 
+#### Optional tools
+
+- _Optional_ [Air](https://github.com/cosmtrek/air) is used for hot-reload development
+  - install with `go install github.com/cosmtrek/air@latest`  
+- _Optional_ [golangci-lint](https://golangci-lint.run/) is used for ensuring good coding practices
+  - install with `brew install golangci-lint`
+- _Optional_ [grpcurl](https://github.com/fullstorydev/grpcurl) is used for testing gRPC services
+  - install with `brew install grpcurl`
+- _Optional_ [openssl](https://www.openssl.org/) is used for generating certificates
+  - install with `brew install openssl`
+
 ## Audience
+
 There are two primary audiences for this project. Consumers and Contributors
 
 1. Consuming
@@ -42,34 +54,74 @@ To contribute to the OpenTDF platform, you'll need bit more set setup and should
 
 ## Additional info for Project Consumers & Contributors
 
-### Provisioning Custom Keycloak and Policy Data
+## For Consumers
 
-To provision a custom Keycloak setup, create a yaml following the format of [the sample Keycloak config](service/cmd/keycloak_data.yaml). You can create different realms with separate users, clients, roles, and groups. Run the provisioning with `go run ./service provision keycloak-from-config -f <path-to-your-yaml-file>`.
+The OpenTDF service is the main entry point for the OpenTDF platform. [See service documentation](./service/README.md)
+for more information.
 
-### Generation
+### Quick Start
 
-Our native gRPC service functions are generated from `proto` definitions using [Buf](https://buf.build/docs/introduction).
+<!-- START copy ./service/README.md#quick-start -->
 
-The `Makefile` provides command scripts to invoke `Buf` with the `buf.gen.yaml` config, including OpenAPI docs, grpc docs, and the
-generated code.
+> [!WARNING]
+> This quickstart guide is intended for development and testing purposes only. The OpenTDF platform team does not
+> provide recommendations for production deployments.
 
-For convenience, the `make toolcheck` script checks if you have the necessary dependencies for `proto -> gRPC` generation.
+To get started with the OpenTDF platform make sure you are running the same Go version found in the `go.mod` file.
 
-## Services
+<!-- markdownlint-disable MD034 github embedded sourcecode -->
+https://github.com/opentdf/platform/blob/main/service/go.mod#L3
 
-### Key Access Service (KAS)
+Start the required infrastructure with [compose-spec](https://compose-spec.io).
 
-A KAS controls access to TDF protected content.
+```sh
+# Note this might be `podman compose` on some systems
+docker compose -f docker-compose.yml up
+```
 
-#### Configuration
+Copy the configuration file from the example and update it with your own values.
 
-To enable KAS, you must have stable asymmetric keypairs configured.
-[The temp keys init script](.github/scripts/init-temp-keys.sh) will generate two development keys.
+```sh
+cp opentdf-example.yaml opentdf.yaml
+```
 
-### Policy
+Provision default configurations.
 
-The policy service is responsible for managing policy configurations. It provides a gRPC API for
-creating, updating, and deleting policy configurations. [Docs](https://github.com/opentdf/platform/tree/main/docs)
+```sh
+# Provision keycloak with the default configuration.
+go run ./service provision keycloak
+# Generate the temporary keys for KAS
+./.github/scripts/init-temp-keys.sh
+```
+
+Run the OpenTDF platform service.
+
+```sh
+go run ./service start
+```
+<!-- END copy ./service/README#quick-start -->
+
+## For Contributors
+
+This section is focused on the development of the OpenTDF platform.
+
+### Libraries
+
+Libraries `./lib` are shared libraries that are used across the OpenTDF platform. These libraries are used to provide
+common functionality between the various sub-modules of the platform monorepo. Specifically, these libraries are shared
+between the services and the SDKs.
+
+### Services
+
+Services `./services` are the core building blocks of the OpenTDF platform. Generally, each service is one or more gRPC services that
+are scoped to a namespace. The essence of the service is that it takes a modular binary architecture approach enabling
+multiple deployment models.
+
+### SDKs
+
+SDKs `./sdk` are the contracts which the platform uses to ensure that developers and services can interact with the
+platform. The SDKs contain a native Go SDK and generated Go service SDKs. A full list of SDKs can be found at
+[github.com/opentdf](https://github.com/opentdf).
 
 ### How To Add a New Go Module
 
@@ -137,3 +189,37 @@ COPY lib/foo/ lib/foo/
 1. Add your new `go.mod` directory to the `.github/workflows/checks.yaml`'s `go` job's `matrix.strategry.directory` line.
 2. Add the module to the `license` job in the `checks` workflow as well, especially if you declare _any_ dependencies.
 3. Do the same for any other workflows that should be running on your folder, such as `vuln-check` and `lint`.
+
+---
+
+## Terms and Concepts
+
+Common terms used in the OpenTDF platform.
+
+**Service** is the core service of the OpenTDF platform as well as the sub-services that make up the platform. The main
+service follows a modular binary architecture, while the sub-services are gRPC services with HTTP gateways.
+
+**Policy** is the set of rules that govern access to the platform.
+
+**OIDC** is the OpenID Connect protocol used solely for authentication within the OpenTDF platform.
+
+- **IdP** - Identity Provider. This is the service that authenticates the user.
+- **Keycloak** is the turn-key OIDC provider used within the platform for proof-of-value, but should be replaced with a
+  production-grade OIDC provider or deployment.
+
+**Attribute Based Access Control** (ABAC) is the policy-based access control model used within the OpenTDF platform.
+
+- PEP - A Policy Enforcement Point. This is a service that enforces access control policies.
+- PDP - A Policy Decision Point. This is a service that makes access control decisions.
+
+**Entities** are the main actors within the OpenTDF platform. These include people and systems.
+
+- Person Entity (PE) - A person entity is a person that is interacting with the platform.
+- Non Person Entity (NPE) - A non-person entity is a service or system that is interacting with the platform.
+
+**SDKs** are the contracts which the platform uses to ensure that developers and services can interact with the platform.
+
+- SDK - The native Go OpenTDF SDK (other languages are outside the platform repo).
+  - A full list of SDKs can be found at [github.com/opentdf](https://github.com/opentdf).
+- Service SDK - The SDK generated from the service proto definitions.
+  - The proto definitions are maintained by each service.

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,103 @@
+# OpenTDF Platform Service
+
+The OpenTDF Platform Service is the main entry point for the OpenTDF platform. It provides the scaffolding for running
+OpenTDF and ensures that all required services are configured and running as expected.
+
+> [!NOTE]
+> It is advised to familiarize yourself with the [terms and concepts](../README.md#terms-and-concepts) used in the
+> OpenTDF platform.
+
+## Quick Start
+
+> [!WARNING]
+> This quickstart guide is intended for development and testing purposes only. The OpenTDF platform team does not
+> provide recommendations for production deployments.
+
+To get started with the OpenTDF platform make sure you are running the same Go version found in the `go.mod` file.
+
+<!-- markdownlint-disable MD034 github embedded sourcecode -->
+https://github.com/opentdf/platform/blob/main/service/go.mod#L3
+
+Start the required infrastructure with [compose-spec](https://compose-spec.io).
+
+```sh
+# Note this might be `podman compose` on some systems
+docker compose -f docker-compose.yml up
+```
+
+Copy the configuration file from the example and update it with your own values.
+
+```sh
+cp opentdf-example.yaml opentdf.yaml
+```
+
+Provision default configurations.
+
+```sh
+# Provision keycloak with the default configuration.
+go run ./service provision keycloak
+# Generate the temporary keys for KAS
+./.github/scripts/init-temp-keys.sh
+```
+
+Run the OpenTDF platform service.
+
+```sh
+go run ./service start
+```
+
+## Services
+
+Services are the core building block of the platform. Generally, each service is one or more gRPC services that scoped
+to a namespace.
+
+- *Core Services*
+  - Health - Provides rollup health checks for the platform based on the services running.
+  - Well Known - Provides well-known endpoints for the platform.
+- Authorization - Validates the entity has the correct entitlements based on the policy.
+  - Entity Resolution - Resolves entity authorization using connected services (i.e. IdP).
+- Key Access (KAS) - Controls access to TDF protected content.
+- Policy - Manages the policy for the TDF platform.
+
+## Development
+
+### Generation
+
+Our native gRPC service functions are generated from `proto` definitions using [Buf](https://buf.build/docs/introduction).
+
+The `Makefile` provides command scripts to invoke `Buf` with the `buf.gen.yaml` config, including OpenAPI docs, grpc docs, and the
+generated code.
+
+For convenience, the `make toolcheck` script checks if you have the necessary dependencies for `proto -> gRPC` generation.
+
+### Provisioning Custom Keycloak and Policy Data
+
+To provision a custom Keycloak setup, create a yaml following the format of [the sample Keycloak config](service/cmd/keycloak_data.yaml). You can create different realms with separate users, clients, roles, and groups. Run the provisioning with `go run ./service provision keycloak-from-config -f <path-to-your-yaml-file>`.
+
+### Develop a new service
+
+## Developing a new platform service
+
+This guide will help you to develop a new service within the platform. The platform is focused on a modular binary
+architecture, so the goal of the service is isolation while also getting the benefits of a shared platform.
+
+### Structure
+
+OpenTDF services are located under the `service` directory. Each service should have a unique directory name which is
+expected to relate to the service namespace.
+
+#### Service Namespace
+
+A service namespace is a unique identifier for the service. It is used to identify the service in the platform and to
+enable multiple gRPC services to be rolled up into a single service.
+
+The namespace should be a unique identifier for the service. It should be a single word, all lowercase, and should not
+contain any special characters. It should be the same as the directory name for the service.
+
+### Registration
+
+Services are registered with the platform using the `service.RegisterService` function. This function expects to be
+be given a `serviceregistry.Registration` object.
+
+<!-- markdownlint-disable MD034 github embedded sourcecode -->
+https://github.com/opentdf/platform/blob/459e82aa3c1d278f5ac5f4835f94d9f3fe90727e/service/pkg/serviceregistry/serviceregistry.go#L48-L55


### PR DESCRIPTION
Refactored the docs to reduce the overhead on the top-level (monorepo) README. Extrapolated on the audience direction (Consumer and Contributor) that @dmihalcik-virtru mapped out.

Moved service details under the `./service/README.md` and added a top-level Quick Start for Consumers.