### PR TITLE
chore(core): Allows maintainers to approve go.mod

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,7 @@
 ## General
 
 .gitignore    @opentdf/maintainers
+go.mod        @opentdf/maintainers
 *.sum         @opentdf/maintainers
 
 ### Documentation


### PR DESCRIPTION
- These are often updated for dep updates that may be needed for releases
- We assume people will use their best judgement when adding new dependencies, and we should audit *all* dependencies on some schedule anyway