### PR TITLE
fix(core): update default casbin auth policy

### DIFF
--- a/lib/fixtures/keycloak.go
+++ b/lib/fixtures/keycloak.go
@@ -122,7 +122,7 @@ func SetupKeycloak(ctx context.Context, kcConnectParams KeycloakConnectParams) e
 	opentdfSdkClientID := "opentdf-sdk"
 	opentdfOrgAdminRoleName := "opentdf-org-admin"
 	opentdfAdminRoleName := "opentdf-admin"
-	opentdfReadonlyRoleName := "opentdf-readonly"
+	opentdfStandardRoleName := "opentdf-standard"
 	testingOnlyRoleName := "opentdf-testing-role"
 	opentdfERSClientID := "tdf-entity-resolution"
 	opentdfAuthorizationClientID := "tdf-authorization-svc"
@@ -155,7 +155,7 @@ func SetupKeycloak(ctx context.Context, kcConnectParams KeycloakConnectParams) e
 	}
 
 	// Create Roles
-	roles := []string{opentdfOrgAdminRoleName, opentdfAdminRoleName, opentdfReadonlyRoleName, testingOnlyRoleName}
+	roles := []string{opentdfOrgAdminRoleName, opentdfAdminRoleName, opentdfStandardRoleName, testingOnlyRoleName}
 	for _, role := range roles {
 		_, err := client.CreateRealmRole(ctx, token.AccessToken, kcConnectParams.Realm, gocloak.Role{
 			Name: gocloak.StringP(role),
@@ -175,7 +175,7 @@ func SetupKeycloak(ctx context.Context, kcConnectParams KeycloakConnectParams) e
 	// Get the roles
 	var opentdfOrgAdminRole *gocloak.Role
 	// var opentdfAdminRole *gocloak.Role
-	var opentdfReadonlyRole *gocloak.Role
+	var opentdfStandardRole *gocloak.Role
 	var testingOnlyRole *gocloak.Role
 	realmRoles, err := client.GetRealmRoles(ctx, token.AccessToken, kcConnectParams.Realm, gocloak.GetRoleParams{
 		Search: gocloak.StringP("opentdf"),
@@ -191,8 +191,8 @@ func SetupKeycloak(ctx context.Context, kcConnectParams KeycloakConnectParams) e
 			opentdfOrgAdminRole = role
 		// case opentdfAdminRoleName:
 		// 	opentdfAdminRole = role
-		case opentdfReadonlyRoleName:
-			opentdfReadonlyRole = role
+		case opentdfStandardRoleName:
+			opentdfStandardRole = role
 		case testingOnlyRoleName:
 			testingOnlyRole = role
 		}
@@ -251,7 +251,7 @@ func SetupKeycloak(ctx context.Context, kcConnectParams KeycloakConnectParams) e
 		Secret:                    gocloak.StringP("secret"),
 		DirectAccessGrantsEnabled: gocloak.BoolP(true),
 		ProtocolMappers:           &protocolMappers,
-	}, []gocloak.Role{*opentdfReadonlyRole, *testingOnlyRole}, nil)
+	}, []gocloak.Role{*opentdfStandardRole, *testingOnlyRole}, nil)
 	if err != nil {
 		return err
 	}
