### PR TITLE
fix(core): Return 404 if public key not found

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -191,7 +191,7 @@ jobs:
       - run: curl --show-error --fail-with-body --insecure localhost:8080/kas/v2/kas_public_key
       - run: curl --show-error --fail-with-body --insecure localhost:8080/kas/v2/kas_public_key?algorithm=ec:secp256r1
       - run: |-
-          curl_status=$(curl -o -I -L -s -w "%{http_code}" localhost:8080/kas/v2/kas_public_key?algorithm=invalid)
+          curl_status=$(curl -o /dev/null -s -w "%{http_code}" localhost:8080/kas/v2/kas_public_key?algorithm=invalid)
           [ $curl_status = 404 ]
       - run: go run ./examples encrypt "Hello Virtru"
       - run: go run ./examples decrypt sensitive.txt.tdf

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -193,6 +193,7 @@ jobs:
       - run: |-
           curl_status=$(curl -o /dev/null -s -w "%{http_code}" localhost:8080/kas/v2/kas_public_key?algorithm=invalid)
           [ $curl_status = 404 ]
+      - run: grpcurl -d '{"algorithm":"invalid"}' -plaintext localhost:8080 kas.AccessService/PublicKey  2>&1  | grep NotFound
       - run: go run ./examples encrypt "Hello Virtru"
       - run: go run ./examples decrypt sensitive.txt.tdf
       - run: go run ./examples decrypt sensitive.txt.tdf | grep "Hello Virtru"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -188,7 +188,11 @@ jobs:
       - run: grpcurl -plaintext localhost:8080 list
       - run: grpcurl -plaintext localhost:8080 grpc.health.v1.Health.Check
       - run: grpcurl -plaintext localhost:8080 kas.AccessService/PublicKey
-      - run: curl --show-error --fail --insecure localhost:8080/kas/v2/kas_public_key
+      - run: curl --show-error --fail-with-body --insecure localhost:8080/kas/v2/kas_public_key
+      - run: curl --show-error --fail-with-body --insecure localhost:8080/kas/v2/kas_public_key?algorithm=ec:secp256r1
+      - run: |-
+          curl_status=$(curl -o -I -L -s -w "%{http_code}" localhost:8080/kas/v2/kas_public_key?algorithm=invalid)
+          [ $curl_status = 404 ]
       - run: go run ./examples encrypt "Hello Virtru"
       - run: go run ./examples decrypt sensitive.txt.tdf
       - run: go run ./examples decrypt sensitive.txt.tdf | grep "Hello Virtru"

--- a/service/internal/security/standard_crypto.go
+++ b/service/internal/security/standard_crypto.go
@@ -107,49 +107,50 @@ func (s StandardCrypto) RSAPublicKey(keyID string) (string, error) {
 		return "", ErrCertNotFound
 	}
 
-	for _, e := range s.rsaKeys {
-		if keyID == "" || e.Identifier == keyID {
-			pem, err := e.asymEncryption.PublicKeyInPemFormat()
-			if err != nil {
-				return "", fmt.Errorf("failed to retrieve rsa public key file: %w", err)
-			}
-			return pem, nil
-		}
+	// TODO: For now ignore the key id
+	slog.Info("⚠️ Ignoring the", slog.String("key id", keyID))
+
+	pem, err := s.rsaKeys[0].asymEncryption.PublicKeyInPemFormat()
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve rsa public key file: %w", err)
 	}
-	return "", ErrCertNotFound
+
+	return pem, nil
 }
 
