### PR TITLE
fix: Issue #1008 : Use exchange info's TLS Configuration for cert based auth

### DIFF
--- a/sdk/idp_cert_exchange.go
+++ b/sdk/idp_cert_exchange.go
@@ -38,12 +38,12 @@ func NewCertExchangeTokenSource(info oauth.CertExchangeInfo, credentials oauth.C
 	return &exchangeSource, nil
 }
 
-func (c *CertExchangeTokenSource) AccessToken(ctx context.Context, client *http.Client) (auth.AccessToken, error) {
+func (c *CertExchangeTokenSource) AccessToken(ctx context.Context, _ *http.Client) (auth.AccessToken, error) {
 	c.tokenMutex.Lock()
 	defer c.tokenMutex.Unlock()
 
 	if c.token == nil || c.token.Expired() {
-		tok, err := oauth.DoCertExchange(ctx, client, c.IdpEndpoint, c.info, c.credentials, c.key)
+		tok, err := oauth.DoCertExchange(ctx, c.IdpEndpoint, c.info, c.credentials, c.key)
 		if err != nil {
 			return "", err
 		}

--- a/sdk/internal/oauth/oauth.go
+++ b/sdk/internal/oauth/oauth.go
@@ -308,11 +308,17 @@ func getTokenExchangeRequest(ctx context.Context, tokenEndpoint, dpopNonce strin
 	return req, nil
 }
 
-func DoCertExchange(ctx context.Context, client *http.Client, tokenEndpoint string, exchangeInfo CertExchangeInfo, clientCredentials ClientCredentials, key jwk.Key) (*Token, error) {
+func DoCertExchange(ctx context.Context, tokenEndpoint string, exchangeInfo CertExchangeInfo, clientCredentials ClientCredentials, key jwk.Key) (*Token, error) {
 	req, err := getCertExchangeRequest(ctx, tokenEndpoint, clientCredentials, exchangeInfo, key)
 	if err != nil {
 		return nil, err
 	}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: exchangeInfo.TLSConfig,
+		},
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error making request to IdP for certificate exchange: %w", err)

--- a/sdk/internal/oauth/oauth_test.go
+++ b/sdk/internal/oauth/oauth_test.go
@@ -88,11 +88,6 @@ func (s *OAuthSuite) TestCertExchangeFromKeycloak() {
 
 	tok, err := DoCertExchange(
 		context.Background(),
-		&http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tlsConfig,
-			},
-		},
 		s.keycloakHTTPSEndpoint,
 		exhcangeInfo,
 		clientCredentials,


### PR DESCRIPTION
Fix for #1008 