### PR TITLE
chore(core): Don't require installing go-licenses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ tidy:
 	for m in $(HAND_MODS); do (cd $$m && go mod tidy) || exit 1; done
 
 license:
-	for m in $(HAND_MODS); do (cd $$m && go-licenses check --disallowed_types=forbidden --include_tests ./) || exit 1; done
+	for m in $(HAND_MODS); do (cd $$m && go run github.com/google/go-licenses@v1.6.0 check --disallowed_types=forbidden --include_tests ./) || exit 1; done
 
 lint: proto-lint go-lint
 


### PR DESCRIPTION
use `go run X` instead of `go install X && X`