### PR TITLE
chore(ci): Prefer using keycloak image for keytool

### DIFF
--- a/.github/scripts/init-temp-keys.cmd
+++ b/.github/scripts/init-temp-keys.cmd
@@ -21,4 +21,4 @@ set hostKeyDir=%hostKeyDir%/keys
 set "hostKeyDir=%hostKeyDir:\=/%"
 
 openssl pkcs12 -export -in keys/keycloak-ca.pem -inkey keys/keycloak-ca-private.pem -out keys/ca.p12 -nodes -passout pass:password
-docker run -v %hostKeyDir%:/keys openjdk:latest keytool -importkeystore -srckeystore /keys/ca.p12 -srcstoretype PKCS12 -destkeystore /keys/ca.jks -deststoretype JKS -srcstorepass "password" -deststorepass "password" -noprompt
+docker run -v %hostKeyDir%:/keys --entrypoint keytool cgr.dev/chainguard/keycloak@sha256:37895558d2e0e93ffff75da5900f9ae7e79ec6d1c390b18b2ecea6cee45ec26f -importkeystore -srckeystore /keys/ca.p12 -srcstoretype PKCS12 -destkeystore /keys/ca.jks -deststoretype JKS -srcstorepass "password" -deststorepass "password" -noprompt

--- a/.github/scripts/init-temp-keys.sh
+++ b/.github/scripts/init-temp-keys.sh
@@ -86,10 +86,16 @@ openssl req -new -nodes -newkey rsa:2048 -keyout keys/sampleuser.key -out keys/s
 openssl x509 -req -in keys/sampleuser.req -CA keys/keycloak-ca.pem  -CAkey keys/keycloak-ca-private.pem -CAcreateserial -out keys/sampleuser.crt -days 3650
 
 openssl pkcs12 -export -in keys/keycloak-ca.pem -inkey keys/keycloak-ca-private.pem -out keys/ca.p12 -nodes -passout pass:password
-docker run -v $(pwd)/keys:/keys openjdk:latest keytool -importkeystore -srckeystore /keys/ca.p12 \
-                                      -srcstoretype PKCS12 \
-                                      -destkeystore /keys/ca.jks \
-                                      -deststoretype JKS \
-                                      -srcstorepass "password" \
-                                      -deststorepass "password" \
-                                      -noprompt
+docker run \
+    -v $(pwd)/keys:/keys \
+    --entrypoint keytool \
+    --user $(id -u):$(id -g) \
+    cgr.dev/chainguard/keycloak@sha256:37895558d2e0e93ffff75da5900f9ae7e79ec6d1c390b18b2ecea6cee45ec26f \
+    -importkeystore \
+    -srckeystore /keys/ca.p12 \
+    -srcstoretype PKCS12 \
+    -destkeystore /keys/ca.jks \
+    -deststoretype JKS \
+    -srcstorepass "password" \
+    -deststorepass "password" \
+    -noprompt


### PR DESCRIPTION
- Generally, the user will already need a keycloak image, which has keytool packed in
- The `openjdk` image is unmaintained