### PR TITLE
fix: NanoTDF secure key from debug logging and iv conflict risk

### DIFF
--- a/sdk/nanotdf_test.go
+++ b/sdk/nanotdf_test.go
@@ -241,6 +241,23 @@ func NotTestCreateNanoTDF(t *testing.T) {
 	}
 }
 
+func TestNonZeroRandomPaddedIV(t *testing.T) {
+	iv, err := nonZeroRandomPaddedIV()
+	require.NoError(t, err)
+	require.NotNil(t, iv)
+	assert.Equal(t, ocrypto.GcmStandardNonceSize, len(iv))
+
+	// Ensure that the IV is not all zeros
+	allZero := true
+	for _, b := range iv {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	assert.False(t, allZero, "IV should not be all zeros")
+}
+
 func TestCreateNanoTDF(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/sdk/nanotdf_test.go
+++ b/sdk/nanotdf_test.go
@@ -245,7 +245,7 @@ func TestNonZeroRandomPaddedIV(t *testing.T) {
 	iv, err := nonZeroRandomPaddedIV()
 	require.NoError(t, err)
 	require.NotNil(t, iv)
-	assert.Len(t, ocrypto.GcmStandardNonceSize, iv)
+	assert.Len(t, iv, ocrypto.GcmStandardNonceSize)
 
 	// Ensure that the IV is not all zeros
 	allZero := true

--- a/sdk/nanotdf_test.go
+++ b/sdk/nanotdf_test.go
@@ -245,7 +245,7 @@ func TestNonZeroRandomPaddedIV(t *testing.T) {
 	iv, err := nonZeroRandomPaddedIV()
 	require.NoError(t, err)
 	require.NotNil(t, iv)
-	assert.Equal(t, ocrypto.GcmStandardNonceSize, len(iv))
+	assert.Len(t, ocrypto.GcmStandardNonceSize, iv)
 
 	// Ensure that the IV is not all zeros
 	allZero := true


### PR DESCRIPTION
This change removes two debug logs where the nanoTDF key was encoded and logged.

In addition this fixes a small 1 in 16 million chance that an all zero IV could be used on the data (resulting in a key + iv reuse when compared to the policy).