### PR TITLE
feat(policy): 1256 resource mapping groups db support

### DIFF
--- a/service/policy/db/migrations/20240806142109_add_resource_mapping_groups.md
+++ b/service/policy/db/migrations/20240806142109_add_resource_mapping_groups.md
@@ -1,0 +1,32 @@
+# Diagram for 20240806142109_add_resource_mapping_groups.sql
+
+## Background
+
+This schema reflects the addition of a `resource_mapping_groups` table, allowing existing Resource Mappings to be grouped by namespace and a common name. The migration also updates the `resource_mappings` table to include a `group_id` column, which will be used to optionally associate a Resource Mapping with a group.
+
+# ERD
+
+```mermaid
+---
+title: Database Schema Mermaid Diagram
+---
+
+erDiagram
+
+    ResourceMappingGroup ||--|{ ResourceMapping : has
+
+    ResourceMappingGroup {
+        uuid         id                 PK
+        uuid         namespace_id
+        varchar      name
+        compIdx      comp_key           UK "namespace_id + name"
+    }
+
+    ResourceMapping {
+        uuid         id                 PK
+        uuid         attribute_value_id FK
+        varchar[]    terms
+        jsonb        metadata
+        uuid         group_id           FK
+    }
+```

--- a/service/policy/db/migrations/20240806142109_add_resource_mapping_groups.sql
+++ b/service/policy/db/migrations/20240806142109_add_resource_mapping_groups.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS resource_mapping_groups (
     UNIQUE(namespace_id, name)
 );
 
-ALTER TABLE resource_mappings ADD COLUMN group_id UUID REFERENCES resource_mapping_groups(id);
+ALTER TABLE resource_mappings ADD COLUMN group_id UUID REFERENCES resource_mapping_groups(id) ON DELETE SET NULL;
 
 -- +goose StatementEnd
 

--- a/service/policy/db/migrations/20240806142109_add_resource_mapping_groups.sql
+++ b/service/policy/db/migrations/20240806142109_add_resource_mapping_groups.sql
@@ -8,7 +8,14 @@ CREATE TABLE IF NOT EXISTS resource_mapping_groups (
     UNIQUE(namespace_id, name)
 );
 
