### PR TITLE
fix(core): policy db should use pool connection hook to set search_path

### DIFF
--- a/service/pkg/db/db.go
+++ b/service/pkg/db/db.go
@@ -158,13 +158,6 @@ func New(ctx context.Context, config Config, logCfg logger.Config, o ...OptsFunc
 		}
 	}
 
-	// Set the Client search_path to the schema
-	q := fmt.Sprintf("SET search_path TO %s", config.Schema)
-	if _, err := c.Pgx.Exec(ctx, q); err != nil {
-		return nil, fmt.Errorf("failed to SET search_path for db Client schema to [%s]: %w", config.Schema, err)
-	}
-
-	slog.Info("successfully set database client search_path", slog.String("schema", config.Schema))
 	return &c, nil
 }
 
@@ -185,7 +178,21 @@ func (c Config) buildConfig() (*pgxpool.Config, error) {
 		c.Database,
 		c.SSLMode,
 	)
-	return pgxpool.ParseConfig(u)
+	parsed, err := pgxpool.ParseConfig(u)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pgx config: %w", err)
+	}
+	// Configure the search_path schema immediately on connection opening
+	parsed.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, fmt.Sprintf("SET search_path TO %s", c.Schema))
+		if err != nil {
+			slog.Error("failed to set database client search_path", slog.String("schema", c.Schema), slog.String("error", err.Error()))
+			return err
+		}
+		slog.Info("successfully set database client search_path", slog.String("schema", c.Schema))
+		return nil
+	}
+	return parsed, nil
 }
 
 // Common function for all queryRow calls

--- a/service/pkg/db/db.go
+++ b/service/pkg/db/db.go
@@ -189,7 +189,7 @@ func (c Config) buildConfig() (*pgxpool.Config, error) {
 			slog.Error("failed to set database client search_path", slog.String("schema", c.Schema), slog.String("error", err.Error()))
 			return err
 		}
-		slog.Info("successfully set database client search_path", slog.String("schema", c.Schema))
+		slog.Debug("successfully set database client search_path", slog.String("schema", c.Schema))
 		return nil
 	}
 	return parsed, nil

--- a/service/pkg/db/db_test.go
+++ b/service/pkg/db/db_test.go
@@ -49,5 +49,7 @@ func Test_BuildConfig(t *testing.T) {
 		cfg, err := test.config.buildConfig()
 		require.NoError(t, err)
 		assert.Equal(t, test.want, cfg.ConnString())
+		// AfterConnect hook was defined when building
+		assert.NotNil(t, cfg.AfterConnect)
 	}
 }


### PR DESCRIPTION
Resolves #1442

Instead of executing the `SET search_path` on the first connection found when a pool is instantiated, we should utilize the `AfterConnect` [PGX hook](https://github.com/jackc/pgx/blob/4f7e19d67df4d411ac1c19373390021a2f23aa07/pgxtest/pgxtest.go#L37) which exposes a connection immediately after it's opened and before it's utilized.