### PR TITLE
fix(policy): run migrations on db only once for all policy services

### DIFF
--- a/service/pkg/db/db_migration.go
+++ b/service/pkg/db/db_migration.go
@@ -55,6 +55,9 @@ func migrationInit(ctx context.Context, c *Client, migrations *embed.FS) (*goose
 // RunMigrations runs the migrations for the schema
 // Schema will be created if it doesn't exist
 func (c *Client) RunMigrations(ctx context.Context, migrations *embed.FS) (int, error) {
+	if migrations == nil {
+		return 0, fmt.Errorf("migrations FS is required when to run migrations")
+	}
 	slog.Info("running migration up", slog.String("schema", c.config.Schema), slog.String("database", c.config.Database))
 
 	// Create schema if it doesn't exist

--- a/service/pkg/db/db_migration.go
+++ b/service/pkg/db/db_migration.go
@@ -56,7 +56,7 @@ func migrationInit(ctx context.Context, c *Client, migrations *embed.FS) (*goose
 // Schema will be created if it doesn't exist
 func (c *Client) RunMigrations(ctx context.Context, migrations *embed.FS) (int, error) {
 	if migrations == nil {
-		return 0, fmt.Errorf("migrations FS is required when to run migrations")
+		return 0, fmt.Errorf("migrations FS is required to run migrations")
 	}
 	slog.Info("running migration up", slog.String("schema", c.config.Schema), slog.String("database", c.config.Database))
 


### PR DESCRIPTION
Closes #742 

1. Runs migrations just once and IFF at least one service requires a DB connection
2. Resolves pass by value error where struct pointer `*db.Client` outside for loop was not reassigned within `startService` function due to copy of value. Returns a `*db.Client` instead of resolving with `**db.Client` parameter for better readability.

Service starting logs after these changes:
```shell
time=2024-06-26T16:54:22.597-07:00 level=INFO msg="starting services"
time=2024-06-26T16:54:22.597-07:00 level=INFO msg="skipping migrations" namespace=wellknown service=wellknownconfiguration.WellKnownService runMigrations=true reason="service does not require a database"
time=2024-06-26T16:54:22.597-07:00 level=INFO msg="started service" namespace=wellknown service=wellknownconfiguration.WellKnownService
time=2024-06-26T16:54:22.597-07:00 level=INFO msg="skipping migrations" namespace=entityresolution service=entityresolution.EntityResolutionService runMigrations=true reason="service does not require a database"
time=2024-06-26T16:54:22.597-07:00 level=INFO msg="started service" namespace=entityresolution service=entityresolution.EntityResolutionService
time=2024-06-26T16:54:22.597-07:00 level=INFO msg="creating database client" namespace=policy
time=2024-06-26T16:54:22.611-07:00 level=INFO msg="running database migrations"
time=2024-06-26T16:54:22.612-07:00 level=INFO msg="running migration up" schema=opentdf_policy database=opentdf
time=2024-06-26T16:54:22.617-07:00 level=INFO msg="migration db info " "current version"=20240618000000
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="migration up complete" "post-op version"=20240618000000
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="database migrations complete" applied=0
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="started service" namespace=policy service=policy.attributes.AttributesService
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="skipping migrations" namespace=policy service=policy.namespaces.NamespaceService runMigrations=true reason="required migrations already ran"
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="started service" namespace=policy service=policy.namespaces.NamespaceService
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="skipping migrations" namespace=policy service=policy.resourcemapping.ResourceMappingService runMigrations=true reason="required migrations already ran"
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="started service" namespace=policy service=policy.resourcemapping.ResourceMappingService
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="skipping migrations" namespace=policy service=policy.subjectmapping.SubjectMappingService runMigrations=true reason="required migrations already ran"
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="started service" namespace=policy service=policy.subjectmapping.SubjectMappingService
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="skipping migrations" namespace=policy service=policy.kasregistry.KeyAccessServerRegistryService runMigrations=true reason="required migrations already ran"
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="started service" namespace=policy service=policy.kasregistry.KeyAccessServerRegistryService
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="skipping migrations" namespace=health service=grpc.health.v1.Health runMigrations=true reason="service does not require a database"
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="started service" namespace=health service=grpc.health.v1.Health
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="skipping migrations" namespace=authorization service=authorization.AuthorizationService runMigrations=true reason="service does not require a database"
time=2024-06-26T16:54:22.619-07:00 level=DEBUG msg="authorization service client config" config="{ClientID:tdf-authorization-svc ClientSecret:secret TokenURL:http://localhost:8888/auth/realms/opentdf/protocol/openid-connect/token Scopes:[] EndpointParams:map[] AuthStyle:0 authStyleCache:{v:{v:<nil>}}}"
time=2024-06-26T16:54:22.619-07:00 level=DEBUG msg="authorization service token source created" token_source="&{new:0x14000412450 mu:{state:0 sema:0} t:<nil> expiryDelta:100}"
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="started service" namespace=authorization service=authorization.AuthorizationService
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="skipping migrations" namespace=kas service=kas.AccessService runMigrations=true reason="service does not require a database"
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="started service" namespace=kas service=kas.AccessService
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="starting opentdf"
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="services running"
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="service running" namespace=wellknown service=wellknownconfiguration.WellKnownService database=false
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="service running" namespace=entityresolution service=entityresolution.EntityResolutionService database=false
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="service running" namespace=policy service=policy.attributes.AttributesService database=true
time=2024-06-26T16:54:22.619-07:00 level=INFO msg="service running" namespace=policy service=policy.namespaces.NamespaceService database=true
time=2024-06-26T16:54:22.620-07:00 level=INFO msg="service running" namespace=policy service=policy.resourcemapping.ResourceMappingService database=true
time=2024-06-26T16:54:22.620-07:00 level=INFO msg="service running" namespace=policy service=policy.subjectmapping.SubjectMappingService database=true
time=2024-06-26T16:54:22.620-07:00 level=INFO msg="service running" namespace=policy service=policy.kasregistry.KeyAccessServerRegistryService database=true
time=2024-06-26T16:54:22.620-07:00 level=INFO msg="service running" namespace=health service=grpc.health.v1.Health database=false
time=2024-06-26T16:54:22.620-07:00 level=INFO msg="service running" namespace=authorization service=authorization.AuthorizationService database=false
time=2024-06-26T16:54:22.620-07:00 level=INFO msg="service running" namespace=kas service=kas.AccessService database=false
time=2024-06-26T16:54:22.620-07:00 level=INFO msg="starting http server" address=:8080
time=2024-06-26T16:54:22.620-07:00 level=INFO msg="starting in process grpc server"
```