### PR TITLE
fix(kas): remove unused hostname check

### DIFF
--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -264,10 +264,6 @@ func (p *Provider) Rewrap(ctx context.Context, in *kaspb.RewrapRequest) (*kaspb.
 		return nil, err
 	}
 
-	if !strings.HasPrefix(body.KeyAccess.URL, p.URI.String()) {
-		p.Logger.InfoContext(ctx, "mismatched key access url", "keyAccessURL", body.KeyAccess.URL, "kasURL", p.URI.String())
-	}
-
 	if body.Algorithm == "" {
 		p.Logger.DebugContext(ctx, "default rewrap algorithm")
 		body.Algorithm = "rsa:2048"


### PR DESCRIPTION
This error has been confusing for others and myself when trying to debug issues in KAS. Longer term we might want to validate the hostname but right now this has no effect. 