### PR TITLE
fix(core): Update hkdf salt

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,8 +5,6 @@ env:
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/examples/cmd/decrypt.go
+++ b/examples/cmd/decrypt.go
@@ -41,6 +41,7 @@ func decrypt(cmd *cobra.Command, args []string) error {
 	}
 
 	defer file.Close()
+	cmd.Println("# TDF")
 
 	tdfreader, err := client.LoadTDF(file)
 	if err != nil {
@@ -52,7 +53,7 @@ func decrypt(cmd *cobra.Command, args []string) error {
 	if err != nil && err != io.EOF {
 		return err
 	}
-	cmd.Println()
+	cmd.Println("\n-----\n\n# NANO")
 
 	nTdfFile, err := os.Open("sensitive.txt.ntdf")
 	if err != nil {

--- a/examples/cmd/encrypt.go
+++ b/examples/cmd/encrypt.go
@@ -81,8 +81,8 @@ func encrypt(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nanoTDFCOnfig.SetKasURL(fmt.Sprintf("http://%s", cmd.Flag("platformEndpoint").Value.String()))
 	nanoTDFCOnfig.SetAttributes(attributes)
+	nanoTDFCOnfig.SetKasURL(fmt.Sprintf("http://%s/kas", cmd.Flag("platformEndpoint").Value.String()))
 
 	nTDFile := "sensitive.txt.ntdf"
 	strReader = strings.NewReader(plainText)

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -66,6 +66,7 @@ server:
         p,	role:user,		/kas/kas_public_key,  									read,			allow
         p,	role:user,		/kas/v2/kas_public_key,									read,			allow
         p,	role:user,		/kas/v2/rewrap,													write,		allow
+        p,	role:user,		/entityresolution/resolve,							write,  	allow
         
         # Role: Org-Admin
         ## gRPC routes
@@ -126,6 +127,7 @@ server:
         p,	role:unknown,			/health,																read,		allow
         p,	role:unknown,			/kas/v2/kas_public_key,									read,		allow
         p,	role:unknown,			/kas/kas_public_key,										read,		allow
+        p,	role:unknown,			/entityresolution/resolve,							write,	allow
 
       ## Custom model (see https://casbin.org/docs/syntax-for-models/)
       model: #|

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -40,16 +40,93 @@ server:
       ## Maps the external role to the opentdf role
       ## Note: left side is used in the policy, right side is the external role
       map:
-      #  readonly: opentdf-readonly
-      #  admin: opentdf-admin
-      #  org-admin: opentdf-org-admin
+        readonly: opentdf-readonly
+        admin: opentdf-admin
+        user: default-roles-opentdf
+        org-admin: opentdf-org-admin
 
       ## Custom policy (see examples https://github.com/casbin/casbin/tree/master/examples)
-      csv: #|
-      #  p, role:org-admin, policy:attributes, *, *, allow
-      #  p, role:org-admin, policy:subject-mappings, *, *, allow
-      #  p, role:org-admin, policy:resource-mappings, *, *, allow
-      #  p, role:org-admin, policy:kas-registry, *, *, allow
+      csv: |
+        ## Roles (prefixed with role:)
+        # org-admin - organization admin
+        # admin - admin
+        # readonly - readonly
+        # user - rewrap
+        # unknown - unknown role or no role
+        ## Actions
+        # read - read the resource
+        # write - write to the resource
+        # delete - delete the resource
+        # unsafe - unsafe actions
+        
+        # Role: user
+        p,	role:user,		kas.AccessService/PublicKey,						read,			allow
+        p,	role:user,		kas.AccessService/Rewrap, 			        write,		allow
+        p,	role:user,		/,																      read,			allow
+        p,	role:user,		/kas/kas_public_key,  									read,			allow
+        p,	role:user,		/kas/v2/kas_public_key,									read,			allow
+        p,	role:user,		/kas/v2/rewrap,													write,		allow
+        
+        # Role: Org-Admin
+        ## gRPC routes
+        p,	role:org-admin,		policy.*,																*,			allow
+        p,	role:org-admin,		kasregistry.*,													*,			allow
+        p,	role:org-admin,		kas.AccessService/LegacyPublicKey,			*,			allow
+        p,	role:org-admin,		kas.AccessService/PublicKey,						*,			allow
+        p,	role:org-admin,		kas.AccessService/Rewrap, 			            *,			allow
+        ## HTTP routes
+        p,	role:org-admin,		/health,																*,			allow
+        p,	role:org-admin,		/attributes*,														*,			allow
+        p,	role:org-admin,		/namespaces*,														*,			allow
+        p,	role:org-admin,		/subject-mappings*,											*,			allow
+        p,	role:org-admin,		/resource-mappings*,										*,			allow
+        p,	role:org-admin,		/key-access-servers*,										*,			allow
+        p,	role:org-admin,		/kas.AccessService/LegacyPublicKey,			*,			allow
+        # add unsafe actions to the org-admin role
+        
+        # Role: Admin
+        ## gRPC routes
+        p,	role:admin,		policy.*,																		*,			allow
+        p,	role:admin,		kasregistry.*,															*,			allow
+        p,	role:admin,		kas.AccessService/Info,					            *,			allow
+        p,	role:admin,		kas.AccessService/Rewrap, 			            *,			allow
+        p,	role:admin,		kas.AccessService/LegacyPublicKey,					*,			allow
+        p,	role:admin,		kas.AccessService/PublicKey,								*,			allow
+        ## HTTP routes
+        p,	role:admin,		/health,																		*,			allow
+        p,	role:admin,		/attributes*,																*,			allow
+        p,	role:admin,		/namespaces*,																*,			allow
+        p,	role:admin,		/subject-mappings*,													*,			allow
+        p,	role:admin,		/resource-mappings*,												*,			allow
+        p,	role:admin,		/key-access-servers*,												*,			allow
+        p,	role:admin,		/kas.AccessService/LegacyPublicKey,					*,			allow
+        
+        ## Role: Readonly
+        ## gRPC routes
+        p,	role:readonly,		policy.*,																read,			allow
+        p,	role:readonly,		kasregistry.*,													read,			allow
+        p,	role:readonly,		kas.AccessService/Info,		 		             *,			allow
+        p,	role:readonly,    kas.AccessService/Rewrap, 			           *,			allow
+        p,	role:readonly,    kas.AccessService/LegacyPublicKey,				 *,			allow
+        p,	role:readonly,    kas.AccessService/PublicKey,							 *,			allow
+        ## HTTP routes
+        p,	role:readonly,		/health,																read,			allow
+        p,	role:readonly,		/attributes*,														read,			allow
+        p,	role:readonly,		/namespaces*,														read,			allow
+        p,	role:readonly,		/subject-mappings*,											read,			allow
+        p,	role:readonly,		/resource-mappings*,										read,			allow
+        p,	role:readonly,		/key-access-servers*,										read,			allow
+        p,	role:readonly,		/kas.AccessService/LegacyPublicKey,			read,			allow
+        
+        # Public routes
+        ## gRPC routes
+        p,	role:unknown,			kas.AccessService/LegacyPublicKey,			other,	allow
+        p,	role:unknown,			kas.AccessService/PublicKey,						other,	allow
+        ## HTTP routes
+        p,	role:unknown,			/health,																read,		allow
+        p,	role:unknown,			/kas/v2/kas_public_key,									read,		allow
+        p,	role:unknown,			/kas/kas_public_key,										read,		allow
+
       ## Custom model (see https://casbin.org/docs/syntax-for-models/)
       model: #|
       #  [request_definition]

--- a/sdk/kas_client.go
+++ b/sdk/kas_client.go
@@ -214,7 +214,7 @@ func (k *KASClient) unwrapNanoTDF(header string, kasURL string) ([]byte, error) 
 		return nil, fmt.Errorf("ocrypto.ComputeECDHKey failed :%w", err)
 	}
 
-	sessionKey, err = ocrypto.CalculateHKDF([]byte(kNanoTDFMagicStringAndVersion), sessionKey)
+	sessionKey, err = ocrypto.CalculateHKDF(versionSalt(), sessionKey)
 	if err != nil {
 		return nil, fmt.Errorf("ocrypto.CalculateHKDF failed:%w", err)
 	}

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -165,6 +165,20 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 			return
 		}
 		origin := r.Header.Get("Origin")
+		if origin == "" {
+			origin = r.Host
+			if r.TLS != nil {
+				origin = "https://" + origin
+				if strings.HasSuffix(origin, ":443") {
+					origin = origin[:len(origin)-4]
+				}
+			} else {
+				origin = "http://" + origin
+				if strings.HasSuffix(origin, ":80") {
+					origin = origin[:len(origin)-3]
+				}
+			}
+		}
 		accessTok, ctxWithJWK, err := a.checkToken(r.Context(), header, receiverInfo{
 			u: normalizeURL(origin, r.URL),
 			m: r.Method,

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -168,15 +168,9 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 		if origin == "" {
 			origin = r.Host
 			if r.TLS != nil {
-				origin = "https://" + origin
-				if strings.HasSuffix(origin, ":443") {
-					origin = origin[:len(origin)-4]
-				}
+				origin = "https://" + strings.TrimSuffix(origin, ":443")
 			} else {
-				origin = "http://" + origin
-				if strings.HasSuffix(origin, ":80") {
-					origin = origin[:len(origin)-3]
-				}
+				origin = "http://" + strings.TrimSuffix(origin, ":80")
 			}
 		}
 		accessTok, ctxWithJWK, err := a.checkToken(r.Context(), header, receiverInfo{

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -494,7 +494,7 @@ func (s *AuthSuite) TestDPoPEndToEnd_HTTP() {
 	})
 	s.Require().NoError(err)
 	req.Header.Set("authorization", fmt.Sprintf("Bearer %s", signedTok))
-	dpopTok, err := addingInterceptor.GetDPoPToken("/attributes", "GET", string(signedTok))
+	dpopTok, err := addingInterceptor.GetDPoPToken(server.URL+"/attributes", "GET", string(signedTok))
 	s.Require().NoError(err)
 	req.Header.Set("DPoP", dpopTok)
 

--- a/service/internal/security/hsm.go
+++ b/service/internal/security/hsm.go
@@ -752,12 +752,6 @@ func (h *HSMSession) RSADecrypt(hash crypto.Hash, keyID string, keyLabel string,
 	return decrypt, nil
 }
 
-func versionSalt() []byte {
-	digest := sha256.New()
-	digest.Write([]byte("L1L"))
-	return digest.Sum(nil)
-}
-
 func (h *HSMSession) ECCertificate(string) (string, error) {
 	return "", nil
 }

--- a/service/internal/security/standard_crypto.go
+++ b/service/internal/security/standard_crypto.go
@@ -226,7 +226,7 @@ func (s StandardCrypto) GenerateNanoTDFSymmetricKey(ephemeralPublicKeyBytes []by
 		return nil, fmt.Errorf("ocrypto.ComputeECDHKey failed: %w", err)
 	}
 
-	key, err := ocrypto.CalculateHKDF([]byte(kNanoTDFMagicStringAndVersion), symmetricKey)
+	key, err := ocrypto.CalculateHKDF(versionSalt(), symmetricKey)
 	if err != nil {
 		return nil, fmt.Errorf("ocrypto.CalculateHKDF failed:%w", err)
 	}

--- a/service/internal/security/standard_crypto.go
+++ b/service/internal/security/standard_crypto.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -267,7 +268,8 @@ func (s StandardCrypto) GenerateNanoTDFSessionKey(privateKey any, ephemeralPubli
 		return nil, fmt.Errorf("GenerateNanoTDFSessionKey failed to ecdhKey.ECDH: %w", err)
 	}
 
-	derivedKey, err := ocrypto.CalculateHKDF([]byte(kNanoTDFMagicStringAndVersion), sessionKey)
+	salt := versionSalt()
+	derivedKey, err := ocrypto.CalculateHKDF(salt, sessionKey)
 	if err != nil {
 		return nil, fmt.Errorf("ocrypto.CalculateHKDF failed:%w", err)
 	}
@@ -290,4 +292,10 @@ func ConvertEphemeralPublicKeyBytesToECDSAPublicKey(ephemeralPublicKeyBytes []by
 }
 
 func (s StandardCrypto) Close() {
+}
+
+func versionSalt() []byte {
+	digest := sha256.New()
+	digest.Write([]byte(kNanoTDFMagicStringAndVersion))
+	return digest.Sum(nil)
 }


### PR DESCRIPTION
> salt - This is a non-random value tied to the magic number and version SHA256(MAGIC_NUMBER + VERSION). So for this version of the nanotdf the value of the salt is 3de3ca1e50cf62d8b6aba603a96fca6761387a7ac86c3d3afe85ae2d1812edfc in hex.

source: https://github.com/opentdf/spec/tree/main/schema/nanotdf#4-ecc-encryption-key-derivation