### PR TITLE
chore(docs): Fix typo in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Start the required infrastructure with [compose-spec](https://compose-spec.io).
 
 ```sh
 # Note this might be `podman compose` on some systems
-docker compose -f docker-compose.yml up
+docker compose -f docker-compose.yaml up
 ```
 
 Copy the configuration file from the example and update it with your own values.

--- a/service/README.md
+++ b/service/README.md
@@ -22,7 +22,7 @@ Start the required infrastructure with [compose-spec](https://compose-spec.io).
 
 ```sh
 # Note this might be `podman compose` on some systems
-docker compose -f docker-compose.yml up
+docker compose -f docker-compose.yaml up
 ```
 
 Copy the configuration file from the example and update it with your own values.


### PR DESCRIPTION
In README.md files, changed mention of docker-compose.yml -> docker-compose.yaml to match the actual filename.