### PR TITLE
refactor(ci): Removes wiremock from sdk tests

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -3,7 +3,6 @@ module github.com/opentdf/platform/sdk
 go 1.21
 
 require (
-	github.com/docker/go-connections v0.5.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/lestrrat-go/jwx/v2 v2.0.21
@@ -12,7 +11,6 @@ require (
 	github.com/opentdf/platform/protocol/go v0.2.4
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.28.0
-	github.com/wiremock/go-wiremock v1.9.0
 	google.golang.org/grpc v1.62.1
 	google.golang.org/protobuf v1.33.0
 )
@@ -32,6 +30,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/docker v25.0.2+incompatible // indirect
+	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -152,8 +152,6 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
-github.com/wiremock/go-wiremock v1.9.0 h1:9xcU4/IoEfgCaH4TGhQTtiQyBh2eMtu9JB6ppWduK+E=
-github.com/wiremock/go-wiremock v1.9.0/go.mod h1:/uvO0XFheyy8XetvQqm4TbNQRsGPlByeNegzLzvXs0c=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 
 	"github.com/opentdf/platform/lib/ocrypto"
+	"github.com/opentdf/platform/sdk/auth"
 	"github.com/opentdf/platform/sdk/internal/oauth"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -15,23 +16,24 @@ type Option func(*config)
 
 // Internal config struct for building SDK options.
 type config struct {
-	dialOption            grpc.DialOption
-	tlsConfig             *tls.Config
-	clientCredentials     *oauth.ClientCredentials
-	tokenExchange         *oauth.TokenExchangeInfo
-	tokenEndpoint         string
-	scopes                []string
-	policyConn            *grpc.ClientConn
-	authorizationConn     *grpc.ClientConn
-	entityresolutionConn  *grpc.ClientConn
-	extraDialOptions      []grpc.DialOption
-	certExchange          *oauth.CertExchangeInfo
-	wellknownConn         *grpc.ClientConn
-	platformConfiguration PlatformConfiguration
-	kasSessionKey         *ocrypto.RsaKeyPair
-	dpopKey               *ocrypto.RsaKeyPair
-	ipc                   bool
-	tdfFeatures           tdfFeatures
+	dialOption              grpc.DialOption
+	tlsConfig               *tls.Config
+	clientCredentials       *oauth.ClientCredentials
+	tokenExchange           *oauth.TokenExchangeInfo
+	tokenEndpoint           string
+	scopes                  []string
+	policyConn              *grpc.ClientConn
+	authorizationConn       *grpc.ClientConn
+	entityresolutionConn    *grpc.ClientConn
+	extraDialOptions        []grpc.DialOption
+	certExchange            *oauth.CertExchangeInfo
+	wellknownConn           *grpc.ClientConn
+	platformConfiguration   PlatformConfiguration
+	kasSessionKey           *ocrypto.RsaKeyPair
+	dpopKey                 *ocrypto.RsaKeyPair
+	ipc                     bool
+	tdfFeatures             tdfFeatures
+	customAccessTokenSource auth.AccessTokenSource
 }
 
 // Options specific to TDF protocol features
@@ -88,6 +90,12 @@ func WithTLSCredentials(tls *tls.Config, audience []string) Option {
 func WithTokenEndpoint(tokenEndpoint string) Option {
 	return func(c *config) {
 		c.tokenEndpoint = tokenEndpoint
+	}
+}
+
+func withCustomAccessTokenSource(a auth.AccessTokenSource) Option {
+	return func(c *config) {
+		c.customAccessTokenSource = a
 	}
 }
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -188,6 +188,10 @@ func SanitizePlatformEndpoint(e string) (string, error) {
 }
 
 func buildIDPTokenSource(c *config) (auth.AccessTokenSource, error) {
+	if c.customAccessTokenSource != nil {
+		return c.customAccessTokenSource, nil
+	}
+
 	if (c.clientCredentials == nil) != (c.tokenEndpoint == "") {
 		return nil, errors.New("either both or neither of client credentials and token endpoint must be specified")
 	}

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -95,7 +95,7 @@ func (s SDK) CreateTDF(writer io.Writer, reader io.ReadSeeker, opts ...TDFOption
 		return nil, fmt.Errorf("readSeeker.Seek failed: %w", err)
 	}
 
-	tdfConfig, err := NewTDFConfig(opts...)
+	tdfConfig, err := newTDFConfig(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("NewTDFConfig failed: %w", err)
 	}

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -28,12 +28,15 @@ const (
 
 // KASInfo contains Key Access Server information.
 type KASInfo struct {
-	// URL of the KAS server``
+	// URL of the KAS server
 	URL string
-	// Public key can be empty. If it is empty, the public key will be fetched from the KAS server.
+	// Public key can be empty.
+	// If it is empty, the public key will be fetched from the KAS server.
 	PublicKey string
 	// Key identifier associated with the given key, if present.
 	KID string
+	// The algorithm associated with this key
+	Algorithm string
 }
 
 type TDFOption func(*TDFConfig) error
@@ -54,8 +57,7 @@ type TDFConfig struct {
 	kasInfoList               []KASInfo
 }
 
-// NewTDFConfig CreateTDF a new instance of a tdf config.
-func NewTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
+func newTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
 	rsaKeyPair, err := ocrypto.NewRSAKeyPair(tdf3KeySize)
 	if err != nil {
 		return nil, fmt.Errorf("ocrypto.NewRSAKeyPair failed: %w", err)
@@ -101,6 +103,11 @@ func WithDataAttributes(attributes ...string) TDFOption {
 
 // WithKasInformation adds all the kas urls and their corresponding public keys
 // that is required to create and read the tdf.
+// For writing TDFs, this is optional, but adding it can bypass key lookup.
+// For reading TDFs, this is the list of allowed KASes to contact for key rewrap.
+//
+// During creation, if the public key is set, the kas will not be contacted for the latest key.
+// Please make sure to set the KID if the PublicKey is set to include a KID in any key wrappers.
 func WithKasInformation(kasInfoList ...KASInfo) TDFOption {
 	return func(c *TDFConfig) error {
 		newKasInfos := make([]KASInfo, 0)

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -45,7 +45,6 @@ type tdfTest struct {
 	fileSize    int64
 	tdfFileSize float64
 	checksum    string
-	kasInfoList []KASInfo
 	mimeType    string
 }
 
@@ -556,7 +555,7 @@ type FakeWellKnown struct {
 	v map[string]interface{}
 }
 
-func (f *FakeWellKnown) GetWellKnownConfiguration(ctx context.Context, in *wellknownpb.GetWellKnownConfigurationRequest) (*wellknownpb.GetWellKnownConfigurationResponse, error) {
+func (f *FakeWellKnown) GetWellKnownConfiguration(_ context.Context, _ *wellknownpb.GetWellKnownConfigurationRequest) (*wellknownpb.GetWellKnownConfigurationResponse, error) {
 	cfg, err := structpb.NewStruct(f.v)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- replaces wiremock of keycloak and well-known services with
  - use traditional mocks for AccessToken
  - use in-process grpc for wellknownconfig
- wiremock has been causing me lots of trouble with my colima setup
- and also most of our services are easier to mock locally anyway