### PR TITLE
feat(sdk)!: Autoconfigure with grants

### DIFF
--- a/examples/cmd/encrypt.go
+++ b/examples/cmd/encrypt.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	nanoFormat           bool
+	autoconfigure        bool
 	noKIDInKAO           bool
 	outputName           string
 	joinedDataAttributes string
@@ -29,6 +30,7 @@ func init() {
 	}
 	encryptCmd.Flags().StringVarP(&joinedDataAttributes, "data-attributes", "a", "https://example.com/attr/attr1/value/value1", "space separated list of data attributes")
 	encryptCmd.Flags().BoolVar(&nanoFormat, "nano", false, "Output in nanoTDF format")
+	encryptCmd.Flags().BoolVar(&autoconfigure, "autoconfigure", true, "Use attribute grants to select kases")
 	encryptCmd.Flags().BoolVar(&noKIDInKAO, "no-kid-in-kao", false, "[deprecated] Disable storing key identifiers in TDF KAOs")
 	encryptCmd.Flags().StringVarP(&outputName, "output", "o", "sensitive.txt.tdf", "name or path of output file; - for stdout")
 
@@ -76,6 +78,7 @@ func encrypt(cmd *cobra.Command, args []string) error {
 
 	if !nanoFormat {
 		tdf, err := client.CreateTDF(out, in,
+			sdk.WithAutoconfigure(autoconfigure),
 			sdk.WithDataAttributes(attributes...),
 			sdk.WithKasInformation(
 				sdk.KASInfo{

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -40,7 +40,7 @@ func main() {
   _, err := s.CreateTDF(
     ciphertext,
     plaintext,
-    sdk.WithAttributes("https://example.com/attr/Classification/value/Open"),
+    sdk.WithDataAttributes("https://example.com/attr/Classification/value/Open"),
   )
   if err != nil {
     panic(err)

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/opentdf/platform/protocol/go v0.2.8
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.28.0
+	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 	google.golang.org/grpc v1.62.1
 	google.golang.org/protobuf v1.33.0
 )
@@ -75,7 +76,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	golang.org/x/crypto v0.24.0 // indirect
-	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/sdk/internal/autoconfigure/granter_test.go
+++ b/sdk/internal/autoconfigure/granter_test.go
@@ -1,0 +1,262 @@
+package autoconfigure
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+const (
+	AUS_KAS     = "http://kas.au/"
+	CAN_KAS     = "http://kas.ca/"
+	GBR_KAS     = "http://kas.uk/"
+	NZL_KAS     = "http://kas.nz/"
+	USA_KAS     = "http://kas.us/"
+	HCS_USA_KAS = "http://hcs.kas.us/"
+	SI_USA_KAS  = "http://si.kas.us/"
+	authority   = "https://virtru.com/"
+
+	CLS AttributeName = "https://virtru.com/attr/Classification"
+	N2K AttributeName = "https://virtru.com/attr/Need%20to%20Know"
+	REL AttributeName = "https://virtru.com/attr/Releasable%20To"
+
+	CLS_Allowed      AttributeValue = "https://virtru.com/attr/Classification/value/Allowed"
+	CLS_Confidential AttributeValue = "https://virtru.com/attr/Classification/value/Confidential"
+	CLS_Secret       AttributeValue = "https://virtru.com/attr/Classification/value/Secret"
+	CLS_TopSecret    AttributeValue = "https://virtru.com/attr/Classification/value/Top%20Secret"
+
+	N2K_HCS AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/HCS"
+	N2K_INT AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/INT"
+	N2K_SI  AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/SI"
+
+	REL_FVEY AttributeValue = "https://virtru.com/attr/Releasable%20To/value/FVEY"
+	REL_AUS  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/AUS"
+	REL_CAN  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/CAN"
+	REL_GBR  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/GBR"
+	REL_NZL  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/NZL"
+	REL_USA  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/USA"
+)
+
+func mockAttributeFor(fqn AttributeName) *policy.Attribute {
+	ns := policy.Namespace{
+		Id:   "v",
+		Name: "virtru.com",
+		Fqn:  "https://virtru.com",
+	}
+	switch fqn {
+	case CLS:
+		return &policy.Attribute{
+			Id:        "CLS",
+			Namespace: &ns,
+			Name:      "Classification",
+			Rule:      policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY,
+			Fqn:       string(fqn),
+		}
+	case N2K:
+		return &policy.Attribute{
+			Id:        "N2K",
+			Namespace: &ns,
+			Name:      "Need to Know",
+			Rule:      policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF,
+			Fqn:       string(fqn),
+		}
+	case REL:
+		return &policy.Attribute{
+			Id:        "REL",
+			Namespace: &ns,
+			Name:      "Releasable To",
+			Rule:      policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+			Fqn:       string(fqn),
+		}
+	}
+	return nil
+}
+func mockValueFor(fqn AttributeValue) *policy.Value {
+	an := fqn.Prefix()
+	a := mockAttributeFor(AttributeName(an))
+	v := fqn.Value()
+	p := policy.Value{
+		Id:        a.Id + ":" + v,
+		Attribute: a,
+		Value:     v,
+		Fqn:       string(fqn),
+	}
+
+	switch an {
+	case N2K:
+		switch fqn.Value() {
+		case "INT":
+			p.Grants = make([]*policy.KeyAccessServer, 1)
+			p.Grants[0] = &policy.KeyAccessServer{Uri: GBR_KAS}
+		case "HCS":
+			p.Grants = make([]*policy.KeyAccessServer, 1)
+			p.Grants[0] = &policy.KeyAccessServer{Uri: HCS_USA_KAS}
+		case "SI":
+			p.Grants = make([]*policy.KeyAccessServer, 1)
+			p.Grants[0] = &policy.KeyAccessServer{Uri: SI_USA_KAS}
+		}
+
+	case REL:
+		switch fqn.Value() {
+		case "FVEY":
+			p.Grants = make([]*policy.KeyAccessServer, 5)
+			p.Grants[0] = &policy.KeyAccessServer{Uri: AUS_KAS}
+			p.Grants[1] = &policy.KeyAccessServer{Uri: CAN_KAS}
+			p.Grants[2] = &policy.KeyAccessServer{Uri: GBR_KAS}
+			p.Grants[3] = &policy.KeyAccessServer{Uri: NZL_KAS}
+			p.Grants[4] = &policy.KeyAccessServer{Uri: USA_KAS}
+		case "AUS":
+			p.Grants = make([]*policy.KeyAccessServer, 1)
+			p.Grants[0] = &policy.KeyAccessServer{Uri: AUS_KAS}
+		case "CAN":
+			p.Grants = make([]*policy.KeyAccessServer, 1)
+			p.Grants[0] = &policy.KeyAccessServer{Uri: CAN_KAS}
+		case "GBR":
+			p.Grants = make([]*policy.KeyAccessServer, 1)
+			p.Grants[0] = &policy.KeyAccessServer{Uri: GBR_KAS}
+		case "NZL":
+			p.Grants = make([]*policy.KeyAccessServer, 1)
+			p.Grants[0] = &policy.KeyAccessServer{Uri: NZL_KAS}
+		case "USA":
+			p.Grants = make([]*policy.KeyAccessServer, 1)
+			p.Grants[0] = &policy.KeyAccessServer{Uri: USA_KAS}
+		}
+	}
+	return &p
+}
+
+func TestAttributeInstanceFromURL(t *testing.T) {
+	for _, tc := range []struct {
+		n, u              string
+		auth, name, value string
+	}{
+		{"number", "http://e/attr/a/value/1", "http://e", "a", "1"},
+		{"space", "http://e/attr/a/value/%20", "http://e", "a", " "},
+		{"emoji", "http://e/attr/a/value/%F0%9F%98%81", "http://e", "a", "😁"},
+		{"numberdef", "http://e/attr/1/value/one", "http://e", "1", "one"},
+	} {
+		t.Run(tc.n, func(t *testing.T) {
+			a, err := NewAttributeValue(tc.u)
+			require.NoError(t, err)
+			assert.Equal(t, tc.auth, a.Authority())
+			assert.Equal(t, tc.name, a.Name())
+			assert.Equal(t, tc.value, a.Value())
+		})
+	}
+}
+
+func valuesToPolicy(p ...AttributeValue) []*policy.Value {
+	v := make([]*policy.Value, len(p))
+	for i, ai := range p {
+		v[i] = mockValueFor(ai)
+	}
+	return v
+}
+
+func TestConfigurationServicePutGet(t *testing.T) {
+	for _, tc := range []struct {
+		n      string
+		policy []AttributeValue
+		size   int
+		kases  []string
+	}{
+		{"default", []AttributeValue{CLS_Allowed}, 1, []string{}},
+		{"one-country", []AttributeValue{REL_GBR}, 1, []string{GBR_KAS}},
+		{"two-country", []AttributeValue{REL_GBR, REL_NZL}, 2, []string{GBR_KAS, NZL_KAS}},
+		{"with-default", []AttributeValue{CLS_Allowed, REL_GBR}, 2, []string{GBR_KAS}},
+		{"need-to-know", []AttributeValue{CLS_TopSecret, REL_USA, N2K_SI}, 3, []string{USA_KAS, SI_USA_KAS}},
+	} {
+		t.Run(tc.n, func(t *testing.T) {
+			v := valuesToPolicy(tc.policy...)
+			grants, err := NewGranterFromAttributes(v...)
+			require.NoError(t, err)
+			assert.Len(t, grants.grants, tc.size)
+			assert.Subset(t, tc.policy, maps.Keys(grants.grants))
+			actualKases := make(map[string]bool)
+			for _, g := range grants.grants {
+				require.NotNil(t, g)
+				for _, k := range g.kases {
+					actualKases[k] = true
+				}
+			}
+			assert.ElementsMatch(t, tc.kases, maps.Keys(actualKases))
+		})
+	}
+}
+
+func TestReasonerConstructAttributeBoolean(t *testing.T) {
+	for _, tc := range []struct {
+		n                   string
+		policy              []AttributeValue
+		ats, keyed, reduced string
+		plan                []SplitStep
+	}{
+		{
+			"one actual with default",
+			[]AttributeValue{CLS_Secret, REL_CAN},
+			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/CAN",
+			"[DEFAULT]&(http://kas.ca/)",
+			"(http://kas.ca/)",
+			[]SplitStep{{CAN_KAS, ""}},
+		},
+		{
+			"one defaulted attr",
+			[]AttributeValue{CLS_Secret},
+			"https://virtru.com/attr/Classification/value/Secret",
+			"[DEFAULT]",
+			"",
+			[]SplitStep{{USA_KAS, ""}},
+		},
+		{
+			"empty policy",
+			[]AttributeValue{},
+			"∅",
+			"",
+			"",
+			[]SplitStep{{USA_KAS, ""}},
+		},
+		{
+			"simple with all three ops",
+			[]AttributeValue{CLS_Secret, REL_GBR, N2K_INT},
+			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/GBR&https://virtru.com/attr/Need%20to%20Know/value/INT",
+			"[DEFAULT]&(http://kas.uk/)&(http://kas.uk/)",
+			"(http://kas.uk/)",
+			[]SplitStep{{GBR_KAS, ""}},
+		},
+		{
+			"compartments",
+			[]AttributeValue{CLS_Secret, REL_GBR, REL_USA, N2K_HCS, N2K_SI},
+			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/{GBR,USA}&https://virtru.com/attr/Need%20to%20Know/value/{HCS,SI}",
+			"[DEFAULT]&(http://kas.uk/⋁http://kas.us/)&(http://hcs.kas.us/⋀http://si.kas.us/)",
+			"(http://kas.uk/⋁http://kas.us/)&(http://hcs.kas.us/)&(http://si.kas.us/)",
+			[]SplitStep{{GBR_KAS, "1"}, {USA_KAS, "1"}, {HCS_USA_KAS, "2"}, {SI_USA_KAS, "3"}},
+		},
+	} {
+		t.Run(tc.n, func(t *testing.T) {
+			reasoner, err := NewGranterFromAttributes(valuesToPolicy(tc.policy...)...)
+			require.NoError(t, err)
+
+			actualAB, err := reasoner.constructAttributeBoolean()
+			require.NoError(t, err)
+			assert.Equal(t, tc.ats, actualAB.String())
+
+			actualKeyed, err := reasoner.insertKeysForAttribute(*actualAB)
+			require.NoError(t, err)
+			assert.Equal(t, tc.keyed, actualKeyed.String())
+
+			r := actualKeyed.reduce()
+			assert.Equal(t, tc.reduced, r.String())
+
+			i := 0
+			plan, err := reasoner.Plan(USA_KAS, func() string {
+				i++
+				return fmt.Sprintf("%d", i)
+			})
+			assert.Equal(t, tc.plan, plan)
+		})
+	}
+}

--- a/sdk/internal/autoconfigure/granter_test.go
+++ b/sdk/internal/autoconfigure/granter_test.go
@@ -251,12 +251,14 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 	for _, tc := range []struct {
 		n                   string
 		policy              []AttributeValueFQN
+		defaults            []string
 		ats, keyed, reduced string
 		plan                []SplitStep
 	}{
 		{
 			"one actual with default",
 			[]AttributeValueFQN{clsS, rel2can},
+			[]string{kasUs},
 			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/CAN",
 			"[DEFAULT]&(http://kas.ca/)",
 			"(http://kas.ca/)",
@@ -265,6 +267,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 		{
 			"one defaulted attr",
 			[]AttributeValueFQN{clsS},
+			[]string{kasUs},
 			"https://virtru.com/attr/Classification/value/Secret",
 			"[DEFAULT]",
 			"",
@@ -273,14 +276,25 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 		{
 			"empty policy",
 			[]AttributeValueFQN{},
+			[]string{kasUs},
 			"∅",
 			"",
 			"",
 			[]SplitStep{{kasUs, ""}},
 		},
 		{
+			"old school splits",
+			[]AttributeValueFQN{},
+			[]string{kasAu, kasCa, kasUs},
+			"∅",
+			"",
+			"",
+			[]SplitStep{{kasAu, "1"}, {kasCa, "2"}, {kasUs, "3"}},
+		},
+		{
 			"simple with all three ops",
 			[]AttributeValueFQN{clsS, rel2gbr, n2kInt},
+			[]string{kasUs},
 			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/GBR&https://virtru.com/attr/Need%20to%20Know/value/INT",
 			"[DEFAULT]&(http://kas.uk/)&(http://kas.uk/)",
 			"(http://kas.uk/)",
@@ -289,6 +303,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 		{
 			"compartments",
 			[]AttributeValueFQN{clsS, rel2gbr, rel2usa, n2kHCS, n2kSI},
+			[]string{kasUs},
 			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/{GBR,USA}&https://virtru.com/attr/Need%20to%20Know/value/{HCS,SI}",
 			"[DEFAULT]&(http://kas.uk/⋁http://kas.us/)&(http://hcs.kas.us/⋀http://si.kas.us/)",
 			"(http://kas.uk/⋁http://kas.us/)&(http://hcs.kas.us/)&(http://si.kas.us/)",
@@ -310,7 +325,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			assert.Equal(t, tc.reduced, r.String())
 
 			i := 0
-			plan, err := reasoner.Plan(kasUs, func() string {
+			plan, err := reasoner.Plan(tc.defaults, func() string {
 				i++
 				return fmt.Sprintf("%d", i)
 			})

--- a/sdk/internal/autoconfigure/granter_test.go
+++ b/sdk/internal/autoconfigure/granter_test.go
@@ -11,34 +11,34 @@ import (
 )
 
 const (
-	AUS_KAS     = "http://kas.au/"
-	CAN_KAS     = "http://kas.ca/"
-	GBR_KAS     = "http://kas.uk/"
-	NZL_KAS     = "http://kas.nz/"
-	USA_KAS     = "http://kas.us/"
-	HCS_USA_KAS = "http://hcs.kas.us/"
-	SI_USA_KAS  = "http://si.kas.us/"
-	authority   = "https://virtru.com/"
+	kasAu     = "http://kas.au/"
+	kasCa     = "http://kas.ca/"
+	kasUk     = "http://kas.uk/"
+	kasNz     = "http://kas.nz/"
+	kasUs     = "http://kas.us/"
+	kasUsHCS  = "http://hcs.kas.us/"
+	kasUsSA   = "http://si.kas.us/"
+	authority = "https://virtru.com/"
 
 	CLS AttributeName = "https://virtru.com/attr/Classification"
 	N2K AttributeName = "https://virtru.com/attr/Need%20to%20Know"
 	REL AttributeName = "https://virtru.com/attr/Releasable%20To"
 
-	CLS_Allowed      AttributeValue = "https://virtru.com/attr/Classification/value/Allowed"
-	CLS_Confidential AttributeValue = "https://virtru.com/attr/Classification/value/Confidential"
-	CLS_Secret       AttributeValue = "https://virtru.com/attr/Classification/value/Secret"
-	CLS_TopSecret    AttributeValue = "https://virtru.com/attr/Classification/value/Top%20Secret"
+	clsA  AttributeValue = "https://virtru.com/attr/Classification/value/Allowed"
+	clsC  AttributeValue = "https://virtru.com/attr/Classification/value/Confidential"
+	clsS  AttributeValue = "https://virtru.com/attr/Classification/value/Secret"
+	clsTS AttributeValue = "https://virtru.com/attr/Classification/value/Top%20Secret"
 
-	N2K_HCS AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/HCS"
-	N2K_INT AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/INT"
-	N2K_SI  AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/SI"
+	n2kHCS AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/HCS"
+	n2kInt AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/INT"
+	n2kSI  AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/SI"
 
-	REL_FVEY AttributeValue = "https://virtru.com/attr/Releasable%20To/value/FVEY"
-	REL_AUS  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/AUS"
-	REL_CAN  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/CAN"
-	REL_GBR  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/GBR"
-	REL_NZL  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/NZL"
-	REL_USA  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/USA"
+	rel25eye AttributeValue = "https://virtru.com/attr/Releasable%20To/value/FVEY"
+	rel2aus  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/AUS"
+	rel2can  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/CAN"
+	rel2gbr  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/GBR"
+	rel2nzl  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/NZL"
+	rel2usa  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/USA"
 )
 
 func mockAttributeFor(fqn AttributeName) *policy.Attribute {
@@ -77,10 +77,10 @@ func mockAttributeFor(fqn AttributeName) *policy.Attribute {
 }
 func mockValueFor(fqn AttributeValue) *policy.Value {
 	an := fqn.Prefix()
-	a := mockAttributeFor(AttributeName(an))
+	a := mockAttributeFor(an)
 	v := fqn.Value()
 	p := policy.Value{
-		Id:        a.Id + ":" + v,
+		Id:        a.GetId() + ":" + v,
 		Attribute: a,
 		Value:     v,
 		Fqn:       string(fqn),
@@ -91,40 +91,42 @@ func mockValueFor(fqn AttributeValue) *policy.Value {
 		switch fqn.Value() {
 		case "INT":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: GBR_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasUk}
 		case "HCS":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: HCS_USA_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasUsHCS}
 		case "SI":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: SI_USA_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasUsSA}
 		}
 
 	case REL:
 		switch fqn.Value() {
 		case "FVEY":
 			p.Grants = make([]*policy.KeyAccessServer, 5)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: AUS_KAS}
-			p.Grants[1] = &policy.KeyAccessServer{Uri: CAN_KAS}
-			p.Grants[2] = &policy.KeyAccessServer{Uri: GBR_KAS}
-			p.Grants[3] = &policy.KeyAccessServer{Uri: NZL_KAS}
-			p.Grants[4] = &policy.KeyAccessServer{Uri: USA_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasAu}
+			p.Grants[1] = &policy.KeyAccessServer{Uri: kasCa}
+			p.Grants[2] = &policy.KeyAccessServer{Uri: kasUk}
+			p.Grants[3] = &policy.KeyAccessServer{Uri: kasNz}
+			p.Grants[4] = &policy.KeyAccessServer{Uri: kasUs}
 		case "AUS":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: AUS_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasAu}
 		case "CAN":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: CAN_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasCa}
 		case "GBR":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: GBR_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasUk}
 		case "NZL":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: NZL_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasNz}
 		case "USA":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: USA_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasUs}
 		}
+	case CLS:
+		// defaults only
 	}
 	return &p
 }
@@ -164,11 +166,11 @@ func TestConfigurationServicePutGet(t *testing.T) {
 		size   int
 		kases  []string
 	}{
-		{"default", []AttributeValue{CLS_Allowed}, 1, []string{}},
-		{"one-country", []AttributeValue{REL_GBR}, 1, []string{GBR_KAS}},
-		{"two-country", []AttributeValue{REL_GBR, REL_NZL}, 2, []string{GBR_KAS, NZL_KAS}},
-		{"with-default", []AttributeValue{CLS_Allowed, REL_GBR}, 2, []string{GBR_KAS}},
-		{"need-to-know", []AttributeValue{CLS_TopSecret, REL_USA, N2K_SI}, 3, []string{USA_KAS, SI_USA_KAS}},
+		{"default", []AttributeValue{clsA}, 1, []string{}},
+		{"one-country", []AttributeValue{rel2gbr}, 1, []string{kasUk}},
+		{"two-country", []AttributeValue{rel2gbr, rel2nzl}, 2, []string{kasUk, kasNz}},
+		{"with-default", []AttributeValue{clsA, rel2gbr}, 2, []string{kasUk}},
+		{"need-to-know", []AttributeValue{clsTS, rel2usa, n2kSI}, 3, []string{kasUs, kasUsSA}},
 	} {
 		t.Run(tc.n, func(t *testing.T) {
 			v := valuesToPolicy(tc.policy...)
@@ -197,19 +199,19 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 	}{
 		{
 			"one actual with default",
-			[]AttributeValue{CLS_Secret, REL_CAN},
+			[]AttributeValue{clsS, rel2can},
 			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/CAN",
 			"[DEFAULT]&(http://kas.ca/)",
 			"(http://kas.ca/)",
-			[]SplitStep{{CAN_KAS, ""}},
+			[]SplitStep{{kasCa, ""}},
 		},
 		{
 			"one defaulted attr",
-			[]AttributeValue{CLS_Secret},
+			[]AttributeValue{clsS},
 			"https://virtru.com/attr/Classification/value/Secret",
 			"[DEFAULT]",
 			"",
-			[]SplitStep{{USA_KAS, ""}},
+			[]SplitStep{{kasUs, ""}},
 		},
 		{
 			"empty policy",
@@ -217,31 +219,30 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			"∅",
 			"",
 			"",
-			[]SplitStep{{USA_KAS, ""}},
+			[]SplitStep{{kasUs, ""}},
 		},
 		{
 			"simple with all three ops",
-			[]AttributeValue{CLS_Secret, REL_GBR, N2K_INT},
+			[]AttributeValue{clsS, rel2gbr, n2kInt},
 			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/GBR&https://virtru.com/attr/Need%20to%20Know/value/INT",
 			"[DEFAULT]&(http://kas.uk/)&(http://kas.uk/)",
 			"(http://kas.uk/)",
-			[]SplitStep{{GBR_KAS, ""}},
+			[]SplitStep{{kasUk, ""}},
 		},
 		{
 			"compartments",
-			[]AttributeValue{CLS_Secret, REL_GBR, REL_USA, N2K_HCS, N2K_SI},
+			[]AttributeValue{clsS, rel2gbr, rel2usa, n2kHCS, n2kSI},
 			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/{GBR,USA}&https://virtru.com/attr/Need%20to%20Know/value/{HCS,SI}",
 			"[DEFAULT]&(http://kas.uk/⋁http://kas.us/)&(http://hcs.kas.us/⋀http://si.kas.us/)",
 			"(http://kas.uk/⋁http://kas.us/)&(http://hcs.kas.us/)&(http://si.kas.us/)",
-			[]SplitStep{{GBR_KAS, "1"}, {USA_KAS, "1"}, {HCS_USA_KAS, "2"}, {SI_USA_KAS, "3"}},
+			[]SplitStep{{kasUk, "1"}, {kasUs, "1"}, {kasUsHCS, "2"}, {kasUsSA, "3"}},
 		},
 	} {
 		t.Run(tc.n, func(t *testing.T) {
 			reasoner, err := NewGranterFromAttributes(valuesToPolicy(tc.policy...)...)
 			require.NoError(t, err)
 
-			actualAB, err := reasoner.constructAttributeBoolean()
-			require.NoError(t, err)
+			actualAB := reasoner.constructAttributeBoolean()
 			assert.Equal(t, tc.ats, actualAB.String())
 
 			actualKeyed, err := reasoner.insertKeysForAttribute(*actualAB)
@@ -252,10 +253,11 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			assert.Equal(t, tc.reduced, r.String())
 
 			i := 0
-			plan, err := reasoner.Plan(USA_KAS, func() string {
+			plan, err := reasoner.Plan(kasUs, func() string {
 				i++
 				return fmt.Sprintf("%d", i)
 			})
+			require.NoError(t, err)
 			assert.Equal(t, tc.plan, plan)
 		})
 	}

--- a/sdk/internal/autoconfigure/granter_test.go
+++ b/sdk/internal/autoconfigure/granter_test.go
@@ -142,7 +142,7 @@ func TestAttributeInstanceFromURL(t *testing.T) {
 		{"numberdef", "http://e/attr/1/value/one", "http://e", "1", "one"},
 	} {
 		t.Run(tc.n, func(t *testing.T) {
-			a, err := NewAttributeValue(tc.u)
+			a, err := NewAttributeValueFQN(tc.u)
 			require.NoError(t, err)
 			assert.Equal(t, tc.auth, a.Authority())
 			assert.Equal(t, tc.name, a.Name())

--- a/sdk/internal/autoconfigure/granter_test.go
+++ b/sdk/internal/autoconfigure/granter_test.go
@@ -20,28 +20,28 @@ const (
 	kasUsSA   = "http://si.kas.us/"
 	authority = "https://virtru.com/"
 
-	CLS AttributeName = "https://virtru.com/attr/Classification"
-	N2K AttributeName = "https://virtru.com/attr/Need%20to%20Know"
-	REL AttributeName = "https://virtru.com/attr/Releasable%20To"
+	CLS AttributeNameFQN = "https://virtru.com/attr/Classification"
+	N2K AttributeNameFQN = "https://virtru.com/attr/Need%20to%20Know"
+	REL AttributeNameFQN = "https://virtru.com/attr/Releasable%20To"
 
-	clsA  AttributeValue = "https://virtru.com/attr/Classification/value/Allowed"
-	clsC  AttributeValue = "https://virtru.com/attr/Classification/value/Confidential"
-	clsS  AttributeValue = "https://virtru.com/attr/Classification/value/Secret"
-	clsTS AttributeValue = "https://virtru.com/attr/Classification/value/Top%20Secret"
+	clsA  AttributeValueFQN = "https://virtru.com/attr/Classification/value/Allowed"
+	clsC  AttributeValueFQN = "https://virtru.com/attr/Classification/value/Confidential"
+	clsS  AttributeValueFQN = "https://virtru.com/attr/Classification/value/Secret"
+	clsTS AttributeValueFQN = "https://virtru.com/attr/Classification/value/Top%20Secret"
 
-	n2kHCS AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/HCS"
-	n2kInt AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/INT"
-	n2kSI  AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/SI"
+	n2kHCS AttributeValueFQN = "https://virtru.com/attr/Need%20to%20Know/value/HCS"
+	n2kInt AttributeValueFQN = "https://virtru.com/attr/Need%20to%20Know/value/INT"
+	n2kSI  AttributeValueFQN = "https://virtru.com/attr/Need%20to%20Know/value/SI"
 
-	rel25eye AttributeValue = "https://virtru.com/attr/Releasable%20To/value/FVEY"
-	rel2aus  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/AUS"
-	rel2can  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/CAN"
-	rel2gbr  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/GBR"
-	rel2nzl  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/NZL"
-	rel2usa  AttributeValue = "https://virtru.com/attr/Releasable%20To/value/USA"
+	rel25eye AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/FVEY"
+	rel2aus  AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/AUS"
+	rel2can  AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/CAN"
+	rel2gbr  AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/GBR"
+	rel2nzl  AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/NZL"
+	rel2usa  AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/USA"
 )
 
-func mockAttributeFor(fqn AttributeName) *policy.Attribute {
+func mockAttributeFor(fqn AttributeNameFQN) *policy.Attribute {
 	ns := policy.Namespace{
 		Id:   "v",
 		Name: "virtru.com",
@@ -75,7 +75,7 @@ func mockAttributeFor(fqn AttributeName) *policy.Attribute {
 	}
 	return nil
 }
-func mockValueFor(fqn AttributeValue) *policy.Value {
+func mockValueFor(fqn AttributeValueFQN) *policy.Value {
 	an := fqn.Prefix()
 	a := mockAttributeFor(an)
 	v := fqn.Value()
@@ -151,7 +151,7 @@ func TestAttributeInstanceFromURL(t *testing.T) {
 	}
 }
 
-func valuesToPolicy(p ...AttributeValue) []*policy.Value {
+func valuesToPolicy(p ...AttributeValueFQN) []*policy.Value {
 	v := make([]*policy.Value, len(p))
 	for i, ai := range p {
 		v[i] = mockValueFor(ai)
@@ -162,15 +162,15 @@ func valuesToPolicy(p ...AttributeValue) []*policy.Value {
 func TestConfigurationServicePutGet(t *testing.T) {
 	for _, tc := range []struct {
 		n      string
-		policy []AttributeValue
+		policy []AttributeValueFQN
 		size   int
 		kases  []string
 	}{
-		{"default", []AttributeValue{clsA}, 1, []string{}},
-		{"one-country", []AttributeValue{rel2gbr}, 1, []string{kasUk}},
-		{"two-country", []AttributeValue{rel2gbr, rel2nzl}, 2, []string{kasUk, kasNz}},
-		{"with-default", []AttributeValue{clsA, rel2gbr}, 2, []string{kasUk}},
-		{"need-to-know", []AttributeValue{clsTS, rel2usa, n2kSI}, 3, []string{kasUs, kasUsSA}},
+		{"default", []AttributeValueFQN{clsA}, 1, []string{}},
+		{"one-country", []AttributeValueFQN{rel2gbr}, 1, []string{kasUk}},
+		{"two-country", []AttributeValueFQN{rel2gbr, rel2nzl}, 2, []string{kasUk, kasNz}},
+		{"with-default", []AttributeValueFQN{clsA, rel2gbr}, 2, []string{kasUk}},
+		{"need-to-know", []AttributeValueFQN{clsTS, rel2usa, n2kSI}, 3, []string{kasUs, kasUsSA}},
 	} {
 		t.Run(tc.n, func(t *testing.T) {
 			v := valuesToPolicy(tc.policy...)
@@ -193,13 +193,13 @@ func TestConfigurationServicePutGet(t *testing.T) {
 func TestReasonerConstructAttributeBoolean(t *testing.T) {
 	for _, tc := range []struct {
 		n                   string
-		policy              []AttributeValue
+		policy              []AttributeValueFQN
 		ats, keyed, reduced string
 		plan                []SplitStep
 	}{
 		{
 			"one actual with default",
-			[]AttributeValue{clsS, rel2can},
+			[]AttributeValueFQN{clsS, rel2can},
 			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/CAN",
 			"[DEFAULT]&(http://kas.ca/)",
 			"(http://kas.ca/)",
@@ -207,7 +207,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 		},
 		{
 			"one defaulted attr",
-			[]AttributeValue{clsS},
+			[]AttributeValueFQN{clsS},
 			"https://virtru.com/attr/Classification/value/Secret",
 			"[DEFAULT]",
 			"",
@@ -215,7 +215,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 		},
 		{
 			"empty policy",
-			[]AttributeValue{},
+			[]AttributeValueFQN{},
 			"∅",
 			"",
 			"",
@@ -223,7 +223,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 		},
 		{
 			"simple with all three ops",
-			[]AttributeValue{clsS, rel2gbr, n2kInt},
+			[]AttributeValueFQN{clsS, rel2gbr, n2kInt},
 			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/GBR&https://virtru.com/attr/Need%20to%20Know/value/INT",
 			"[DEFAULT]&(http://kas.uk/)&(http://kas.uk/)",
 			"(http://kas.uk/)",
@@ -231,7 +231,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 		},
 		{
 			"compartments",
-			[]AttributeValue{clsS, rel2gbr, rel2usa, n2kHCS, n2kSI},
+			[]AttributeValueFQN{clsS, rel2gbr, rel2usa, n2kHCS, n2kSI},
 			"https://virtru.com/attr/Classification/value/Secret&https://virtru.com/attr/Releasable%20To/value/{GBR,USA}&https://virtru.com/attr/Need%20to%20Know/value/{HCS,SI}",
 			"[DEFAULT]&(http://kas.uk/⋁http://kas.us/)&(http://hcs.kas.us/⋀http://si.kas.us/)",
 			"(http://kas.uk/⋁http://kas.us/)&(http://hcs.kas.us/)&(http://si.kas.us/)",

--- a/sdk/kas_client.go
+++ b/sdk/kas_client.go
@@ -327,7 +327,7 @@ func (c *kasKeyCache) store(ki KASInfo) {
 	c.c[cacheKey] = timeStampedKASInfo{ki, time.Now()}
 }
 
-func (s SDK) getPublicKey(url, algorithm string) (*KASInfo, error) {
+func (s SDK) getPublicKey(ctx context.Context, url, algorithm string) (*KASInfo, error) {
 	if cachedValue := s.kasKeyCache.get(url, algorithm); nil != cachedValue {
 		return cachedValue, nil
 	}
@@ -341,7 +341,6 @@ func (s SDK) getPublicKey(url, algorithm string) (*KASInfo, error) {
 	}
 	defer conn.Close()
 
-	ctx := context.Background()
 	serviceClient := kas.NewAccessServiceClient(conn)
 
 	req := kas.PublicKeyRequest{

--- a/sdk/nanotdf_config.go
+++ b/sdk/nanotdf_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/opentdf/platform/lib/ocrypto"
+	"github.com/opentdf/platform/sdk/internal/autoconfigure"
 )
 
 // ============================================================================================================
@@ -19,7 +20,7 @@ import (
 type NanoTDFConfig struct {
 	keyPair      ocrypto.ECKeyPair
 	kasPublicKey *ecdh.PublicKey
-	attributes   []string
+	attributes   []autoconfigure.AttributeValue
 	cipher       CipherMode
 	kasURL       ResourceLocator
 	sigCfg       signatureConfig
@@ -61,8 +62,16 @@ func (config *NanoTDFConfig) SetKasURL(url string) error {
 }
 
 // SetAttributes - set the attributes to be used for this nanoTDF
-func (config *NanoTDFConfig) SetAttributes(attributes []string) {
-	config.attributes = attributes
+func (config *NanoTDFConfig) SetAttributes(attributes []string) error {
+	config.attributes = make([]autoconfigure.AttributeValue, len(attributes))
+	for i, a := range attributes {
+		v, err := autoconfigure.NewAttributeValue(a)
+		if err != nil {
+			return err
+		}
+		config.attributes[i] = v
+	}
+	return nil
 }
 
 // EnableECDSAPolicyBinding enable ecdsa policy binding
@@ -73,7 +82,13 @@ func (config *NanoTDFConfig) EnableECDSAPolicyBinding() {
 // WithNanoDataAttributes appends the given data attributes to the bound policy
 func WithNanoDataAttributes(attributes ...string) NanoTDFOption {
 	return func(c *NanoTDFConfig) error {
-		c.attributes = append(c.attributes, attributes...)
+		for _, a := range attributes {
+			v, err := autoconfigure.NewAttributeValue(a)
+			if err != nil {
+				return err
+			}
+			c.attributes = append(c.attributes, v)
+		}
 		return nil
 	}
 }

--- a/sdk/nanotdf_config.go
+++ b/sdk/nanotdf_config.go
@@ -65,7 +65,7 @@ func (config *NanoTDFConfig) SetKasURL(url string) error {
 func (config *NanoTDFConfig) SetAttributes(attributes []string) error {
 	config.attributes = make([]autoconfigure.AttributeValueFQN, len(attributes))
 	for i, a := range attributes {
-		v, err := autoconfigure.NewAttributeValue(a)
+		v, err := autoconfigure.NewAttributeValueFQN(a)
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func (config *NanoTDFConfig) EnableECDSAPolicyBinding() {
 func WithNanoDataAttributes(attributes ...string) NanoTDFOption {
 	return func(c *NanoTDFConfig) error {
 		for _, a := range attributes {
-			v, err := autoconfigure.NewAttributeValue(a)
+			v, err := autoconfigure.NewAttributeValueFQN(a)
 			if err != nil {
 				return err
 			}

--- a/sdk/nanotdf_config.go
+++ b/sdk/nanotdf_config.go
@@ -20,7 +20,7 @@ import (
 type NanoTDFConfig struct {
 	keyPair      ocrypto.ECKeyPair
 	kasPublicKey *ecdh.PublicKey
-	attributes   []autoconfigure.AttributeValue
+	attributes   []autoconfigure.AttributeValueFQN
 	cipher       CipherMode
 	kasURL       ResourceLocator
 	sigCfg       signatureConfig
@@ -63,7 +63,7 @@ func (config *NanoTDFConfig) SetKasURL(url string) error {
 
 // SetAttributes - set the attributes to be used for this nanoTDF
 func (config *NanoTDFConfig) SetAttributes(attributes []string) error {
-	config.attributes = make([]autoconfigure.AttributeValue, len(attributes))
+	config.attributes = make([]autoconfigure.AttributeValueFQN, len(attributes))
 	for i, a := range attributes {
 		v, err := autoconfigure.NewAttributeValue(a)
 		if err != nil {

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -431,7 +431,7 @@ func (s SDK) prepareManifest(ctx context.Context, t *TDFObject, tdfConfig TDFCon
 }
 
 // create policy object
-func createPolicyObject(attributes []autoconfigure.AttributeValue) (PolicyObject, error) {
+func createPolicyObject(attributes []autoconfigure.AttributeValueFQN) (PolicyObject, error) {
 	uuidObj, err := uuid.NewUUID()
 	if err != nil {
 		return PolicyObject{}, fmt.Errorf("uuid.NewUUID failed: %w", err)

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -122,7 +122,12 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 	}
 
 	if tdfConfig.autoconfigure {
-		g, err := autoconfigure.NewGranterFromService(ctx, s.Attributes, tdfConfig.attributes...)
+		var g autoconfigure.Granter
+		if len(tdfConfig.attributeValues) > 0 {
+			g, err = autoconfigure.NewGranterFromAttributes(tdfConfig.attributeValues...)
+		} else {
+			g, err = autoconfigure.NewGranterFromService(ctx, s.Attributes, tdfConfig.attributes...)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -91,13 +91,20 @@ func (s SDK) CreateTDF(writer io.Writer, reader io.ReadSeeker, opts ...TDFOption
 	return s.CreateTDFContext(context.Background(), writer, reader, opts...)
 }
 
-func (s SDK) defaultKas(c *TDFConfig) string {
+func (s SDK) defaultKas(c *TDFConfig) []string {
+	allk := make([]string, 0, len(c.kasInfoList))
+	defk := make([]string, 0)
 	for _, k := range c.kasInfoList {
-		if k.Default || len(c.kasInfoList) == 1 {
-			return k.URL
+		if k.Default {
+			defk = append(defk, k.URL)
+		} else if len(defk) == 0 {
+			allk = append(allk, k.URL)
 		}
 	}
-	return ""
+	if len(defk) == 0 {
+		return allk
+	}
+	return defk
 }
 
 // CreateTDF reads plain text from the given reader and saves it to the writer, subject to the given options

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -137,7 +137,7 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 	}
 
 	tdfObject := &TDFObject{}
-	err = s.prepareManifest(tdfObject, *tdfConfig)
+	err = s.prepareManifest(ctx, tdfObject, *tdfConfig)
 	if err != nil {
 		return nil, fmt.Errorf("fail to create a new split key: %w", err)
 	}
@@ -272,7 +272,7 @@ func (r *Reader) Manifest() Manifest {
 }
 
 // prepare the manifest for TDF
-func (s SDK) prepareManifest(t *TDFObject, tdfConfig TDFConfig) error { //nolint:funlen,gocognit // Better readability keeping it as is
+func (s SDK) prepareManifest(ctx context.Context, t *TDFObject, tdfConfig TDFConfig) error { //nolint:funlen,gocognit // Better readability keeping it as is
 	manifest := Manifest{}
 	if len(tdfConfig.kasInfoList) == 0 {
 		return errInvalidKasInfo
@@ -321,7 +321,7 @@ func (s SDK) prepareManifest(t *TDFObject, tdfConfig TDFConfig) error { //nolint
 		// Public key was passed in with kasInfoList
 		ki, ok := latestKASInfo[splitInfo.KAS]
 		if !ok || ki.PublicKey == "" {
-			k, err := s.getPublicKey(splitInfo.KAS, "rsa:2048")
+			k, err := s.getPublicKey(ctx, splitInfo.KAS, "rsa:2048")
 			if err != nil {
 				return fmt.Errorf("unable to retrieve public key from KAS at [%s]: %w", splitInfo.KAS, err)
 			}

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -81,6 +81,7 @@ func newTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
 	}
 
 	c := &TDFConfig{
+		autoconfigure:             true,
 		tdfPrivateKey:             privateKey,
 		tdfPublicKey:              publicKey,
 		defaultSegmentSize:        defaultSegmentSize,
@@ -186,12 +187,13 @@ func WithSegmentSize(size int64) TDFOption {
 	}
 }
 
-// WithAutoconfigure enables inferring KAS info for encrypt from data attributes
+// WithAutoconfigure toggles inferring KAS info for encrypt from data attributes.
 // This will use the Attributes service to look up key access grants.
 // These are KAS URLs associated with attributes.
-func WithAutoconfigure() TDFOption {
+// Defaults to enabled.
+func WithAutoconfigure(enable bool) TDFOption {
 	return func(c *TDFConfig) error {
-		c.autoconfigure = true
+		c.autoconfigure = enable
 		c.splitPlan = nil
 		return nil
 	}

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -105,7 +105,7 @@ func WithDataAttributes(attributes ...string) TDFOption {
 	return func(c *TDFConfig) error {
 		c.attributeValues = nil
 		for _, a := range attributes {
-			v, err := autoconfigure.NewAttributeValue(a)
+			v, err := autoconfigure.NewAttributeValueFQN(a)
 			if err != nil {
 				return err
 			}
@@ -126,7 +126,7 @@ func WithAttributes(attributes ...*policy.Value) TDFOption {
 		c.attributeValues = make([]*policy.Value, len(attributes))
 		for i, a := range attributes {
 			c.attributeValues[i] = a
-			afqn, err := autoconfigure.NewAttributeValue(a.GetFqn())
+			afqn, err := autoconfigure.NewAttributeValueFQN(a.GetFqn())
 			if err != nil {
 				// TODO: update service to validate and encode FQNs properly
 				return err

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -58,7 +58,7 @@ type TDFConfig struct {
 	integrityAlgorithm        IntegrityAlgorithm
 	segmentIntegrityAlgorithm IntegrityAlgorithm
 	assertions                []Assertion //nolint:unused // TODO
-	attributes                []autoconfigure.AttributeValue
+	attributes                []autoconfigure.AttributeValueFQN
 	attributeValues           []*policy.Value
 	kasInfoList               []KASInfo
 	splitPlan                 []autoconfigure.SplitStep
@@ -122,7 +122,7 @@ func WithDataAttributes(attributes ...string) TDFOption {
 // it to the `CreateTDF` method with this option.
 func WithAttributes(attributes ...*policy.Value) TDFOption {
 	return func(c *TDFConfig) error {
-		c.attributes = make([]autoconfigure.AttributeValue, len(attributes))
+		c.attributes = make([]autoconfigure.AttributeValueFQN, len(attributes))
 		c.attributeValues = make([]*policy.Value, len(attributes))
 		for i, a := range attributes {
 			c.attributeValues[i] = a

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -116,12 +116,12 @@ func WithDataAttributes(attributes ...string) TDFOption {
 	}
 }
 
-// WithAttributes appends the given data attributes to the bound policy.
+// WithDataAttributeValues appends the given data attributes to the bound policy.
 // Unlike `WithDataAttributes`, this will not trigger an attribute definition lookup
 // during autoconfigure. That is, to use autoconfigure in an 'offline' context,
 // you must first store the relevant attribute information locally and load
 // it to the `CreateTDF` method with this option.
-func WithAttributes(attributes ...*policy.Value) TDFOption {
+func WithDataAttributeValues(attributes ...*policy.Value) TDFOption {
 	return func(c *TDFConfig) error {
 		c.attributes = make([]autoconfigure.AttributeValueFQN, len(attributes))
 		c.attributeValues = make([]*policy.Value, len(attributes))

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -614,7 +614,7 @@ func (s *TDFSuite) Test_Autoconfigure() {
 			fileSize:         5,
 			tdfFileSize:      1733,
 			checksum:         "ed968e840d10d2d313a870bc131a4e2c311d7ad09bdf32b3418147221f51a6e2",
-			policy:           []autoconfigure.AttributeValue{CLS_Allowed},
+			policy:           []autoconfigure.AttributeValue{clsAllowed},
 			expectedPlanSize: 1,
 		},
 		{
@@ -622,7 +622,7 @@ func (s *TDFSuite) Test_Autoconfigure() {
 			fileSize:         5,
 			tdfFileSize:      2517,
 			checksum:         "ed968e840d10d2d313a870bc131a4e2c311d7ad09bdf32b3418147221f51a6e2",
-			policy:           []autoconfigure.AttributeValue{REL_AUS, REL_USA},
+			policy:           []autoconfigure.AttributeValue{rel2aus, rel2usa},
 			expectedPlanSize: 2,
 		},
 	} {
@@ -691,15 +691,16 @@ func (s *TDFSuite) testEncrypt(sdk *SDK, kasInfoList []KASInfo, plainTextFilenam
 	if test.mimeType != "" {
 		encryptOpts = append(encryptOpts, WithMimeType(test.mimeType))
 	}
-	if len(test.policy) > 0 {
+	switch {
+	case len(test.policy) > 0:
 		da := make([]string, len(test.policy))
 		for i := 0; i < len(da); i++ {
 			da[i] = string(test.policy[i])
 		}
 		encryptOpts = append(encryptOpts, WithAutoconfigure(), WithDataAttributes(da...))
-	} else if len(test.splitPlan) == 0 {
+	case len(test.splitPlan) == 0:
 		encryptOpts = append(encryptOpts, withSplitPlan(autoconfigure.SplitStep{KAS: kasInfoList[0].URL, SplitID: ""}))
-	} else {
+	default:
 		encryptOpts = append(encryptOpts, withSplitPlan(test.splitPlan...))
 	}
 
@@ -816,11 +817,11 @@ func (s *TDFSuite) startBackend() {
 		{"https://a.kas/", mockRSAPrivateKey1, mockRSAPublicKey1},
 		{"https://b.kas/", mockRSAPrivateKey2, mockRSAPublicKey2},
 		{"https://c.kas/", mockRSAPrivateKey3, mockRSAPublicKey3},
-		{AUS_KAS, mockRSAPrivateKey1, mockRSAPublicKey1},
-		{CAN_KAS, mockRSAPrivateKey2, mockRSAPublicKey2},
-		{GBR_KAS, mockRSAPrivateKey2, mockRSAPublicKey2},
-		{NZL_KAS, mockRSAPrivateKey3, mockRSAPublicKey3},
-		{USA_KAS, mockRSAPrivateKey1, mockRSAPublicKey1},
+		{kasAu, mockRSAPrivateKey1, mockRSAPublicKey1},
+		{kasCa, mockRSAPrivateKey2, mockRSAPublicKey2},
+		{lasUk, mockRSAPrivateKey2, mockRSAPublicKey2},
+		{kasNz, mockRSAPrivateKey3, mockRSAPublicKey3},
+		{kasUs, mockRSAPrivateKey1, mockRSAPublicKey1},
 	} {
 		grpcListener := bufconn.Listen(1024 * 1024)
 		url, err := url.Parse(ki.url)
@@ -881,34 +882,30 @@ func (f *FakeWellKnown) GetWellKnownConfiguration(_ context.Context, _ *wellknow
 }
 
 const (
-	AUS_KAS     = "https://kas.au/"
-	CAN_KAS     = "https://kas.ca/"
-	GBR_KAS     = "https://kas.uk/"
-	NZL_KAS     = "https://kas.nz/"
-	USA_KAS     = "https://kas.us/"
-	HCS_USA_KAS = "https://hcs.kas.us/"
-	SI_USA_KAS  = "https://si.kas.us/"
-	authority   = "https://virtru.com/"
+	kasAu     = "https://kas.au/"
+	kasCa     = "https://kas.ca/"
+	lasUk     = "https://kas.uk/"
+	kasNz     = "https://kas.nz/"
+	kasUs     = "https://kas.us/"
+	kasUsHcs  = "https://hcs.kas.us/"
+	kasUsSI   = "https://si.kas.us/"
+	authority = "https://virtru.com/"
 
 	CLS autoconfigure.AttributeName = "https://virtru.com/attr/Classification"
 	N2K autoconfigure.AttributeName = "https://virtru.com/attr/Need%20to%20Know"
 	REL autoconfigure.AttributeName = "https://virtru.com/attr/Releasable%20To"
 
-	CLS_Allowed      autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Allowed"
-	CLS_Confidential autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Confidential"
-	CLS_Secret       autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Secret"
-	CLS_TopSecret    autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Top%20Secret"
+	clsAllowed autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Allowed"
+	clsConf    autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Confidential"
+	clsSec     autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Secret"
+	clsTS      autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Top%20Secret"
 
-	N2K_HCS autoconfigure.AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/HCS"
-	N2K_INT autoconfigure.AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/INT"
-	N2K_SI  autoconfigure.AttributeValue = "https://virtru.com/attr/Need%20to%20Know/value/SI"
-
-	REL_FVEY autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/FVEY"
-	REL_AUS  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/AUS"
-	REL_CAN  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/CAN"
-	REL_GBR  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/GBR"
-	REL_NZL  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/NZL"
-	REL_USA  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/USA"
+	rel25eye autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/FVEY"
+	rel2aus  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/AUS"
+	rel2can  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/CAN"
+	rel2gbr  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/GBR"
+	rel2nzl  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/NZL"
+	rel2usa  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/USA"
 )
 
 func mockAttributeFor(fqn autoconfigure.AttributeName) *policy.Attribute {
@@ -947,10 +944,10 @@ func mockAttributeFor(fqn autoconfigure.AttributeName) *policy.Attribute {
 }
 func mockValueFor(fqn autoconfigure.AttributeValue) *policy.Value {
 	an := fqn.Prefix()
-	a := mockAttributeFor(autoconfigure.AttributeName(an))
+	a := mockAttributeFor(an)
 	v := fqn.Value()
 	p := policy.Value{
-		Id:        a.Id + ":" + v,
+		Id:        a.GetId() + ":" + v,
 		Attribute: a,
 		Value:     v,
 		Fqn:       string(fqn),
@@ -961,39 +958,39 @@ func mockValueFor(fqn autoconfigure.AttributeValue) *policy.Value {
 		switch fqn.Value() {
 		case "INT":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: GBR_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: lasUk}
 		case "HCS":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: HCS_USA_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasUsHcs}
 		case "SI":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: SI_USA_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasUsSI}
 		}
 
 	case REL:
 		switch fqn.Value() {
 		case "FVEY":
 			p.Grants = make([]*policy.KeyAccessServer, 5)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: AUS_KAS}
-			p.Grants[1] = &policy.KeyAccessServer{Uri: CAN_KAS}
-			p.Grants[2] = &policy.KeyAccessServer{Uri: GBR_KAS}
-			p.Grants[3] = &policy.KeyAccessServer{Uri: NZL_KAS}
-			p.Grants[4] = &policy.KeyAccessServer{Uri: USA_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasAu}
+			p.Grants[1] = &policy.KeyAccessServer{Uri: kasCa}
+			p.Grants[2] = &policy.KeyAccessServer{Uri: lasUk}
+			p.Grants[3] = &policy.KeyAccessServer{Uri: kasNz}
+			p.Grants[4] = &policy.KeyAccessServer{Uri: kasUs}
 		case "AUS":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: AUS_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasAu}
 		case "CAN":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: CAN_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasCa}
 		case "GBR":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: GBR_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: lasUk}
 		case "NZL":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: NZL_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasNz}
 		case "USA":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: USA_KAS}
+			p.Grants[0] = &policy.KeyAccessServer{Uri: kasUs}
 		}
 	}
 	return &p

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -1003,7 +1003,7 @@ type FakeAttributes struct {
 func (f *FakeAttributes) GetAttributeValuesByFqns(_ context.Context, in *attributespb.GetAttributeValuesByFqnsRequest) (*attributespb.GetAttributeValuesByFqnsResponse, error) {
 	r := make(map[string]*attributespb.GetAttributeValuesByFqnsResponse_AttributeAndValue)
 	for _, fqn := range in.GetFqns() {
-		av, err := autoconfigure.NewAttributeValue(fqn)
+		av, err := autoconfigure.NewAttributeValueFQN(fqn)
 		if err != nil {
 			slog.Error("invalid fqn", "notfqn", fqn, "error", err)
 			return nil, status.New(codes.InvalidArgument, fmt.Sprintf("invalid attribute fqn [%s]", fqn)).Err()

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -402,7 +402,6 @@ func (s *TDFSuite) Test_TDFReader() { //nolint:gocognit // requires for testing 
 				readSeeker,
 				WithKasInformation(kasInfoList...),
 				WithSegmentSize(readAtTest.segmentSize),
-				WithAutoconfigure(false),
 			)
 			s.Require().NoError(err)
 
@@ -700,9 +699,9 @@ func (s *TDFSuite) testEncrypt(sdk *SDK, kasInfoList []KASInfo, plainTextFilenam
 		}
 		encryptOpts = append(encryptOpts, WithDataAttributes(da...))
 	case len(test.splitPlan) == 0:
-		encryptOpts = append(encryptOpts, WithAutoconfigure(false), withSplitPlan(autoconfigure.SplitStep{KAS: kasInfoList[0].URL, SplitID: ""}))
+		encryptOpts = append(encryptOpts, withSplitPlan(autoconfigure.SplitStep{KAS: kasInfoList[0].URL, SplitID: ""}))
 	default:
-		encryptOpts = append(encryptOpts, WithAutoconfigure(false), withSplitPlan(test.splitPlan...))
+		encryptOpts = append(encryptOpts, withSplitPlan(test.splitPlan...))
 	}
 
 	tdfObj, err := sdk.CreateTDF(fileWriter, readSeeker, encryptOpts...)

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -402,6 +402,7 @@ func (s *TDFSuite) Test_TDFReader() { //nolint:gocognit // requires for testing 
 				readSeeker,
 				WithKasInformation(kasInfoList...),
 				WithSegmentSize(readAtTest.segmentSize),
+				WithAutoconfigure(false),
 			)
 			s.Require().NoError(err)
 
@@ -697,11 +698,11 @@ func (s *TDFSuite) testEncrypt(sdk *SDK, kasInfoList []KASInfo, plainTextFilenam
 		for i := 0; i < len(da); i++ {
 			da[i] = string(test.policy[i])
 		}
-		encryptOpts = append(encryptOpts, WithAutoconfigure(), WithDataAttributes(da...))
+		encryptOpts = append(encryptOpts, WithDataAttributes(da...))
 	case len(test.splitPlan) == 0:
-		encryptOpts = append(encryptOpts, withSplitPlan(autoconfigure.SplitStep{KAS: kasInfoList[0].URL, SplitID: ""}))
+		encryptOpts = append(encryptOpts, WithAutoconfigure(false), withSplitPlan(autoconfigure.SplitStep{KAS: kasInfoList[0].URL, SplitID: ""}))
 	default:
-		encryptOpts = append(encryptOpts, withSplitPlan(test.splitPlan...))
+		encryptOpts = append(encryptOpts, WithAutoconfigure(false), withSplitPlan(test.splitPlan...))
 	}
 
 	tdfObj, err := sdk.CreateTDF(fileWriter, readSeeker, encryptOpts...)

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -53,7 +53,7 @@ type tdfTest struct {
 	checksum         string
 	mimeType         string
 	splitPlan        []autoconfigure.SplitStep
-	policy           []autoconfigure.AttributeValue
+	policy           []autoconfigure.AttributeValueFQN
 	expectedPlanSize int
 }
 
@@ -614,7 +614,7 @@ func (s *TDFSuite) Test_Autoconfigure() {
 			fileSize:         5,
 			tdfFileSize:      1733,
 			checksum:         "ed968e840d10d2d313a870bc131a4e2c311d7ad09bdf32b3418147221f51a6e2",
-			policy:           []autoconfigure.AttributeValue{clsAllowed},
+			policy:           []autoconfigure.AttributeValueFQN{clsAllowed},
 			expectedPlanSize: 1,
 		},
 		{
@@ -622,7 +622,7 @@ func (s *TDFSuite) Test_Autoconfigure() {
 			fileSize:         5,
 			tdfFileSize:      2517,
 			checksum:         "ed968e840d10d2d313a870bc131a4e2c311d7ad09bdf32b3418147221f51a6e2",
-			policy:           []autoconfigure.AttributeValue{rel2aus, rel2usa},
+			policy:           []autoconfigure.AttributeValueFQN{rel2aus, rel2usa},
 			expectedPlanSize: 2,
 		},
 	} {
@@ -891,24 +891,24 @@ const (
 	kasUsSI   = "https://si.kas.us/"
 	authority = "https://virtru.com/"
 
-	CLS autoconfigure.AttributeName = "https://virtru.com/attr/Classification"
-	N2K autoconfigure.AttributeName = "https://virtru.com/attr/Need%20to%20Know"
-	REL autoconfigure.AttributeName = "https://virtru.com/attr/Releasable%20To"
+	CLS autoconfigure.AttributeNameFQN = "https://virtru.com/attr/Classification"
+	N2K autoconfigure.AttributeNameFQN = "https://virtru.com/attr/Need%20to%20Know"
+	REL autoconfigure.AttributeNameFQN = "https://virtru.com/attr/Releasable%20To"
 
-	clsAllowed autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Allowed"
-	clsConf    autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Confidential"
-	clsSec     autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Secret"
-	clsTS      autoconfigure.AttributeValue = "https://virtru.com/attr/Classification/value/Top%20Secret"
+	clsAllowed autoconfigure.AttributeValueFQN = "https://virtru.com/attr/Classification/value/Allowed"
+	clsConf    autoconfigure.AttributeValueFQN = "https://virtru.com/attr/Classification/value/Confidential"
+	clsSec     autoconfigure.AttributeValueFQN = "https://virtru.com/attr/Classification/value/Secret"
+	clsTS      autoconfigure.AttributeValueFQN = "https://virtru.com/attr/Classification/value/Top%20Secret"
 
-	rel25eye autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/FVEY"
-	rel2aus  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/AUS"
-	rel2can  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/CAN"
-	rel2gbr  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/GBR"
-	rel2nzl  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/NZL"
-	rel2usa  autoconfigure.AttributeValue = "https://virtru.com/attr/Releasable%20To/value/USA"
+	rel25eye autoconfigure.AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/FVEY"
+	rel2aus  autoconfigure.AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/AUS"
+	rel2can  autoconfigure.AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/CAN"
+	rel2gbr  autoconfigure.AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/GBR"
+	rel2nzl  autoconfigure.AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/NZL"
+	rel2usa  autoconfigure.AttributeValueFQN = "https://virtru.com/attr/Releasable%20To/value/USA"
 )
 
-func mockAttributeFor(fqn autoconfigure.AttributeName) *policy.Attribute {
+func mockAttributeFor(fqn autoconfigure.AttributeNameFQN) *policy.Attribute {
 	ns := policy.Namespace{
 		Id:   "v",
 		Name: "virtru.com",
@@ -942,7 +942,7 @@ func mockAttributeFor(fqn autoconfigure.AttributeName) *policy.Attribute {
 	}
 	return nil
 }
-func mockValueFor(fqn autoconfigure.AttributeValue) *policy.Value {
+func mockValueFor(fqn autoconfigure.AttributeValueFQN) *policy.Value {
 	an := fqn.Prefix()
 	a := mockAttributeFor(an)
 	v := fqn.Value()

--- a/test/tdf-roundtrips.bats
+++ b/test/tdf-roundtrips.bats
@@ -5,7 +5,7 @@
 
 @test "examples: roundtrip Z-TDF" {
   echo "[INFO] create a tdf3 format file"
-  run go run ./examples encrypt --autoconfigure false "Hello Zero Trust"
+  run go run ./examples encrypt --autoconfigure=false "Hello Zero Trust"
   echo "[INFO] echoing output; if successful, this is just the manifest"
   echo "$output"
 
@@ -22,7 +22,7 @@
 
 @test "examples: roundtrip nanoTDF" {
   echo "[INFO] creating nanotdf file"
-  go run ./examples encrypt --autoconfigure false -o sensitive.txt.ntdf --nano "Hello NanoTDF"
+  go run ./examples encrypt --autoconfigure=false -o sensitive.txt.ntdf --nano "Hello NanoTDF"
 
   echo "[INFO] decrypting nanotdf..."
   go run ./examples decrypt sensitive.txt.ntdf
@@ -34,8 +34,8 @@
   [ $(grpcurl -plaintext "localhost:8080" "kas.AccessService/PublicKey" | jq -e -r .kid) = r1 ]
 
   echo "[INFO] encrypting samples"
-  go run ./examples encrypt --autoconfigure false -o sensitive-with-no-kid.txt.tdf --no-kid-in-kao "Hello Legacy"
-  go run ./examples encrypt --autoconfigure false -o sensitive-with-kid.txt.tdf "Hello with Key Identifier"
+  go run ./examples encrypt --autoconfigure=false -o sensitive-with-no-kid.txt.tdf --no-kid-in-kao "Hello Legacy"
+  go run ./examples encrypt --autoconfigure=false -o sensitive-with-kid.txt.tdf "Hello with Key Identifier"
 
   echo "[INFO] decrypting..."
   go run ./examples decrypt sensitive-with-no-kid.txt.tdf | grep "Hello Legacy"
@@ -59,8 +59,8 @@
   [ $(grpcurl -plaintext "localhost:8080" "kas.AccessService/PublicKey" | jq -e -r .kid) = r1 ]
 
   echo "[INFO] encrypting samples"
-  go run ./examples encrypt --autoconfigure false -o sensitive-with-no-kid.txt.tdf --no-kid-in-kao "Hello Legacy"
-  go run ./examples encrypt --autoconfigure false -o sensitive-with-kid.txt.tdf "Hello with Key Identifier"
+  go run ./examples encrypt --autoconfigure=false -o sensitive-with-no-kid.txt.tdf --no-kid-in-kao "Hello Legacy"
+  go run ./examples encrypt --autoconfigure=false -o sensitive-with-kid.txt.tdf "Hello with Key Identifier"
 
   echo "[INFO] decrypting..."
   go run ./examples decrypt sensitive-with-no-kid.txt.tdf | grep "Hello Legacy"

--- a/test/tdf-roundtrips.bats
+++ b/test/tdf-roundtrips.bats
@@ -5,7 +5,7 @@
 
 @test "examples: roundtrip Z-TDF" {
   echo "[INFO] create a tdf3 format file"
-  run go run ./examples encrypt "Hello Zero Trust"
+  run go run ./examples encrypt --autoconfigure false "Hello Zero Trust"
   echo "[INFO] echoing output; if successful, this is just the manifest"
   echo "$output"
 
@@ -22,7 +22,7 @@
 
 @test "examples: roundtrip nanoTDF" {
   echo "[INFO] creating nanotdf file"
-  go run ./examples encrypt -o sensitive.txt.ntdf --nano "Hello NanoTDF"
+  go run ./examples encrypt --autoconfigure false -o sensitive.txt.ntdf --nano "Hello NanoTDF"
 
   echo "[INFO] decrypting nanotdf..."
   go run ./examples decrypt sensitive.txt.ntdf
@@ -34,8 +34,8 @@
   [ $(grpcurl -plaintext "localhost:8080" "kas.AccessService/PublicKey" | jq -e -r .kid) = r1 ]
 
   echo "[INFO] encrypting samples"
-  go run ./examples encrypt -o sensitive-with-no-kid.txt.tdf --no-kid-in-kao "Hello Legacy"
-  go run ./examples encrypt -o sensitive-with-kid.txt.tdf "Hello with Key Identifier"
+  go run ./examples encrypt --autoconfigure false -o sensitive-with-no-kid.txt.tdf --no-kid-in-kao "Hello Legacy"
+  go run ./examples encrypt --autoconfigure false -o sensitive-with-kid.txt.tdf "Hello with Key Identifier"
 
   echo "[INFO] decrypting..."
   go run ./examples decrypt sensitive-with-no-kid.txt.tdf | grep "Hello Legacy"
@@ -59,8 +59,8 @@
   [ $(grpcurl -plaintext "localhost:8080" "kas.AccessService/PublicKey" | jq -e -r .kid) = r1 ]
 
   echo "[INFO] encrypting samples"
-  go run ./examples encrypt -o sensitive-with-no-kid.txt.tdf --no-kid-in-kao "Hello Legacy"
-  go run ./examples encrypt -o sensitive-with-kid.txt.tdf "Hello with Key Identifier"
+  go run ./examples encrypt --autoconfigure false -o sensitive-with-no-kid.txt.tdf --no-kid-in-kao "Hello Legacy"
+  go run ./examples encrypt --autoconfigure false -o sensitive-with-kid.txt.tdf "Hello with Key Identifier"
 
   echo "[INFO] decrypting..."
   go run ./examples decrypt sensitive-with-no-kid.txt.tdf | grep "Hello Legacy"


### PR DESCRIPTION
Allows looking up the `grants` fields of the data attributes to determine which KAS or set of KASes should be used to wrap a given document key.

Basic flow:

```go
   s, err := sdk.New(/* config options */)
   s.CreateTDFContext(out, in, sdk.WithDataAttributes("http://your/attr/tag/value/here"))
```

this will look up any grants associated with the policy and use them to generate a KAO that shares and/or splits the values across the given KAS elements as needed.

Note that this changes several default behaviors:

1. Use `WithAutoconfigure(false)` to disable the new attribute kas grant lookup code
2. Previously, calls to `WithDataAttribute` did no validation (would not return errors). Now they use a regex to validate the FQN format (even with autoconfigure disabled).
3. With Autoconfigure enabled, the encrypt method will do a lookup for attribute Value objects from the policy service. To bypass this, either disable autoconfigure or use the `WithDataAttributeValues` method instead, which allows passing in pre-populated Value objects

The current 'fixtures' for grants will need to be updated to work with this, as they currently give a variety of grants to things like `kas.example.com` which do not exist