### PR TITLE
feat: add dev_mode flag

### DIFF
--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Config struct {
-	DevMode	bool                                    	`mapstructure:"dev_mode"`
+	DevMode  bool                                     `mapstructure:"dev_mode"`
 	DB       db.Config                                `yaml:"db"`
 	OPA      opa.Config                               `yaml:"opa"`
 	Server   server.Config                            `yaml:"server"`

--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -17,6 +17,7 @@ import (
 )
 
 type Config struct {
+	DevMode	bool                                    	`mapstructure:"dev_mode"`
 	DB       db.Config                                `yaml:"db"`
 	OPA      opa.Config                               `yaml:"opa"`
 	Server   server.Config                            `yaml:"server"`

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -16,6 +16,15 @@ import (
 	wellknown "github.com/opentdf/platform/service/wellknownconfiguration"
 )
 
+const devModeMessage = `
+██████╗ ███████╗██╗   ██╗███████╗██╗      ██████╗ ██████╗ ███╗   ███╗███████╗███╗   ██╗████████╗    ███╗   ███╗ ██████╗ ██████╗ ███████╗
+██╔══██╗██╔════╝██║   ██║██╔════╝██║     ██╔═══██╗██╔══██╗████╗ ████║██╔════╝████╗  ██║╚══██╔══╝    ████╗ ████║██╔═══██╗██╔══██╗██╔════╝
+██║  ██║█████╗  ██║   ██║█████╗  ██║     ██║   ██║██████╔╝██╔████╔██║█████╗  ██╔██╗ ██║   ██║       ██╔████╔██║██║   ██║██║  ██║█████╗  
+██║  ██║██╔══╝  ╚██╗ ██╔╝██╔══╝  ██║     ██║   ██║██╔═══╝ ██║╚██╔╝██║██╔══╝  ██║╚██╗██║   ██║       ██║╚██╔╝██║██║   ██║██║  ██║██╔══╝  
+██████╔╝███████╗ ╚████╔╝ ███████╗███████╗╚██████╔╝██║     ██║ ╚═╝ ██║███████╗██║ ╚████║   ██║       ██║ ╚═╝ ██║╚██████╔╝██████╔╝███████╗
+╚═════╝ ╚══════╝  ╚═══╝  ╚══════╝╚══════╝ ╚═════╝ ╚═╝     ╚═╝     ╚═╝╚══════╝╚═╝  ╚═══╝   ╚═╝       ╚═╝     ╚═╝ ╚═════╝ ╚═════╝ ╚══════╝                                                                                        
+`
+
 func Start(f ...StartOptions) error {
 	startConfig := StartConfig{}
 	for _, fn := range f {
@@ -30,6 +39,10 @@ func Start(f ...StartOptions) error {
 	conf, err := config.LoadConfig(startConfig.ConfigKey, startConfig.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("could not load config: %w", err)
+	}
+
+	if conf.DevMode {
+		fmt.Println(devModeMessage)
 	}
 
 	// Set allowed public routes when platform is being extended

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -42,7 +42,7 @@ func Start(f ...StartOptions) error {
 	}
 
 	if conf.DevMode {
-		fmt.Println(devModeMessage)
+		fmt.Println(devModeMessage) //nolint:forbidigo // This ascii art is only displayed in dev mode
 	}
 
 	// Set allowed public routes when platform is being extended

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -42,7 +42,7 @@ func Start(f ...StartOptions) error {
 	}
 
 	if conf.DevMode {
-		fmt.Println(devModeMessage) //nolint:forbidigo // This ascii art is only displayed in dev mode
+		fmt.Print(devModeMessage) //nolint:forbidigo // This ascii art is only displayed in dev mode
 	}
 
 	// Set allowed public routes when platform is being extended


### PR DESCRIPTION
This flag is currently only used to signal that the helm chart was deployed with the embedded keycloak and postgres and that this is not a production deployment.