### PR TITLE
chore(core): set some startup logs to debug

### DIFF
--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -344,7 +344,6 @@ func (p *Provider) tdf3Rewrap(ctx context.Context, body *RequestBody, entity *en
 	}
 
 	if !access {
-		p.Logger.WarnContext(ctx, "Access Denied; no reason given")
 		p.Logger.Audit.RewrapFailure(ctx, auditEventParams)
 		return nil, err403("forbidden")
 	}

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -35,7 +35,7 @@ func Start(f ...StartOptions) error {
 
 	slog.Info("starting opentdf services")
 
-	slog.Info("loading configuration")
+	slog.Debug("loading configuration")
 	conf, err := config.LoadConfig(startConfig.ConfigKey, startConfig.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("could not load config: %w", err)
@@ -50,7 +50,7 @@ func Start(f ...StartOptions) error {
 		conf.Server.Auth.PublicRoutes = startConfig.PublicRoutes
 	}
 
-	slog.Info("starting logger")
+	slog.Debug("starting logger")
 	logger, err := logger.NewLogger(conf.Logger)
 	if err != nil {
 		return fmt.Errorf("could not start logger: %w", err)
@@ -65,7 +65,7 @@ func Start(f ...StartOptions) error {
 	conf.Server.WellKnownConfigRegister = wellknown.RegisterConfiguration
 
 	// Create new server for grpc & http. Also will support in process grpc potentially too
-	logger.Info("init opentdf server")
+	logger.Debug("init opentdf server")
 	conf.Server.WellKnownConfigRegister = wellknown.RegisterConfiguration
 	otdf, err := server.NewOpenTDFServer(conf.Server, logger)
 	if err != nil {
@@ -88,7 +88,7 @@ func Start(f ...StartOptions) error {
 		}
 	}
 
-	logger.Info("registering services")
+	logger.Debug("registering services")
 	if err := registerServices(); err != nil {
 		logger.Error("issue registering services", slog.String("error", err.Error()))
 		return fmt.Errorf("issue registering services: %w", err)


### PR DESCRIPTION
chore(kas): remove want log on access denied

Switches some log statements to `debug` to try and reduce more noise. Also removes the `warn` log statement on access denied decision in kas because we have audit so a user will know why a rewrap was denied. 