### PR TITLE
fix(ci): double stale issue length and do not close issues automatically

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,4 +13,5 @@ jobs:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e
         with:
           days-before-stale: 120
+	 # negative number means they will never be closed automatically [https://github.com/actions/stale#days-before-close]
           days-before-close: -1

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,4 +1,4 @@
-name: 'Close stale issues and PRs'
+name: 'Detect stale issues and PRs'
 on:
   schedule:
     - cron: '0 0 * * *'
@@ -11,3 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e
+        with:
+          days-before-stale: 120
+          days-before-close: -1


### PR DESCRIPTION
Resolves #1264 

- Doubles stale time from default 60 days to 120 days
- Sets job to _not_ auto-close stale issues & PRs