### PR TITLE
fix(examples): let attributes example work

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -197,6 +197,7 @@ jobs:
         uses: bats-core/bats-action@2.0.0
       - run: test/service-start.bats
       - run: test/tdf-roundtrips.bats
+      - run: test/policy-service.bats
       - name: create roundtrip test data and run tests
         run: go test ./service/rttests -v
       - name: enable staic entitlements rego policy

--- a/examples/cmd/attributes.go
+++ b/examples/cmd/attributes.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/attributes"
 	"github.com/opentdf/platform/protocol/go/policy/namespaces"
-	"github.com/opentdf/platform/sdk"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -28,7 +27,7 @@ func init() {
 }
 
 func attributesExample() error {
-	s, err := sdk.New(platformEndpoint, sdk.WithInsecurePlaintextConn())
+	s, err := newSDK()
 	if err != nil {
 		slog.Error("could not connect", slog.String("error", err.Error()))
 		return err
@@ -52,7 +51,7 @@ func attributesExample() error {
 	if exampleNamespace == nil {
 		slog.Info("creating new namespace")
 		resp, err := s.Namespaces.CreateNamespace(context.Background(), &namespaces.CreateNamespaceRequest{
-			Name: "example",
+			Name: "example.io",
 		})
 		if err != nil {
 			return err

--- a/examples/cmd/decrypt.go
+++ b/examples/cmd/decrypt.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/opentdf/platform/sdk"
 	"github.com/spf13/cobra"
 )
 
@@ -28,11 +27,7 @@ func decrypt(cmd *cobra.Command, args []string) error {
 	tdfFile := args[0]
 
 	// Create new client
-	client, err := sdk.New(platformEndpoint,
-		sdk.WithInsecurePlaintextConn(),
-		sdk.WithClientCredentials("opentdf-sdk", "secret", nil),
-		sdk.WithTokenEndpoint("http://localhost:8888/auth/realms/opentdf/protocol/openid-connect/token"),
-	)
+	client, err := newSDK()
 	if err != nil {
 		return err
 	}

--- a/examples/cmd/encrypt.go
+++ b/examples/cmd/encrypt.go
@@ -56,7 +56,7 @@ func encrypt(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create new offline client
-	client, err := sdk.New(platformEndpoint, opts...)
+	client, err := newSDK()
 	if err != nil {
 		return err
 	}

--- a/examples/cmd/examples.go
+++ b/examples/cmd/examples.go
@@ -2,19 +2,44 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"strings"
 
+	"github.com/opentdf/platform/sdk"
 	"github.com/spf13/cobra"
 )
 
-var platformEndpoint string
+var (
+	platformEndpoint  string
+	clientCredentials string
+	tokenEndpoint     string
+)
 
 var ExamplesCmd = &cobra.Command{
 	Use: "examples",
 }
 
 func init() {
+	log.SetFlags(log.LstdFlags | log.Llongfile)
+	ExamplesCmd.PersistentFlags().StringVarP(&clientCredentials, "creds", "", "opentdf-sdk:secret", "client id:secret credentials")
 	ExamplesCmd.PersistentFlags().StringVarP(&platformEndpoint, "platformEndpoint", "e", "localhost:8080", "Platform Endpoint")
+	ExamplesCmd.PersistentFlags().StringVarP(&tokenEndpoint, "tokenEndpoint", "t", "http://localhost:8888/auth/realms/opentdf/protocol/openid-connect/token", "OAuth token endpoint")
+}
+
+func newSDK() (*sdk.SDK, error) {
+	opts := []sdk.Option{sdk.WithInsecurePlaintextConn()}
+	if clientCredentials != "" {
+		i := strings.Index(clientCredentials, ":")
+		if i < 0 {
+			return nil, fmt.Errorf("invalid client id/secret pair")
+		}
+		opts = append(opts, sdk.WithClientCredentials(clientCredentials[:i], clientCredentials[i+1:], nil))
+	}
+	if tokenEndpoint != "" {
+		opts = append(opts, sdk.WithTokenEndpoint(tokenEndpoint))
+	}
+	return sdk.New(platformEndpoint, opts...)
 }
 
 func Execute() {

--- a/test/policy-service.bats
+++ b/test/policy-service.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+# Tests for policy service administration
+
+@test "gRPC: lists attributes" {
+  run grpcurl -plaintext "localhost:8080" list
+  echo "$output"
+  [ $status = 0 ]
+  [[ $output = *grpc.health.v1.Health* ]]
+  [[ $output = *wellknownconfiguration.WellKnownService* ]]
+}
+
+@test "gRPC: attributes example" {
+  run go run ./examples --creds opentdf:secret attributes
+  echo "$output"
+  [[ $output = *"listing namespaces"* ]]
+  [ $status = 0 ]
+}

--- a/test/service-start.bats
+++ b/test/service-start.bats
@@ -73,3 +73,10 @@
   echo "$output"
   [[ $output = *NotFound* ]]
 }
+
+@test "gRPC: attributes example" {
+  run go run ./examples --creds opentdf:secret attributes
+  echo "$output"
+  [[ $output = *listing namespaces* ]]
+  [ $status = 0 ]
+}

--- a/test/service-start.bats
+++ b/test/service-start.bats
@@ -2,14 +2,6 @@
 
 # Tests for validating that the system is nominally running
 
-@test "gRPC: lists attributes" {
-  run grpcurl -plaintext "localhost:8080" list
-  echo "$output"
-  [ $status = 0 ]
-  [[ $output = *grpc.health.v1.Health* ]]
-  [[ $output = *wellknownconfiguration.WellKnownService* ]]
-}
-
 @test "gRPC: health check is healthy" {
   run grpcurl -plaintext "localhost:8080" "grpc.health.v1.Health.Check"
   echo "$output"
@@ -72,11 +64,4 @@
   run grpcurl -d '{"algorithm":"invalid"}' -plaintext "localhost:8080" "kas.AccessService/PublicKey" 
   echo "$output"
   [[ $output = *NotFound* ]]
-}
-
-@test "gRPC: attributes example" {
-  run go run ./examples --creds opentdf:secret attributes
-  echo "$output"
-  [ $output = *listing namespaces* ]
-  [ $status = 0 ]
 }

--- a/test/service-start.bats
+++ b/test/service-start.bats
@@ -77,6 +77,6 @@
 @test "gRPC: attributes example" {
   run go run ./examples --creds opentdf:secret attributes
   echo "$output"
-  [[ $output = *listing namespaces* ]]
+  [ $output = *listing namespaces* ]
   [ $status = 0 ]
 }


### PR DESCRIPTION
- adds tokenEndpoint and creds params to root example command
- Use the admin creds in a test instead of the 'standard' creds
- namespaces must be valid dns names