### PR TITLE
feat(core): KID in NanoTDF Policy Key Access

### DIFF
--- a/lib/ocrypto/ec_key_pair.go
+++ b/lib/ocrypto/ec_key_pair.go
@@ -30,6 +30,30 @@ type ECKeyPair struct {
 	PrivateKey *ecdsa.PrivateKey
 }
 
+// GetECCompressedKeyLengthFromECCMode returns the length of the compressed key
+// for a given ECC mode. The function first obtains the elliptic curve using the
+// GetECCurveFromECCMode function. It then calculates the length of the elliptic curve
+// coordinate in bytes. Finally, it calculates the length of the compressed key, which
+// includes the type indicator byte and the coordinate byte.
+//
+// The compressed form of the key is 1 byte for the type indicator plus the length of
+// the coordinate, which is equal to the elliptic curve's bit size divided by 8.
+func GetECCompressedKeyLengthFromECCMode(mode ECCMode) (int, error) {
+	c, err := GetECCurveFromECCMode(mode)
+	if err != nil {
+		return 0, err
+	}
+
+	// Get the length of coordinate in bytes
+	pointSize := (c.Params().BitSize + 7) / 8
+	// The compressed form of the key is 1 byte for the type indicator and then
+	// 2 coordinates, each of length pointSize.
+	// But in the compressed form, we only have one coordinate plus the type byte.
+	compressedKeySize := 1 + pointSize
+
+	return compressedKeySize, nil
+}
+
 // GetECCurveFromECCMode return elliptic curve from ecc mode
 func GetECCurveFromECCMode(mode ECCMode) (elliptic.Curve, error) {
 	var c elliptic.Curve

--- a/sdk/nanotdf_policy.go
+++ b/sdk/nanotdf_policy.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"encoding/binary"
 	"errors"
+	"github.com/opentdf/platform/lib/ocrypto"
 	"io"
 )
 
@@ -43,7 +44,7 @@ type PolicyBody struct {
 // }
 
 // readPolicyBody - helper function to decode input data into a PolicyBody object
-func (pb *PolicyBody) readPolicyBody(reader io.Reader) error {
+func (pb *PolicyBody) readPolicyBody(reader io.Reader, eccMode ocrypto.ECCMode) error {
 	var mode policyType
 	if err := binary.Read(reader, binary.BigEndian, &mode); err != nil {
 		return err
@@ -59,7 +60,7 @@ func (pb *PolicyBody) readPolicyBody(reader io.Reader) error {
 	case policyTypeEmbeddedPolicyEncrypted:
 	case policyTypeEmbeddedPolicyEncryptedPolicyKeyAccess:
 		var ep embeddedPolicy
-		if err := ep.readEmbeddedPolicy(reader); err != nil {
+		if err := ep.readEmbeddedPolicy(reader, eccMode); err != nil {
 			return errors.Join(ErrNanoTDFHeaderRead, err)
 		}
 		pb.ep = ep

--- a/service/kas/access/provider.go
+++ b/service/kas/access/provider.go
@@ -40,6 +40,8 @@ type KASConfig struct {
 type CurrentKeyFor struct {
 	Algorithm string `mapstructure:"alg"`
 	KID       string `mapstructure:"kid"`
+	// PublicKeyBytes represents the compressed public key in the form of a byte slice.
+	PublicKeyBytes []byte `mapstructure:"public_key"`
 	// Indicates that the key should not be serves by default,
 	// but instead is allowed for legacy reasons on decrypt (rewrap) only
 	Legacy bool `mapstructure:"legacy"`


### PR DESCRIPTION
Added a new function lookupKidByPublicKey to the Provider in the KAS service, which looks up the key ID based on the provided public key. This function is utilized for key ID lookup in the NanoTDF rewrap method instead of the previous method. Also, included the PublicKeyBytes in the NanoTDF struct and other relevant areas. Moreover, created GetECCompressedKeyLengthFromECCMode in the EC Key Pair to extract the length of the compressed key given an ECC mode. The new approach allows us to associate public keys with their respective key IDs more efficiently.