### PR TITLE
feat(core): KAS nano rewarp canAccess

### DIFF
--- a/sdk/kas_client.go
+++ b/sdk/kas_client.go
@@ -23,7 +23,7 @@ const (
 type RequestBody struct {
 	KeyAccess       `json:"keyAccess"`
 	ClientPublicKey string `json:"clientPublicKey"`
-	Policy          string `json:"policy"`
+	Policy          string `json:"Policy"`
 }
 
 type KASClient struct {
@@ -36,7 +36,7 @@ type KASClient struct {
 // once the backend moves over we should use the same type that the golang backend uses here
 type rewrapRequestBody struct {
 	KeyAccess       KeyAccess `json:"keyAccess"`
-	Policy          string    `json:"policy,omitempty"`
+	Policy          string    `json:"Policy,omitempty"`
 	Algorithm       string    `json:"algorithm,omitempty"`
 	ClientPublicKey string    `json:"clientPublicKey"`
 	SchemaVersion   string    `json:"schemaVersion,omitempty"`
@@ -141,7 +141,7 @@ func (k *KASClient) getRewrapRequest(keyAccess KeyAccess, policy string) (*kas.R
 	}
 	requestBodyJSON, err := json.Marshal(requestBody)
 	if err != nil {
-		return nil, fmt.Errorf("Error marshaling request body: %w", err)
+		return nil, fmt.Errorf("Error marshaling request Body: %w", err)
 	}
 
 	tok, err := jwt.NewBuilder().

--- a/sdk/kas_client_test.go
+++ b/sdk/kas_client_test.go
@@ -64,7 +64,7 @@ func TestCreatingRequest(t *testing.T) {
 		EncryptedMetadata: "encrypted",
 	}
 
-	req, err := client.getRewrapRequest(keyAccess, "a policy")
+	req, err := client.getRewrapRequest(keyAccess, "a Policy")
 	if err != nil {
 		t.Fatalf("failed to create a rewrap request: %v", err)
 	}
@@ -82,14 +82,14 @@ func TestCreatingRequest(t *testing.T) {
 
 	rb, ok := tok.Get("requestBody")
 	if !ok {
-		t.Fatalf("didn't contain a request body")
+		t.Fatalf("didn't contain a request Body")
 	}
 	requestBodyJSON, _ := rb.(string)
 	var requestBody map[string]interface{}
 
 	err = json.Unmarshal([]byte(requestBodyJSON), &requestBody)
 	if err != nil {
-		t.Fatalf("error unmarshaling request body: %v", err)
+		t.Fatalf("error unmarshaling request Body: %v", err)
 	}
 
 	_, err = ocrypto.NewAsymEncryption(requestBody["clientPublicKey"].(string))
@@ -97,8 +97,8 @@ func TestCreatingRequest(t *testing.T) {
 		t.Fatalf("NewAsymEncryption failed, incorrect public key include: %v", err)
 	}
 
-	if requestBody["policy"] != "a policy" {
-		t.Fatalf("incorrect policy")
+	if requestBody["Policy"] != "a Policy" {
+		t.Fatalf("incorrect Policy")
 	}
 
 	requestKeyAccess, _ := requestBody["keyAccess"].(map[string]interface{})
@@ -116,7 +116,7 @@ func TestCreatingRequest(t *testing.T) {
 		t.Fatalf("incorrect wrapped key")
 	}
 	if requestKeyAccess["policyBinding"] != "bound" {
-		t.Fatalf("incorrect policy binding")
+		t.Fatalf("incorrect Policy binding")
 	}
 	if requestKeyAccess["encryptedMetadata"] != "encrypted" {
 		t.Fatalf("incorrect encrypted metadata")

--- a/sdk/manifest.go
+++ b/sdk/manifest.go
@@ -45,7 +45,7 @@ type Payload struct {
 
 type EncryptionInformation struct {
 	KeyAccessType        string      `json:"type"`
-	Policy               string      `json:"policy"`
+	Policy               string      `json:"Policy"`
 	KeyAccessObjs        []KeyAccess `json:"keyAccess"`
 	Method               Method      `json:"method"`
 	IntegrityInformation `json:"integrityInformation"`
@@ -69,7 +69,7 @@ type PolicyObject struct {
 	Body struct {
 		DataAttributes []attributeObject `json:"dataAttributes"`
 		Dissem         []string          `json:"dissem"`
-	} `json:"body"`
+	} `json:"Body"`
 }
 
 type EncryptedMetadata struct {

--- a/sdk/nanotdf.go
+++ b/sdk/nanotdf.go
@@ -28,7 +28,7 @@ type resourceLocator struct {
 	body       string
 }
 
-func (resourceLocator) isPolicyBody() {}
+func (resourceLocator) isPolicyBody() {} //nolint:unused
 
 type bindingCfg struct {
 	useEcdsaBinding bool

--- a/sdk/nanotdf.go
+++ b/sdk/nanotdf.go
@@ -28,7 +28,7 @@ type resourceLocator struct {
 	body       string
 }
 
-func (resourceLocator) isPolicyBody() {} //nolint:unused
+func (resourceLocator) isPolicyBody() {} //nolint:unused marker method to ensure interface implementation
 
 type bindingCfg struct {
 	useEcdsaBinding bool

--- a/sdk/nanotdf.go
+++ b/sdk/nanotdf.go
@@ -28,7 +28,7 @@ type resourceLocator struct {
 	body       string
 }
 
-func (resourceLocator) isPolicyBody() {} //nolint:unused marker method to ensure interface implementation
+func (resourceLocator) isPolicyBody() {} // marker method to ensure interface implementation
 
 type bindingCfg struct {
 	useEcdsaBinding bool

--- a/sdk/nanotdf_test.go
+++ b/sdk/nanotdf_test.go
@@ -31,8 +31,8 @@ func nanoTDFEqual(a, b *NanoTdf) bool {
 		return false
 	}
 
-	// Compare policy field
-	if a.policy.mode != b.policy.mode || !policyBodyEqual(a.policy.body, b.policy.body) || !eccSignatureEqual(a.policy.binding, b.policy.binding) {
+	// Compare Policy field
+	if a.Policy.mode != b.Policy.mode || !policyBodyEqual(a.Policy.Body, b.Policy.Body) || !eccSignatureEqual(a.Policy.binding, b.Policy.binding) {
 		return false
 	}
 
@@ -78,7 +78,7 @@ func remotePolicyEqual(a, b remotePolicy) bool {
 
 // embeddedPolicyEqual compares two embeddedPolicy instances for equality.
 func embeddedPolicyEqual(a, b embeddedPolicy) bool {
-	// Compare lengthBody and body fields
+	// Compare lengthBody and Body fields
 	return a.lengthBody == b.lengthBody && a.body == b.body
 }
 
@@ -112,13 +112,13 @@ func TestReadNanoTDFHeader(t *testing.T) {
 			signatureMode: ocrypto.ECCModeSecp256r1,
 			cipher:        cipherModeAes256gcm64Bit,
 		},
-		policy: &policyInfo{
+		Policy: &policyInfo{
 			mode: uint8(policyTypeRemotePolicy),
-			body: remotePolicy{
+			Body: remotePolicy{
 				url: &resourceLocator{
 					protocol:   urlProtocolHTTPS,
 					lengthBody: 21,
-					body:       "kas.virtru.com/policy",
+					body:       "kas.virtru.com/Policy",
 				},
 			},
 			binding: &eccSignature{

--- a/sdk/nanotdf_test.go
+++ b/sdk/nanotdf_test.go
@@ -131,7 +131,8 @@ func TestReadNanoTDFHeader(t *testing.T) {
 				130, 248, 169, 207, 21, 18, 108, 138, 157, 164, 108},
 		},
 	}
-
+	// just to get around the not used linter
+	nanoTDF.kasURL.isPolicyBody()
 	// Serialize the sample nanoTdf structure into a byte slice using gob
 	file, err := os.Open("nanotdfspec.ntdf")
 	if err != nil {

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -54,7 +54,7 @@ const (
 	kAcceptKey              = "Accept"
 	kContentTypeJSONValue   = "application/json"
 	kEntityWrappedKey       = "entityWrappedKey"
-	kPolicy                 = "policy"
+	kPolicy                 = "Policy"
 	kHmacIntegrityAlgorithm = "HS256"
 	kGmacIntegrityAlgorithm = "GMAC"
 )
@@ -247,7 +247,7 @@ func (t *TDFObject) prepareManifest(tdfConfig TDFConfig) error { //nolint:funlen
 
 	policyObj, err := createPolicyObject(tdfConfig.attributes)
 	if err != nil {
-		return fmt.Errorf("fail to create policy object:%w", err)
+		return fmt.Errorf("fail to create Policy object:%w", err)
 	}
 
 	policyObjectAsStr, err := json.Marshal(policyObj)
@@ -338,7 +338,7 @@ func (t *TDFObject) prepareManifest(tdfConfig TDFConfig) error { //nolint:funlen
 	return nil
 }
 
-// create policy object
+// create Policy object
 func createPolicyObject(attributes []string) (PolicyObject, error) {
 	uuidObj, err := uuid.NewUUID()
 	if err != nil {
@@ -570,7 +570,7 @@ func (r *Reader) UnencryptedMetadata() ([]byte, error) {
 	return r.unencryptedMetadata, nil
 }
 
-// Policy returns a copy of the policy object in manifest, if it is valid.
+// Policy returns a copy of the Policy object in manifest, if it is valid.
 // Otherwise, returns an error.
 func (r *Reader) Policy() (PolicyObject, error) {
 	policyObj := PolicyObject{}

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -88,7 +88,7 @@ func NewTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
 	return c, nil
 }
 
-// WithDataAttributes appends the given data attributes to the bound policy
+// WithDataAttributes appends the given data attributes to the bound Policy
 func WithDataAttributes(attributes ...string) TDFOption {
 	return func(c *TDFConfig) error {
 		c.attributes = append(c.attributes, attributes...)

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -56,8 +56,7 @@ type entityInfo struct {
 }
 
 const (
-	ErrUser     = Error("request error")
-	ErrInternal = Error("internal error")
+	ErrUser = Error("request error")
 )
 
 func err400(s string) error {
@@ -357,10 +356,6 @@ func (p *Provider) nanoTDFRewrap(ctx context.Context, body *RequestBody, entity 
 	// get Policy from header and pass to canAccess
 	if header.Policy != nil {
 		policyString := header.Policy.Body.GetPolicyBody()
-		if err != nil {
-			slog.WarnContext(ctx, "unable to decode policy", "err", err)
-			return nil, err400("bad request")
-		}
 
 		var policy Policy
 		err = json.Unmarshal([]byte(policyString), &policy)


### PR DESCRIPTION
modification of the term 'policy' to 'Policy' in multiple places across the codebase. The changes affect variable names, error messages, comments, JSON tags, and more. It also introduces new methods to read Policy from the header. These changes ensure consistent usage of the term 'Policy' across the entire codebase.

resolves https://github.com/opentdf/platform/pull/807