### PR TITLE
feat(sdk): Improve KAS key lookup and caching

### DIFF
--- a/lib/ocrypto/ec_key_pair.go
+++ b/lib/ocrypto/ec_key_pair.go
@@ -51,6 +51,20 @@ func GetECCurveFromECCMode(mode ECCMode) (elliptic.Curve, error) {
 	return c, nil
 }
 
+func (mode ECCMode) String() string {
+	switch mode {
+	case ECCModeSecp256r1:
+		return "ec:secp256r1"
+	case ECCModeSecp384r1:
+		return "ec:secp384r1"
+	case ECCModeSecp521r1:
+		return "ec:secp521r1"
+	case ECCModeSecp256k1:
+		return "ec:secp256k1"
+	}
+	return "unspecified"
+}
+
 // NewECKeyPair Generates an EC key pair of the given bit size.
 func NewECKeyPair(mode ECCMode) (ECKeyPair, error) {
 	var c elliptic.Curve

--- a/sdk/kas_client.go
+++ b/sdk/kas_client.go
@@ -326,8 +326,10 @@ func (c *kasKeyCache) store(ki KASInfo) {
 }
 
 func (s SDK) getPublicKey(ctx context.Context, url, algorithm string) (*KASInfo, error) {
-	if cachedValue := s.kasKeyCache.get(url, algorithm); nil != cachedValue {
-		return cachedValue, nil
+	if s.kasKeyCache != nil {
+		if cachedValue := s.kasKeyCache.get(url, algorithm); nil != cachedValue {
+			return cachedValue, nil
+		}
 	}
 	grpcAddress, err := getGRPCAddress(url)
 	if err != nil {
@@ -363,6 +365,8 @@ func (s SDK) getPublicKey(ctx context.Context, url, algorithm string) (*KASInfo,
 		KID:       kid,
 		PublicKey: resp.GetPublicKey(),
 	}
-	s.kasKeyCache.store(ki)
+	if s.kasKeyCache != nil {
+		s.kasKeyCache.store(ki)
+	}
 	return &ki, nil
 }

--- a/sdk/nanotdf_config.go
+++ b/sdk/nanotdf_config.go
@@ -91,30 +91,6 @@ func WithNanoDataAttributes(attributes ...string) NanoTDFOption {
 	}
 }
 
-type NanoKASInfo struct {
-	kasPublicKeyPem string
-	kasURL          string
-}
-
-// WithNanoKasInformation adds the first kas url and its corresponding public key
-// that is required to create and read the nanotdf.  Note that only the first
-// entry is used, as multi-kas is not supported for nanotdf
-func WithNanoKasInformation(kasInfoList ...NanoKASInfo) NanoTDFOption {
-	return func(c *NanoTDFConfig) error {
-		newKasInfos := make([]NanoKASInfo, 0)
-		newKasInfos = append(newKasInfos, kasInfoList...)
-		err := c.kasURL.setURL(newKasInfos[0].kasURL)
-		if err != nil {
-			return err
-		}
-		c.kasPublicKey, err = ocrypto.ECPubKeyFromPem([]byte(newKasInfos[0].kasPublicKeyPem))
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-}
-
 // WithECDSAPolicyBinding enable ecdsa policy binding
 func WithECDSAPolicyBinding() NanoTDFOption {
 	return func(c *NanoTDFConfig) error {

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/authorization"
 	"github.com/opentdf/platform/protocol/go/entityresolution"
+	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/attributes"
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
 	"github.com/opentdf/platform/protocol/go/policy/namespaces"
@@ -423,4 +424,21 @@ func getTokenEndpoint(c config) (string, error) {
 	}
 
 	return tokenEndpoint, nil
+}
+
+// StoreKASKeys caches the given values as the public keys associated with the
+// KAS at the given URL, replacing any existing keys that are cached for that URL
+// with the same algorithm and URL.
+// Only one key per url and algorithm is stored in the cache,
+// so only store the most recent known key per url & algorithm pair.
+func (s *SDK) StoreKASKeys(url string, keys *policy.KasPublicKeySet) error {
+	for _, key := range keys.GetKeys() {
+		s.kasKeyCache.store(KASInfo{
+			URL:       url,
+			PublicKey: key.GetPem(),
+			KID:       key.GetKid(),
+			Algorithm: algProto2String(key.GetAlg()),
+		})
+	}
+	return nil
 }

--- a/service/logger/audit/test.pb.go
+++ b/service/logger/audit/test.pb.go
@@ -7,12 +7,13 @@
 package audit
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	common "github.com/opentdf/platform/protocol/go/common"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (


### PR DESCRIPTION
- Adds new method, `sdk.SDK.StoreKASKeys` to load kas key cache
- Use the sdk's `getPublicKey` method from the nanotdf code as expected, which defers to the cache
- Removes dead or duplicated code that (tried to) do this
- Fixes https://github.com/opentdf/platform/issues/1547