### PR TITLE
chore(core): Updates golangci-lint to 1.60

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -63,9 +63,9 @@ jobs:
         if: env.IS_RELEASE_BRANCH == 'true'
         working-directory: ${{ matrix.directory }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86
         with:
-          version: v1.59
+          version: v1.60
           working-directory: ${{ matrix.directory }}
           skip-cache: true
           args: --out-format=colored-line-number

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,6 +66,9 @@ linters-settings:
             recommendations:
               - github.com/google/uuid
             reason: "gofrs' package is not go module"
+  gosec:
+    excludes:
+      - G115 # integer overflow protection; 
 
   govet:
     # Enable all analyzers.

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ all: toolcheck clean build lint license test
 toolcheck:
 	@echo "Checking for required tools..."
 	@which buf > /dev/null || (echo "buf not found, please install it from https://docs.buf.build/installation" && exit 1)
-	@which golangci-lint > /dev/null || (echo "golangci-lint not found, run  'go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1'" && exit 1)
+	@which golangci-lint > /dev/null || (echo "golangci-lint not found, run  'go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3'" && exit 1)
 	@which protoc-gen-doc > /dev/null || (echo "protoc-gen-doc not found, run 'go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1'" && exit 1)
-	@golangci-lint --version | grep "version v\?1.59" > /dev/null || (echo "golangci-lint version must be v1.59 or later [$$(golangci-lint --version)]" && exit 1)
+	@golangci-lint --version | grep "version v\?1.60" > /dev/null || (echo "golangci-lint version must be v1.60 or later [$$(golangci-lint --version)]" && exit 1)
 	@which goimports >/dev/null || (echo "goimports not found, run 'go install golang.org/x/tools/cmd/goimports@latest'")
 
 fix: tidy fmt

--- a/sdk/internal/oauth/oauth_test.go
+++ b/sdk/internal/oauth/oauth_test.go
@@ -111,7 +111,7 @@ func (s *OAuthSuite) TestCertExchangeFromKeycloak() {
 
 	expectedThumbprint := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(hash)
 	s.Equal(expectedThumbprint, idpKeyFingerprint, "didn't get expected fingerprint")
-	s.Greaterf(tok.ExpiresIn, int64(0), "invalid expiration is before current time: %v", tok)
+	s.Positivef(tok.ExpiresIn, "invalid expiration is before current time: %v", tok)
 	s.Falsef(tok.Expired(), "got a token that is currently expired: %v", tok)
 
 	name, ok := tokenDetails.Get("name")
@@ -157,7 +157,7 @@ func (s *OAuthSuite) TestGettingAccessTokenFromKeycloak() {
 
 	expectedThumbprint := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(hash)
 	s.Equal(expectedThumbprint, idpKeyFingerprint, "didn't get expected fingerprint")
-	s.Greaterf(tok.ExpiresIn, int64(0), "invalid expiration is before current time: %v", tok)
+	s.Positivef(tok.ExpiresIn, "invalid expiration is before current time: %v", tok)
 	s.Falsef(tok.Expired(), "got a token that is currently expired: %v", tok)
 
 	// verify that we got a token that has the opentdf-standard role, which only the sdk client has
@@ -218,7 +218,7 @@ func (s *OAuthSuite) TestDoingTokenExchangeWithKeycloak() {
 
 	expectedThumbprint := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(hash)
 	s.Equal(expectedThumbprint, idpKeyFingerprint, "didn't get expected fingerprint")
-	s.Greaterf(subjectToken.ExpiresIn, int64(0), "invalid expiration is before current time: %v", subjectToken)
+	s.Positivef(subjectToken.ExpiresIn, "invalid expiration is before current time: %v", subjectToken)
 	s.Falsef(subjectToken.Expired(), "got a token that is currently expired: %v", subjectToken)
 
 	// verify that we got a token that has the opentdf-standard role, which only the sdk client has

--- a/service/integration/attribute_values_test.go
+++ b/service/integration/attribute_values_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/opentdf/platform/service/internal/fixtures"
 	"github.com/opentdf/platform/service/pkg/db"
 	policydb "github.com/opentdf/platform/service/policy/db"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -595,9 +594,9 @@ func (s *AttributeValuesSuite) Test_DeactivateAttribute_Cascades_List() {
 	}
 
 	for _, tableTest := range tests {
-		s.T().Run(tableTest.name, func(t *testing.T) {
+		s.Run(tableTest.name, func() {
 			found := tableTest.testFunc(tableTest.state)
-			assert.Equal(t, tableTest.isFound, found)
+			s.Equal(tableTest.isFound, found)
 		})
 	}
 }

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/opentdf/platform/service/internal/fixtures"
 	"github.com/opentdf/platform/service/pkg/db"
 	policydb "github.com/opentdf/platform/service/policy/db"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -997,9 +996,9 @@ func (s *AttributesSuite) Test_DeactivateAttribute_Cascades_List() {
 	}
 
 	for _, tableTest := range tests {
-		s.T().Run(tableTest.name, func(t *testing.T) {
+		s.Run(tableTest.name, func() {
 			found := tableTest.testFunc(tableTest.state)
-			assert.Equal(t, tableTest.isFound, found)
+			s.Equal(tableTest.isFound, found)
 		})
 	}
 }

--- a/service/integration/namespaces_test.go
+++ b/service/integration/namespaces_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/opentdf/platform/service/internal/fixtures"
 	"github.com/opentdf/platform/service/pkg/db"
 	policydb "github.com/opentdf/platform/service/policy/db"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -371,9 +370,9 @@ func (s *NamespacesSuite) Test_DeactivateNamespace_Cascades_List() {
 	}
 
 	for _, tableTest := range tests {
-		s.T().Run(tableTest.name, func(t *testing.T) {
+		s.Run(tableTest.name, func() {
 			found := tableTest.testFunc(tableTest.state)
-			assert.Equal(t, tableTest.isFound, found)
+			s.Equal(tableTest.isFound, found)
 		})
 	}
 }

--- a/service/integration/resource_mappings_test.go
+++ b/service/integration/resource_mappings_test.go
@@ -385,7 +385,7 @@ func (s *ResourceMappingsSuite) Test_ListResourceMappings() {
 				break
 			}
 		}
-		s.True(found, fmt.Sprintf("expected to find mapping %s", testMapping.ID))
+		s.True(found, "expected to find mapping %s", testMapping.ID)
 	}
 }
 


### PR DESCRIPTION
- disables new integer overflow check with too many hits
- fixes other issues
- Fixes #1409 