### PR TITLE
feat(core): KID in NanoTDF Policy

### DIFF
--- a/sdk/manifest.go
+++ b/sdk/manifest.go
@@ -71,6 +71,7 @@ type PolicyObject struct {
 	Body struct {
 		DataAttributes []attributeObject `json:"dataAttributes"`
 		Dissem         []string          `json:"dissem"`
+		KeyIdentifier  string            `json:"kid"`
 	} `json:"body"`
 }
 

--- a/sdk/nanotdf_config.go
+++ b/sdk/nanotdf_config.go
@@ -18,14 +18,15 @@ import (
 // ============================================================================================================
 
 type NanoTDFConfig struct {
-	keyPair      ocrypto.ECKeyPair
-	kasPublicKey *ecdh.PublicKey
-	attributes   []autoconfigure.AttributeValueFQN
-	cipher       CipherMode
-	kasURL       ResourceLocator
-	sigCfg       signatureConfig
-	policy       policyInfo
-	bindCfg      bindingConfig
+	keyPair        ocrypto.ECKeyPair
+	kasPublicKey   *ecdh.PublicKey
+	kasPublicKeyID string
+	attributes     []autoconfigure.AttributeValueFQN
+	cipher         CipherMode
+	kasURL         ResourceLocator
+	sigCfg         signatureConfig
+	policy         policyInfo
+	bindCfg        bindingConfig
 }
 
 type NanoTDFOption func(*NanoTDFConfig) error

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -440,6 +440,11 @@ func (s SDK) prepareManifest(ctx context.Context, t *TDFObject, tdfConfig TDFCon
 
 // create policy object
 func createPolicyObject(attributes []autoconfigure.AttributeValueFQN) (PolicyObject, error) {
+	return createPolicyObjectKid(attributes, "")
+}
+
+// create policy object with kid
+func createPolicyObjectKid(attributes []autoconfigure.AttributeValueFQN, kid string) (PolicyObject, error) {
 	uuidObj, err := uuid.NewUUID()
 	if err != nil {
 		return PolicyObject{}, fmt.Errorf("uuid.NewUUID failed: %w", err)
@@ -452,9 +457,11 @@ func createPolicyObject(attributes []autoconfigure.AttributeValueFQN) (PolicyObj
 		attributeObj := attributeObject{}
 		attributeObj.Attribute = attribute.String()
 		policyObj.Body.DataAttributes = append(policyObj.Body.DataAttributes, attributeObj)
-		policyObj.Body.Dissem = make([]string, 0)
 	}
-
+	policyObj.Body.Dissem = make([]string, 0)
+	if kid != "" {
+		policyObj.Body.KeyIdentifier = kid
+	}
 	return policyObj, nil
 }
 

--- a/service/kas/access/policy.go
+++ b/service/kas/access/policy.go
@@ -13,6 +13,7 @@ type Policy struct {
 type PolicyBody struct {
 	DataAttributes []Attribute `json:"dataAttributes"`
 	Dissem         []string    `json:"dissem"`
+	KeyIdentifier  string      `json:"kid"`
 }
 
 // Audit helper methods


### PR DESCRIPTION
Key Identifier(kid) has been added to PolicyObject's Body in both the manifest and the nanotdf_config files. A method to fetch kasPublicKey along with its accompanying kid from KAS has been created. Logic to add the fetched kid into the config.policy has also been added. This kid will be used while creating a PolicyObject.

#900 
#717 
#1203