### PR TITLE
fix(service): cleanup the cryptoprovider config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,12 @@ The server configuration is used to define how the application runs its server.
 | `auth.audience`    | The audience for the IDP.                             |         |
 | `auth.issuer`      | The issuer for the IDP.                               |         |
 | `auth.enforceDPoP` | If true, DPoP bindings on Access Tokens are enforced. | `false` |
+| `cryptoProvider.type` | The type of crypto provider to use. Valid values are `standard` or `hsm` | `standard` |
+| `cryptoProvider.hsm.modulePath` | The configuration for the HSM crypto provider. |         |
+| `cryptoProvider.hsm.pin` | The pin for the HSM crypto provider. |         |
+| `cryptoProvider.hsm.slotId` | The slot id for the HSM crypto provider. |         |
+| `cryptoProvider.hsm.slotLabel` | The slot label for the HSM crypto provider. |         |
+| `cryptoProvider.hsm.keys` | List of keys by `name` and `label` |         |
 
 Example:
 
@@ -58,6 +64,16 @@ server:
     enabled: true
     audience: https://example.com
     issuer: https://example.com
+  cryptoProvider:
+    type: hsm
+    hsm:
+      modulePath: /path/to/module
+      pin: 1234
+      slotId: 0
+      slotLabel: "mySlot"
+      keys:
+        - name: "myKey"
+          label: "myLabel"
 ```
 
 ## Database Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,11 +2,15 @@
 
 This guide provides details about the configuration setup for our application, including logger, services (specifically entitlements), and server configurations.
 
-- [Logger Configuration](#logger-configuration)
-- [Server Configuration](#server-configuration)
-- [Database Configuration](#database-configuration)
-- [OPA Configuration](#opa-configuration)
-- [Services Configuration](#services-configuration)
+- [Configuration Guide](#configuration-guide)
+  - [Logger Configuration](#logger-configuration)
+  - [Server Configuration](#server-configuration)
+  - [Database Configuration](#database-configuration)
+  - [OPA Configuration](#opa-configuration)
+  - [Services Configuration](#services-configuration)
+    - [Key Access Server (KAS)](#key-access-server-kas)
+    - [Policy](#policy)
+    - [Authorization](#authorization)
 
 ## Logger Configuration
 
@@ -31,23 +35,23 @@ logger:
 
 The server configuration is used to define how the application runs its server.
 
-| Field              | Description                                           | Default |
-| ------------------ | ----------------------------------------------------- | ------- |
-| `port`             | The port number for the server.                       | `9000`  |
-| `host`             | The host address for the server.                      | `""`    |
-| `grpc.reflection`  | The configuration for the grpc server.                | `true`  |
-| `tls.enabled`      | Enable tls.                                           | `false` |
-| `tls.cert`         | The path to the tls certificate.                      |         |
-| `tls.key`          | The path to the tls key.                              |         |
-| `auth.audience`    | The audience for the IDP.                             |         |
-| `auth.issuer`      | The issuer for the IDP.                               |         |
-| `auth.enforceDPoP` | If true, DPoP bindings on Access Tokens are enforced. | `false` |
-| `cryptoProvider.type` | The type of crypto provider to use. Valid values are `standard` or `hsm` | `standard` |
-| `cryptoProvider.hsm.modulePath` | The configuration for the HSM crypto provider. |         |
-| `cryptoProvider.hsm.pin` | The pin for the HSM crypto provider. |         |
-| `cryptoProvider.hsm.slotId` | The slot id for the HSM crypto provider. |         |
-| `cryptoProvider.hsm.slotLabel` | The slot label for the HSM crypto provider. |         |
-| `cryptoProvider.hsm.keys` | List of keys by `name` and `label` |         |
+| Field                           | Description                                                              | Default    |
+| ------------------------------- | ------------------------------------------------------------------------ | ---------- |
+| `port`                          | The port number for the server.                                          | `9000`     |
+| `host`                          | The host address for the server.                                         | `""`       |
+| `grpc.reflection`               | The configuration for the grpc server.                                   | `true`     |
+| `tls.enabled`                   | Enable tls.                                                              | `false`    |
+| `tls.cert`                      | The path to the tls certificate.                                         |            |
+| `tls.key`                       | The path to the tls key.                                                 |            |
+| `auth.audience`                 | The audience for the IDP.                                                |            |
+| `auth.issuer`                   | The issuer for the IDP.                                                  |            |
+| `auth.enforceDPoP`              | If true, DPoP bindings on Access Tokens are enforced.                    | `false`    |
+| `cryptoProvider.type`           | The type of crypto provider to use. Valid values are `standard` or `hsm` | `standard` |
+| `cryptoProvider.hsm.modulePath` | The configuration for the HSM crypto provider.                           |            |
+| `cryptoProvider.hsm.pin`        | The pin for the HSM crypto provider.                                     |            |
+| `cryptoProvider.hsm.slotId`     | The slot id for the HSM crypto provider.                                 |            |
+| `cryptoProvider.hsm.slotLabel`  | The slot label for the HSM crypto provider.                              |            |
+| `cryptoProvider.hsm.keys`       | List of keys by `name` and `label`                                       |            |
 
 Example:
 
@@ -70,10 +74,10 @@ server:
       modulePath: /path/to/module
       pin: 1234
       slotId: 0
-      slotLabel: "mySlot"
+      slotLabel: 'mySlot'
       keys:
-        - name: "myKey"
-          label: "myLabel"
+        - name: 'myKey'
+          label: 'myLabel'
 ```
 
 ## Database Configuration
