### PR TITLE
fix(core): Fix deadlock when registering config with duplicate namespace

### DIFF
--- a/service/wellknownconfiguration/wellknown_configuration.go
+++ b/service/wellknownconfiguration/wellknown_configuration.go
@@ -27,11 +27,11 @@ var (
 
 func RegisterConfiguration(namespace string, config any) error {
 	rwMutex.Lock()
+	defer rwMutex.Unlock()
 	if _, ok := wellKnownConfiguration[namespace]; ok {
 		return fmt.Errorf("namespace %s configuration already registered", namespace)
 	}
 	wellKnownConfiguration[namespace] = config
-	rwMutex.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
This small bug was found while browsing through the code base.  This PR closes #1461 