### PR TITLE
chore: Auto Merge Release Version Bumps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,5 +117,6 @@ jobs:
           git restore .
           git pull origin update-go-mods-for-${{ matrix.path }}
           gh pr create -B main -H update-go-mods-for-${{ matrix.path }} --fill
+          gh pr merge --auto
         env:
           GITHUB_TOKEN: "${{ steps.generate_token.outputs.token }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,6 +117,6 @@ jobs:
           git restore .
           git pull origin update-go-mods-for-${{ matrix.path }}
           gh pr create -B main -H update-go-mods-for-${{ matrix.path }} --fill
-          gh pr merge --auto
+          gh pr merge --auto --squash
         env:
           GITHUB_TOKEN: "${{ steps.generate_token.outputs.token }}"


### PR DESCRIPTION
- auto merge PRs submitted with releases

I think that th is still may require an approving review to unblock the merge. Currently investigating if there's a way we could get around that by polssibly making @opentdf-automation a codeowner of these go mod files?