@@ -985,7 +985,8 @@ func createCertExchange(ctx context.Context, connectParams *KeycloakConnectParam
 
 // updateExecutionConfig Posts an authentication execution config (body) to keycloak for a given execution
 func updateExecutionConfig(ctx context.Context, client *gocloak.GoCloak, execution *gocloak.ModifyAuthenticationExecutionRepresentation,
-	connectParams *KeycloakConnectParams, accessToken string, body interface{}) error {
+	connectParams *KeycloakConnectParams, accessToken string, body interface{},
+) error {
 	updateURL := fmt.Sprintf("%s/admin/realms/%s/authentication/executions/%s/config", connectParams.BasePath,
 		connectParams.Realm, *execution.ID)
 	resp, respErr := client.GetRequestWithBearerAuth(ctx, accessToken).SetBody(body).

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -34,13 +34,13 @@ server:
     issuer: http://localhost:8888/auth/realms/opentdf
     policy:
       ## Default policy for all requests
-      default: #"role:readonly"
+      default: #"role:standard"
       ## Dot notation is used to access nested claims (i.e. realm_access.roles)
       claim: # realm_access.roles
       ## Maps the external role to the opentdf role
       ## Note: left side is used in the policy, right side is the external role
       map:
-        readonly: opentdf-readonly
+        standard: opentdf-standard
         admin: opentdf-admin
         user: default-roles-opentdf
         org-admin: opentdf-org-admin
@@ -50,7 +50,7 @@ server:
         ## Roles (prefixed with role:)
         # org-admin - organization admin
         # admin - admin
-        # readonly - readonly
+        # standard - standard
         # user - rewrap
         # unknown - unknown role or no role
         ## Actions
@@ -102,22 +102,22 @@ server:
         p,	role:admin,		/key-access-servers*,												*,			allow
         p,	role:admin,		/kas.AccessService/LegacyPublicKey,					*,			allow
         
-        ## Role: Readonly
+        ## Role: Standard
         ## gRPC routes
-        p,	role:readonly,		policy.*,																read,			allow
-        p,	role:readonly,		kasregistry.*,													read,			allow
-        p,	role:readonly,		kas.AccessService/Info,		 		             *,			allow
-        p,	role:readonly,    kas.AccessService/Rewrap, 			           *,			allow
-        p,	role:readonly,    kas.AccessService/LegacyPublicKey,				 *,			allow
-        p,	role:readonly,    kas.AccessService/PublicKey,							 *,			allow
+        p,	role:standard,		policy.*,																read,			allow
+        p,	role:standard,		kasregistry.*,													read,			allow
+        p,	role:standard,		kas.AccessService/Info,		 		             *,			allow
+        p,	role:standard,    kas.AccessService/Rewrap, 			           *,			allow
+        p,	role:standard,    kas.AccessService/LegacyPublicKey,				 *,			allow
+        p,	role:standard,    kas.AccessService/PublicKey,							 *,			allow
         ## HTTP routes
-        p,	role:readonly,		/health,																read,			allow
-        p,	role:readonly,		/attributes*,														read,			allow
-        p,	role:readonly,		/namespaces*,														read,			allow
-        p,	role:readonly,		/subject-mappings*,											read,			allow
-        p,	role:readonly,		/resource-mappings*,										read,			allow
-        p,	role:readonly,		/key-access-servers*,										read,			allow
-        p,	role:readonly,		/kas.AccessService/LegacyPublicKey,			read,			allow
+        p,	role:standard,		/health,																read,			allow
+        p,	role:standard,		/attributes*,														read,			allow
+        p,	role:standard,		/namespaces*,														read,			allow
+        p,	role:standard,		/subject-mappings*,											read,			allow
+        p,	role:standard,		/resource-mappings*,										read,			allow
+        p,	role:standard,		/key-access-servers*,										read,			allow
+        p,	role:standard,		/kas.AccessService/LegacyPublicKey,			read,			allow
         
         # Public routes
         ## gRPC routes

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -40,94 +40,16 @@ server:
       ## Maps the external role to the opentdf role
       ## Note: left side is used in the policy, right side is the external role
       map:
-        standard: opentdf-standard
-        admin: opentdf-admin
-        user: default-roles-opentdf
-        org-admin: opentdf-org-admin
+        # standard: opentdf-standard
+        # admin: opentdf-admin
+        # org-admin: opentdf-org-admin
 
       ## Custom policy (see examples https://github.com/casbin/casbin/tree/master/examples)
-      csv: |
-        ## Roles (prefixed with role:)
-        # org-admin - organization admin
-        # admin - admin
-        # standard - standard
-        # user - rewrap
-        # unknown - unknown role or no role
-        ## Actions
-        # read - read the resource
-        # write - write to the resource
-        # delete - delete the resource
-        # unsafe - unsafe actions
-        
-        # Role: user
-        p,	role:user,		kas.AccessService/PublicKey,						read,			allow
-        p,	role:user,		kas.AccessService/Rewrap, 			        write,		allow
-        p,	role:user,		/,																      read,			allow
-        p,	role:user,		/kas/kas_public_key,  									read,			allow
-        p,	role:user,		/kas/v2/kas_public_key,									read,			allow
-        p,	role:user,		/kas/v2/rewrap,													write,		allow
-        p,	role:user,		/entityresolution/resolve,							write,  	allow
-        
-        # Role: Org-Admin
-        ## gRPC routes
-        p,	role:org-admin,		policy.*,																*,			allow
-        p,	role:org-admin,		kasregistry.*,													*,			allow
-        p,	role:org-admin,		kas.AccessService/LegacyPublicKey,			*,			allow
-        p,	role:org-admin,		kas.AccessService/PublicKey,						*,			allow
-        p,	role:org-admin,		kas.AccessService/Rewrap, 			            *,			allow
-        ## HTTP routes
-        p,	role:org-admin,		/health,																*,			allow
-        p,	role:org-admin,		/attributes*,														*,			allow
-        p,	role:org-admin,		/namespaces*,														*,			allow
-        p,	role:org-admin,		/subject-mappings*,											*,			allow
-        p,	role:org-admin,		/resource-mappings*,										*,			allow
-        p,	role:org-admin,		/key-access-servers*,										*,			allow
-        p,	role:org-admin,		/kas.AccessService/LegacyPublicKey,			*,			allow
-        # add unsafe actions to the org-admin role
-        
-        # Role: Admin
-        ## gRPC routes
-        p,	role:admin,		policy.*,																		*,			allow
-        p,	role:admin,		kasregistry.*,															*,			allow
-        p,	role:admin,		kas.AccessService/Info,					            *,			allow
-        p,	role:admin,		kas.AccessService/Rewrap, 			            *,			allow
-        p,	role:admin,		kas.AccessService/LegacyPublicKey,					*,			allow
-        p,	role:admin,		kas.AccessService/PublicKey,								*,			allow
-        ## HTTP routes
-        p,	role:admin,		/health,																		*,			allow
-        p,	role:admin,		/attributes*,																*,			allow
-        p,	role:admin,		/namespaces*,																*,			allow
-        p,	role:admin,		/subject-mappings*,													*,			allow
-        p,	role:admin,		/resource-mappings*,												*,			allow
-        p,	role:admin,		/key-access-servers*,												*,			allow
-        p,	role:admin,		/kas.AccessService/LegacyPublicKey,					*,			allow
-        
-        ## Role: Standard
-        ## gRPC routes
-        p,	role:standard,		policy.*,																read,			allow
-        p,	role:standard,		kasregistry.*,													read,			allow
-        p,	role:standard,		kas.AccessService/Info,		 		             *,			allow
-        p,	role:standard,    kas.AccessService/Rewrap, 			           *,			allow
-        p,	role:standard,    kas.AccessService/LegacyPublicKey,				 *,			allow
-        p,	role:standard,    kas.AccessService/PublicKey,							 *,			allow
-        ## HTTP routes
-        p,	role:standard,		/health,																read,			allow
-        p,	role:standard,		/attributes*,														read,			allow
-        p,	role:standard,		/namespaces*,														read,			allow
-        p,	role:standard,		/subject-mappings*,											read,			allow
-        p,	role:standard,		/resource-mappings*,										read,			allow
-        p,	role:standard,		/key-access-servers*,										read,			allow
-        p,	role:standard,		/kas.AccessService/LegacyPublicKey,			read,			allow
-        
-        # Public routes
-        ## gRPC routes
-        p,	role:unknown,			kas.AccessService/LegacyPublicKey,			other,	allow
-        p,	role:unknown,			kas.AccessService/PublicKey,						other,	allow
-        ## HTTP routes
-        p,	role:unknown,			/health,																read,		allow
-        p,	role:unknown,			/kas/v2/kas_public_key,									read,		allow
-        p,	role:unknown,			/kas/kas_public_key,										read,		allow
-        p,	role:unknown,			/entityresolution/resolve,							write,	allow
+      csv: #|
+      #  p, role:org-admin, policy:attributes, *, *, allow
+      #  p, role:org-admin, policy:subject-mappings, *, *, allow
+      #  p, role:org-admin, policy:resource-mappings, *, *, allow
+      #  p, role:org-admin, policy:kas-registry, *, *, allow
 
       ## Custom model (see https://casbin.org/docs/syntax-for-models/)
       model: #|

--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -34,13 +34,13 @@ server:
     issuer: http://keycloak:8888/auth/realms/opentdf
     policy:
       ## Default policy for all requests
-      default: #"role:readonly"
+      default: #"role:standard"
       ## Dot notation is used to access nested claims (i.e. realm_access.roles)
       claim: # realm_access.roles
       ## Maps the external role to the opentdf role
       ## Note: left side is used in the policy, right side is the external role
       map:
-      #  readonly: opentdf-readonly
+      #  standard: opentdf-standard
       #  admin: opentdf-admin
       #  org-admin: opentdf-org-admin
 

--- a/opentdf-with-hsm.yaml
+++ b/opentdf-with-hsm.yaml
@@ -37,7 +37,7 @@ server:
       - "opentdf-sdk"
     policy:
       ## Default policy for all requests
-      default: #"role:readonly"
+      default: #"role:standard"
       ## Role map is used to map external roles to opentdf roles (opentdf_role:idp_role) the benefit of this is that you
       ## can use the builtin policy if desired
       roles:
@@ -46,7 +46,7 @@ server:
         ## Maps the external role to the opentdf role
         ## Note: left side is used in the policy, right side is the external role
         map:
-        #  readonly: opentdf-readonly
+        #  standard: opentdf-standard
         #  admin: opentdf-admin
         #  org-admin: opentdf-org-admin
       ## Custom policy (see examples https://github.com/casbin/casbin/tree/master/examples)

--- a/sdk/internal/oauth/oauth_test.go
+++ b/sdk/internal/oauth/oauth_test.go
@@ -165,7 +165,7 @@ func (s *OAuthSuite) TestGettingAccessTokenFromKeycloak() {
 	s.Greaterf(tok.ExpiresIn, int64(0), "invalid expiration is before current time: %v", tok)
 	s.Falsef(tok.Expired(), "got a token that is currently expired: %v", tok)
 
-	// verify that we got a token that has the opentdf-readonly role, which only the sdk client has
+	// verify that we got a token that has the opentdf-standard role, which only the sdk client has
 	ra, ok := tokenDetails.Get("realm_access")
 	s.Require().True(ok)
 	raMap, ok := ra.(map[string]interface{})
@@ -174,7 +174,7 @@ func (s *OAuthSuite) TestGettingAccessTokenFromKeycloak() {
 	s.Require().True(ok)
 	rolesList, ok := roles.([]interface{})
 	s.Require().True(ok)
-	s.Require().True(slices.Contains(rolesList, "opentdf-readonly"), "missing the `opentdf-readonly` role")
+	s.Require().True(slices.Contains(rolesList, "opentdf-standard"), "missing the `opentdf-standard` role")
 }
 
 func (s *OAuthSuite) TestDoingTokenExchangeWithKeycloak() {
@@ -226,7 +226,7 @@ func (s *OAuthSuite) TestDoingTokenExchangeWithKeycloak() {
 	s.Greaterf(subjectToken.ExpiresIn, int64(0), "invalid expiration is before current time: %v", subjectToken)
 	s.Falsef(subjectToken.Expired(), "got a token that is currently expired: %v", subjectToken)
 
-	// verify that we got a token that has the opentdf-readonly role, which only the sdk client has
+	// verify that we got a token that has the opentdf-standard role, which only the sdk client has
 	ra, ok := tokenDetails.Get("realm_access")
 	s.Require().True(ok)
 	raMap, ok := ra.(map[string]interface{})
@@ -235,7 +235,7 @@ func (s *OAuthSuite) TestDoingTokenExchangeWithKeycloak() {
 	s.Require().True(ok)
 	rolesList, ok := roles.([]interface{})
 	s.Require().True(ok)
-	s.Require().True(slices.Contains(rolesList, "opentdf-readonly"), "missing the `opentdf-readonly` role")
+	s.Require().True(slices.Contains(rolesList, "opentdf-standard"), "missing the `opentdf-standard` role")
 
 	// verify that the calling client is the authorized party
 	azpClaim, ok := tokenDetails.Get("azp")

--- a/service/cmd/keycloak_data.yaml
+++ b/service/cmd/keycloak_data.yaml
@@ -15,7 +15,7 @@ realms:
     custom_realm_roles:
       - name: opentdf-org-admin
       - name: opentdf-admin
-      - name: opentdf-readonly
+      - name: opentdf-standard
     custom_client_roles:
       tdf-entity-resolution:
         - name: entity-resolution-test-role
@@ -46,7 +46,7 @@ realms:
           protocolMappers:
             - *customAudMapper
         sa_realm_roles: 
-          - opentdf-readonly
+          - opentdf-standard
       - client:
           clientID: tdf-entity-resolution
           enabled: true

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -402,7 +402,7 @@ func (s *AuthSuite) TestDPoPEndToEnd_GRPC() {
 	s.Require().NoError(tok.Set("iss", s.server.URL))
 	s.Require().NoError(tok.Set("aud", "test"))
 	s.Require().NoError(tok.Set("cid", "client2"))
-	s.Require().NoError(tok.Set("realm_access", map[string][]string{"roles": {"opentdf-readonly"}}))
+	s.Require().NoError(tok.Set("realm_access", map[string][]string{"roles": {"opentdf-standard"}}))
 	thumbprint, err := dpopKey.Thumbprint(crypto.SHA256)
 	s.Require().NoError(err)
 	cnf := map[string]string{"jkt": base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(thumbprint)}
@@ -465,7 +465,7 @@ func (s *AuthSuite) TestDPoPEndToEnd_HTTP() {
 	s.Require().NoError(tok.Set("iss", s.server.URL))
 	s.Require().NoError(tok.Set("aud", "test"))
 	s.Require().NoError(tok.Set("cid", "client2"))
-	s.Require().NoError(tok.Set("realm_access", map[string][]string{"roles": {"opentdf-readonly"}}))
+	s.Require().NoError(tok.Set("realm_access", map[string][]string{"roles": {"opentdf-standard"}}))
 	thumbprint, err := dpopKey.Thumbprint(crypto.SHA256)
 	s.Require().NoError(err)
 	cnf := map[string]string{"jkt": base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(thumbprint)}

--- a/service/internal/auth/casbin.go
+++ b/service/internal/auth/casbin.go
@@ -19,7 +19,7 @@ var defaultRole = "unknown"
 var defaultRoleClaim = "realm_access.roles"
 
 var defaultRoleMap = map[string]string{
-	"readonly":  "opentdf-readonly",
+	"standard":  "opentdf-standard",
 	"admin":     "opentdf-admin",
 	"org-admin": "opentdf-org-admin",
 }
@@ -28,7 +28,7 @@ var defaultPolicy = `
 ## Roles (prefixed with role:)
 # org-admin - organization admin
 # admin - admin
-# readonly - readonly
+# standard - standard
 # unknown - unknown role or no role
 
 ## Resources
@@ -77,22 +77,25 @@ p,	role:admin,		/key-access-servers*,												*,			allow
 p,	role:admin,		/kas.AccessService/LegacyPublicKey,					*,			allow
 p,	role:admin,		/kas/v2/rewrap,						  				*,      allow
 
-## Role: Readonly
+## Role: Standard
 ## gRPC routes
-p,	role:readonly,		policy.*,																read,			allow
-p,	role:readonly,		kasregistry.*,													read,			allow
-p,	role:readonly,		kas.AccessService/Info,		 		             *,			allow
-p,	role:readonly,    kas.AccessService/Rewrap, 			           *,			allow
-p,	role:readonly,    kas.AccessService/LegacyPublicKey,				 *,			allow
-p,	role:readonly,    kas.AccessService/PublicKey,							 *,			allow
+p,	role:standard,		policy.*,																read,			allow
+p,	role:standard,		kasregistry.*,													read,			allow
+p,	role:standard,		kas.AccessService/Info,		 		             *,			allow
+p,	role:standard,    kas.AccessService/Rewrap, 			           *,			allow
+p,	role:standard,    kas.AccessService/LegacyPublicKey,				 *,			allow
+p,	role:standard,    kas.AccessService/PublicKey,							 *,			allow
 ## HTTP routes
-p,	role:readonly,		/health,																read,			allow
-p,	role:readonly,		/attributes*,														read,			allow
-p,	role:readonly,		/namespaces*,														read,			allow
-p,	role:readonly,		/subject-mappings*,											read,			allow
-p,	role:readonly,		/resource-mappings*,										read,			allow
-p,	role:readonly,		/key-access-servers*,										read,			allow
-p,	role:readonly,		/kas.AccessService/LegacyPublicKey,			read,			allow
+p,	role:standard,		/health,																read,			allow
+p,	role:standard,		/attributes*,														read,			allow
+p,	role:standard,		/namespaces*,														read,			allow
+p,	role:standard,		/subject-mappings*,											read,			allow
+p,	role:standard,		/resource-mappings*,										read,			allow
+p,	role:standard,		/key-access-servers*,										read,			allow
+p,	role:standard,		/kas/kas_public_key,  									read,			allow
+p,	role:standard,		/kas/v2/kas_public_key,									read,			allow
+p,	role:standard,		/kas/v2/rewrap,													write,		allow
+p,	role:standard,		/entityresolution/resolve,							write,  	allow
 
 # Public routes
 ## gRPC routes

--- a/service/internal/auth/casbin_test.go
+++ b/service/internal/auth/casbin_test.go
@@ -23,7 +23,7 @@ type AuthnCasbinSuite struct {
 	suite.Suite
 }
 
-func (s *AuthnCasbinSuite) buildTokenRoles(orgAdmin bool, admin bool, readonly bool, roleMaps []string) []interface{} {
+func (s *AuthnCasbinSuite) buildTokenRoles(orgAdmin bool, admin bool, standard bool, roleMaps []string) []interface{} {
 	orgAdminRole := "opentdf-org-admin"
 	if len(roleMaps) > 0 {
 		orgAdminRole = roleMaps[0]
@@ -32,9 +32,9 @@ func (s *AuthnCasbinSuite) buildTokenRoles(orgAdmin bool, admin bool, readonly b
 	if len(roleMaps) > 1 {
 		adminRole = roleMaps[1]
 	}
-	readonlyRole := "opentdf-readonly"
+	standardRole := "opentdf-standard"
 	if len(roleMaps) > 2 {
-		readonlyRole = roleMaps[2]
+		standardRole = roleMaps[2]
 	}
 
 	i := 0
@@ -48,34 +48,34 @@ func (s *AuthnCasbinSuite) buildTokenRoles(orgAdmin bool, admin bool, readonly b
 		roles[i] = adminRole
 		i++
 	}
-	if readonly {
-		roles[i] = readonlyRole
+	if standard {
+		roles[i] = standardRole
 	}
 
 	return roles
 }
 
-func (s *AuthnCasbinSuite) newTokWithDefaultClaim(orgAdmin bool, admin bool, readonly bool) (string, jwt.Token) {
+func (s *AuthnCasbinSuite) newTokWithDefaultClaim(orgAdmin bool, admin bool, standard bool) (string, jwt.Token) {
 	tok := jwt.New()
-	tokenRoles := s.buildTokenRoles(orgAdmin, admin, readonly, nil)
+	tokenRoles := s.buildTokenRoles(orgAdmin, admin, standard, nil)
 	if err := tok.Set("realm_access", map[string]interface{}{"roles": tokenRoles}); err != nil {
 		s.T().Fatal(err)
 	}
 	return "", tok
 }
 
-func (s *AuthnCasbinSuite) newTokenWithCustomClaim(orgAdmin bool, admin bool, readonly bool) (string, jwt.Token) {
+func (s *AuthnCasbinSuite) newTokenWithCustomClaim(orgAdmin bool, admin bool, standard bool) (string, jwt.Token) {
 	tok := jwt.New()
-	tokenRoles := s.buildTokenRoles(orgAdmin, admin, readonly, nil)
+	tokenRoles := s.buildTokenRoles(orgAdmin, admin, standard, nil)
 	if err := tok.Set("test", map[string]interface{}{"test_roles": map[string]interface{}{"roles": tokenRoles}}); err != nil {
 		s.T().Fatal(err)
 	}
 	return "test.test_roles.roles", tok
 }
 
-func (s *AuthnCasbinSuite) newTokenWithCustomRoleMap(orgAdmin bool, admin bool, readonly bool) (string, jwt.Token) {
+func (s *AuthnCasbinSuite) newTokenWithCustomRoleMap(orgAdmin bool, admin bool, standard bool) (string, jwt.Token) {
 	tok := jwt.New()
-	tokenRoles := s.buildTokenRoles(orgAdmin, admin, readonly, []string{"test-org-admin", "test-admin", "test-readonly"})
+	tokenRoles := s.buildTokenRoles(orgAdmin, admin, standard, []string{"test-org-admin", "test-admin", "test-standard"})
 	if err := tok.Set("realm_access", map[string]interface{}{"roles": tokenRoles}); err != nil {
 		s.T().Fatal(err)
 	}
@@ -155,10 +155,10 @@ func (s *AuthnCasbinSuite) Test_NewEnforcerWithBadCustomModel() {
 func (s *AuthnCasbinSuite) Test_Enforcement() {
 	orgadmin := []bool{true, false, false}
 	admin := []bool{false, true, false}
-	readonly := []bool{false, false, true}
+	standard := []bool{false, false, true}
 	unknown := []bool{false, false, false}
 
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		allowed  bool
 		roles    []bool
@@ -229,34 +229,34 @@ func (s *AuthnCasbinSuite) Test_Enforcement() {
 			action:   "read",
 		},
 
-		// readonly role
+		// standard role
 		{
 			allowed:  true,
-			roles:    readonly,
+			roles:    standard,
 			resource: "policy.attributes.DoSomething",
 			action:   "read",
 		},
 		{
 			allowed:  false,
-			roles:    readonly,
+			roles:    standard,
 			resource: "policy.attributes.DoSomething",
 			action:   "write",
 		},
 		{
 			allowed:  true,
-			roles:    readonly,
+			roles:    standard,
 			resource: "/attributes",
 			action:   "read",
 		},
 		{
 			allowed:  false,
-			roles:    readonly,
+			roles:    standard,
 			resource: "/attributes",
 			action:   "write",
 		},
 		{
 			allowed:  false,
-			roles:    readonly,
+			roles:    standard,
 			resource: "non-existent",
 			action:   "read",
 		},
@@ -303,7 +303,7 @@ func (s *AuthnCasbinSuite) Test_Enforcement() {
 		case test.roles[1]:
 			actor = "admin"
 		case test.roles[2]:
-			actor = "readonly"
+			actor = "standard"
 		default:
 			actor = "undefined"
 		}
@@ -343,7 +343,7 @@ func (s *AuthnCasbinSuite) Test_Enforcement() {
 				RoleMap: map[string]string{
 					"org-admin": "test-org-admin",
 					"admin":     "test-admin",
-					"readonly":  "test-readonly",
+					"standard":  "test-standard",
 				},
 			},
 		})
@@ -357,7 +357,7 @@ func (s *AuthnCasbinSuite) Test_Enforcement() {
 		}
 		s.Equal(test.allowed, allowed)
 		slog.Info("running test w/ client_id", slog.String("name", name))
-		var roleMap = make(map[string]string)
+		roleMap := make(map[string]string)
 		if test.roles[0] {
 			roleMap["org-admin"] = "test"
 		}
@@ -365,7 +365,7 @@ func (s *AuthnCasbinSuite) Test_Enforcement() {
 			roleMap["admin"] = "test"
 		}
 		if test.roles[2] {
-			roleMap["readonly"] = "test"
+			roleMap["standard"] = "test"
 		}
 
 		enforcer, err = NewCasbinEnforcer(CasbinConfig{

--- a/service/internal/auth/casbin_test.go
+++ b/service/internal/auth/casbin_test.go
@@ -260,6 +260,24 @@ func (s *AuthnCasbinSuite) Test_Enforcement() {
 			resource: "non-existent",
 			action:   "read",
 		},
+		{
+			allowed:  true,
+			roles:    standard,
+			resource: "/kas/kas_public_key",
+			action:   "read",
+		},
+		{
+			allowed:  true,
+			roles:    standard,
+			resource: "/kas/v2/kas_public_key",
+			action:   "read",
+		},
+		{
+			allowed:  true,
+			roles:    standard,
+			resource: "/kas/v2/rewrap",
+			action:   "write",
+		},
 
 		// undefined role
 		{


### PR DESCRIPTION
Resolves https://github.com/opentdf/platform/issues/928

Rename `readonly` base casbin policy role in route auth middleware to `standard` to reflect that there are base _write_ routes like `/kas/v2/rewrap` that should not be gated to admins and should not be read only (POST method over REST).