### PR TITLE
fix(core): OPA consoleLogger only DEBUG

### DIFF
--- a/service/internal/opa/opa.go
+++ b/service/internal/opa/opa.go
@@ -53,12 +53,19 @@ func NewEngine(config Config) (*Engine, error) {
 	logger := AdapterSlogger{
 		logger: asl,
 	}
+
+	var consoleLogger opalog.Logger
+	if logger.GetLevel() <= opalog.Debug {
+		consoleLogger = nil
+	} else {
+		consoleLogger = &logger
+	}
 	slog.Debug("plugging in plugins")
 	subjectmappingbuiltin.SubjectMappingBuiltin()
 	opa, err := sdk.New(context.Background(), sdk.Options{
 		Config:        bytes.NewReader(bConfig),
 		Logger:        &logger,
-		ConsoleLogger: &logger,
+		ConsoleLogger: consoleLogger,
 		ID:            "opentdf",
 		Ready:         nil,
 		Store:         nil,


### PR DESCRIPTION
The consoleLogger is now initialized based on the logger level. If the logger level is equal to or less than opalog.Debug, the consoleLogger is set to nil, otherwise it is set to logger. This change allows for more flexible handling of logging within the application.