### PR TITLE
fix(sdk): Fix handling of kas rewrap errors

### DIFF
--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -806,10 +806,10 @@ func (r *Reader) doPayloadKeyUnwrap(ctx context.Context) error { //nolint:gocogn
 			wrappedKey, err = client.unwrap(ctx, keyAccessObj, r.manifest.EncryptionInformation.Policy)
 			if err != nil {
 				errToReturn := fmt.Errorf("doPayloadKeyUnwrap splitKey.rewrap failed: %w", err)
-				if !strings.Contains(err.Error(), codes.InvalidArgument.String()) {
+				if strings.Contains(err.Error(), codes.InvalidArgument.String()) {
 					return fmt.Errorf("%w: %w", ErrRewrapBadRequest, errToReturn)
 				}
-				if !strings.Contains(err.Error(), codes.PermissionDenied.String()) {
+				if strings.Contains(err.Error(), codes.PermissionDenied.String()) {
 					return fmt.Errorf("%w: %w", errRewrapForbidden, errToReturn)
 				}
 				return errToReturn


### PR DESCRIPTION
reversed handling of requests
successful error detection in xtest https://github.com/opentdf/tests/actions/runs/11635869428/job/32406122022?pr=220