### PR TITLE
fix(core): increase internal grpc message size limit

### DIFF
--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"net/netip"
@@ -377,6 +378,7 @@ func (s inProcessServer) Conn() *grpc.ClientConn {
 	clientInterceptors = append(clientInterceptors, sdkAudit.MetadataAddingClientInterceptor)
 
 	defaultOptions := []grpc.DialOption{
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt64), grpc.MaxCallSendMsgSize(math.MaxInt64)),
 		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
 			conn, err := s.ln.Dial()
 			if err != nil {


### PR DESCRIPTION
Due to changes somehow related to unsafe actions, the DSP / COP function `GetMyEntitlements` (getting entitlements by access token) started failing. 

The breaking change is [here](https://github.com/opentdf/platform/commit/4a3042625d0d08951bc36053ba053dc44fcffe99#diff-6dfc9f9359c6ea6dbaf8df5306e47732e636997b51bd20ef1eaef77f6d39823dR175-R176).

Essentially, we exceeded the in process / internal grpc server's message size limit when passing attribute values in responses. Internal services should be able to communicate freely.