### PR TITLE
feat(ci): Get traffic metrics for OpenTDF repos 

### DIFF
--- a/.github/scripts/metrics.js
+++ b/.github/scripts/metrics.js
@@ -1,0 +1,49 @@
+async function getMetrics(github) {   
+    // Views -- last 14 days
+    const views = await github.rest.repos.getViews({
+        owner: process.env.OWNER,
+        repo: process.env.REPO,
+        })
+    
+    // Clones -- last 14 days
+    const clones = await github.rest.repos.getClones({
+        owner: process.env.OWNER,
+        repo: process.env.REPO,
+        })
+
+    // General info -- includes forks, stars, watchers
+    const get_info = await github.rest.repos.get({
+        owner: process.env.OWNER,
+        repo: process.env.REPO,
+    })
+
+
+    // Commits -- last 14 days getParticipationStats: ["GET /repos/{owner}/{repo}/stats/participation"] -- add togethor last two
+    const commits = await github.rest.repos.getParticipationStats({
+        owner: process.env.OWNER,
+        repo: process.env.REPO,
+        })
+    
+
+    // Referral Sources -- last 14 days getTopReferrers: ["GET /repos/{owner}/{repo}/traffic/popular/referrers"]
+    const referrals = await github.rest.repos.getTopReferrers({
+        owner: process.env.OWNER,
+        repo: process.env.REPO,
+        })
+    
+    const data = {
+        timestamp: new Date(),
+        event_type: process.env.EVENT_TYPE,
+        views: views.data.count, 
+        clones: clones.data.count, 
+        forks: get_info.data.forks_count,
+        stars: get_info.data.stargazers_count,
+        watchers: get_info.data.subscribers_count,
+        commits: commits.data.all[commits.data.all.length-1] + commits.data.all[commits.data.all.length-2],
+        top_referral_sources: referrals.data
+    }
+    // Retained Usage: Opening Issues, opening PRs, writing comments, posting/commenting on Discussions
+    return data
+} 
+
+module.exports = ({github, context}) => getMetrics(github, context)

--- a/.github/workflows/traffic.yaml
+++ b/.github/workflows/traffic.yaml
@@ -1,0 +1,74 @@
+on:
+  schedule: 
+    # runs once a week on sunday
+    - cron: "55 23 * * 0"
+
+    
+jobs:
+  traffic:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: 'write'
+    strategy:
+      matrix:
+        repo-values:
+          - {repo: platform, event: ""}
+          - {repo: otdfctl, event: backend-}
+          - {repo: spec, event: frontend-}
+          - {repo: tests, event: tests-}
+          - {repo: client-web, event: clientweb-}
+          - {repo: client-cpp, event: cpp-sdk-}
+          - {repo: java-sdk, event: java-sdk-}
+          - {repo: charts, event: charts-}
+          - {repo: nifi, event: nifi-}
+    steps:
+    - name: Generate a token
+      id: generate_token
+      uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+      with:
+        app-id: "${{ secrets.APP_ID }}"
+        private-key: "${{ secrets.AUTOMATION_KEY }}"
+        owner: opentdf 
+    - name: checkout repo
+      uses: actions/checkout@v3
+
+    - id: get-date
+      name: Set current date as env variable
+      run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+
+    - name: Get Traffic
+      uses: actions/github-script@v6
+      id: get-traffic
+      env:
+        OWNER: opentdf
+        REPO: ${{ matrix.repo-values.repo }}
+        EVENT_TYPE: opentdf-${{ matrix.repo-values.event }}github
+        TODAY_DATE: ${{ steps.get-date.outputs.DATE }}
+      with:
+        github-token: ${{ steps.generate_token.outputs.token }} 
+        retries: 3
+        script: |
+          var fs = require('fs')
+          const getMetrics = require('./.github/scripts/metrics.js')
+          const result = await getMetrics({github})
+          console.log(result)
+          const jsonObj = JSON.stringify(result)
+          await fs.writeFile(process.env.TODAY_DATE + "-" + process.env.EVENT_TYPE +".json", jsonObj, err =>{
+          if(err) throw err})
+          return result
+          
+    #https://github.com/marketplace/actions/authenticate-to-google-cloud#setup
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@62cf5bd3e4211a0a0b51f2c6d6a37129d828611d'
+      with:
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY }}
+        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+    - id: 'upload-file'
+      uses: 'google-github-actions/upload-cloud-storage@v1'
+      with:
+        path: './${{ steps.get-date.outputs.DATE }}-opentdf-${{ matrix.repo-values.event }}github.json'
+        destination: 'prj-opentdf-4fc4-opentdf-github-metrics-bucket-us-38uz'
+        project_id: 'prj-opentdf-4fc4'
+


### PR DESCRIPTION
this PR runs a workflow once a week to get Github repo traffic metrics for each of the opentdf public repos. it puts it in a gcp bucket where bigquery can be integrated. Goal is to be able to visualize the data over time to see views, referral sources, clones, etc. can be expanded in the future if we want any more info. 

https://github.com/opentdf/platform/actions/runs/10904129901
^ this was a successful run of the workflow. 