### PR TITLE
chore(ci): replaces awk with go mod edit

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -89,7 +89,7 @@ jobs:
         run: ./.github/scripts/work-init.sh
       - if:  github.head_ref == format('release-please--branches--main--components--{0}', matrix.directory)
         name: prevent tagging with replace directives
-        run: awk '/^replace /{r=1};END{exit !r}' go.mod
+        run: go mod edit --json | jq -e '.Replace | not'
         working-directory: ${{ matrix.directory }}
       - run: go mod download
         working-directory: ${{ matrix.directory }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,13 +81,11 @@ jobs:
           cd ${{matrix.path}}
           for x in ${{join(fromJson(needs.release-please.outputs.paths_released), ' ')}}; do
             pkg=github.com/opentdf/platform/${x}
-            if awk -v p="^replace ${pkg}"  '$0 !~ p {r=1; print};END{exit !r}' go.mod > go.mod.tmp; then
-              mv go.mod.tmp go.mod
-            else
-              rm go.mod.tmp
+            if go mod edit --json | jq -e '.Replace.[] | select(.Old.Path == env.pkg)'; then
+              go mod edit --dropreplace=$pkg
             fi
             echo "Should we update [${pkg}] in [${{ matrix.path }}]?"
-            if grep "$pkg"<go.mod; then
+            if go mod edit --json | jq -e '.Require.[] | select(.Path == env.pkg)'; then
               ver=$(jq -r .\[\"${x}\"\] < "${GITHUB_WORKSPACE}/.release-please-manifest.json")
               echo "go get ${pkg}@v${ver}"
               go get "${pkg}@v${ver}"


### PR DESCRIPTION
- The `go mod edit` (and associated commands), with jq, provides more clear, and less brittle, functionality to inspect and modify replace and require directives than relying on grep, awk, etc.