### PR TITLE
fix(authz): handle pagination in authz service

### DIFF
--- a/service/authorization/authorization_test.go
+++ b/service/authorization/authorization_test.go
@@ -57,6 +57,10 @@ type mySubjectMappingClient struct {
 	sm.SubjectMappingServiceClient
 }
 
+type paginatedMockSubjectMappingClient struct {
+	sm.SubjectMappingServiceClient
+}
+
 func (*mySubjectMappingClient) ListSubjectMappings(_ context.Context, _ *sm.ListSubjectMappingsRequest, _ ...grpc.CallOption) (*sm.ListSubjectMappingsResponse, error) {
 	return &listSubjectMappings, nil
 }
@@ -67,6 +71,52 @@ func (*myERSClient) CreateEntityChainFromJwt(_ context.Context, _ *entityresolut
 
 func (*myERSClient) ResolveEntities(_ context.Context, _ *entityresolution.ResolveEntitiesRequest, _ ...grpc.CallOption) (*entityresolution.ResolveEntitiesResponse, error) {
 	return &resolveEntitiesResp, nil
+}
+
+var (
+	smPaginationOffset = 3
+	smListCallCount    = 0
+)
+
+func (*paginatedMockSubjectMappingClient) ListSubjectMappings(_ context.Context, _ *sm.ListSubjectMappingsRequest, _ ...grpc.CallOption) (*sm.ListSubjectMappingsResponse, error) {
+	smListCallCount++
+	// simulate paginated list and policy LIST behavior
+	if smPaginationOffset > 0 {
+		rsp := &sm.ListSubjectMappingsResponse{
+			SubjectMappings: nil,
+			Pagination: &policy.PageResponse{
+				NextOffset: int32(smPaginationOffset),
+			},
+		}
+		smPaginationOffset = 0
+		return rsp, nil
+	}
+	return &listSubjectMappings, nil
+}
+
+type paginatedMockAttributesClient struct {
+	attr.AttributesServiceClient
+}
+
+var (
+	attrPaginationOffset = 3
+	attrListCallCount    = 0
+)
+
+func (*paginatedMockAttributesClient) ListAttributes(_ context.Context, _ *attr.ListAttributesRequest, _ ...grpc.CallOption) (*attr.ListAttributesResponse, error) {
+	attrListCallCount++
+	// simulate paginated list and policy LIST behavior
+	if attrPaginationOffset > 0 {
+		rsp := &attr.ListAttributesResponse{
+			Attributes: nil,
+			Pagination: &policy.PageResponse{
+				NextOffset: int32(attrPaginationOffset),
+			},
+		}
+		attrPaginationOffset = 0
+		return rsp, nil
+	}
+	return &listAttributeResp, nil
 }
 
 func TestGetComprehensiveHierarchy(t *testing.T) {
@@ -761,6 +811,91 @@ func Test_GetEntitlementsFqnCasing(t *testing.T) {
 	assert.Len(t, resp.Msg.GetEntitlements(), 1)
 	assert.Equal(t, "e1", resp.Msg.GetEntitlements()[0].GetEntityId())
 	assert.Equal(t, []string{"https://www.example.org/attr/foo/value/value1"}, resp.Msg.GetEntitlements()[0].GetAttributeValueFqns())
+}
+
+func Test_GetEntitlements_HandlesPagination(t *testing.T) {
+	logger := logger.CreateTestLogger()
+
+	listAttributeResp = attr.ListAttributesResponse{}
+	attrDef := policy.Attribute{
+		Name: mockAttrName,
+		Namespace: &policy.Namespace{
+			Name: mockNamespace,
+		},
+		Rule: policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF,
+		Values: []*policy.Value{
+			{
+				Value: mockAttrValue1,
+			},
+			{
+				Value: mockAttrValue2,
+			},
+		},
+	}
+	listAttributeResp.Attributes = []*policy.Attribute{&attrDef}
+	userRepresentation := map[string]interface{}{
+		"A": "B",
+		"C": "D",
+	}
+	userStruct, _ := structpb.NewStruct(userRepresentation)
+	resolveEntitiesResp = entityresolution.ResolveEntitiesResponse{
+		EntityRepresentations: []*entityresolution.EntityRepresentation{
+			{
+				OriginalId: "e1",
+				AdditionalProps: []*structpb.Struct{
+					userStruct,
+				},
+			},
+		},
+	}
+
+	ctxb := context.Background()
+
+	rego := rego.New(
+		rego.Query("data.example.p"),
+		rego.Module("example.rego",
+			`package example
+			p = {"e1":["https://www.example.org/attr/foo/value/value1"]} { true }`,
+		))
+
+	// Run evaluation.
+	prepared, err := rego.PrepareForEval(ctxb)
+	require.NoError(t, err)
+
+	as := AuthorizationService{
+		logger: logger, sdk: &otdf.SDK{
+			SubjectMapping:  &paginatedMockSubjectMappingClient{},
+			Attributes:      &paginatedMockAttributesClient{},
+			EntityResoution: &myERSClient{},
+		},
+		eval: prepared,
+	}
+
+	req := connect.Request[authorization.GetEntitlementsRequest]{
+		Msg: &authorization.GetEntitlementsRequest{
+			Entities: []*authorization.Entity{{Id: "e1", EntityType: &authorization.Entity_ClientId{ClientId: "testclient"}, Category: authorization.Entity_CATEGORY_ENVIRONMENT}},
+			// Using mixed case here
+			Scope: &authorization.ResourceAttribute{AttributeValueFqns: []string{"https://www.example.org/attr/foo/value/VaLuE1"}},
+		},
+	}
+
+	for fqn := range makeScopeMap(req.Msg.GetScope()) {
+		assert.Equal(t, fqn, strings.ToLower(fqn))
+	}
+
+	resp, err := as.GetEntitlements(ctxb, &req)
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Len(t, resp.Msg.GetEntitlements(), 1)
+	assert.Equal(t, "e1", resp.Msg.GetEntitlements()[0].GetEntityId())
+	assert.Equal(t, []string{"https://www.example.org/attr/foo/value/value1"}, resp.Msg.GetEntitlements()[0].GetAttributeValueFqns())
+
+	// paginated successfully
+	assert.Equal(t, 2, smListCallCount)
+	assert.Zero(t, smPaginationOffset)
+	assert.Equal(t, 2, attrListCallCount)
+	assert.Zero(t, attrPaginationOffset)
 }
 
 func Test_GetEntitlementsWithComprehensiveHierarchy(t *testing.T) {


### PR DESCRIPTION
### Proposed Changes

* Handle pagination limit/offset in `authorization.GetEntitlements`
* If quantity of attributes or subject mappings exceeds default "list" API limit as configured, we need to retrieve all to make accurate entitlement decision

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

