### PR TITLE
chore(ci): Adds bats-assert as test dep 

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -134,6 +134,8 @@ jobs:
       matrix:
         crypto:
           - standard
+    env:
+      BATS_LIB_PATH: "${{ github.workspace }}/test/bats/lib/"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
@@ -189,6 +191,9 @@ jobs:
       - run: go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.8.9
       - name: Setup Bats and bats libs
         uses: bats-core/bats-action@2.0.0
+        with:
+          support-path: ${{ github.workspace }}/test/bats/lib/bats-support
+          assert-path: ${{ github.workspace }}/test/bats/lib/bats-assert
       - run: test/service-start.bats
       - run: test/tdf-roundtrips.bats
       - name: create roundtrip test data and run tests

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,17 @@
+# Integration Tests
+
+To run locally, first install bats:
+
+```sh
+brew install bats-core
+brew tap bats-core/bats-core
+brew install bats-support
+brew install bats-assert
+export BATS_LIB_PATH=/opt/homebrew/lib
+```
+
+Then, run:
+
+```sh
+./test/[your test].bats
+```

--- a/test/service-start.bats
+++ b/test/service-start.bats
@@ -42,42 +42,38 @@ setup() {
 
 @test "REST: new public key endpoint (no algorithm)" {
   run curl -s --show-error --fail-with-body --insecure "localhost:8080/kas/v2/kas_public_key"
-  echo "output=$output"
-  p=$(jq -r .publicKey <<<"${output}")
-
-  # Is public key
-  [[ "$p" = "-----BEGIN PUBLIC KEY"-----* ]]
-
-  # Is an RSA key
-  printf '%s\n' "$p" | openssl asn1parse | grep rsaEncryption
 
   # Has expected kid
-  [ $(jq -r .kid <<<"${output}") = r1 ]
+  assert_equal "$(jq -r .kid <<<"${output}")" r1
+
+  run jq -r .publicKey <<<"${output}"
+  assert_regex "$output" "^-----BEGIN PUBLIC KEY-----"
+
+  # Is an RSA key
+  run openssl asn1parse <<<$output
+  assert_line --partial rsaEncryption
 }
 
 @test "REST: new public key endpoint (ec)" {
   run curl -s --show-error --fail-with-body --insecure "localhost:8080/kas/v2/kas_public_key?algorithm=ec:secp256r1"
-  echo "$output"
-
-  # Is public key
-  p=$(jq -r .publicKey <<<"${output}")
-  [[ "$p" = "-----BEGIN PUBLIC KEY"-----* ]]
-
-  # Is an EC P256r1 curve
-  printf '%s\n' "$p" | openssl asn1parse | grep prime256v1
 
   # Has expected kid
-  [ $(jq -r .kid <<<"${output}") = e1 ]
+  assert_equal "$(jq -r .kid <<<"${output}")" e1
+
+  run jq -r .publicKey <<<"${output}"
+  assert_regex "$output" "^-----BEGIN PUBLIC KEY-----"
+
+  # Is an EC P256r1 curve
+  run openssl asn1parse <<<$output
+  assert_line --partial prime256v1
 }
 
 @test "REST: public key endpoint (unknown algorithm)" {
   run curl -o /dev/null -s -w "%{http_code}" "localhost:8080/kas/v2/kas_public_key?algorithm=invalid"
-  echo "$output"
-  [ $output = 404 ]
+  assert_output 404
 }
 
 @test "gRPC: public key endpoint (unknown algorithm)" {
   run grpcurl -d '{"algorithm":"invalid"}' -plaintext "localhost:8080" "kas.AccessService/PublicKey" 
-  echo "$output"
-  [[ $output = *NotFound* ]]
+  assert_output --partial NotFound
 }


### PR DESCRIPTION
Should we do this?

Pros:
- tests are easier to read
- test output is significantly more actionable in the event of an error

Cons:
- Installing libraries requires more work for developers
- harder to write - developers need to think about the BATs model and know names of the helper functions and helper variables.
