### PR TITLE
chore(ci): Remove keytool step 🚧

### DIFF
--- a/.github/scripts/init-temp-keys.cmd
+++ b/.github/scripts/init-temp-keys.cmd
@@ -20,5 +20,4 @@ set "hostKeyDir=%cd%"
 set hostKeyDir=%hostKeyDir%/keys
 set "hostKeyDir=%hostKeyDir:\=/%"
 
-openssl pkcs12 -export -in keys/keycloak-ca.pem -inkey keys/keycloak-ca-private.pem -out keys/ca.p12 -nodes -passout pass:password
-docker run -v %hostKeyDir%:/keys --entrypoint keytool cgr.dev/chainguard/keycloak@sha256:37895558d2e0e93ffff75da5900f9ae7e79ec6d1c390b18b2ecea6cee45ec26f -importkeystore -srckeystore /keys/ca.p12 -srcstoretype PKCS12 -destkeystore /keys/ca.jks -deststoretype JKS -srcstorepass "password" -deststorepass "password" -noprompt
+openssl pkcs12 -export -in keys/keycloak-ca.pem -inkey keys/keycloak-ca-private.pem -out keys/ca.p12 -keypbe NONE -certpbe NONE -passout pass:

--- a/.github/scripts/init-temp-keys.sh
+++ b/.github/scripts/init-temp-keys.sh
@@ -85,17 +85,4 @@ openssl x509 -req -in keys/localhost.req -CA keys/keycloak-ca.pem  -CAkey keys/k
 openssl req -new -nodes -newkey rsa:2048 -keyout keys/sampleuser.key -out keys/sampleuser.req -batch -subj "/CN=sampleuser"
 openssl x509 -req -in keys/sampleuser.req -CA keys/keycloak-ca.pem  -CAkey keys/keycloak-ca-private.pem -CAcreateserial -out keys/sampleuser.crt -days 3650
 
-openssl pkcs12 -export -in keys/keycloak-ca.pem -inkey keys/keycloak-ca-private.pem -out keys/ca.p12 -nodes -passout pass:password
-docker run \
-    -v $(pwd)/keys:/keys \
-    --entrypoint keytool \
-    --user $(id -u):$(id -g) \
-    cgr.dev/chainguard/keycloak@sha256:37895558d2e0e93ffff75da5900f9ae7e79ec6d1c390b18b2ecea6cee45ec26f \
-    -importkeystore \
-    -srckeystore /keys/ca.p12 \
-    -srcstoretype PKCS12 \
-    -destkeystore /keys/ca.jks \
-    -deststoretype JKS \
-    -srcstorepass "password" \
-    -deststorepass "password" \
-    -noprompt
+openssl pkcs12 -export -in keys/keycloak-ca.pem -inkey keys/keycloak-ca-private.pem -out keys/ca.p12 -keypbe NONE -certpbe NONE -passout pass:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     volumes:
     - ./keys/localhost.crt:/etc/x509/tls/localhost.crt
     - ./keys/localhost.key:/etc/x509/tls/localhost.key
-    - ./keys/ca.jks:/truststore/truststore.jks
+    - ./keys/ca.p12:/truststore/truststore.pfx
     # This is kc 24.0.1 with opentdf protocol mapper on board
     image: cgr.dev/chainguard/keycloak@sha256:37895558d2e0e93ffff75da5900f9ae7e79ec6d1c390b18b2ecea6cee45ec26f
     restart: always

--- a/sdk/internal/oauth/oauth_test.go
+++ b/sdk/internal/oauth/oauth_test.go
@@ -548,7 +548,7 @@ func setupKeycloak(ctx context.Context, t *testing.T) (tc.Container, string, str
 			"--spi-truststore-file-hostname-verification-policy=ANY",
 		},
 		Files: []tc.ContainerFile{
-			{HostFilePath: "testdata/ca.jks", ContainerFilePath: "/truststore/truststore.jks", FileMode: int64(0o777)},
+			{HostFilePath: "testdata/ca.p12", ContainerFilePath: "/truststore/truststore.jks", FileMode: int64(0o777)},
 			{HostFilePath: "testdata/localhost.crt", ContainerFilePath: "/etc/x509/tls/localhost.crt", FileMode: int64(0o777)},
 			{HostFilePath: "testdata/localhost.key", ContainerFilePath: "/etc/x509/tls/localhost.key", FileMode: int64(0o777)},
 		},


### PR DESCRIPTION
- instead of a JKS encrypted with 'password', just store self-signed CA as a plain text pkcs12 file