### PR TITLE
fix(core): swap out internal issuer for external issuer endpoint

### DIFF
--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -136,7 +136,7 @@ func (s *AuthSuite) SetupTest() {
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		if r.URL.Path == "/.well-known/openid-configuration" {
-			_, err := w.Write([]byte(fmt.Sprintf(`{"jwks_uri": "%s/jwks"}`, s.server.URL)))
+			_, err := w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","jwks_uri": "%s/jwks"}`, s.server.URL, s.server.URL)))
 			if err != nil {
 				panic(err)
 			}
@@ -173,6 +173,7 @@ func (s *AuthSuite) SetupTest() {
 		&logger.Logger{
 			Logger: slog.New(slog.Default().Handler()),
 		},
+		func(n string, config any) error { return nil },
 	)
 
 	s.Require().NoError(err)
@@ -603,7 +604,9 @@ func (s *AuthSuite) Test_Allowing_Auth_With_No_DPoP() {
 	config.AuthNConfig = authnConfig
 	auth, err := NewAuthenticator(context.Background(), config, &logger.Logger{
 		Logger: slog.New(slog.Default().Handler()),
-	})
+	},
+		func(n string, config any) error { return nil },
+	)
 
 	s.Require().NoError(err)
 

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -173,7 +173,7 @@ func (s *AuthSuite) SetupTest() {
 		&logger.Logger{
 			Logger: slog.New(slog.Default().Handler()),
 		},
-		func(n string, config any) error { return nil },
+		func(_ string, _ any) error { return nil },
 	)
 
 	s.Require().NoError(err)
@@ -605,7 +605,7 @@ func (s *AuthSuite) Test_Allowing_Auth_With_No_DPoP() {
 	auth, err := NewAuthenticator(context.Background(), config, &logger.Logger{
 		Logger: slog.New(slog.Default().Handler()),
 	},
-		func(n string, config any) error { return nil },
+		func(_ string, _ any) error { return nil },
 	)
 
 	s.Require().NoError(err)

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -118,6 +118,7 @@ func NewOpenTDFServer(config Config, logr *logger.Logger) (*OpenTDFServer, error
 			context.Background(),
 			config.Auth,
 			logr,
+			config.WellKnownConfigRegister,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create authentication interceptor: %w", err)
@@ -125,11 +126,6 @@ func NewOpenTDFServer(config Config, logr *logger.Logger) (*OpenTDFServer, error
 		logr.Debug("authentication interceptor enabled")
 	} else {
 		logr.Warn("disabling authentication. this is deprecated and will be removed. if you are using an IdP without DPoP set `enforceDPoP = false`")
-	}
-
-	// Try an register oidc issuer to wellknown service but don't return an error if it fails
-	if err := config.WellKnownConfigRegister("platform_issuer", config.Auth.Issuer); err != nil {
-		logr.Warn("failed to register platform issuer", slog.String("error", err.Error()))
 	}
 
 	// Create grpc server and in process grpc server


### PR DESCRIPTION
When the platform points to an internal issuer endpoint. Example keycloak is running within a k8s cluster we should try to replace it if its different from what is returned from the  discovery endpoint. 