### PR TITLE
chore(ci): add git-town workflow

### DIFF
--- a/.github/workflows/git-town.yaml
+++ b/.github/workflows/git-town.yaml
@@ -1,0 +1,22 @@
+name: Git Town
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  git-town:
+    name: Display the branch stack
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - uses: git-town/action@7cec053e109396e49a15328a749b32552e6f91db
+        with:
+          skip-single-stacks: true
+          main-branch: main

--- a/.github/workflows/git-town.yaml
+++ b/.github/workflows/git-town.yaml
@@ -3,7 +3,7 @@ name: Git Town
 on:
   pull_request:
     branches:
-      - '**'
+      - main
 
 jobs:
   git-town:


### PR DESCRIPTION
Adding git-town workflow to do a poc around stacked prs as we migrate to connect-rpc.

https://github.com/marketplace/actions/git-town-github-action