### PR TITLE
chore(ci): Support go.mod replace directives

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -84,7 +84,12 @@ jobs:
             sdk/go.sum
             service/go.sum
       - if: env.IS_RELEASE_BRANCH == 'true'
+        name: prevent depending on unreleased upstream changes
         run: ./.github/scripts/work-init.sh
+      - if:  github.head_ref == format('release-please--branches--main--components--{0}', matrix.directory)
+        name: prevent tagging with replace directives
+        run: awk '/^replace /{r=1};END{exit !r}' go.mod
+        working-directory: ${{ matrix.directory }}
       - run: go mod download
         working-directory: ${{ matrix.directory }}
       - run: go mod verify

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,6 +76,11 @@ jobs:
           cd ${{matrix.path}}
           for x in ${{join(fromJson(needs.release-please.outputs.paths_released), ' ')}}; do
             pkg=github.com/opentdf/platform/${x}
+            if awk -v p="^replace ${pkg}"  '$0 !~ p {r=1; print};END{exit !r}' go.mod > go.mod.tmp; then
+              mv go.mod.tmp go.mod
+            else
+              rm go.mod.tmp
+            fi
             echo "Should we update [${pkg}] in [${{ matrix.path }}]?"
             if grep "$pkg"<go.mod; then
               ver=$(jq -r .\[\"${x}\"\] < "${GITHUB_WORKSPACE}/.release-please-manifest.json")


### PR DESCRIPTION
- To let `go mod tidy` work with new packages in downstream workspace mods, we need to insert replace directives
- However we don't want these to get tagged! To work around this:
  - fail checks if on a release branch for a module that has *any* replace directives
  - During dep update check, remove any replace directives for that dep.
- The dep update is a brittle - notably it doesn't support paranthesized grouping of replace directives