### PR TITLE
chore: Remove unused keycloakdb service from docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
       - "8888:8888"
       - "8443:8443"
     healthcheck:
-      test: 
+      test:
         - CMD-SHELL
         - |
           [ -f /tmp/HealthCheck.java ] || echo "public class HealthCheck { 
@@ -66,23 +66,10 @@ services:
               java.net.HttpURLConnection conn = (java.net.HttpURLConnection)new java.net.URL(args[0]).openConnection(); 
               System.exit(java.net.HttpURLConnection.HTTP_OK == conn.getResponseCode() ? 0 : 1); 
             } 
-          }" > /tmp/HealthCheck.java && java /tmp/HealthCheck.java https://localhost:9001/auth/health/live      
+          }" > /tmp/HealthCheck.java && java /tmp/HealthCheck.java https://localhost:9001/auth/health/live
       timeout: 10s
       retries: 3
       start_period: 2m
-  keycloakdb:
-    image: postgres:15-alpine
-    restart: always
-    user: postgres
-    environment:
-      POSTGRES_PASSWORD: changeme
-      POSTGRES_USER: postgres
-      POSTGRES_DB: keycloak
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
   opentdfdb:
     image: postgres:15-alpine
     restart: always


### PR DESCRIPTION
The keycloakdb service has been removed from the docker-compose file as it was not necessary for the current setup. This change helps streamline the configuration and prevents unnecessary resource allocation

### Proposed Changes

* Keycloak runs in dev mode, no need for Postgres

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