@@ -154,4 +158,4 @@ services:
 
 | Field     | Description              | Default |
 | --------- | ------------------------ | ------- |
-| `enabled` | Enable the Authorization |
+| `enabled` | Enable the Authorization | `true`  |

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -27,7 +27,6 @@ services:
     realm: "opentdf"
     legacykeycloak: true
 server:
-
   auth:
     enabled: true
     enforceDPoP: false
@@ -70,7 +69,7 @@ server:
   cors:
     enabled: false
     # '*' to allow any origin or a specific domain like 'https://yourdomain.com'
-    allowedorigins: '*'
+    allowedorigins: "*"
     # List of methods. Examples: 'GET,POST,PUT'
     allowedmethods:
       - GET
@@ -95,9 +94,7 @@ server:
   grpc:
     reflectionEnabled: true # Default is false
   cryptoProvider:
-    hsm:
-      enabled: false
-      pin:
+    type: standard
     standard:
       rsa:
         123:

--- a/opentdf-example-no-kas.yaml
+++ b/opentdf-example-no-kas.yaml
@@ -22,7 +22,7 @@ server:
   cors:
     enabled: false
     # '*' to allow any origin or a specific domain like 'https://yourdomain.com'
-    allowedorigins: '*'
+    allowedorigins: "*"
     # List of methods. Examples: 'GET,POST,PUT'
     allowedmethods:
       - GET
@@ -46,8 +46,6 @@ server:
     maxage: 3600
   grpc:
     reflectionEnabled: true # Default is false
-  hsm:
-    enabled: false
   port: 8080
 opa:
   embedded: true # Only for local development

--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -69,7 +69,7 @@ server:
   cors:
     enabled: false
     # '*' to allow any origin or a specific domain like 'https://yourdomain.com'
-    allowedorigins: '*'
+    allowedorigins: "*"
     # List of methods. Examples: 'GET,POST,PUT'
     allowedmethods:
       - GET
@@ -94,9 +94,7 @@ server:
   grpc:
     reflectionEnabled: true # Default is false
   cryptoProvider:
-    hsm:
-      enabled: false
-      pin:
+    type: standard
     standard:
       rsa:
         123:

--- a/opentdf-with-hsm.yaml
+++ b/opentdf-with-hsm.yaml
@@ -31,7 +31,7 @@ server:
     enabled: true
     enforceDPoP: false
     audience: "http://localhost:8080"
-    issuer:  http://localhost:8888/auth/realms/opentdf
+    issuer: http://localhost:8888/auth/realms/opentdf
     clients:
       - "opentdf"
       - "opentdf-sdk"
@@ -74,7 +74,7 @@ server:
   cors:
     enabled: false
     # '*' to allow any origin or a specific domain like 'https://yourdomain.com'
-    allowedorigins: '*'
+    allowedorigins: "*"
     # List of methods. Examples: 'GET,POST,PUT'
     allowedmethods:
       - GET
@@ -99,8 +99,8 @@ server:
   grpc:
     reflectionEnabled: true # Default is false
   cryptoProvider:
+    type: hsm
     hsm:
-      enabled: true
       # As configured by init-temp-keys.sh --hsm
       pin: "12345"
       slotlabel: "dev-token"
@@ -109,18 +109,6 @@ server:
           label: development-rsa-kas
         ec:
           label: development-ec-kas
-    standard:
-      rsa:
-        123:
-          privateKeyPath: kas-private.pem
-          publicKeyPath: kas-cert.pem
-        456:
-          privateKeyPath: kas-private.pem
-          publicKeyPath: kas-cert.pem
-      ec:
-        123:
-          privateKeyPath: kas-ec-private.pem
-          publicKeyPath: kas-ec-cert.pem
   port: 8080
 opa:
   embedded: true # Only for local development

--- a/service/internal/security/hsm.go
+++ b/service/internal/security/hsm.go
@@ -55,7 +55,6 @@ type HSMSession struct {
 }
 
 type HSMConfig struct {
-	Enabled    bool               `yaml:"enabled"`
 	ModulePath string             `yaml:"modulePath,omitempty"`
 	PIN        string             `yaml:"pin,omitempty"`
 	SlotID     uint               `yaml:"slotId,omitempty"`

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -24,7 +24,6 @@ var (
 	config = security.Config{
 		Type: "hsm",
 		HSMConfig: security.HSMConfig{
-			Enabled:    true,
 			ModulePath: "",
 			PIN:        "12345",
 			SlotID:     0,


### PR DESCRIPTION
Tries to cleanup the `cryptoProvider` configuration by removing the redundant fields of `hsm.enabled` and `cryptoProvider.type`. 