### PR TITLE
fix(sdk): DoS protection through TDF segment sizes

### DIFF
--- a/sdk/fuzz_test.go
+++ b/sdk/fuzz_test.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"io"
 	"net/http"
@@ -46,6 +47,13 @@ func (f *fakeTokenSource) MakeToken(func(jwk.Key) ([]byte, error)) ([]byte, erro
 	return []byte("fake token"), nil
 }
 
+type fakeWriter struct {
+}
+
+func (fw *fakeWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
 func unverifiedBase64Bytes(str string) []byte {
 	b, _ := base64.StdEncoding.DecodeString(str)
 	return b
@@ -66,7 +74,7 @@ func FuzzLoadTDF(f *testing.F) {
 		require.NoError(f, err)
 		return err
 	}))
-	// seed with large manifest allocation
+	// seed with large manifest allocation up front
 	f.Add(unverifiedBase64Bytes("UEsDBC0ACAAAAH11LzEAAAAAAAAAAAAAAAAJAAAAM" +
 		"C5wYXlsb2Fk5LJYrTiapi/CUQ0dlqMU0/VmunX+qRIyQghasf6aEVBLBwgke7o5HwAAAB8A" +
 		"AABQSwMELQAIAAAAfXUvMQAAAAAAAAAAAAAAAA8AAAAwLm1hbmlmZXN0Lmpzb257ImVOY3J" +
@@ -97,6 +105,85 @@ func FuzzLoadTDF(f *testing.F) {
 		"HCALoriwCBQAAAgUAAFBLAQItAC0ACAAAAH11LzEke7o5HwAAAB8AAAAJAAAAAAAAAAAAAA" +
 		"AAAAAAAAAwLnBheWxvYWRQSwECLQAtAAgAAAB9dS8xAuiuLAIE///tBQAADwAAAAAAAAAAA" +
 		"AAAAABWAAAAMC5tYW5pZmVzdC5qc29uUEsFBgAAAAACAAIAdAAAAJUFAAAAAA=="))
+	// small manifest lies about payload sizes, instead defines maximum values
+	f.Add(unverifiedBase64Bytes("UEsDBC0ACAAAAF2CRjEAAAAAAAAAAAAAAAAJAAAAM" +
+		"C5wYXlsb2FkTWCxOyxyaAcOOlXw7VBpYSZPdIIa1yc0DEIZVk+Cn1BLBwgrOASPHwAAAB8A" +
+		"AABQSwMELQAIAAAAXYJGMQAAAAAAAAAAAAAAAA8AAAAwLm1hbmlmZXN0Lmpzb257ImVuY3J" +
+		"5cHRpb25JbmZvcm1hdGlvbiI6eyJ0eXBlIjoic3BsaXQiLCJwb2xpY3kiOiJleUoxZFdsa0" +
+		"lqb2lZVGcxT0dKa05qTXRObU0yWWkweE1XVm1MV0UxTjJFdE1EQXdZekk1TVRabE9HVTFJa" +
+		"XdpWW05a2VTSTZleUprWVhSaFFYUjBjbWxpZFhSbGN5STZiblZzYkN3aVpHbHpjMlZ0SWpw" +
+		"dWRXeHNmWDA9Iiwia2V5QWNjZXNzIjpbeyJ0eXBlIjoid3JhcHBlZCIsInVybCI6ImV4YW1" +
+		"wbGUuY29tIiwicHJvdG9jb2wiOiJrYXMiLCJ3cmFwcGVkS2V5IjoiQUVab1E0ZFpjSlpxTl" +
+		"h3L0tEd20zQ1J1YUxrRVBXeEVuQnBwUWZhTzZ1c2k1bWxBVnR4SnZHYTliU3lpc0taWFVnU" +
+		"kVpZDdwVzRQeTdSb2E1MWxXOFA0Mk1sYlZEdlJiL1g0NlBwemUrbmIzQlMxS05yWVBwakNU" +
+		"YitaUkdFNzByRHpMNXRWYmNVRzN1YnhNREJGd3NQMXM0cTd6OGhjVHpodVZpSEZ4SVdRcUd" +
+		"rYzNEM01QRjU2NzFneUlwOWxyVWZsSnZxZGFGRlZmejEyRFJhWGVRYVRVMDdDN21XZi9IRj" +
+		"ltaHlWZmVMazUxLzJlQkIvYkcyOUIvc0IzKzVWKy9YWFZZeXNzc0s3YzU0UVByd1BOYzBZN" +
+		"HFvWFgwMWY3QWcyY2JWaFJmMjluOXV0RU81aWFUUmRpWVFuNXdYeTBtSFZGTVRIWlVFYUg4" +
+		"UmhCTHpsQVNRPT0iLCJwb2xpY3lCaW5kaW5nIjp7ImFsZyI6IkhTMjU2IiwiaGFzaCI6Ilp" +
+		"XWXlPREEzT0RFNFlqZ3pZemcyTW1Vek5tWmhNREEyTnpCbE9XWTVZemRtWXpZNE9HUmlOal" +
+		"U0TjJZMll6WmpZVE13WWpoaU9UQXlaR0UxTlRjd05BPT0ifX1dLCJtZXRob2QiOnsiYWxnb" +
+		"3JpdGhtIjoiQUVTLTI1Ni1HQ00iLCJpdiI6IiIsImlzU3RyZWFtYWJsZSI6dHJ1ZX0sImlu" +
+		"dGVncml0eUluZm9ybWF0aW9uIjp7InJvb3RTaWduYXR1cmUiOnsiYWxnIjoiSFMyNTYiLCJ" +
+		"zaWciOiJOekZrTWpKaU16RTFPRGszWmpBeE9UZzBNVE0xWmpnd09HTTVPV0l5TTJVME5UTX" +
+		"paR1ppTWpsbFlUYzFNR1EzTm1VMlpXRmlPRFpoWXprek5ESXdNZz09In0sInNlZ21lbnRIY" +
+		"XNoQWxnIjoiR01BQyIsInNlZ21lbnRTaXplRGVmYXVsdCI6MjA5NzE1MiwiZW5jcnlwdGVk" +
+		"U2VnbWVudFNpemVEZWZhdWx0IjoyMDk3MTgwLCJzZWdtZW50cyI6W3siaGFzaCI6Ik5qRXl" +
+		"OalJtTnpRNE1qRmhaRGN5TnpNME1HTTBNakU1TlRZMFpqZ3lPV1k9Iiwic2VnbWVudFNpem" +
+		"UiOjMsImVuY3J5cHRlZFNlZ21lbnRTaXplIjozMX1dfX0sInBheWxvYWQiOnsidHlwZSI6I" +
+		"nJlZmVyZW5jZSIsInVybCI6IjAucGF5bG9hZCIsInByb3RvY29sIjoiemlwIiwibWltZVR5" +
+		"cGUiOiJhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0iLCJpc0VuY3J5cHRlZCI6dHJ1ZX19UEs" +
+		"HCDH2fQf//////////1BLAQItAC0ACAAAAF2CRjErOASPHwAAAB8AAAAJAAAAAAAAAAAAAA" +
+		"AAAAAAAAAwLnBheWxvYWRQSwECLQAtAAgAAABdgkYxMfZ9BwIFAAACBQAADwAAAAAAAAAAA" +
+		"AAAAABWAAAAMC5tYW5pZmVzdC5qc29uUEsFBgAAAAACAAIAdAAAAJUFAAAAAA=="))
+	// fuzzed failure from above seed with size overflow, will fail on WriteTo action
+	f.Add(unverifiedBase64Bytes("UEsDBC0ACAAAAF2uLzEAAAAAAAAAAAAAAAAJAAAAM" +
+		"C5wYXlsb2FkThU3KcYXLpEEfhvsuHrxvIer1/zmhcGctLZ6o0RNOFBLBwhp296fHwAAAB8A" +
+		"AABQSwMELQAIAAAAXa4vMQAAAAAAAAAAAAAAAA8AAAAwLm1hbmlmZXN0Lmpzb257ImVuY3J" +
+		"5cHRpb25JbmZvcm1hdGlvbiI6eyJ0eXBlIjoic3BsaXQiLCJwb2xpY3kiOiJleUoxZFdsa0" +
+		"lqb2lOalpsTkRJME5qQXROV0kxTUMweE1XVm1MVGt6Wm1JdE1EQXdZekk1TVRabE9HVTFJa" +
+		"XdpWW05a2VTSTZleUprWVhSaFFYUjBjbWxpZFhSbGN5STZiblZzYkN3aVpHbHpjMlZ0SWpw" +
+		"dWRXeHNmWDA9Iiwia2V5QWNjZXNzIjpbeyJ0eXBlIjoid3JhcHBlZCIsInVybCI6ImV4YW1" +
+		"wbGUuY29tIiwicHJvdG9jb2wiOiJrYXMiLCJ3cmFwcGVkS2V5IjoiSlFGUW1qVWlFdHdwOW" +
+		"Q1S3QvaythQmY0djA4akVSUjNhRnBldmV5cHVLdXhQODU1TUVRVFZ2R2k5VG9sdnBROUpne" +
+		"GRxdTNRdWVEMFp5SG9VZTM1cEU4U05wSCtEOXJjemFTMTh6MDVZME9KVUxyTEpwWUQrVDFa" +
+		"SWIyQ29razlsT0ZJalV6cUpqWkpPUE1GdDVsRjhEUlhSeDVGZm1oUEFKQkx4UmprTmpZUnJ" +
+		"lbWI4UW5wWFNXcWVDREZiYnJ4azNEcVpKaTdCODllYjlzbjFBNUZmUEk3Vjkwa0crSEN6Kz" +
+		"RVcGhNUzM0R1c5MXNTSkZpZ0ZJM2VBUEhiTTZoRnU2QndsZjdKK3hTUFZtd1FCdVVXMUxwe" +
+		"HFDQ3dkNFRxT3JPVXplWEE4aFJTdncvNW82VUlLZGpFUEhua0s1dXVwbStuTENBcmRONFA5" +
+		"L2JkS0h3ZXR3PT0iLCJwb2xpY3lCaW5kaW5nIjp7ImFsZyI6IkhTMjU2IiwiaGFzaCI6Ik5" +
+		"XUTROVEl5TW1WaU1tWTFZMlJqT0dJeFpUQTJOakk0WVdFME9XRmhaV05qTnpjMk1XSXdNVF" +
+		"U0WldRNVptTm1ZekJqTnpsbU5USTJZV0poTjJaall3PT0ifX1dLCJtZXRob2QiOnsiYWxnb" +
+		"3JpdGhtIjoiQUVTLTI1Ni1HQ00iLCJpdiI6IiIsImlzU3RyZWFtYWJsZSI6dHJ1ZX0sImlu" +
+		"dGVncml0eUluZm9ybWF0aW9uIjp7InJvb3RTaWduYXR1cmUiOnsiYWxnIjoiSFMyNTYiLCJ" +
+		"zaWciOiJPRFV5WWpKaU9HVmlaR1V3T0RFMk5HRmtNMkV5T0dObU9ETXdNR0k1WkRWa01HTm" +
+		"lNRFk1WlRBMFkyRXpNRFZtTm1Sak1UWmxZVGcxT0RjMlkyRXlNdz09In0sInNlZ21lbnRIY" +
+		"XNoQWxnIjoiR01BQyIsInNlZ21lbnRTaVplRGVmYXVsdCI6MjA5NzE1MiwiZW5jcnlwdGVk" +
+		"U2VnbWVudFNpemVEZWZhdWx0IjoyMDk3MTgwLCJzZWdtZW50cyI6W3siaGFzaCI6IlltTTR" +
+		"OMkZpWkRkbVkyVTJPRFZqTVRsallqUmlOamRoWVRNME5EUmtNemc9Iiwic2VnbWVudFNpem" +
+		"UiOjMsImVuY3J5cHRlZFNlZ21lbnRTaXplIjotMX1dfX0sInBheWxvYWQiOnsidHlwZSI6I" +
+		"nJlZmVyZW5jZSIsInVybCI6IjAucGF5bG9hZCIsInByb3RvY29sIjoiemlwIiwibWltZVR5" +
+		"cGUiOiJhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0iLCJpc0VuY3J5cHRlZCI6dHJ1ZX19UEs" +
+		"HCNSOqYACBQAAAgUAAFBLAQItAC0ACAAAAF2uLzFp296fHwAAAB8AAAAJAAAAAAAAAAAAAA" +
+		"AAAAAAAAAwLnBheWxvYWRQSwECLQAtAAgAAABdri8x1I6pgAIFAAACBQAADwAAAAAAAAAAA" +
+		"AAAAABWAAAAMC5tYW5pZmVzdC5qc29uUEsFBgAAAAACAAIAdAAAAJUFAAAAAA=="))
+	// large segment sizes
+	// commented out because payload is too large to provide an efficient seed context - only use for manual testing
+	/*f.Add(writeBytes(func(writer io.Writer) error {
+		size := math.MaxInt32 / 100 // just small enough to allow allocation for writing
+		reader := bytes.NewReader(make([]byte, size))
+		_, err := sdk.CreateTDF(writer, reader, func(tdfConfig *TDFConfig) error {
+			tdfConfig.kasInfoList = []KASInfo{{
+				URL:       "example.com",
+				PublicKey: mockRSAPublicKey1,
+				Default:   true,
+			}}
+			tdfConfig.defaultSegmentSize = int64(size)
+			return nil
+		})
+		require.NoError(f, err)
+		return err
+	}))*/
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		r, err := sdk.LoadTDF(bytes.NewReader(data))
@@ -105,7 +192,22 @@ func FuzzLoadTDF(f *testing.F) {
 			return
 		}
 		assert.NotNil(t, r)
-		// TODO fuzz r somewhat
+
+		// set fake payloadKey and associated data to avoid grpc request
+		r.payloadKey = make([]byte, kKeySize)
+		_, _ = rand.Read(r.payloadKey)
+		gcm, err := ocrypto.NewAESGcm(r.payloadKey)
+		require.NoError(t, err)
+		for _, seg := range r.manifest.EncryptionInformation.IntegrityInformation.Segments {
+			r.payloadSize += seg.Size
+		}
+		r.unencryptedMetadata = []byte{}
+		r.aesGcm = gcm
+
+		// validate TDF is safe to write, the segment sizes will result in allocations for example
+		_, _ = r.WriteTo(&fakeWriter{})
+		// DataAttributes builds a slice of attributes
+		_, _ = r.DataAttributes()
 	})
 }
 

