### PR TITLE
feat(authz): Add name to entity id when retrieved from token

### DIFF
--- a/service/entityresolution/keycloak/keycloak_entity_resolution.go
+++ b/service/entityresolution/keycloak/keycloak_entity_resolution.go
@@ -373,7 +373,7 @@ func getEntitiesFromToken(ctx context.Context, kcConfig KeycloakConfig, jwtStrin
 	}
 	entities = append(entities, &authorization.Entity{
 		EntityType: &authorization.Entity_ClientId{ClientId: extractedValueCasted},
-		Id:         fmt.Sprintf("jwtentity-%d", entityID),
+		Id:         fmt.Sprintf("jwtentity-%d-clientid-%s", entityID, extractedValueCasted),
 		Category:   authorization.Entity_CATEGORY_ENVIRONMENT,
 	})
 	entityID++
@@ -396,21 +396,21 @@ func getEntitiesFromToken(ctx context.Context, kcConfig KeycloakConfig, jwtStrin
 		if clientid != "" {
 			entities = append(entities, &authorization.Entity{
 				EntityType: &authorization.Entity_ClientId{ClientId: clientid},
-				Id:         fmt.Sprintf("jwtentity-%d", entityID),
+				Id:         fmt.Sprintf("jwtentity-%d-clientid-%s", entityID, clientid),
 				Category:   authorization.Entity_CATEGORY_SUBJECT,
 			})
 		} else {
 			// if the returned clientId is empty, no client found, its not a serive account proceed with username
 			entities = append(entities, &authorization.Entity{
 				EntityType: &authorization.Entity_UserName{UserName: extractedValueUsernameCasted},
-				Id:         fmt.Sprintf("jwtentity-%d", entityID),
+				Id:         fmt.Sprintf("jwtentity-%d-username-%s", entityID, extractedValueUsernameCasted),
 				Category:   authorization.Entity_CATEGORY_SUBJECT,
 			})
 		}
 	} else {
 		entities = append(entities, &authorization.Entity{
 			EntityType: &authorization.Entity_UserName{UserName: extractedValueUsernameCasted},
-			Id:         fmt.Sprintf("jwtentity-%d", entityID),
+			Id:         fmt.Sprintf("jwtentity-%d-username-%s", entityID, extractedValueUsernameCasted),
 			Category:   authorization.Entity_CATEGORY_SUBJECT,
 		})
 	}


### PR DESCRIPTION
resolves https://github.com/opentdf/platform/issues/1615
before: `jwtentity-0` or `jwtentity-1`
now includes more useful info in the entity name
```
       {
          "id": "jwtentity-0-clientid-tdf-entity-resolution-public",
          "client_id": "tdf-entity-resolution-public",
          "category": "CATEGORY_ENVIRONMENT"
        },
        {
          "id": "jwtentity-1-username-sample-user",
          "user_name": "sample-user",
          "category": "CATEGORY_SUBJECT"
        }
```
This is useful for parsing access decisions triggered by kas. Access decisions only reference the entityID so, previously, it was be difficult to know what entity it is referring to without looking through the rest of the logs. This change should provide more context and save debugging time.