### PR TITLE
chore(ci): Let go.work sdk target 1.21

### DIFF
--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -22,5 +22,5 @@ jobs:
       - name: govluncheck
         uses: golang/govulncheck-action@3a32958c2706f7048305d5a2e53633d7e37e97d0
         with:
-          go-version-file: ${{ matrix.directory }}/go.mod
+          go-version-input: "1.22.5"
           work-dir: ${{ matrix.directory }}

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.22.5
+go 1.21
 
 use (
 	./examples


### PR DESCRIPTION
This is consistent with the go.mod files and will reduce the number of toolchains local devs will install.
I updated govulncheck to use the same version as other CI actions (currently latest - maybe it should just be latest (the default - so unspecified)?)