### PR TITLE
fix: Fixtures CodeQL alert for potentially unsafe quoting

### DIFF
--- a/service/internal/fixtures/db.go
+++ b/service/internal/fixtures/db.go
@@ -62,7 +62,8 @@ func (d *DBInterface) UUIDArrayWrap(v []string) string {
 }
 
 func (d *DBInterface) StringWrap(v string) string {
-	return "'" + v + "'"
+	escaped := strings.ReplaceAll(v, "'", "''")
+	return "'" + escaped + "'"
 }
 
 func (d *DBInterface) OptionalStringWrap(v string) string {


### PR DESCRIPTION
Fixes [https://github.com/opentdf/platform/security/code-scanning/7](https://github.com/opentdf/platform/security/code-scanning/7) and closes #1694

This change resolves the CodeQL alert in fixtures by ensuring that if the string contains any single quotes they are escaped using two single quotes.