### PR TITLE
fix: Simplify request ID extraction from context for AUDIT

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -68,7 +68,7 @@ linters-settings:
             reason: "gofrs' package is not go module"
   gosec:
     excludes:
-      - G115 # integer overflow protection; 
+      - G115 # integer overflow protection;
 
   govet:
     # Enable all analyzers.
@@ -138,7 +138,7 @@ linters:
     - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
     - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
     - exhaustive # checks exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
+    # - exportloopref # checks for pointers to enclosing loop variables Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
     # - fatcontext
     - forbidigo # forbids identifiers
     - forcetypeassert # finds forced type assertions

--- a/service/logger/audit/getDecision_test.go
+++ b/service/logger/audit/getDecision_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/opentdf/platform/protocol/go/authorization"
 )
 
@@ -80,9 +79,8 @@ func TestCreateGetDecisionEventHappyPathSuccess(t *testing.T) {
 		t.Fatalf("event client info did not match expected: got %+v, want %+v", event.ClientInfo, expectedClientInfo)
 	}
 
-	expectedRequestID, _ := uuid.Parse(TestRequestID)
-	if event.RequestID != expectedRequestID {
-		t.Fatalf("event request ID did not match expected: got %v, want %v", event.RequestID, expectedRequestID)
+	if event.RequestID != TestRequestID {
+		t.Fatalf("event request ID did not match expected: got %v, want %v", event.RequestID, TestRequestID)
 	}
 
 	validateRecentEventTimestamp(t, event)

--- a/service/logger/audit/helpers_test.go
+++ b/service/logger/audit/helpers_test.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"context"
+	"github.com/google/uuid"
 	"testing"
 	"time"
 
@@ -9,7 +10,6 @@ import (
 )
 
 const (
-	TestRequestID     = "60d77895-b330-42da-92d2-5a9aa773fa1b"
 	TestUserAgent     = "test-user-agent"
 	TestActorID       = "test-actor-id"
 	TestRequestIP     = "192.168.1.1"
@@ -17,6 +17,8 @@ const (
 	TestAlgorithm     = "rsa"
 	TestPolicyBinding = "test-policy-binding"
 )
+
+var TestRequestID = uuid.New()
 
 func createTestContext() context.Context {
 	ctx := context.Background()

--- a/service/logger/audit/helpers_test.go
+++ b/service/logger/audit/helpers_test.go
@@ -2,10 +2,10 @@ package audit
 
 import (
 	"context"
-	"github.com/google/uuid"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	sdkAudit "github.com/opentdf/platform/sdk/audit"
 )
 

--- a/service/logger/audit/policy_test.go
+++ b/service/logger/audit/policy_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -81,9 +80,8 @@ func Test_CreatePolicyEvent_HappyPath(t *testing.T) {
 		t.Fatalf("event client info did not match expected: got %+v, want %+v", event.ClientInfo, expectedClientInfo)
 	}
 
-	expectedRequestID, _ := uuid.Parse(TestRequestID)
-	if event.RequestID != expectedRequestID {
-		t.Fatalf("event request ID did not match expected: got %v, want %v", event.RequestID, expectedRequestID)
+	if event.RequestID != TestRequestID {
+		t.Fatalf("event request ID did not match expected: got %v, want %v", event.RequestID, TestRequestID)
 	}
 
 	validateRecentEventTimestamp(t, event)

--- a/service/logger/audit/rewrap_test.go
+++ b/service/logger/audit/rewrap_test.go
@@ -81,9 +81,8 @@ func TestCreateRewrapAuditEventHappyPath(t *testing.T) {
 		t.Fatalf("event client info did not match expected: got %+v, want %+v", event.ClientInfo, expectedClientInfo)
 	}
 
-	expectedRequestID, _ := uuid.Parse(TestRequestID)
-	if event.RequestID != expectedRequestID {
-		t.Fatalf("event request ID did not match expected: got %v, want %v", event.RequestID, expectedRequestID)
+	if event.RequestID != TestRequestID {
+		t.Fatalf("event request ID did not match expected: got %v, want %v", event.RequestID, TestRequestID)
 	}
 
 	validateRecentEventTimestamp(t, event)

--- a/service/logger/audit/utils.go
+++ b/service/logger/audit/utils.go
@@ -72,10 +72,8 @@ type ContextData struct {
 func GetAuditDataFromContext(ctx context.Context) ContextData {
 	// Extract the request ID from context
 
-	requestIDString, _ := ctx.Value(sdkAudit.RequestIDContextKey).(string)
-
-	requestID, err := uuid.Parse(requestIDString)
-	if err != nil {
+	requestID, found := ctx.Value(sdkAudit.RequestIDContextKey).(uuid.UUID)
+	if !found {
 		requestID = uuid.Nil
 	}
 

--- a/service/logger/audit/utils.go
+++ b/service/logger/audit/utils.go
@@ -68,7 +68,7 @@ type ContextData struct {
 	ActorID   string
 }
 
-// GetAuditDataFromContext Gets relevant audit data from the context object.
+// GetAuditDataFromContext gets relevant audit data from the context object
 func GetAuditDataFromContext(ctx context.Context) ContextData {
 	// Extract the request ID from context
 

--- a/service/logger/audit/utils.go
+++ b/service/logger/audit/utils.go
@@ -68,7 +68,7 @@ type ContextData struct {
 	ActorID   string
 }
 
-// Gets relevant audit data from the context object.
+// GetAuditDataFromContext Gets relevant audit data from the context object.
 func GetAuditDataFromContext(ctx context.Context) ContextData {
 	// Extract the request ID from context
 

--- a/service/logger/audit/utils_test.go
+++ b/service/logger/audit/utils_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGetAuditDataFromContextHappyPath(t *testing.T) {
 	ctx := context.Background()
-	testRequestID := uuid.New().String()
+	testRequestID := uuid.New()
 	testUserAgent := "test-user-agent"
 	testRequestIP := "192.168.0.1"
 	testActorID := "test-actor-id"
@@ -27,7 +27,7 @@ func TestGetAuditDataFromContextHappyPath(t *testing.T) {
 
 	auditData := GetAuditDataFromContext(ctx)
 
-	if auditData.RequestID.String() != testRequestID {
+	if auditData.RequestID.String() != testRequestID.String() {
 		t.Fatalf("RequestID did not match: %v", auditData.RequestID)
 	}
 
@@ -62,6 +62,67 @@ func TestGetAuditDataFromContextDefaultsPath(t *testing.T) {
 	}
 
 	if auditData.ActorID != defaultNone {
+		t.Fatalf("ActorID did not match: %v", auditData.ActorID)
+	}
+}
+func TestGetAuditDataFromContextWithNoKeys(t *testing.T) {
+	ctx := context.Background()
+	auditData := GetAuditDataFromContext(ctx)
+
+	if auditData.RequestID != uuid.Nil {
+		t.Fatalf("RequestID did not match: %v", auditData.RequestID)
+	}
+
+	if auditData.UserAgent != "None" {
+		t.Fatalf("UserAgent did not match: %v", auditData.UserAgent)
+	}
+
+	if auditData.RequestIP != "None" {
+		t.Fatalf("RequestIP did not match: %v", auditData.RequestIP)
+	}
+
+	if auditData.ActorID != "None" {
+		t.Fatalf("ActorID did not match: %v", auditData.ActorID)
+	}
+}
+func TestGetAuditDataFromContextWithPartialKeys(t *testing.T) {
+	ctx := context.Background()
+	testUserAgent := "partial-user-agent"
+	testActorID := "partial-actor-id"
+
+	// Set relevant context keys
+	ctx = context.WithValue(ctx, sdkAudit.UserAgentContextKey, testUserAgent)
+	ctx = context.WithValue(ctx, sdkAudit.ActorIDContextKey, testActorID)
+
+	auditData := GetAuditDataFromContext(ctx)
+
+	if auditData.RequestID != uuid.Nil {
+		t.Fatalf("RequestID did not match: %v", auditData.RequestID)
+	}
+
+	if auditData.UserAgent != testUserAgent {
+		t.Fatalf("UserAgent did not match: %v", auditData.UserAgent)
+	}
+
+	if auditData.RequestIP != "None" {
+		t.Fatalf("RequestIP did not match: %v", auditData.RequestIP)
+	}
+
+	if auditData.ActorID != testActorID {
+		t.Fatalf("ActorID did not match: %v", auditData.ActorID)
+	}
+}
+
+func TestGetAuditDataFromContextWrongType(t *testing.T) {
+	ctx := context.Background()
+	testActorID := 12345
+
+	// Set relevant context keys
+	ctx = context.WithValue(ctx, sdkAudit.ActorIDContextKey, testActorID)
+
+	auditData := GetAuditDataFromContext(ctx)
+
+	if auditData.ActorID != "None" {
 		t.Fatalf("ActorID did not match: %v", auditData.ActorID)
 	}
 }


### PR DESCRIPTION
Refactored the code to directly fetch the request ID as a UUID type instead of first parsing it from a string. This change eliminates unnecessary error handling and simplifies logic for extracting the request ID from the context.z

Resolves #1489 