### PR TITLE
feat(core): KID in NanoTDF KAS ResourceLocator

### DIFF
--- a/sdk/kas_client.go
+++ b/sdk/kas_client.go
@@ -156,6 +156,7 @@ func (k *KASClient) getNanoTDFRewrapRequest(header string, kasURL string, pubKey
 }
 
 func (k *KASClient) makeNanoTDFRewrapRequest(ctx context.Context, header string, kasURL string, pubKey string) (*kas.RewrapResponse, error) {
+
 	rewrapRequest, err := k.getNanoTDFRewrapRequest(header, kasURL, pubKey)
 	if err != nil {
 		return nil, err
@@ -241,6 +242,11 @@ func getGRPCAddress(kasURL string) (string, error) {
 	if port == "" {
 		port = "443"
 	}
+
+	// if kid query parameter then remove it
+	queries := parsedURL.Query()
+	queries.Del("kid")
+	parsedURL.RawQuery = queries.Encode()
 
 	return net.JoinHostPort(parsedURL.Hostname(), port), nil
 }

--- a/sdk/nanotdf.go
+++ b/sdk/nanotdf.go
@@ -689,8 +689,9 @@ func (s SDK) CreateNanoTDF(writer io.Writer, reader io.Reader, config NanoTDFCon
 	// compute kid from kasPublicKey -or- use new endpoint that provides kid JWKS
 	kidHash := sha256.Sum256([]byte(kasPublicKey))
 	kidHex := hex.EncodeToString(kidHash[:])
+	slog.Debug("kasPublicKey", slog.String("fingerprint", kidHex))
 	// FIXME for now, it will be hardcoded to match opentdf.yaml
-	kasURLKid, err := addQueryParamToURL(kasURL, "kid", kidHex)
+	kasURLKid, err := addQueryParamToURL(kasURL, "kid", "e0")
 	if err != nil {
 		return 0, fmt.Errorf("addQueryParamToURL failed: %w", err)
 	}

--- a/sdk/resource_locator.go
+++ b/sdk/resource_locator.go
@@ -101,8 +101,8 @@ func (rl *ResourceLocator) setURL(url string) error {
 	return errors.New("unsupported protocol: " + url)
 }
 
-// getURL - Retrieve a fully qualified protocol+body URL string from a ResourceLocator struct
-func (rl ResourceLocator) getURL() (string, error) {
+// GetURL - Retrieve a fully qualified protocol+body URL string from a ResourceLocator struct
+func (rl ResourceLocator) GetURL() (string, error) {
 	if rl.protocol == urlProtocolHTTPS {
 		return kPrefixHTTPS + rl.body, nil
 	}

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -15,6 +15,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -369,18 +370,34 @@ func (p *Provider) tdf3Rewrap(ctx context.Context, body *RequestBody, entity *en
 }
 
 func (p *Provider) nanoTDFRewrap(ctx context.Context, body *RequestBody, entity *entityInfo) (*kaspb.RewrapResponse, error) {
-	// TODO Lookup KID from request content
-	// Should this be in the locator or somewhere else?
-	kid, err := p.lookupKid(ctx, security.AlgorithmECP256R1)
-	if err != nil {
-		p.Logger.WarnContext(ctx, "failure to find default kid for ec", "err", err)
-		return nil, err400("bad request")
-	}
 	headerReader := bytes.NewReader(body.KeyAccess.Header)
 
 	header, _, err := sdk.NewNanoTDFHeaderFromReader(headerReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse NanoTDF header: %w", err)
+	}
+	// Lookup KID from nano header
+	kasUrlString, err := header.GetKasUrl().GetURL()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse NanoTDF.kasUrl header: %w", err)
+	}
+	if kasUrlString == "" {
+		return nil, err400("kasUrl not present in header")
+	}
+	kasUrl, err := url.Parse(kasUrlString)
+	if err != nil {
+		return nil, fmt.Errorf("error when parsing kasUrl: %v", err)
+	}
+
+	query := kasUrl.Query()
+	if len(query) == 0 {
+		return nil, err400("no query parameters found in kasUrl")
+	}
+
+	kid := query.Get("kid")
+	if kid == "" {
+		p.Logger.WarnContext(ctx, "failure to find kid in kasUrl")
+		return nil, err400("bad request")
 	}
 
 	ecCurve, err := header.ECCurve()
@@ -396,7 +413,7 @@ func (p *Provider) nanoTDFRewrap(ctx context.Context, body *RequestBody, entity 
 	// extract the policy
 	policy, err := extractNanoPolicy(symmetricKey, header)
 	if err != nil {
-		return nil, fmt.Errorf("Error extracting policy: %w", err)
+		return nil, fmt.Errorf("error extracting policy: %w", err)
 	}
 
 	// check the policy binding

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -413,7 +413,7 @@ func (p *Provider) nanoTDFRewrap(ctx context.Context, body *RequestBody, entity 
 	// extract the policy
 	policy, err := extractNanoPolicy(symmetricKey, header)
 	if err != nil {
-		return nil, fmt.Errorf("error extracting policy: %w", err)
+		return nil, fmt.Errorf("Error extracting policy: %w", err)
 	}
 
 	// check the policy binding


### PR DESCRIPTION
Proposed format for KAS URL
```
https://kas.example.com?kid=e0
```

The 'getURL' method has been updated to 'GetURL' in the ResourceLocator struct. Also, a 'GetKasUrl' method has been added to the NanoTDFHeader struct. These updates ensure KID is effectively fetched and used within the code. A Query parameter handling function 'addQueryParamToURL' has also been added to help in adding "kid" parameter to the URL.

#900 
#717 
#1203
