### PR TITLE
chore(core): ability to turn on pprof routes 

### DIFF
--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -213,7 +213,7 @@ func newHTTPServer(c Config, h http.Handler, a *auth.Authentication, g *grpc.Ser
 	if c.EnablePprof {
 		h = pprofHandler(h)
 		// Need to extend write timeout to collect pprof data.
-		writeTimeoutOverride = 30 * time.Second //nolint:gomnd // easier to read that we are overriding the default
+		writeTimeoutOverride = 30 * time.Second //nolint:mnd // easier to read that we are overriding the default
 	}
 
 	// Add grpc handler

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"net/http/pprof"
-	_ "net/http/pprof"
 
 	"github.com/bufbuild/protovalidate-go"
 	"github.com/go-chi/cors"
@@ -237,20 +236,20 @@ func newHTTPServer(c Config, h http.Handler, a *auth.Authentication, g *grpc.Ser
 // ppprof handler
 func pprofHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/debug/pprof/":
-			pprof.Index(w, r)
-		case "/debug/pprof/cmdline":
-			pprof.Cmdline(w, r)
-		case "/debug/pprof/heap":
-			pprof.Index(w, r)
-		case "/debug/pprof/profile":
-			pprof.Profile(w, r)
-		case "/debug/pprof/symbol":
-			pprof.Symbol(w, r)
-		case "/debug/pprof/trace":
-			pprof.Trace(w, r)
-		default:
+		if strings.HasPrefix(r.URL.Path, "/debug/pprof/") {
+			switch r.URL.Path {
+			case "/debug/pprof/cmdline":
+				pprof.Cmdline(w, r)
+			case "/debug/pprof/profile":
+				pprof.Profile(w, r)
+			case "/debug/pprof/symbol":
+				pprof.Symbol(w, r)
+			case "/debug/pprof/trace":
+				pprof.Trace(w, r)
+			default:
+				pprof.Index(w, r)
+			}
+		} else {
 			h.ServeHTTP(w, r)
 		}
 	})

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -213,7 +213,7 @@ func newHTTPServer(c Config, h http.Handler, a *auth.Authentication, g *grpc.Ser
 	if c.EnablePprof {
 		h = pprofHandler(h)
 		// Need to extend write timeout to collect pprof data.
-		writeTimeoutOverride = 30 * time.Second
+		writeTimeoutOverride = 30 * time.Second //nolint:gomnd // easier to read that we are overriding the default
 	}
 
 	// Add grpc handler


### PR DESCRIPTION
Exposes pprof routes so we can capture profiling information when facing a performance issue. 