### PR TITLE
feat(core): Adds authn time skew config

### DIFF
--- a/service/internal/auth/config.go
+++ b/service/internal/auth/config.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/opentdf/platform/service/internal/logger"
 )
@@ -15,11 +16,13 @@ type Config struct {
 
 // AuthNConfig is the configuration need for the platform to validate tokens
 type AuthNConfig struct { //nolint:revive // AuthNConfig is a valid name
-	EnforceDPoP  bool         `yaml:"enforceDPoP" json:"enforceDPoP" mapstructure:"enforceDPoP" default:"false"`
-	Issuer       string       `yaml:"issuer" json:"issuer"`
-	Audience     string       `yaml:"audience" json:"audience"`
-	Policy       PolicyConfig `yaml:"policy" json:"policy" mapstructure:"policy"`
-	CacheRefresh string       `mapstructure:"cache_refresh_interval"`
+	EnforceDPoP  bool          `yaml:"enforceDPoP" json:"enforceDPoP" mapstructure:"enforceDPoP" default:"false"`
+	Issuer       string        `yaml:"issuer" json:"issuer"`
+	Audience     string        `yaml:"audience" json:"audience"`
+	Policy       PolicyConfig  `yaml:"policy" json:"policy" mapstructure:"policy"`
+	CacheRefresh string        `mapstructure:"cache_refresh_interval"`
+	DPoPSkew     time.Duration `mapstructure:"dpopskew" default:"1h"`
+	TokenSkew    time.Duration `mapstructure:"skew" default:"1m"`
 }
 
 type PolicyConfig struct {


### PR DESCRIPTION
- Adds acceptable skew control to oidc configuration
  - for idp provided tokens, use `skew` (default 1 minute)
  - for client provided tokens (dpop tokens), use `dpopskew` (default 1 hour)
- This should reduce flakiness on some tests