### PR TITLE
chore: Auto Approve Version Bumps

### DIFF
--- a/.github/workflows/auto-approve-version-bumps.yaml
+++ b/.github/workflows/auto-approve-version-bumps.yaml
@@ -1,0 +1,14 @@
+name: Auto Approve Version Bumps
+
+on: pull_request_target
+
+jobs:
+  auto-approve-version-bumps:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v4
+        if: |
+          github.actor == 'opentdf-automation' &&
+          startsWith(github.event.pull_request.title, 'fix(core): Autobump'

--- a/.github/workflows/auto-approve-version-bumps.yaml
+++ b/.github/workflows/auto-approve-version-bumps.yaml
@@ -8,6 +8,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - run: |
+          echo "actor: ${{ github.actor }}"
+          echo "title: ${{ github.event.pull_request.title }}"
       - uses: hmarr/auto-approve-action@v4
         if: |
           github.actor == 'opentdf-automation' &&


### PR DESCRIPTION
Auto approves version bump PRs that satisfy the following conditions

- author is `opentdf-automation`
- PR title starts with `fix(core): Autobump`

I believe this will have the PR be approved by the GH actions bot. WE may need to add that bot as a codeowner to the mod files or maybe generate a token for a dedicated bot separate from opentdf-automation?