### PR TITLE
chore(ci): SEC-4101 Update pr-checks workflow to add `deps` tag

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -40,6 +40,7 @@ jobs:
           #   - main: used for automated releases
           #   - core: related to any core need such as the core service or monorepo
           #   - ci: anything related to ci
+          #   - deps: dependency update
           #   - docs: anything related solely to documentation
           #   - sdk: related to sdk changes in the /sdk directory
           #   - policy: related to policy service changes (i.e. /service/policy)
@@ -49,6 +50,7 @@ jobs:
             main
             core
             ci
+            deps
             docs
             sdk
             policy


### PR DESCRIPTION
As part of SEC-4101 & Closes #1316 I am reviewing our current dependency configurations.  Currently the PR checks are failing due to the PR using `chore(deps)` for the PR prefix.  For example: https://github.com/opentdf/platform/pull/1311