### PR TITLE
fix(core): Add NanoTDF KID padding removal and update logging level

### DIFF
--- a/sdk/resource_locator.go
+++ b/sdk/resource_locator.go
@@ -150,6 +150,7 @@ func (rl *ResourceLocator) setURLWithIdentifier(url string, identifier string) e
 }
 
 // GetIdentifier - identifier is returned if the correct protocol enum is set else error
+// padding is removed unlike rl.identifier direct access
 func (rl ResourceLocator) GetIdentifier() (string, error) {
 	// read the identifier if it exists
 	switch rl.protocol & 0xf0 {
@@ -159,7 +160,10 @@ func (rl ResourceLocator) GetIdentifier() (string, error) {
 		if rl.identifier == "" {
 			return "", fmt.Errorf("no resource locator identifer: %d", rl.protocol)
 		}
-		return rl.identifier, nil
+		// remove padding
+		cleanedIdentifier := strings.TrimRight(rl.identifier, "\x00")
+		cleanedIdentifier = strings.TrimLeft(cleanedIdentifier, "\x00")
+		return cleanedIdentifier, nil
 	}
 	return "", fmt.Errorf("unsupported identifer protocol: %x", rl.protocol)
 }

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -402,16 +402,16 @@ func (p *Provider) nanoTDFRewrap(ctx context.Context, body *RequestBody, entity 
 	// Lookup KID from nano header
 	kid, err := header.GetKasURL().GetIdentifier()
 	if err != nil {
-		p.Logger.InfoContext(ctx, "nanoTDFRewrap GetIdentifier", "kid", kid, "err", err)
+		p.Logger.DebugContext(ctx, "nanoTDFRewrap GetIdentifier", "kid", kid, "err", err)
 		// legacy nano with KID
 		kid, err = p.lookupKid(ctx, security.AlgorithmECP256R1)
 		if err != nil {
 			p.Logger.ErrorContext(ctx, "failure to find default kid for ec", "err", err)
 			return nil, err400("bad request")
 		}
-		p.Logger.InfoContext(ctx, "nanoTDFRewrap lookupKid", "kid", kid)
+		p.Logger.DebugContext(ctx, "nanoTDFRewrap lookupKid", "kid", kid)
 	}
-	p.Logger.InfoContext(ctx, "nanoTDFRewrap", "kid", kid)
+	p.Logger.DebugContext(ctx, "nanoTDFRewrap", "kid", kid)
 	ecCurve, err := header.ECCurve()
 	if err != nil {
 		return nil, fmt.Errorf("ECCurve failed: %w", err)


### PR DESCRIPTION
Introduced padding removal logic in the `GetIdentifier` method of `ResourceLocator` to ensure cleaned identifiers. Also changed log level from Info to Debug in `nanoTDFRewrap` for more appropriate logging detail.

resolves #1467 