### PR TITLE
feat(core): add doublestar for public routes

### DIFF
--- a/service/go.mod
+++ b/service/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/bytecodealliance/wasmtime-go/v3 v3.0.2 // indirect
 	github.com/casbin/govaluate v1.1.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect

--- a/service/go.mod
+++ b/service/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/Nerzal/gocloak/v13 v13.9.0
+	github.com/bmatcuk/doublestar v1.3.4
 	github.com/bufbuild/protovalidate-go v0.6.0
 	github.com/casbin/casbin/v2 v2.84.0
 	github.com/creasty/defaults v1.7.0
@@ -42,7 +43,6 @@ require (
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/bytecodealliance/wasmtime-go/v3 v3.0.2 // indirect
 	github.com/casbin/govaluate v1.1.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect

--- a/service/go.sum
+++ b/service/go.sum
@@ -34,6 +34,8 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bufbuild/protovalidate-go v0.6.0 h1:Jgs1kFuZ2LHvvdj8SpCLA1W/+pXS8QSM3F/E2l3InPY=
 github.com/bufbuild/protovalidate-go v0.6.0/go.mod h1:1LamgoYHZ2NdIQH0XGczGTc6Z8YrTHjcJVmiBaar4t4=
 github.com/bytecodealliance/wasmtime-go/v3 v3.0.2 h1:3uZCA/BLTIu+DqCfguByNMJa2HVHpXvjfy0Dy7g6fuA=

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -9,11 +9,11 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
 
+	"github.com/bmatcuk/doublestar"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
@@ -528,7 +528,7 @@ func validateDPoP(accessToken jwt.Token, acessTokenRaw string, dpopInfo receiver
 
 func (a Authentication) isPublicRoute(path string) func(string) bool {
 	return func(route string) bool {
-		matched, err := filepath.Match(route, path)
+		matched, err := doublestar.Match(route, path)
 		if err != nil {
 			a.logger.Warn("error matching route", slog.String("route", route), slog.String("path", path), slog.String("error", err.Error()))
 			return false

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -158,7 +158,17 @@ func (s *AuthSuite) SetupTest() {
 				Issuer:      s.server.URL,
 				Audience:    "test",
 			},
-			PublicRoutes: []string{"/public", "/public2/*", "/public3/static", "/static/*", "/static/*/*"},
+			PublicRoutes: []string{
+				"/public",
+				"/public2/*",
+				"/public3/static",
+				"/static/*",
+				"/static/*/*",
+				"/static-doublestar/**",
+				"/static-doublestar2/**/*",
+				"/static-doublestar3/*/**",
+				"/static-doublestar4/x/**",
+			},
 		},
 		&logger.Logger{
 			Logger: slog.New(slog.Default().Handler()),
@@ -620,6 +630,11 @@ func (s *AuthSuite) Test_PublicPath_Matches() {
 	s.Require().True(slices.ContainsFunc(s.auth.publicRoutes, s.auth.isPublicRoute("/public2/")))
 	s.Require().True(slices.ContainsFunc(s.auth.publicRoutes, s.auth.isPublicRoute("/static/test")))
 	s.Require().True(slices.ContainsFunc(s.auth.publicRoutes, s.auth.isPublicRoute("/static/test/next")))
+
+	s.Require().True(slices.ContainsFunc(s.auth.publicRoutes, s.auth.isPublicRoute("/static-doublestar/test")))
+	s.Require().True(slices.ContainsFunc(s.auth.publicRoutes, s.auth.isPublicRoute("/static-doublestar2/test/next")))
+	s.Require().True(slices.ContainsFunc(s.auth.publicRoutes, s.auth.isPublicRoute("/static-doublestar3/test/next")))
+	s.Require().True(slices.ContainsFunc(s.auth.publicRoutes, s.auth.isPublicRoute("/static-doublestar4/x/test/next")))
 
 	// Failing routes
 	s.Require().False(slices.ContainsFunc(s.auth.publicRoutes, s.auth.isPublicRoute("/public3/")))


### PR DESCRIPTION
Adds doublestar support to enable this

```
/mypep/*                         
/mypep/*/*                       
/mypep/dist/*                 
/mypep/dist/*/*
/mypep/dist/js/*
/mypep/dist/js/*/*
/mypep/dist/js/import/*
/mypep/dist/js/import/*/*
/mypep/assets/*                  
/mypep/assets/*/*
/mypep/assets/images/*
/mypep/assets/images/*/*
/mypep/assets/styles/*
/mypep/assets/styles/*/*
``` 

to this

```
/mypep/*
/mypep/*/*
/mypep/dist/**
/mypep/assets/**
```