### PR TITLE
refactor(core): remove extra jwt parse from authn interceptor

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -106,8 +106,6 @@ func NewAuthenticator(ctx context.Context, cfg Config, logr *logger.Logger) (*Au
 		return nil, err
 	}
 
-	// cfg.OIDCConfiguration = *oidcConfig
-
 	cacheInterval, err := time.ParseDuration(cfg.CacheRefresh)
 	if err != nil {
 		logr.ErrorContext(ctx, fmt.Sprintf("Invalid cache_refresh_interval [%s]", cfg.CacheRefresh), "err", err)

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -254,7 +254,7 @@ func (s *AuthSuite) Test_CheckToken_When_Missing_Issuer_Expect_Error() {
 
 	_, _, err = s.auth.checkToken(context.Background(), []string{fmt.Sprintf("Bearer %s", string(signedTok))}, receiverInfo{}, nil)
 	s.Require().Error(err)
-	s.Equal("missing issuer", err.Error())
+	s.Equal("\"iss\" not satisfied: claim \"iss\" does not exist", err.Error())
 }
 
 func (s *AuthSuite) Test_CheckToken_When_Invalid_Issuer_Value_Expect_Error() {

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -269,7 +269,7 @@ func (s *AuthSuite) Test_CheckToken_When_Invalid_Issuer_Value_Expect_Error() {
 
 	_, _, err = s.auth.checkToken(context.Background(), []string{fmt.Sprintf("Bearer %s", string(signedTok))}, receiverInfo{}, nil)
 	s.Require().Error(err)
-	s.Contains(err.Error(), "invalid issuer")
+	s.Contains(err.Error(), "\"iss\" not satisfied: values do not match")
 }
 
 func (s *AuthSuite) Test_CheckToken_When_Audience_Missing_Expect_Error() {

--- a/service/internal/auth/config.go
+++ b/service/internal/auth/config.go
@@ -14,12 +14,11 @@ type Config struct {
 
 // AuthNConfig is the configuration need for the platform to validate tokens
 type AuthNConfig struct { //nolint:revive // AuthNConfig is a valid name
-	EnforceDPoP       bool   `yaml:"enforceDPoP" json:"enforceDPoP" mapstructure:"enforceDPoP" default:"false"`
-	Issuer            string `yaml:"issuer" json:"issuer"`
-	Audience          string `yaml:"audience" json:"audience"`
-	OIDCConfiguration `yaml:"-" json:"-"`
-	Policy            PolicyConfig `yaml:"policy" json:"policy" mapstructure:"policy"`
-	CacheRefresh      string       `mapstructure:"cache_refresh_interval"`
+	EnforceDPoP  bool         `yaml:"enforceDPoP" json:"enforceDPoP" mapstructure:"enforceDPoP" default:"false"`
+	Issuer       string       `yaml:"issuer" json:"issuer"`
+	Audience     string       `yaml:"audience" json:"audience"`
+	Policy       PolicyConfig `yaml:"policy" json:"policy" mapstructure:"policy"`
+	CacheRefresh string       `mapstructure:"cache_refresh_interval"`
 }
 
 type PolicyConfig struct {


### PR DESCRIPTION
Parsing a jwt is not a free operation and in `authn` we were first parsing the token to extract the issuer. Currently this is not necessary because we only support 1 issuer in our `authn` configuration. 

This pull request removes that unnecessary  parse call and moves to passing the keyset directly into the jwt parse call. 

The reason this came about is when we were profiling our service under load it was obvious there was some slight over head doing this twice. 

![image](https://github.com/opentdf/platform/assets/18211470/c3a458dc-d34f-4abf-9cf0-b6e1a340721c)
