### PR TITLE
feat(sdk): Lets SDK use PublicKeys from policy service

### DIFF
--- a/examples/cmd/kas.go
+++ b/examples/cmd/kas.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var algorithm, key, keyIdentifier string
+var algorithm, kas, key, keyIdentifier string
 
 func init() {
 	kasc := &cobra.Command{

--- a/sdk/nanotdf_config.go
+++ b/sdk/nanotdf_config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/opentdf/platform/lib/ocrypto"
-	"github.com/opentdf/platform/sdk/internal/autoconfigure"
 )
 
 // ============================================================================================================
@@ -20,7 +19,7 @@ import (
 type NanoTDFConfig struct {
 	keyPair      ocrypto.ECKeyPair
 	kasPublicKey *ecdh.PublicKey
-	attributes   []autoconfigure.AttributeValueFQN
+	attributes   []AttributeValueFQN
 	cipher       CipherMode
 	kasURL       ResourceLocator
 	sigCfg       signatureConfig
@@ -63,9 +62,9 @@ func (config *NanoTDFConfig) SetKasURL(url string) error {
 
 // SetAttributes - set the attributes to be used for this nanoTDF
 func (config *NanoTDFConfig) SetAttributes(attributes []string) error {
-	config.attributes = make([]autoconfigure.AttributeValueFQN, len(attributes))
+	config.attributes = make([]AttributeValueFQN, len(attributes))
 	for i, a := range attributes {
-		v, err := autoconfigure.NewAttributeValueFQN(a)
+		v, err := NewAttributeValueFQN(a)
 		if err != nil {
 			return err
 		}
@@ -83,7 +82,7 @@ func (config *NanoTDFConfig) EnableECDSAPolicyBinding() {
 func WithNanoDataAttributes(attributes ...string) NanoTDFOption {
 	return func(c *NanoTDFConfig) error {
 		for _, a := range attributes {
-			v, err := autoconfigure.NewAttributeValueFQN(a)
+			v, err := NewAttributeValueFQN(a)
 			if err != nil {
 				return err
 			}

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -135,7 +135,7 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 		if len(tdfConfig.attributeValues) > 0 {
 			g, err = newGranterFromAttributes(tdfConfig.attributeValues...)
 		} else if len(tdfConfig.attributes) > 0 {
-			g, err = newGranterFromService(ctx, s.Attributes, tdfConfig.attributes...)
+			g, err = newGranterFromService(ctx, s.kasKeyCache, s.Attributes, tdfConfig.attributes...)
 		}
 		if err != nil {
 			return nil, err
@@ -440,7 +440,7 @@ func (s SDK) prepareManifest(ctx context.Context, t *TDFObject, tdfConfig TDFCon
 
 		for _, kasInfo := range conjunction[splitID] {
 			if len(kasInfo.PublicKey) == 0 {
-				return errKasPubKeyMissing
+				return fmt.Errorf("splitID:[%s], kas:[%s]: %w", splitID, kasInfo.URL, errKasPubKeyMissing)
 			}
 
 			// wrap the key with kas public key

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/policy"
-	"github.com/opentdf/platform/sdk/internal/autoconfigure"
 )
 
 const (
@@ -58,10 +57,10 @@ type TDFConfig struct {
 	integrityAlgorithm        IntegrityAlgorithm
 	segmentIntegrityAlgorithm IntegrityAlgorithm
 	assertions                []AssertionConfig
-	attributes                []autoconfigure.AttributeValueFQN
+	attributes                []AttributeValueFQN
 	attributeValues           []*policy.Value
 	kasInfoList               []KASInfo
-	splitPlan                 []autoconfigure.SplitStep
+	splitPlan                 []keySplitStep
 }
 
 func newTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
@@ -106,7 +105,7 @@ func WithDataAttributes(attributes ...string) TDFOption {
 	return func(c *TDFConfig) error {
 		c.attributeValues = nil
 		for _, a := range attributes {
-			v, err := autoconfigure.NewAttributeValueFQN(a)
+			v, err := NewAttributeValueFQN(a)
 			if err != nil {
 				return err
 			}
@@ -118,16 +117,16 @@ func WithDataAttributes(attributes ...string) TDFOption {
 
 // WithDataAttributeValues appends the given data attributes to the bound policy.
 // Unlike `WithDataAttributes`, this will not trigger an attribute definition lookup
-// during autoconfigure. That is, to use autoconfigure in an 'offline' context,
+// during  That is, to use autoconfigure in an 'offline' context,
 // you must first store the relevant attribute information locally and load
 // it to the `CreateTDF` method with this option.
 func WithDataAttributeValues(attributes ...*policy.Value) TDFOption {
 	return func(c *TDFConfig) error {
-		c.attributes = make([]autoconfigure.AttributeValueFQN, len(attributes))
+		c.attributes = make([]AttributeValueFQN, len(attributes))
 		c.attributeValues = make([]*policy.Value, len(attributes))
 		for i, a := range attributes {
 			c.attributeValues[i] = a
-			afqn, err := autoconfigure.NewAttributeValueFQN(a.GetFqn())
+			afqn, err := NewAttributeValueFQN(a.GetFqn())
 			if err != nil {
 				// TODO: update service to validate and encode FQNs properly
 				return err
@@ -154,9 +153,9 @@ func WithKasInformation(kasInfoList ...KASInfo) TDFOption {
 	}
 }
 
-func withSplitPlan(p ...autoconfigure.SplitStep) TDFOption {
+func withSplitPlan(p ...keySplitStep) TDFOption {
 	return func(c *TDFConfig) error {
-		c.splitPlan = make([]autoconfigure.SplitStep, len(p))
+		c.splitPlan = make([]keySplitStep, len(p))
 		copy(c.splitPlan, p)
 		c.autoconfigure = false
 		return nil

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -21,10 +21,8 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/opentdf/platform/lib/ocrypto"
 	kaspb "github.com/opentdf/platform/protocol/go/kas"
-	"github.com/opentdf/platform/protocol/go/policy"
 	attributespb "github.com/opentdf/platform/protocol/go/policy/attributes"
 	wellknownpb "github.com/opentdf/platform/protocol/go/wellknownconfiguration"
-	"github.com/opentdf/platform/sdk/internal/autoconfigure"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -54,8 +52,8 @@ type tdfTest struct {
 	tdfFileSize      float64
 	checksum         string
 	mimeType         string
-	splitPlan        []autoconfigure.SplitStep
-	policy           []autoconfigure.AttributeValueFQN
+	splitPlan        []keySplitStep
+	policy           []AttributeValueFQN
 	expectedPlanSize int
 }
 
@@ -979,7 +977,7 @@ func (s *TDFSuite) Test_KeySplits() {
 			fileSize:    5,
 			tdfFileSize: 2664,
 			checksum:    "ed968e840d10d2d313a870bc131a4e2c311d7ad09bdf32b3418147221f51a6e2",
-			splitPlan: []autoconfigure.SplitStep{
+			splitPlan: []keySplitStep{
 				{KAS: "https://a.kas/", SplitID: "a"},
 				{KAS: "https://b.kas/", SplitID: "a"},
 				{KAS: `https://c.kas/`, SplitID: "a"},
@@ -990,7 +988,7 @@ func (s *TDFSuite) Test_KeySplits() {
 			fileSize:    5,
 			tdfFileSize: 2664,
 			checksum:    "ed968e840d10d2d313a870bc131a4e2c311d7ad09bdf32b3418147221f51a6e2",
-			splitPlan: []autoconfigure.SplitStep{
+			splitPlan: []keySplitStep{
 				{KAS: "https://a.kas/", SplitID: "a"},
 				{KAS: "https://b.kas/", SplitID: "b"},
 				{KAS: "https://c.kas/", SplitID: "c"},
@@ -1001,7 +999,7 @@ func (s *TDFSuite) Test_KeySplits() {
 			fileSize:    5,
 			tdfFileSize: 3211,
 			checksum:    "ed968e840d10d2d313a870bc131a4e2c311d7ad09bdf32b3418147221f51a6e2",
-			splitPlan: []autoconfigure.SplitStep{
+			splitPlan: []keySplitStep{
 				{KAS: "https://a.kas/", SplitID: "a"},
 				{KAS: "https://b.kas/", SplitID: "a"},
 				{KAS: "https://b.kas/", SplitID: "b"},
@@ -1044,7 +1042,7 @@ func (s *TDFSuite) Test_Autoconfigure() {
 			fileSize:         5,
 			tdfFileSize:      1733,
 			checksum:         "ed968e840d10d2d313a870bc131a4e2c311d7ad09bdf32b3418147221f51a6e2",
-			policy:           []autoconfigure.AttributeValueFQN{clsAllowed},
+			policy:           []AttributeValueFQN{clsA},
 			expectedPlanSize: 1,
 		},
 		{
@@ -1052,7 +1050,7 @@ func (s *TDFSuite) Test_Autoconfigure() {
 			fileSize:         5,
 			tdfFileSize:      2517,
 			checksum:         "ed968e840d10d2d313a870bc131a4e2c311d7ad09bdf32b3418147221f51a6e2",
-			policy:           []autoconfigure.AttributeValueFQN{rel2aus, rel2usa},
+			policy:           []AttributeValueFQN{rel2aus, rel2usa},
 			expectedPlanSize: 2,
 		},
 	} {
@@ -1070,6 +1068,7 @@ func (s *TDFSuite) Test_Autoconfigure() {
 				_ = os.Remove(plaintTextFileName)
 				_ = os.Remove(tdfFileName)
 			}()
+			s.sdk.kasKeyCache.store(KASInfo{})
 
 			// test encrypt
 			tdo := s.testEncrypt(s.sdk, kasInfoList, plaintTextFileName, tdfFileName, test)
@@ -1247,7 +1246,7 @@ func (s *TDFSuite) startBackend() {
 		{"https://c.kas/", mockRSAPrivateKey3, mockRSAPublicKey3},
 		{kasAu, mockRSAPrivateKey1, mockRSAPublicKey1},
 		{kasCa, mockRSAPrivateKey2, mockRSAPublicKey2},
-		{lasUk, mockRSAPrivateKey2, mockRSAPublicKey2},
+		{kasUk, mockRSAPrivateKey2, mockRSAPublicKey2},
 		{kasNz, mockRSAPrivateKey3, mockRSAPublicKey3},
 		{kasUs, mockRSAPrivateKey1, mockRSAPublicKey1},
 	} {
@@ -1309,116 +1308,6 @@ func (f *FakeWellKnown) GetWellKnownConfiguration(_ context.Context, _ *wellknow
 	}, nil
 }
 
-const (
-	kasAu     = "https://kas.au/"
-	kasCa     = "https://kas.ca/"
-	lasUk     = "https://kas.uk/"
-	kasNz     = "https://kas.nz/"
-	kasUs     = "https://kas.us/"
-	kasUsHcs  = "https://hcs.kas.us/"
-	kasUsSI   = "https://si.kas.us/"
-	authority = "https://virtru.com/"
-)
-
-var (
-	CLS, _ = autoconfigure.NewAttributeNameFQN("https://virtru.com/attr/Classification")
-	N2K, _ = autoconfigure.NewAttributeNameFQN("https://virtru.com/attr/Need%20to%20Know")
-	REL, _ = autoconfigure.NewAttributeNameFQN("https://virtru.com/attr/Releasable%20To")
-
-	clsAllowed, _ = autoconfigure.NewAttributeValueFQN("https://virtru.com/attr/Classification/value/Allowed")
-
-	rel2aus, _ = autoconfigure.NewAttributeValueFQN("https://virtru.com/attr/Releasable%20To/value/AUS")
-	rel2usa, _ = autoconfigure.NewAttributeValueFQN("https://virtru.com/attr/Releasable%20To/value/USA")
-)
-
-func mockAttributeFor(fqn autoconfigure.AttributeNameFQN) *policy.Attribute {
-	ns := policy.Namespace{
-		Id:   "v",
-		Name: "virtru.com",
-		Fqn:  "https://virtru.com",
-	}
-	switch fqn {
-	case CLS:
-		return &policy.Attribute{
-			Id:        "CLS",
-			Namespace: &ns,
-			Name:      "Classification",
-			Rule:      policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY,
-			Fqn:       fqn.String(),
-		}
-	case N2K:
-		return &policy.Attribute{
-			Id:        "N2K",
-			Namespace: &ns,
-			Name:      "Need to Know",
-			Rule:      policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF,
-			Fqn:       fqn.String(),
-		}
-	case REL:
-		return &policy.Attribute{
-			Id:        "REL",
-			Namespace: &ns,
-			Name:      "Releasable To",
-			Rule:      policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
-			Fqn:       fqn.String(),
-		}
-	}
-	return nil
-}
-func mockValueFor(fqn autoconfigure.AttributeValueFQN) *policy.Value {
-	an := fqn.Prefix()
-	a := mockAttributeFor(an)
-	v := fqn.Value()
-	p := policy.Value{
-		Id:        a.GetId() + ":" + v,
-		Attribute: a,
-		Value:     v,
-		Fqn:       fqn.String(),
-	}
-
-	switch an {
-	case N2K:
-		switch fqn.Value() {
-		case "INT":
-			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: lasUk}
-		case "HCS":
-			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: kasUsHcs}
-		case "SI":
-			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: kasUsSI}
-		}
-
-	case REL:
-		switch fqn.Value() {
-		case "FVEY":
-			p.Grants = make([]*policy.KeyAccessServer, 5)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: kasAu}
-			p.Grants[1] = &policy.KeyAccessServer{Uri: kasCa}
-			p.Grants[2] = &policy.KeyAccessServer{Uri: lasUk}
-			p.Grants[3] = &policy.KeyAccessServer{Uri: kasNz}
-			p.Grants[4] = &policy.KeyAccessServer{Uri: kasUs}
-		case "AUS":
-			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: kasAu}
-		case "CAN":
-			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: kasCa}
-		case "GBR":
-			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: lasUk}
-		case "NZL":
-			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: kasNz}
-		case "USA":
-			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = &policy.KeyAccessServer{Uri: kasUs}
-		}
-	}
-	return &p
-}
-
 type FakeAttributes struct {
 	attributespb.UnimplementedAttributesServiceServer
 }
@@ -1426,7 +1315,7 @@ type FakeAttributes struct {
 func (f *FakeAttributes) GetAttributeValuesByFqns(_ context.Context, in *attributespb.GetAttributeValuesByFqnsRequest) (*attributespb.GetAttributeValuesByFqnsResponse, error) {
 	r := make(map[string]*attributespb.GetAttributeValuesByFqnsResponse_AttributeAndValue)
 	for _, fqn := range in.GetFqns() {
-		av, err := autoconfigure.NewAttributeValueFQN(fqn)
+		av, err := NewAttributeValueFQN(fqn)
 		if err != nil {
 			slog.Error("invalid fqn", "notfqn", fqn, "error", err)
 			return nil, status.New(codes.InvalidArgument, fmt.Sprintf("invalid attribute fqn [%s]", fqn)).Err()

--- a/test/policy-service.bats
+++ b/test/policy-service.bats
@@ -43,6 +43,11 @@
   [[ $output = *"registered kas"* ]]
   [ $status = 0 ]
 
+  run go run ./examples --creds opentdf:secret kas add -k https://example.io --public-key MY_PUBLIC_KEY --kid my-public-key --algorithm rsa:2048
+  echo "$output"
+  [[ $output = *"registered kas"* ]]
+  [ $status = 0 ]
+
   run go run ./examples --creds opentdf:secret kas ls
   echo "$output"
   [[ $output = *"https://example.io"* ]]

--- a/test/policy-service.bats
+++ b/test/policy-service.bats
@@ -16,7 +16,7 @@
   [[ $output = *"listing namespaces"* ]]
   [ $status = 0 ]
 
-  run go run ./examples --creds opentdf:secret attributes add -a https://example.io/attr/IntellectualProperty -v "TradeSecret Proprietary BusinessSensitive Open" --rule hierarchy 
+  run go run ./examples --creds opentdf:secret attributes add -a https://example.io/attr/IntellectualProperty -v "TradeSecret,Proprietary,BusinessSensitive,Open" --rule hierarchy 
   echo "$output"
   [[ $output = *"created attribute"* ]]
   [ $status = 0 ]
@@ -71,7 +71,7 @@
   [[ $output = *"https://c.example.io"* ]]
   [ $status = 0 ]
 
-  go run ./examples --creds opentdf:secret attributes add -a https://grant.example.io/attr/test -v "a b c"
+  go run ./examples --creds opentdf:secret attributes add -a https://grant.example.io/attr/test -v "a,b,c"
 
   go run ./examples --creds opentdf:secret attributes assign -a https://grant.example.io/attr/test -v a -k https://a.example.io
   go run ./examples --creds opentdf:secret attributes assign -a https://grant.example.io/attr/test -v b -k https://b.example.io

--- a/test/tdf-roundtrips.bats
+++ b/test/tdf-roundtrips.bats
@@ -27,6 +27,35 @@
   printf '%s\n' "$output" | grep "Hello Zero Trust"
 }
 
+@test "examples: roundtrip Z-TDF with extra unnecessary, invalid kas" {
+  # TODO: add subject mapping here to remove reliance on `provision fixtures`
+  echo "[INFO] configure attribute with grant for local kas"
+  go run ./examples --creds opentdf:secret kas add --kas http://localhost:8080 --public-key "$(<${BATS_TEST_DIRNAME}/../kas-cert.pem)"
+  go run ./examples --creds opentdf:secret kas add --kas http://localhost:9090 --algorithm "rsa:2048" --kid r2 --public-key "$(<${BATS_TEST_DIRNAME}/../kas-cert.pem)"
+  go run ./examples --creds opentdf:secret attributes unassign -a https://example.com/attr/attr1 -v value1
+  go run ./examples --creds opentdf:secret attributes unassign -a https://example.com/attr/attr1
+  go run ./examples --creds opentdf:secret attributes assign -a https://example.com/attr/attr1 -v value1 -k "http://localhost:8080,http://localhost:9090"
+
+  echo "[INFO] create a tdf3 format file"
+  run go run ./examples encrypt "Hello multikao split"
+  echo "[INFO] echoing output; if successful, this is just the manifest"
+  echo "$output"
+
+  echo "[INFO] Validate the manifest lists the expected kid in its KAO"
+  u1=$(jq -r '.encryptionInformation.keyAccess[0].url' <<<"${output}")
+  u2=$(jq -r '.encryptionInformation.keyAccess[1].url' <<<"${output}")
+  sid1=$(jq -r '.encryptionInformation.keyAccess[0].sid' <<<"${output}")
+  sid2=$(jq -r '.encryptionInformation.keyAccess[1].sid' <<<"${output}")
+  echo "${u1},${sid1} ?= ${u2},${sid2}"
+  [ $u1 != $u2 ]
+  [ $sid1 = $sid2 ]
+
+  echo "[INFO] decrypting..."
+  run go run ./examples decrypt sensitive.txt.tdf
+  echo "$output"
+  printf '%s\n' "$output" | grep "Hello multikao split"
+}
+
 @test "examples: roundtrip nanoTDF" {
   echo "[INFO] creating nanotdf file"
   go run ./examples encrypt -o sensitive.txt.ntdf --nano "Hello NanoTDF"


### PR DESCRIPTION
- During encrypt autoconfigure, load any KAS keys found in the policy service's Kas Registry that are associated with grants
- These are then used to wrap any key access objects
- Adds a bats test that demonstrates loading a key from a KAS that is offline