+COMMENT ON TABLE resource_mapping_groups IS 'Table to store the groups of resource mappings by unique namespace and group name combinations';
+COMMENT ON COLUMN resource_mapping_groups.id IS 'Primary key for the table';
+COMMENT ON COLUMN resource_mapping_groups.namespace_id IS 'Foreign key to the namespace of the attribute';
+COMMENT ON COLUMN resource_mapping_groups.name IS 'Name for the group of resource mappings';
+
 ALTER TABLE resource_mappings ADD COLUMN group_id UUID REFERENCES resource_mapping_groups(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN resource_mappings.group_id IS 'Foreign key to the parent group of the resource mapping';
 
 -- +goose StatementEnd
 

--- a/service/policy/db/migrations/20240806142109_add_resource_mapping_groups.sql
+++ b/service/policy/db/migrations/20240806142109_add_resource_mapping_groups.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE IF NOT EXISTS resource_mapping_groups (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    namespace_id UUID NOT NULL REFERENCES attribute_namespaces(id),
+    name VARCHAR NOT NULL,
+    UNIQUE(namespace_id, name)
+);
+
+ALTER TABLE resource_mappings ADD COLUMN group_id UUID REFERENCES resource_mapping_groups(id);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE resource_mappings DROP COLUMN group_id;
+
+DROP TABLE IF EXISTS resource_mapping_groups;
+
+-- +goose StatementEnd

--- a/service/policy/db/migrations/20240806142109_add_resource_mapping_groups.sql
+++ b/service/policy/db/migrations/20240806142109_add_resource_mapping_groups.sql
@@ -3,7 +3,7 @@
 
 CREATE TABLE IF NOT EXISTS resource_mapping_groups (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    namespace_id UUID NOT NULL REFERENCES attribute_namespaces(id),
+    namespace_id UUID NOT NULL REFERENCES attribute_namespaces(id) ON DELETE CASCADE,
     name VARCHAR NOT NULL,
     UNIQUE(namespace_id, name)
 );
@@ -15,7 +15,7 @@ COMMENT ON COLUMN resource_mapping_groups.name IS 'Name for the group of resourc
 
 ALTER TABLE resource_mappings ADD COLUMN group_id UUID REFERENCES resource_mapping_groups(id) ON DELETE SET NULL;
 
-COMMENT ON COLUMN resource_mappings.group_id IS 'Foreign key to the parent group of the resource mapping';
+COMMENT ON COLUMN resource_mappings.group_id IS 'Foreign key to the parent group of the resource mapping (optional, a resource mapping may not be in a group)';
 
 -- +goose StatementEnd
 

--- a/service/policy/db/models.go
+++ b/service/policy/db/models.go
@@ -139,6 +139,13 @@ type ResourceMapping struct {
 	Metadata         []byte             `json:"metadata"`
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	GroupID          pgtype.UUID        `json:"group_id"`
+}
+
+type ResourceMappingGroup struct {
+	ID          string `json:"id"`
+	NamespaceID string `json:"namespace_id"`
+	Name        string `json:"name"`
 }
 
 type SubjectConditionSet struct {

--- a/service/policy/db/models.go
+++ b/service/policy/db/models.go
@@ -168,13 +168,18 @@ type ResourceMapping struct {
 	Metadata  []byte             `json:"metadata"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
-	GroupID   pgtype.UUID        `json:"group_id"`
+	// Foreign key to the parent group of the resource mapping
+	GroupID pgtype.UUID `json:"group_id"`
 }
 
+// Table to store the groups of resource mappings by unique namespace and group name combinations
 type ResourceMappingGroup struct {
-	ID          string `json:"id"`
+	// Primary key for the table
+	ID string `json:"id"`
+	// Foreign key to the namespace of the attribute
 	NamespaceID string `json:"namespace_id"`
-	Name        string `json:"name"`
+	// Name for the group of resource mappings
+	Name string `json:"name"`
 }
 
 // Table to store sets of conditions that logically entitle subject entity representations to attribute values via a subject mapping

--- a/service/policy/db/models.go
+++ b/service/policy/db/models.go
@@ -168,7 +168,7 @@ type ResourceMapping struct {
 	Metadata  []byte             `json:"metadata"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
-	// Foreign key to the parent group of the resource mapping
+	// Foreign key to the parent group of the resource mapping (optional, a resource mapping may not be in a group)
 	GroupID pgtype.UUID `json:"group_id"`
 }
 

--- a/service/policy/db/query.sql
+++ b/service/policy/db/query.sql
@@ -1,4 +1,6 @@
+---------------------------------------------------------------- 
 -- KEY ACCESS SERVERS
+----------------------------------------------------------------
 
 -- name: ListKeyAccessServers :many
 SELECT id, uri, public_key,
@@ -27,3 +29,22 @@ RETURNING id;
 -- name: DeleteKeyAccessServer :execrows
 DELETE FROM key_access_servers WHERE id = $1;
 
+---------------------------------------------------------------- 
+-- RESOURCE MAPPING GROUPS
+----------------------------------------------------------------
+
+-- name: CreateResourceMappingGroup :one
+INSERT INTO resource_mapping_groups (namespace_id, name)
+VALUES ($1, $2)
+RETURNING id;
+
+-- name: UpdateResourceMappingGroup :one
+UPDATE resource_mapping_groups
+SET
+    -- assuming name is the only modifiable field
+    name = coalesce(sqlc.narg('name'), name)
+WHERE id = $1
+RETURNING id;
+
+-- name: DeleteResourceMappingGroup :execrows
+DELETE FROM resource_mapping_groups WHERE id = $1;

--- a/service/policy/db/query.sql
+++ b/service/policy/db/query.sql
@@ -41,7 +41,7 @@ RETURNING id;
 -- name: UpdateResourceMappingGroup :one
 UPDATE resource_mapping_groups
 SET
-    -- assuming name is the only modifiable field
+    namespace_id = coalesce(sqlc.narg('namespace_id'), namespace_id),
     name = coalesce(sqlc.narg('name'), name)
 WHERE id = $1
 RETURNING id;

--- a/service/policy/db/query.sql
+++ b/service/policy/db/query.sql
@@ -33,6 +33,11 @@ DELETE FROM key_access_servers WHERE id = $1;
 -- RESOURCE MAPPING GROUPS
 ----------------------------------------------------------------
 
+-- name: GetResourceMappingGroup :one
+SELECT id, namespace_id, name
+FROM resource_mapping_groups
+WHERE id = $1;
+
 -- name: CreateResourceMappingGroup :one
 INSERT INTO resource_mapping_groups (namespace_id, name)
 VALUES ($1, $2)

--- a/service/policy/db/query.sql
+++ b/service/policy/db/query.sql
@@ -33,6 +33,10 @@ DELETE FROM key_access_servers WHERE id = $1;
 -- RESOURCE MAPPING GROUPS
 ----------------------------------------------------------------
 
+-- name: ListResourceMappingGroups :many
+SELECT id, namespace_id, name
+FROM resource_mapping_groups;
+
 -- name: GetResourceMappingGroup :one
 SELECT id, namespace_id, name
 FROM resource_mapping_groups

--- a/service/policy/db/query.sql.go
+++ b/service/policy/db/query.sql.go
@@ -208,27 +208,28 @@ func (q *Queries) UpdateKeyAccessServer(ctx context.Context, arg UpdateKeyAccess
 const updateResourceMappingGroup = `-- name: UpdateResourceMappingGroup :one
 UPDATE resource_mapping_groups
 SET
-    -- assuming name is the only modifiable field
-    name = coalesce($2, name)
+    namespace_id = coalesce($2, namespace_id),
+    name = coalesce($3, name)
 WHERE id = $1
 RETURNING id
 `
 
 type UpdateResourceMappingGroupParams struct {
-	ID   string      `json:"id"`
-	Name pgtype.Text `json:"name"`
+	ID          string      `json:"id"`
+	NamespaceID pgtype.UUID `json:"namespace_id"`
+	Name        pgtype.Text `json:"name"`
 }
 
 // UpdateResourceMappingGroup
 //
 //	UPDATE resource_mapping_groups
 //	SET
-//	    -- assuming name is the only modifiable field
-//	    name = coalesce($2, name)
+//	    namespace_id = coalesce($2, namespace_id),
+//	    name = coalesce($3, name)
 //	WHERE id = $1
 //	RETURNING id
 func (q *Queries) UpdateResourceMappingGroup(ctx context.Context, arg UpdateResourceMappingGroupParams) (string, error) {
-	row := q.db.QueryRow(ctx, updateResourceMappingGroup, arg.ID, arg.Name)
+	row := q.db.QueryRow(ctx, updateResourceMappingGroup, arg.ID, arg.NamespaceID, arg.Name)
 	var id string
 	err := row.Scan(&id)
 	return id, err

--- a/service/policy/db/query.sql.go
+++ b/service/policy/db/query.sql.go
@@ -119,15 +119,12 @@ func (q *Queries) GetKeyAccessServer(ctx context.Context, id string) (GetKeyAcce
 }
 
 const getResourceMappingGroup = `-- name: GetResourceMappingGroup :one
-
 SELECT id, namespace_id, name
 FROM resource_mapping_groups
 WHERE id = $1
 `
 
-// --------------------------------------------------------------
-// RESOURCE MAPPING GROUPS
-// --------------------------------------------------------------
+// GetResourceMappingGroup
 //
 //	SELECT id, namespace_id, name
 //	FROM resource_mapping_groups
@@ -175,6 +172,38 @@ func (q *Queries) ListKeyAccessServers(ctx context.Context) ([]ListKeyAccessServ
 			&i.PublicKey,
 			&i.Metadata,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listResourceMappingGroups = `-- name: ListResourceMappingGroups :many
+
+SELECT id, namespace_id, name
+FROM resource_mapping_groups
+`
+
+// --------------------------------------------------------------
+// RESOURCE MAPPING GROUPS
+// --------------------------------------------------------------
+//
+//	SELECT id, namespace_id, name
+//	FROM resource_mapping_groups
+func (q *Queries) ListResourceMappingGroups(ctx context.Context) ([]ResourceMappingGroup, error) {
+	rows, err := q.db.Query(ctx, listResourceMappingGroups)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ResourceMappingGroup
+	for rows.Next() {
+		var i ResourceMappingGroup
+		if err := rows.Scan(&i.ID, &i.NamespaceID, &i.Name); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/service/policy/db/query.sql.go
+++ b/service/policy/db/query.sql.go
@@ -36,7 +36,6 @@ func (q *Queries) CreateKeyAccessServer(ctx context.Context, arg CreateKeyAccess
 }
 
 const createResourceMappingGroup = `-- name: CreateResourceMappingGroup :one
-
 INSERT INTO resource_mapping_groups (namespace_id, name)
 VALUES ($1, $2)
 RETURNING id
@@ -47,9 +46,7 @@ type CreateResourceMappingGroupParams struct {
 	Name        string `json:"name"`
 }
 
-// --------------------------------------------------------------
-// RESOURCE MAPPING GROUPS
-// --------------------------------------------------------------
+// CreateResourceMappingGroup
 //
 //	INSERT INTO resource_mapping_groups (namespace_id, name)
 //	VALUES ($1, $2)
@@ -118,6 +115,27 @@ func (q *Queries) GetKeyAccessServer(ctx context.Context, id string) (GetKeyAcce
 		&i.PublicKey,
 		&i.Metadata,
 	)
+	return i, err
+}
+
+const getResourceMappingGroup = `-- name: GetResourceMappingGroup :one
+
+SELECT id, namespace_id, name
+FROM resource_mapping_groups
+WHERE id = $1
+`
+
+// --------------------------------------------------------------
+// RESOURCE MAPPING GROUPS
+// --------------------------------------------------------------
+//
+//	SELECT id, namespace_id, name
+//	FROM resource_mapping_groups
+//	WHERE id = $1
+func (q *Queries) GetResourceMappingGroup(ctx context.Context, id string) (ResourceMappingGroup, error) {
+	row := q.db.QueryRow(ctx, getResourceMappingGroup, id)
+	var i ResourceMappingGroup
+	err := row.Scan(&i.ID, &i.NamespaceID, &i.Name)
 	return i, err
 }
 


### PR DESCRIPTION
closes #1256 

- add migration for new `resource_mapping_groups` table and related ERD
- add basic SQL queries and `sqlc` generated functions (will be expanded on in follow-up PRs)