### PR TITLE
fix(core): expose rest based healthcheck

### DIFF
--- a/service/health/health.go
+++ b/service/health/health.go
@@ -60,7 +60,7 @@ func NewRegistration() *serviceregistry.Service[grpchealth.Checker] {
 						}
 					})
 					if err != nil {
-						srp.Logger.Error("failed to register healthz endpoint", slog.String("error", err.Error()))
+						panic(errors.Join(errors.New("failed to register healthz endpoint"), err))
 					}
 
 					return nil

--- a/service/health/health.go
+++ b/service/health/health.go
@@ -37,7 +37,7 @@ func NewRegistration() *serviceregistry.Service[grpchealth.Checker] {
 				}
 				hs := HealthService{logger: srp.Logger}
 				return hs, func(_ context.Context, mux *runtime.ServeMux) error {
-					err := mux.HandlePath(http.MethodGet, "/healthz", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+					err := mux.HandlePath(http.MethodGet, "/healthz", func(w http.ResponseWriter, r *http.Request, _ map[string]string) { //nolint:contextcheck // check is not relevant here
 						resp, err := hs.Check(context.Background(), &grpchealth.CheckRequest{
 							Service: r.URL.Query().Get("service"),
 						})

--- a/service/health/health.go
+++ b/service/health/health.go
@@ -2,11 +2,15 @@ package health
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
+	"net/http"
+	"strings"
 
 	"connectrpc.com/connect"
 	"connectrpc.com/grpchealth"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/opentdf/platform/service/logger"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -31,7 +35,27 @@ func NewRegistration() *serviceregistry.Service[grpchealth.Checker] {
 				if err != nil {
 					srp.Logger.Error("failed to set well-known config", slog.String("error", err.Error()))
 				}
-				return HealthService{logger: srp.Logger}, nil
+				hs := HealthService{logger: srp.Logger}
+				return hs, func(_ context.Context, mux *runtime.ServeMux) error {
+					mux.HandlePath(http.MethodGet, "/healthz", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+						resp, err := hs.Check(context.Background(), &grpchealth.CheckRequest{
+							Service: r.URL.Query().Get("service"),
+						})
+						if err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						status := map[string]interface{}{"status": strings.ToUpper(resp.Status.String())}
+						if resp.Status != grpchealth.StatusServing {
+							w.WriteHeader(http.StatusServiceUnavailable)
+							json.NewEncoder(w).Encode(status)
+							return
+						}
+						w.WriteHeader(http.StatusOK)
+						json.NewEncoder(w).Encode(status)
+					})
+					return nil
+				}
 			},
 		},
 	}

--- a/test/service-start.bats
+++ b/test/service-start.bats
@@ -65,3 +65,17 @@
   echo "$output"
   [[ $output = *NotFound* ]]
 }
+
+@test "REST: health check endpoint" {
+  run curl -s -w '%{http_code}' "https://localhost:8080/healthz"
+  echo "$output"
+  [ "${output: -3}" = "200" ]
+  [ $(jq -r .status <<<"${output:0:-3}") = SERVING ]
+}
+
+@test "gRPC: healh check endpoint" {
+  run grpcurl "localhost:8080" "grpc.health.v1.Health.Check"
+  echo "$output"
+  [ $status = 0 ]
+  [ $(jq -r .status <<<"${output}") = SERVING ]
+}


### PR DESCRIPTION
### Proposed Changes

Missed this while migrating to connect-rpc but accidentally removed the REST based healthcheck which causes kubernetes deployments to break. 

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