-func (s StandardCrypto) ECCertificate(keyID string) (string, error) {
+func (s StandardCrypto) ECCertificate(identifier string) (string, error) {
 	if len(s.ecKeys) == 0 {
 		return "", ErrCertNotFound
 	}
 	// this endpoint returns certificate
 	for _, ecKey := range s.ecKeys {
-		if keyID == "" || ecKey.Identifier == keyID {
+		slog.Debug("ecKey", "id", ecKey.Identifier)
+		if ecKey.Identifier == identifier {
 			return ecKey.ecCertificatePEM, nil
 		}
 	}
-	return "", ErrCertNotFound
+	return "", fmt.Errorf("no EC Key found with the given identifier: %s", identifier)
 }
 
-func (s StandardCrypto) ECPublicKey(keyID string) (string, error) {
+func (s StandardCrypto) ECPublicKey(identifier string) (string, error) {
 	if len(s.ecKeys) == 0 {
 		return "", ErrCertNotFound
 	}
 	for _, ecKey := range s.ecKeys {
-		if keyID != "" && ecKey.Identifier != keyID {
+		slog.Debug("ecKey", "id", ecKey.Identifier)
+		if ecKey.Identifier != identifier {
 			continue
 		}
 
 		ecPrivateKey, err := ocrypto.ECPrivateKeyFromPem([]byte(ecKey.ecPrivateKeyPem))
 		if err != nil {
-			return "", fmt.Errorf("ECPrivateKeyFromPem failed: %s %w", keyID, err)
+			return "", fmt.Errorf("ECPrivateKeyFromPem failed: %s %w", identifier, err)
 		}
 
 		ecPublicKey := ecPrivateKey.PublicKey()
 		derBytes, err := x509.MarshalPKIXPublicKey(ecPublicKey)
 		if err != nil {
-			return "", fmt.Errorf("failed to marshal public key: %s %w", keyID, err)
+			return "", fmt.Errorf("failed to marshal public key: %s %w", identifier, err)
 		}
 
 		pemBlock := &pem.Block{
@@ -158,11 +159,11 @@ func (s StandardCrypto) ECPublicKey(keyID string) (string, error) {
 		}
 		pemBytes := pem.EncodeToMemory(pemBlock)
 		if pemBytes == nil {
-			return "", fmt.Errorf("failed to encode public key to PEM: %s", keyID)
+			return "", fmt.Errorf("failed to encode public key to PEM: %s", identifier)
 		}
 		return string(pemBytes), nil
 	}
-	return "", ErrCertNotFound
+	return "", fmt.Errorf("no EC Key found with the given identifier: %s", identifier)
 }
 
 func (s StandardCrypto) RSADecrypt(_ crypto.Hash, keyID string, _ string, ciphertext []byte) ([]byte, error) {
@@ -173,7 +174,6 @@ func (s StandardCrypto) RSADecrypt(_ crypto.Hash, keyID string, _ string, cipher
 	// TODO: For now ignore the key id
 	slog.Info("⚠️ Ignoring the", slog.String("key id", keyID))
 
-	// TODO respect kid
 	data, err := s.rsaKeys[0].asymDecryption.Decrypt(ciphertext)
 	if err != nil {
 		return nil, fmt.Errorf("error decrypting data: %w", err)
@@ -219,7 +219,6 @@ func (s StandardCrypto) GenerateNanoTDFSymmetricKey(ephemeralPublicKeyBytes []by
 	}
 	ephemeralECDSAPublicKeyPEM := pem.EncodeToMemory(pemBlock)
 
-	// TODO respect kid
 	symmetricKey, err := ocrypto.ComputeECDHKey([]byte(s.ecKeys[0].ecPrivateKeyPem), ephemeralECDSAPublicKeyPEM)
 	if err != nil {
 		return nil, fmt.Errorf("ocrypto.ComputeECDHKey failed: %w", err)

--- a/service/kas/access/publicKey.go
+++ b/service/kas/access/publicKey.go
@@ -68,12 +68,16 @@ func (p Provider) LegacyPublicKey(ctx context.Context, in *kaspb.LegacyPublicKey
 			slog.ErrorContext(ctx, "CryptoProvider.ECPublicKey failed", "err", err)
 			return nil, errors.Join(ErrConfig, status.Error(codes.Internal, "configuration error"))
 		}
-	default:
+	case "rsa:2048":
+		fallthrough
+	case "":
 		pem, err = p.CryptoProvider.RSAPublicKey(kid)
 		if err != nil {
 			slog.ErrorContext(ctx, "CryptoProvider.RSAPublicKey failed", "err", err)
 			return nil, errors.Join(ErrConfig, status.Error(codes.Internal, "configuration error"))
 		}
+	default:
+
 	}
 	return &wrapperspb.StringValue{Value: pem}, nil
 }

--- a/service/kas/access/publicKey.go
+++ b/service/kas/access/publicKey.go
@@ -77,7 +77,7 @@ func (p Provider) LegacyPublicKey(ctx context.Context, in *kaspb.LegacyPublicKey
 			return nil, errors.Join(ErrConfig, status.Error(codes.Internal, "configuration error"))
 		}
 	default:
-
+		return nil, errors.Join(ErrConfig, status.Error(codes.NotFound, "invalid algorithm"))
 	}
 	return &wrapperspb.StringValue{Value: pem}, nil
 }

--- a/service/kas/access/publicKey.go
+++ b/service/kas/access/publicKey.go
@@ -30,6 +30,11 @@ func (p Provider) lookupKid(ctx context.Context, algorithm string) (string, erro
 		key = "eccertid"
 	}
 
+	if p.Config == nil || p.Config.ExtraProps == nil {
+		slog.WarnContext(ctx, "using default kid", "kid", defaultKid, "algorithm", algorithm, "certid", key)
+		return defaultKid, nil
+	}
+
 	certid, ok := p.Config.ExtraProps[key]
 	if !ok {
 		slog.WarnContext(ctx, "using default kid", "kid", defaultKid, "algorithm", algorithm, "certid", key)

--- a/service/kas/access/publicKey.go
+++ b/service/kas/access/publicKey.go
@@ -45,7 +45,7 @@ func (p Provider) lookupKid(ctx context.Context, algorithm string) (string, erro
 	kid, ok := certid.(string)
 	if !ok {
 		slog.ErrorContext(ctx, "invalid key configuration", "kid", defaultKid, "algorithm", algorithm, "certid", key)
-		return "", errors.New("services.kas.certid is not a string")
+		return "", ErrConfig
 	}
 	return kid, nil
 }

--- a/service/kas/access/publicKey.go
+++ b/service/kas/access/publicKey.go
@@ -25,8 +25,7 @@ const (
 func (p Provider) lookupKid(ctx context.Context, algorithm string) (string, error) {
 	key := "unknown"
 	defaultKid := "unknown"
-	switch algorithm {
-	case algorithmEc256:
+	if algorithm == algorithmEc256 {
 		defaultKid = "123"
 		key = "eccertid"
 	}


### PR DESCRIPTION
Updates kas_public_key endpoints to return a 404 instead of a 500 if the public key lookup fails. Potential ways a public key is not found:

1. unsupported algorithm
2. unrecognized key identifier (either user supplied TK or default)

This will still 500 on errors in config format or key format

TK should also return 400 on invalid fmt 