### PR TITLE
fix(sdk): Dont require mimetype in manifest schema

### DIFF
--- a/sdk/schema/manifest.schema.json
+++ b/sdk/schema/manifest.schema.json
@@ -33,7 +33,7 @@
             "type": "string"
           }
         },
-        "required": ["type", "url", "protocol", "isEncrypted","mimeType"]
+        "required": ["type", "url", "protocol", "isEncrypted"]
       },
       "encryptionInformation": {
         "type": "object",


### PR DESCRIPTION
### Proposed Changes

* mimetype is not required by the spec, dont require it in the manifest schema

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