--- a/sdk/internal/archive/reader.go
+++ b/sdk/internal/archive/reader.go
@@ -225,7 +225,7 @@ func (reader Reader) ReadFileData(filename string, index int64, length int64) ([
 		return nil, errZipFileNotFound
 	}
 
-	if length > fileNameEntry.length {
+	if length < 0 || length > fileNameEntry.length {
 		return nil, errZipFileSizeError
 	}
 

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -157,6 +157,11 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 	}
 
 	segmentSize := tdfConfig.defaultSegmentSize
+	if segmentSize > maxSegmentSize {
+		return nil, fmt.Errorf("segment size too large: %d", segmentSize)
+	} else if segmentSize < minSegmentSize {
+		return nil, fmt.Errorf("segment size too small: %d", segmentSize)
+	}
 	totalSegments := inputSize / segmentSize
 	if inputSize%segmentSize != 0 {
 		totalSegments++

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -10,6 +10,8 @@ import (
 const (
 	tdf3KeySize        = 2048
 	defaultSegmentSize = 2 * 1024 * 1024 // 2mb
+	maxSegmentSize     = defaultSegmentSize * 2
+	minSegmentSize     = 16 * 1024
 	kasPublicKeyPath   = "/kas_public_key"
 )
 
@@ -177,8 +179,14 @@ func WithMimeType(mimeType string) TDFOption {
 	}
 }
 
-// WithSegmentSize returns an Option that set the default segment size to TDF.
+// WithSegmentSize returns an Option that set the default segment size within the TDF. Any excessively large or small
+// values will be replaced with a supported value.
 func WithSegmentSize(size int64) TDFOption {
+	if size > maxSegmentSize {
+		size = maxSegmentSize
+	} else if size < minSegmentSize {
+		size = minSegmentSize
+	}
 	return func(c *TDFConfig) error {
 		c.defaultSegmentSize = size
 		return nil

--- a/sdk/tdf_config_test.go
+++ b/sdk/tdf_config_test.go
@@ -1,0 +1,97 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeConfig(t *testing.T, cfgFunc TDFOption) *TDFConfig {
+	tdfConfig, err := newTDFConfig(cfgFunc)
+	require.NoError(t, err)
+	return tdfConfig
+}
+
+func TestWithDataAttributes(t *testing.T) {
+	val1 := "https://example.com/attr/Classification/value/S"
+	val2 := "https://example.com/attr/Classification/value/X"
+	cfg := makeConfig(t, WithDataAttributes(val1, val2))
+
+	require.Len(t, cfg.attributes, 2)
+	assert.Equal(t, val1, cfg.attributes[0].url)
+	assert.Equal(t, val2, cfg.attributes[1].url)
+}
+
+func TestWithKasInformation(t *testing.T) {
+	val1 := "https://example.com/1"
+	val2 := "https://example.com/2"
+	cfg := makeConfig(t, WithKasInformation(KASInfo{URL: val1}, KASInfo{URL: val2}))
+
+	require.Len(t, cfg.kasInfoList, 2)
+	assert.Equal(t, val1, cfg.kasInfoList[0].URL)
+	assert.Equal(t, val2, cfg.kasInfoList[1].URL)
+}
+
+func TestWithMetaData(t *testing.T) {
+	md := "foo"
+	cfg := makeConfig(t, WithMetaData(md))
+
+	assert.Equal(t, md, cfg.metaData)
+}
+
+func TestWithMimeType(t *testing.T) {
+	mt := "foo"
+	cfg := makeConfig(t, WithMimeType(mt))
+
+	assert.Equal(t, mt, cfg.mimeType)
+}
+
+func TestWithSegmentSize(t *testing.T) {
+	tests := []struct {
+		name         string
+		optFunc      TDFOption
+		expectedSize int64
+	}{
+		{
+			name: "defaultSize",
+			optFunc: func(_ *TDFConfig) error {
+				return nil // no op
+			},
+			expectedSize: defaultSegmentSize,
+		},
+		{
+			name:         "inRangeSize",
+			optFunc:      WithSegmentSize(1024 * 1024),
+			expectedSize: 1024 * 1024,
+		},
+		{
+			name:         "tooSmallSize",
+			optFunc:      WithSegmentSize(1),
+			expectedSize: minSegmentSize,
+		},
+		{
+			name:         "tooLargeSize",
+			optFunc:      WithSegmentSize(maxSegmentSize + 1),
+			expectedSize: maxSegmentSize,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := makeConfig(t, test.optFunc)
+
+			assert.Equal(t, test.expectedSize, cfg.defaultSegmentSize)
+		})
+	}
+}
+
+func TestWithAssertions(t *testing.T) {
+	id1 := "1"
+	id2 := "2"
+	cfg := makeConfig(t, WithAssertions(AssertionConfig{ID: id1}, AssertionConfig{ID: id2}))
+
+	require.Len(t, cfg.assertions, 2)
+	assert.Equal(t, id1, cfg.assertions[0].ID)
+	assert.Equal(t, id2, cfg.assertions[1].ID)
+}


### PR DESCRIPTION
This fixes three DoS conditions discovered:
* Specifying a very large segment size which could result in the SDK allocating a large buffer in memory
* Specifyin a very small segment size which could result in excessive cpu and io overheads
* Specifying a size in the manifest which will overflow, resulting in a `panic` when a negative byte slice is allocated

Unit testing and fuzz testing was expanded to cover these conditions.  This PR fixes #1535