### PR TITLE
feat(kas): add certificate to legacy rest endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ sdk/nanotest1.ntdf
 *.zip
 sensitive.txt.tdf
 keys/
+/examples/sensitive.txt.ntdf

--- a/service/internal/security/crypto_provider.go
+++ b/service/internal/security/crypto_provider.go
@@ -8,6 +8,7 @@ type CryptoProvider interface {
 	RSADecrypt(hash crypto.Hash, keyID string, keyLabel string, ciphertext []byte) ([]byte, error)
 
 	ECPublicKey(keyID string) (string, error)
+	ECCertificate(keyID string) (string, error)
 	GenerateNanoTDFSymmetricKey(ephemeralPublicKeyBytes []byte) ([]byte, error)
 	GenerateEphemeralKasKeys() (any, []byte, error)
 	GenerateNanoTDFSessionKey(privateKeyHandle any, ephemeralPublicKey []byte) ([]byte, error)

--- a/service/internal/security/hsm.go
+++ b/service/internal/security/hsm.go
@@ -828,3 +828,7 @@ func versionSalt() []byte {
 	digest.Write([]byte("L1L"))
 	return digest.Sum(nil)
 }
+
+func (h *HSMSession) ECCertificate(string) (string, error) {
+	return "", nil
+}

--- a/service/internal/security/standard_crypto.go
+++ b/service/internal/security/standard_crypto.go
@@ -84,14 +84,20 @@ func NewStandardCrypto(cfg StandardConfig) (*StandardCrypto, error) {
 	}
 	for id, kasInfo := range cfg.ECKeys {
 		slog.Info("cfg.ECKeys", "id", id, "kasInfo", kasInfo)
+		// private and public EC KAS key
 		privatePemData, err := os.ReadFile(kasInfo.PrivateKeyPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to EC private key file: %w", err)
 		}
-
+		// certificate EC KAS key
+		ecCertificatePEM, err := os.ReadFile(kasInfo.PublicKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to EC certificate file: %w", err)
+		}
 		standardCrypto.ecKeys = append(standardCrypto.ecKeys, StandardECCrypto{
-			Identifier:      id,
-			ecPrivateKeyPem: string(privatePemData),
+			Identifier:       id,
+			ecPrivateKeyPem:  string(privatePemData),
+			ecCertificatePEM: string(ecCertificatePEM),
 		})
 	}
 

--- a/service/kas/access/provider.go
+++ b/service/kas/access/provider.go
@@ -9,6 +9,7 @@ import (
 	otdf "github.com/opentdf/platform/sdk"
 	"github.com/opentdf/platform/service/internal/logger"
 	"github.com/opentdf/platform/service/internal/security"
+	"github.com/opentdf/platform/service/pkg/serviceregistry"
 )
 
 const (
@@ -23,10 +24,11 @@ type Provider struct {
 	AttributeSvc   *url.URL
 	CryptoProvider security.CryptoProvider
 	Logger         *logger.Logger
+	Config         *serviceregistry.ServiceConfig
 }
 
-// TODO: Not sure what we want to check here?
-func (p Provider) IsReady(ctx context.Context) error {
+func (p *Provider) IsReady(ctx context.Context) error {
+	// TODO: Not sure what we want to check here?
 	slog.DebugContext(ctx, "checking readiness of kas service")
 	return nil
 }

--- a/service/kas/access/publicKey.go
+++ b/service/kas/access/publicKey.go
@@ -29,7 +29,12 @@ func (p *Provider) LegacyPublicKey(ctx context.Context, in *kaspb.LegacyPublicKe
 		return nil, errors.Join(ErrConfig, status.Error(codes.Internal, "configuration error"))
 	}
 	if algorithm == algorithmEc256 {
-		pem, err = p.CryptoProvider.ECPublicKey("unknown")
+		ecCertIDInf := p.Config.ExtraProps["eccertid"]
+		ecCertID, ok := ecCertIDInf.(string)
+		if !ok {
+			return nil, errors.New("services.kas.eccertid is not a string")
+		}
+		pem, err = p.CryptoProvider.ECCertificate(ecCertID)
 		if err != nil {
 			slog.ErrorContext(ctx, "CryptoProvider.ECPublicKey failed", "err", err)
 			return nil, errors.Join(ErrConfig, status.Error(codes.Internal, "configuration error"))

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -15,6 +15,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -272,9 +273,18 @@ func (p *Provider) Rewrap(ctx context.Context, in *kaspb.RewrapRequest) (*kaspb.
 	}
 
 	if body.Algorithm == "ec:secp256r1" {
-		return p.nanoTDFRewrap(ctx, body, entityInfo)
+		rsp, err := p.nanoTDFRewrap(ctx, body, entityInfo)
+		if err != nil {
+			slog.ErrorContext(ctx, "rewrap nano", "err", err)
+		}
+		p.Logger.DebugContext(ctx, "rewrap nano", "rsp", rsp)
+		return rsp, err
 	}
-	return p.tdf3Rewrap(ctx, body, entityInfo)
+	rsp, err := p.tdf3Rewrap(ctx, body, entityInfo)
+	if err != nil {
+		slog.ErrorContext(ctx, "rewrap tdf3", "err", err)
+	}
+	return rsp, err
 }
 
 func (p *Provider) tdf3Rewrap(ctx context.Context, body *RequestBody, entity *entityInfo) (*kaspb.RewrapResponse, error) {

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -35,6 +35,7 @@ func NewRegistration() serviceregistry.Registration {
 				CryptoProvider: srp.OTDF.CryptoProvider,
 				SDK:            srp.SDK,
 				Logger:         srp.Logger,
+				Config:         &srp.Config,
 			}
 
 			if err := srp.RegisterReadinessCheck("kas", p.IsReady); err != nil {


### PR DESCRIPTION
Legacy clients, client-web and client-cpp, use this endpoint and expect a certificate.

Modified the handling of ECC keys by adding a certificate method for ECC. Enhanced readiness checks in the Provider struct by adding Config property. Updated rewrap function to log errors and responses for both 'tdf3' and 'nano' procedures. Also, updated the .gitignore file to ignore 'sensitive.txt.ntdf'.