### PR TITLE
fix(core): Add dependencies to service configs

### DIFF
--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -11,10 +11,15 @@ logger:
 services:
   kas:
     enabled: true
+    dependencies:
+      - authorization
   policy:
     enabled: true
   authorization:
     enabled: true
+    dependencies:
+      - entityresolution
+      - policy
     ersurl: http://localhost:8080/entityresolution/resolve
     clientid: tdf-authorization-svc
     clientsecret: secret

--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -11,6 +11,8 @@ db:
 services:
   kas:
     enabled: true
+    dependencies:
+      - authorization
   policy:
     enabled: true
   entityresolution:
@@ -22,6 +24,9 @@ services:
     legacykeycloak: true
   authorization:
     enabled: true
+    dependencies:
+      - entityresolution
+      - policy
     ersurl: http://localhost:8080/entityresolution/resolve
     clientid: tdf-authorization-svc
     clientsecret: secret

--- a/opentdf-with-hsm.yaml
+++ b/opentdf-with-hsm.yaml
@@ -11,6 +11,8 @@ logger:
 services:
   kas:
     enabled: true
+    dependencies:
+      - authorization
   policy:
     enabled: true
   entityresolution:
@@ -22,6 +24,9 @@ services:
     legacykeycloak: true
   authorization:
     enabled: true
+    dependencies:
+      - entityresolution
+      - policy
     ersurl: http://localhost:8080/entityresolution/resolve
     clientid: tdf-authorization-svc
     clientsecret: secret

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -72,6 +72,19 @@ func Start(f ...StartOptions) error {
 		return fmt.Errorf("issue registering services: %w", err)
 	}
 
+	// verify dependencies
+	slog.Info("verifying dependencies")
+	for name, service := range conf.Services {
+		if service.Enabled && (service.Dependencies != nil) {
+			for _, dep := range service.Dependencies {
+				if !conf.Services[dep].Enabled {
+					slog.Error(fmt.Sprintf("a dependency of %s was not enabled: %s", name, dep))
+					return fmt.Errorf("%s requires the following dependencies to be enabled: %v", name, service.Dependencies)
+				}
+			}
+		}
+	}
+
 	// Create the SDK client for services to use
 	var sdkOptions []sdk.Option
 	for name, service := range conf.Services {

--- a/service/pkg/serviceregistry/serviceregistry.go
+++ b/service/pkg/serviceregistry/serviceregistry.go
@@ -19,9 +19,10 @@ import (
 // ServiceConfig is a struct that holds the configuration for a service and used for the global
 // config rollup powered by Viper (https://github.com/spf13/viper)
 type ServiceConfig struct {
-	Enabled    bool                   `yaml:"enabled"`
-	Remote     RemoteServiceConfig    `yaml:"remote"`
-	ExtraProps map[string]interface{} `json:"-" mapstructure:",remain"`
+	Enabled      bool                   `yaml:"enabled"`
+	Dependencies []string               `yaml:"dependencies"`
+	Remote       RemoteServiceConfig    `yaml:"remote"`
+	ExtraProps   map[string]interface{} `json:"-" mapstructure:",remain"`
 }
 
 type RemoteServiceConfig struct {


### PR DESCRIPTION
Some services require others and make calls to others. Define dependencies for each service that are also required to be enabled for that service to function.
This can be expanded upon to do a waterfall startup if a service ends up requiring another on start.