### PR TITLE
chore(ci): Improve dependabot msgs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: "chore(ci)"
   - package-ecosystem: gomod
     directory: /
     schedule:


### PR DESCRIPTION
- lets gh action update messages start `chore(ci)`