### PR TITLE
fix(kas): Only hit authorization if data attributes not empty

### DIFF
--- a/service/kas/access/accessPdp.go
+++ b/service/kas/access/accessPdp.go
@@ -15,11 +15,11 @@ const (
 )
 
 func (p *Provider) canAccess(ctx context.Context, token *authorization.Token, policy Policy) (bool, error) {
-	if policy.Body.Dissem != nil && len(policy.Body.Dissem) > 0 {
+	if len(policy.Body.Dissem) > 0 {
 		// TODO: Move dissems check to the getdecisions endpoint
 		p.Logger.Error("Dissems check is not enabled in v2 platform kas")
 	}
-	if policy.Body.DataAttributes != nil && len(policy.Body.DataAttributes) > 0 {
+	if len(policy.Body.DataAttributes) > 0 {
 		attrAccess, err := p.checkAttributes(ctx, policy.Body.DataAttributes, token)
 		if err != nil {
 			return false, err

--- a/service/kas/access/accessPdp.go
+++ b/service/kas/access/accessPdp.go
@@ -15,11 +15,11 @@ const (
 )
 
 func (p *Provider) canAccess(ctx context.Context, token *authorization.Token, policy Policy) (bool, error) {
-	if len(policy.Body.Dissem) > 0 {
+	if policy.Body.Dissem != nil && len(policy.Body.Dissem) > 0 {
 		// TODO: Move dissems check to the getdecisions endpoint
 		p.Logger.Error("Dissems check is not enabled in v2 platform kas")
 	}
-	if policy.Body.DataAttributes != nil {
+	if policy.Body.DataAttributes != nil && len(policy.Body.DataAttributes) > 0 {
 		attrAccess, err := p.checkAttributes(ctx, policy.Body.DataAttributes, token)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
### Proposed Changes

* only make authorization call when necessary

go sdk creates a policy object with null in the attributes field if none provided but js fills it with "[]" which still triggered an authorization call -- this change should stop that

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

