### PR TITLE
fix: allow standard users to get authorization decisions

### DIFF
--- a/service/internal/auth/casbin.go
+++ b/service/internal/auth/casbin.go
@@ -89,6 +89,8 @@ p,	role:admin,		/v1/token/authorization,						  				        *,      allow
 p,	role:standard,		policy.*,																read,			allow
 p,	role:standard,		kasregistry.*,													read,			allow
 p,	role:standard,    kas.AccessService/Rewrap, 			           *,			allow
+p,      role:standard,          kas.AuthorizationService/GetDecisions,             *,                   allow
+p,      role:standard,          kas.AuthorizationService/GetDecisionsByToken,      *,                   allow
 ## HTTP routes
 p,	role:standard,		/attributes*,														read,			allow
 p,	role:standard,		/namespaces*,														read,			allow
@@ -97,6 +99,8 @@ p,	role:standard,		/resource-mappings*,										read,			allow
 p,	role:standard,		/key-access-servers*,										read,			allow
 p,	role:standard,		/kas/v2/rewrap,													write,		allow
 p,	role:standard,		/entityresolution/resolve,							write,  	allow
+p,      role:standard,          /v1/authorization,                                                              write,          allow
+p,      role:standard,          /v1/token/authorization,                                                        write,          allow
 
 # Public routes
 ## gRPC routes

--- a/service/internal/auth/casbin.go
+++ b/service/internal/auth/casbin.go
@@ -89,8 +89,8 @@ p,	role:admin,		/v1/token/authorization,						  				        *,      allow
 p,	role:standard,		policy.*,																read,			allow
 p,	role:standard,		kasregistry.*,													read,			allow
 p,	role:standard,    kas.AccessService/Rewrap, 			           *,			allow
-p,      role:standard,          kas.AuthorizationService/GetDecisions,             *,                   allow
-p,      role:standard,          kas.AuthorizationService/GetDecisionsByToken,      *,                   allow
+p,      role:standard,          kas.AuthorizationService/GetDecisions,             read,                   allow
+p,      role:standard,          kas.AuthorizationService/GetDecisionsByToken,      read,                   allow
 ## HTTP routes
 p,	role:standard,		/attributes*,														read,			allow
 p,	role:standard,		/namespaces*,														read,			allow


### PR DESCRIPTION
Lets `standard` users retrieve authorization decisions. [Does not allow these users to retrieve entitlements](https://github.com/opentdf/platform/blob/e3ed0b5ce6039000c9e3c574d3d6ce2931781235/service/authorization/authorization.proto#L289-L305). Implements discussion from https://github.com/virtru-corp/data-security-platform/pull/403.

Resolves https://github.com/opentdf/platform/issues/1645.