### PR TITLE
chore: benchmarks for authorization service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,16 @@ proto-generate:
 	buf generate service
 	buf generate service --template buf.gen.grpc.docs.yaml
 	buf generate service --template buf.gen.openapi.docs.yaml
-	
+
 	buf generate buf.build/grpc-ecosystem/grpc-gateway -o tmp-gen
 	buf generate buf.build/grpc-ecosystem/grpc-gateway -o tmp-gen --template buf.gen.grpc.docs.yaml
 	buf generate buf.build/grpc-ecosystem/grpc-gateway -o tmp-gen --template buf.gen.openapi.docs.yaml
 
 test:
 	for m in $(HAND_MODS); do (cd $$m && go test ./... -race) || exit 1; done
+
+bench:
+	for m in $(HAND_MODS); do (cd $$m && go test -bench ./... -benchmem) || exit 1; done
 
 clean:
 	for m in $(MODS); do (cd $$m && go clean) || exit 1; done

--- a/lib/flattening/flatten_test.go
+++ b/lib/flattening/flatten_test.go
@@ -7,6 +7,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func BenchmarkFlattenMap(b *testing.B) {
+	simpleInput := map[string]interface{}{
+		"a": "aa",
+		"b": 2,
+		"c": 3.1,
+		"d": false,
+	}
+	for n := 0; n < b.N; n++ {
+		_, _ = Flatten(simpleInput)
+	}
+}
+
+func BenchmarkFlattenMapWithinMap(b *testing.B) {
+	simpleInput := map[string]interface{}{
+		"a": "aa",
+		"submap": map[string]interface{}{
+			"b": 2,
+			"c": 3.1,
+			"d": false,
+		},
+	}
+	for n := 0; n < b.N; n++ {
+		_, _ = Flatten(simpleInput)
+	}
+}
+
+func BenchmarkGetFromFlattened(b *testing.B) {
+	flatInput := Flattened{
+		Items: []Item{
+			{Key: ".a", Value: "aa"},
+			// rest of the Items
+		},
+	}
+	queryString := ".a"
+	for n := 0; n < b.N; n++ {
+		_ = GetFromFlattened(flatInput, queryString)
+	}
+}
+
 func TestSimpleMap(t *testing.T) {
 	simpleInput := map[string]interface{}{
 		"a": "aa",

--- a/service/internal/subjectmappingbuiltin/subject_mapping_builtin_test.go
+++ b/service/internal/subjectmappingbuiltin/subject_mapping_builtin_test.go
@@ -13,7 +13,28 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// Subject Mapping evaluation tests
+// SubjectSet Benchmark
+func BenchmarkEvaluateSubjectSet(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := subjectmappingbuiltin.EvaluateSubjectSet(&subjectSet1, flattenedEntity1)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+// SubjectMappings Benchmark
+func BenchmarkEvaluateSubjectMappings(b *testing.B) {
+	additionalProps, _ := structpb.NewStruct(entity1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := subjectmappingbuiltin.EvaluateSubjectMappings(subjectMappingInput1, []*entityresolution.EntityRepresentation{{AdditionalProps: []*structpb.Struct{additionalProps}}})
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
 
 // evaluate condition IN
 var inCondition1 policy.Condition = policy.Condition{


### PR DESCRIPTION
Added benchmark tests within 'Makefile', 'flatten_test.go', and 'subject_mapping_builtin_test.go' files. The newly added benchmarks will facilitate performance testing for certain functions and services in our codebase, enabling us to spot and fix any potential performance issues.

partially resolves https://github.com/opentdf/platform/issues/785
