### PR TITLE
fix(core): database clients pooling improvements

### DIFF
--- a/service/pkg/db/db.go
+++ b/service/pkg/db/db.go
@@ -136,10 +136,9 @@ func New(ctx context.Context, config Config, o ...OptsFunc) (*Client, error) {
 	q := fmt.Sprintf("SET search_path TO %s", config.Schema)
 	if _, err := c.Pgx.Exec(ctx, q); err != nil {
 		return nil, fmt.Errorf("failed to SET search_path for db Client schema to [%s]: %w", config.Schema, err)
-	} else {
-		slog.Info("successfully set database client search_path", slog.String("schema", config.Schema))
 	}
 
+	slog.Info("successfully set database client search_path", slog.String("schema", config.Schema))
 	return &c, nil
 }
 

--- a/service/pkg/db/db.go
+++ b/service/pkg/db/db.go
@@ -132,6 +132,14 @@ func New(ctx context.Context, config Config, o ...OptsFunc) (*Client, error) {
 		}
 	}
 
+	// Set the Client search_path to the schema
+	q := fmt.Sprintf("SET search_path TO %s", config.Schema)
+	if _, err := c.Pgx.Exec(ctx, q); err != nil {
+		return nil, fmt.Errorf("failed to SET search_path for db Client schema to [%s]: %w", config.Schema, err)
+	} else {
+		slog.Info("successfully set database client search_path", slog.String("schema", config.Schema))
+	}
+
 	return &c, nil
 }
 

--- a/service/pkg/db/db_migration.go
+++ b/service/pkg/db/db_migration.go
@@ -42,7 +42,7 @@ func migrationInit(ctx context.Context, c *Client, migrations *embed.FS) (*goose
 	if e != nil {
 		return nil, 0, nil, errors.Join(fmt.Errorf("failed to get current version"), e)
 	}
-	slog.Info("migration db info ", slog.Any("current version", v))
+	slog.Info("migration db info", slog.Any("current version", v))
 
 	// Return the provider, version, and close function
 	return provider, v, func() {

--- a/service/pkg/db/db_migration.go
+++ b/service/pkg/db/db_migration.go
@@ -17,13 +17,6 @@ func migrationInit(ctx context.Context, c *Client, migrations *embed.FS) (*goose
 		return nil, 0, nil, fmt.Errorf("migrations are disabled")
 	}
 
-	// Set the schema
-	q := fmt.Sprintf("SET search_path TO %s", c.config.Schema)
-	if tag, err := c.Pgx.Exec(ctx, q); err != nil {
-		slog.Error("migration error", slog.String("query", q), slog.String("error", err.Error()), slog.Any("tag", tag))
-		return nil, 0, nil, fmt.Errorf("failed to SET search_path [%w]", err)
-	}
-
 	// Cast the pgxpool.Pool to a *sql.DB
 	pool, ok := c.Pgx.(*pgxpool.Pool)
 	if !ok || pool == nil {


### PR DESCRIPTION
Closes #681 

Per service with db connection:
- one client
- one schema
- one shared pool

Not supported (and documented in db package)
- multiple schemas per client
- multiple services sharing a pool (unless rolled up into one service like policy)
- multiple databases per platform Postgres instance
- multiple Postgres servers per platform instance