### PR TITLE
chore(docs): fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - [Configuration](./docs/configuration.md)
 - [Development](#development)
-- [Policy Config Schema](./service/migrations/20240212000000_schema_erd.md)
+- [Policy Config Schema](./service/policy/db/migrations/20240212000000_schema_erd.md)
 - [Policy Config Testing Diagram](./service/integration/testing_diagram.png)
 
 ### Prerequisites for Project Consumers & Contributors


### PR DESCRIPTION
schema diagram link is broken in the top level readme. Updating it to the new path. 
Fixes https://github.com/opentdf/platform/issues/1459