### PR TITLE
chore(ci): fix jq syntax

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,11 +81,11 @@ jobs:
           cd ${{matrix.path}}
           for x in ${{join(fromJson(needs.release-please.outputs.paths_released), ' ')}}; do
             export pkg=github.com/opentdf/platform/${x}
-            if go mod edit --json | jq -e '.Replace.[] | select(.Old.Path == env.pkg)'; then
+            if go mod edit --json | jq -e '.Replace[] | select(.Old.Path == env.pkg)'; then
               go mod edit --dropreplace=$pkg
             fi
             echo "Should we update [${pkg}] in [${{ matrix.path }}]?"
-            if go mod edit --json | jq -e '.Require.[] | select(.Path == env.pkg)'; then
+            if go mod edit --json | jq -e '.Require[] | select(.Path == env.pkg)'; then
               ver=$(jq -r .\[\"${x}\"\] < "${GITHUB_WORKSPACE}/.release-please-manifest.json")
               echo "go get ${pkg}@v${ver}"
               go get "${pkg}@v${ver}"


### PR DESCRIPTION
jq 1.7.1 is fine with the `.[]` syntax but not version 1.6, which the version in the current ubuntu GitHub action runner.

Tested via running

```sh
> docker run -it --rm -v $(pwd)/:/project debian /bin/bash
> apt-get update
> apt-get install curl
> curl -L -o /usr/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64
> chmod +x /usr/bin/jq
> apt-get install golang
> cd project/sdk
> x=lib/fixtures
> export pkg=github.com/opentdf/platform/${x}

>  go mod edit --json | jq -e '.Replace.[] | select(.Old.Path == env.pkg)'
jq: error: syntax error, unexpected '[', expecting FORMAT or QQSTRING_START (Unix shell quoting issues?) at <top-level>, line 1:
.Replace.[] | select(.Old.Path == env.pkg)
jq: 1 compile error

> go mod edit --json | jq -e '.Replace[] | select(.Old.Path == env.pkg)'
jq: error (at <stdin>:399): Cannot iterate over null (null)

> go mod edit --json | jq -e '.Require.[] | select(.Path == env.pkg)'
jq: error: syntax error, unexpected '[', expecting FORMAT or QQSTRING_START (Unix shell quoting issues?) at <top-level>, line 1:
.Require.[] | select(.Path == env.pkg)
jq: 1 compile error

> go mod edit --json | jq -e '.Require[] | select(.Path == env.pkg)'
{
"Path": "github.com/opentdf/platform/lib/fixtures",
"Version": "v0.2.5"
}
```
