### PR TITLE
chore(core): Adds `opendf-hsm` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,13 @@ clean:
 	for m in $(MODS); do (cd $$m && go clean) || exit 1; done
 	rm -f opentdf examples/examples
 
-build: proto-generate opentdf sdk/sdk examples/examples
+build: proto-generate opentdf opentdf-hsm sdk/sdk examples/examples
 
 opentdf: $(shell find service)
-	go build --tags=opentdf.hsm -o opentdf -v service/main.go
+	go build -o opentdf -v service/main.go
+
+opentdf-hsm: $(shell find service)
+	go build --tags=opentdf.hsm -o opentdf-hsm -v service/main.go
 
 sdk/sdk: $(shell find sdk)
 	(cd sdk && go build ./...)

--- a/README-hsm.md
+++ b/README-hsm.md
@@ -16,6 +16,8 @@ On macOS, these can be installed with [brew](https://docs.brew.sh/Installation)
 1. Start with a configuration the enables HSM: `cp opentdf-with-hsm.yaml opentdf.yaml`
 2. Initialize temporary keys and load them: `.github/scripts/init-temp-keys.sh --hsm`
 3. Build or run using the `--tags=opentdf.hsm` flag set.
+   This can be accomplished with `make opentdf-hsm`,
+   which builds a binary named `opentdf-hsm` with the hsm feature enabled.
 
 ### Detailed Configuration
 


### PR DESCRIPTION
- This allows easy building without hsm mode
- should it be included in 'all' or not?