### PR TITLE
fix(authz): remove tokenendpoint configuration

### DIFF
--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -29,7 +29,6 @@ services:
     ersurl: http://localhost:8080/entityresolution/resolve
     clientid: tdf-authorization-svc
     clientsecret: secret
-    tokenendpoint: http://localhost:8888/auth/realms/opentdf/protocol/openid-connect/token
   entityresolution:
     enabled: true
     url: http://localhost:8888/auth

--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -27,7 +27,6 @@ services:
     ersurl: http://localhost:8080/entityresolution/resolve
     clientid: tdf-authorization-svc
     clientsecret: secret
-    tokenendpoint: http://keycloak:8888/auth/realms/opentdf/protocol/openid-connect/token
 server:
   auth:
     enabled: true

--- a/opentdf-with-hsm.yaml
+++ b/opentdf-with-hsm.yaml
@@ -27,7 +27,6 @@ services:
     ersurl: http://localhost:8080/entityresolution/resolve
     clientid: tdf-authorization-svc
     clientsecret: secret
-    tokenendpoint: http://localhost:8888/auth/realms/opentdf/protocol/openid-connect/token
 server:
   auth:
     enabled: true

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -544,3 +544,7 @@ func (a Authentication) isPublicRoute(path string) func(string) bool {
 		return matched
 	}
 }
+
+func (a Authentication) GetIssuer() string {
+	return a.oidcConfiguration.Issuer
+}

--- a/service/internal/auth/casbin.go
+++ b/service/internal/auth/casbin.go
@@ -60,6 +60,8 @@ p,	role:org-admin,		/resource-mappings*,										*,			allow
 p,	role:org-admin,		/key-access-servers*,										*,			allow
 p,	role:org-admin, 	/kas/v2/rewrap,						  		        *,      allow
 p,	role:org-admin,		/unsafe*,										            *,			allow
+p,	role:org-admin,			/entityresolution/resolve,							  write,		allow
+
 
 # Role: Admin
 ## gRPC routes

--- a/service/internal/subjectmappingbuiltin/subject_mapping_builtin.go
+++ b/service/internal/subjectmappingbuiltin/subject_mapping_builtin.go
@@ -90,6 +90,7 @@ func EvaluateSubjectMappings(attributeMappings map[string]*attributes.GetAttribu
 	entitlements := []string{}
 	for _, entity := range jsonEntities {
 		flattenedEntity, err := flattening.Flatten(entity.AsMap())
+		slog.Debug("flattened entity", slog.Any("entity", flattenedEntity))
 		if err != nil {
 			return nil, fmt.Errorf("failure to flatten entity in subject mapping builtin: %w", err)
 		}
@@ -125,6 +126,7 @@ func EvaluateSubjectMappings(attributeMappings map[string]*attributes.GetAttribu
 	for k := range entitlementsSet {
 		entitlements = append(entitlements, k)
 	}
+	slog.Debug("subject mapping result", slog.Any("entitlements", entitlements))
 	return entitlements, nil
 }
 


### PR DESCRIPTION
This pr removes the need for a token endpoint in the authz configuration. It also gives the `org-admin` permission to call the entity resolution service. 

Resolves: #983 