### PR TITLE
fix(core): reduces GetEntitlements calls in GetDecisions

### DIFF
--- a/examples/cmd/benchmark_decision.go
+++ b/examples/cmd/benchmark_decision.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/opentdf/platform/protocol/go/authorization"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	benchmarkCmd := &cobra.Command{
+		Use:   "benchmark-decision",
+		Short: "OpenTDF benchmark tool",
+		Long:  `A OpenTDF benchmark tool to measure throughput and latency with configurable concurrency.`,
+		RunE:  runDecisionBenchmark,
+	}
+
+	benchmarkCmd.Flags().IntVar(&config.ConcurrentRequests, "concurrent", 10, "Number of concurrent requests")
+	benchmarkCmd.Flags().IntVar(&config.RequestCount, "count", 100, "Total number of requests")
+	benchmarkCmd.Flags().IntVar(&config.RequestsPerSecond, "rps", 50, "Requests per second limit")
+	benchmarkCmd.Flags().IntVar(&config.TimeoutSeconds, "timeout", 30, "Timeout in seconds")
+	benchmarkCmd.Flags().Var(&config.TDFFormat, "tdf", "TDF format (tdf3 or nanotdf)")
+	ExamplesCmd.AddCommand(benchmarkCmd)
+}
+
+func runDecisionBenchmark(cmd *cobra.Command, args []string) error {
+	// Create new offline client
+	client, err := newSDK()
+	if err != nil {
+		return err
+	}
+
+	ras := []*authorization.ResourceAttribute{}
+	for i := 0; i < 100; i++ {
+		ras = append(ras, &authorization.ResourceAttribute{AttributeValueFqns: []string{"https://example.com/attr/attr1/value/value1"}})
+	}
+
+	start := time.Now()
+	res, err := client.Authorization.GetDecisions(context.Background(), &authorization.GetDecisionsRequest{
+		DecisionRequests: []*authorization.DecisionRequest{
+			{
+				Actions: []*policy.Action{{Value: &policy.Action_Standard{
+					Standard: policy.Action_STANDARD_ACTION_DECRYPT,
+				}}},
+				EntityChains: []*authorization.EntityChain{
+					{Id: "rewrap-tok", Entities: []*authorization.Entity{
+						{Id: "jwtentity-0-clientid-opentdf-public", EntityType: &authorization.Entity_ClientId{ClientId: "opentdf-public"}, Category: authorization.Entity_CATEGORY_ENVIRONMENT},
+						{Id: "jwtentity-1-username-sample-user", EntityType: &authorization.Entity_UserName{UserName: "sample-user"}, Category: authorization.Entity_CATEGORY_SUBJECT},
+					}}},
+				ResourceAttributes: ras,
+			},
+		},
+	})
+	end := time.Now()
+	totalTime := end.Sub(start)
+
+	numberApproved := 0
+	numberDenied := 0
+	if err == nil {
+		for _, dr := range res.GetDecisionResponses() {
+			if dr.Decision == authorization.DecisionResponse_DECISION_PERMIT {
+				numberApproved += 1
+			} else {
+				numberDenied += 1
+			}
+
+		}
+	}
+
+	// Print results
+	cmd.Printf("\nBenchmark Results:\n")
+	if err == nil {
+		cmd.Printf("Approved Decision Requests: %d\n", numberApproved)
+		cmd.Printf("Denied Decision Requests: %d\n", numberDenied)
+	} else {
+		cmd.Printf("Error: %s\n", err.Error())
+	}
+	cmd.Printf("Total Time: %s\n", totalTime)
+
+	return nil
+}

--- a/examples/cmd/benchmark_decision.go
+++ b/examples/cmd/benchmark_decision.go
@@ -17,11 +17,6 @@ func init() {
 		RunE:  runDecisionBenchmark,
 	}
 
-	benchmarkCmd.Flags().IntVar(&config.ConcurrentRequests, "concurrent", 10, "Number of concurrent requests")
-	benchmarkCmd.Flags().IntVar(&config.RequestCount, "count", 100, "Total number of requests")
-	benchmarkCmd.Flags().IntVar(&config.RequestsPerSecond, "rps", 50, "Requests per second limit")
-	benchmarkCmd.Flags().IntVar(&config.TimeoutSeconds, "timeout", 30, "Timeout in seconds")
-	benchmarkCmd.Flags().Var(&config.TDFFormat, "tdf", "TDF format (tdf3 or nanotdf)")
 	ExamplesCmd.AddCommand(benchmarkCmd)
 }
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -5,6 +5,7 @@ buf.build/gen/go/bufbuild/protovalidate-testing/protocolbuffers/go v1.31.0-20230
 buf.build/gen/go/bufbuild/protovalidate-testing/protocolbuffers/go v1.31.0-20230824200732-8bc04916caea.1/go.mod h1:cJ4gQkiW4uPTUTI3+O2862OzMSTnzrFNwMauHLwPDPg=
 cel.dev/expr v0.15.0 h1:O1jzfJCQBfL5BFoYktaxwIhuttaQPsVWerH9/EEKx0w=
 cel.dev/expr v0.15.0/go.mod h1:TRSuuV7DlVCE/uwv5QbAiW/v8l5O8C4eEPHeu7gf7Sg=
+cel.dev/expr v0.16.0 h1:yloc84fytn4zmJX2GU3TkXGsaieaV7dQ057Qs4sIG2Y=
 cel.dev/expr v0.16.0/go.mod h1:TRSuuV7DlVCE/uwv5QbAiW/v8l5O8C4eEPHeu7gf7Sg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -126,6 +127,7 @@ cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGB
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+cloud.google.com/go/compute/metadata v0.5.0 h1:Zr0eK8JbFv6+Wi4ilXAR8FJ3wyNdpxHKJNPos6LTZOY=
 cloud.google.com/go/compute/metadata v0.5.0/go.mod h1:aHnloV2TPI38yx4s9+wAZhHykWvVCfu7hQbF+9CWoiY=
 cloud.google.com/go/contactcenterinsights v1.12.1/go.mod h1:HHX5wrz5LHVAwfI2smIotQG9x8Qd6gYilaHcLLLmNis=
 cloud.google.com/go/contactcenterinsights v1.13.0 h1:6Vs/YnDG5STGjlWMEjN/xtmft7MrOTOnOZYUZtGTx0w=
@@ -636,6 +638,7 @@ github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa/go.mod h1:x/1Gn8zydmfq
 github.com/cncf/xds/go v0.0.0-20240318125728-8a4994d93e50/go.mod h1:5e1+Vvlzido69INQaVO6d87Qn543Xr6nooe9Kz7oBFM=
 github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b h1:ga8SEFjZ60pxLcmhnThWgvH2wg8376yUJmPhEH4H3kw=
 github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
+github.com/cncf/xds/go v0.0.0-20240723142845-024c85f92f20 h1:N+3sFI5GUjRKBi+i0TxYVST9h4Ie192jJWpHvthBBgg=
 github.com/cncf/xds/go v0.0.0-20240723142845-024c85f92f20/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5 h1:xD/lrqdvwsc+O2bjSSi3YqY73Ke3LAiSCx49aCesA0E=
@@ -928,6 +931,7 @@ github.com/envoyproxy/go-control-plane v0.12.0 h1:4X+VP1GHd1Mhj6IB5mMeGbLCleqxjl
 github.com/envoyproxy/go-control-plane v0.12.0/go.mod h1:ZBTaoJ23lqITozF0M6G4/IragXCQKCnYbmlmtHvwRG0=
 github.com/envoyproxy/go-control-plane v0.12.1-0.20240621013728-1eb8caab5155 h1:IgJPqnrlY2Mr4pYB6oaMKvFvwJ9H+X6CCY5x1vCTcpc=
 github.com/envoyproxy/go-control-plane v0.12.1-0.20240621013728-1eb8caab5155/go.mod h1:5Wkq+JduFtdAXihLmeTJf+tRYIT4KBc2vPXDhwVo1pA=
+github.com/envoyproxy/go-control-plane v0.13.0 h1:HzkeUz1Knt+3bK+8LG1bxOO/jzWZmdxpwC51i202les=
 github.com/envoyproxy/go-control-plane v0.13.0/go.mod h1:GRaKG3dwvFoTg4nj7aXdZnvMg4d7nvT/wl9WgVXn3Q8=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
@@ -1318,6 +1322,7 @@ github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3 h1:jUp75lepDg0ph
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
 github.com/lyft/protoc-gen-star/v2 v2.0.3 h1:/3+/2sWyXeMLzKd1bX+ixWKgEMsULrIivpDsuaF441o=
 github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
+github.com/lyft/protoc-gen-star/v2 v2.0.4-0.20230330145011-496ad1ac90a4 h1:sIXJOMrYnQZJu7OB7ANSF4MYri2fTEGIsRLz6LwI4xE=
 github.com/lyft/protoc-gen-star/v2 v2.0.4-0.20230330145011-496ad1ac90a4/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1957,6 +1962,7 @@ golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.16.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
 golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -2172,6 +2178,7 @@ golang.org/x/telemetry v0.0.0-20240208230135-b75ee8823808 h1:+Kc94D8UVEVxJnLXp/+
 golang.org/x/telemetry v0.0.0-20240208230135-b75ee8823808/go.mod h1:KG1lNk5ZFNssSZLrpVb4sMXKMpGwGXOxSG3rnu2gZQQ=
 golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2 h1:IRJeR9r1pYWsHKTRe/IInb7lYvbBVIqOgsX/u0mbOWY=
 golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2/go.mod h1:TeRTkGYfJXctD9OcfyVLyj2J3IxLnKwHJR8f4D8a3YE=
+golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457 h1:zf5N6UOrA487eEFacMePxjXAJctxKmyjKUsjA11Uzuk=
 golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457/go.mod h1:pRgIJT+bRLFKnoM1ldnzKoxTIn14Yxz928LQRYYgIN0=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -2274,6 +2281,7 @@ golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58
 golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg=
 golang.org/x/tools v0.15.0/go.mod h1:hpksKq4dtpQWS1uQ61JkdqWM3LscIS6Slf+VVkm+wQk=
 golang.org/x/tools v0.18.0/go.mod h1:GL7B4CwcLLeo59yx/9UWWuNOW1n3VZ4f5axWfML7Lcg=
+golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
 golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/service/authorization/authorization.go
+++ b/service/authorization/authorization.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	"golang.org/x/exp/maps"
-
 	"github.com/creasty/defaults"
 	"github.com/go-playground/validator/v10"
 	"github.com/mitchellh/mapstructure"
@@ -187,207 +185,214 @@ func (as *AuthorizationService) GetDecisions(ctx context.Context, req *connect.R
 		DecisionResponses: make([]*authorization.DecisionResponse, 0),
 	}
 	for _, dr := range req.Msg.GetDecisionRequests() {
-		allPertinentFQNs := getAllPertinentAttributeFQNSFromRAS(dr.GetResourceAttributes())
-		var ecChainEntitlementsResponse []*connect.Response[authorization.GetEntitlementsResponse]
-		for _, ec := range dr.GetEntityChains() {
-				entities := ec.GetEntities()
-				if len(entities) == 0 {
-					ecChainEntitlementsResponse = append(ecChainEntitlementsResponse, nil)
-					continue
-				}
-				req := connect.Request[authorization.GetEntitlementsRequest]{
-					Msg: &authorization.GetEntitlementsRequest{
-						Entities: entities,
-						Scope:  &authorization.ResourceAttribute{AttributeValueFqns: allPertinentFQNs},
-					},
-				}
-				ecEntitlements, err := as.GetEntitlements(ctx, &req)
-				if err != nil {
-					// TODO: should all decisions in a request fail if one entity entitlement lookup fails?
-					return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("extra", "getEntitlements request failed"))
-				}
-				ecChainEntitlementsResponse = append(ecChainEntitlementsResponse, ecEntitlements)
-			}
-
-
-
-		for _, ra := range dr.GetResourceAttributes() {
-			as.logger.DebugContext(ctx, "getting resource attributes", slog.String("FQNs", strings.Join(ra.GetAttributeValueFqns(), ", ")))
-
-			// get attribute definition/value combinations
-			dataAttrDefsAndVals, err := retrieveAttributeDefinitions(ctx, ra, as.sdk)
-			if err != nil {
-				// if attribute an FQN does not exist
-				// return deny for all entity chains aginst this RA set and continue to next
-				if errors.Is(err, db.StatusifyError(db.ErrNotFound, "")) {
-					for _, ec := range dr.GetEntityChains() {
-						decisionResp := &authorization.DecisionResponse{
-							Decision:      authorization.DecisionResponse_DECISION_DENY,
-							EntityChainId: ec.GetId(),
-							Action: &policy.Action{
-								Value: &policy.Action_Standard{
-									Standard: policy.Action_STANDARD_ACTION_TRANSMIT,
-								},
-							},
-						}
-						if ra.GetResourceAttributesId() != "" {
-							decisionResp.ResourceAttributesId = ra.GetResourceAttributesId()
-						} else if len(ra.GetAttributeValueFqns()) > 0 {
-							decisionResp.ResourceAttributesId = ra.GetAttributeValueFqns()[0]
-						}
-						rsp.DecisionResponses = append(rsp.DecisionResponses, decisionResp)
-					}
-					continue
-				}
-				return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("fqns", strings.Join(ra.GetAttributeValueFqns(), ", ")))
-			}
-			var attrDefs []*policy.Attribute
-			var attrVals []*policy.Value
-			var fqns []string
-			for fqn, v := range dataAttrDefsAndVals {
-				attrDefs = append(attrDefs, v.GetAttribute())
-				attrVal := v.GetValue()
-				fqns = append(fqns, fqn)
-				attrVal.Fqn = fqn
-				attrVals = append(attrVals, attrVal)
-			}
-
-			attrDefs, err = populateAttrDefValueFqns(attrDefs)
-			if err != nil {
-				return nil, connect.NewError(connect.CodeInternal, err)
-			}
-
-			// get the relevant resource attribute fqns
-			allPertinentFqnsRA := authorization.ResourceAttribute{
-				AttributeValueFqns: ra.GetAttributeValueFqns(),
-			}
-			for _, attrDef := range attrDefs {
-				if attrDef.GetRule() == policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY {
-					for _, value := range attrDef.GetValues() {
-						allPertinentFqnsRA.AttributeValueFqns = append(allPertinentFqnsRA.AttributeValueFqns, value.GetFqn())
-					}
-				}
-			}
-
-			for idx, ec := range dr.GetEntityChains() {
-				//
-				// TODO: we should already have the subject mappings here and be able to just use OPA to trim down the known data attr values to the ones matched up with the entities
-				//
-				entities := ec.GetEntities()
-				auditECEntitlements := make([]audit.EntityChainEntitlement, 0)
-				auditEntityDecisions := make([]audit.EntityDecision, 0)
-
-				// Entitlements for environment entites in chain
-				envEntityAttrValues := make(map[string][]string)
-				// Entitlementsfor sbuject entities in chain
-				subjectEntityAttrValues := make(map[string][]string)
-
-				//nolint:nestif // handle empty entity / attr list
-				if len(entities) == 0 || len(allPertinentFqnsRA.GetAttributeValueFqns()) == 0 {
-					as.logger.WarnContext(ctx, "empty entity list and/or entity data attribute list")
-				} else {
-					
-
-					ecEntitlements := ecChainEntitlementsResponse[idx]
-					for idx, e := range ecEntitlements.Msg.GetEntitlements() {
-						entityID := e.GetEntityId()
-						if entityID == "" {
-							entityID = EntityIDPrefix + fmt.Sprint(idx)
-						}
-						entityCategory := entities[idx].GetCategory()
-						auditECEntitlements = append(auditECEntitlements, audit.EntityChainEntitlement{
-							EntityID:                 entityID,
-							EntityCatagory:           entityCategory.String(),
-							AttributeValueReferences: e.GetAttributeValueFqns(),
-						})
-
-						// If entity type unspecified, include in access decision to err on the side of caution
-						if entityCategory == authorization.Entity_CATEGORY_SUBJECT || entityCategory == authorization.Entity_CATEGORY_UNSPECIFIED {
-							subjectEntityAttrValues[entityID] = e.GetAttributeValueFqns()
-						} else {
-							envEntityAttrValues[entityID] = e.GetAttributeValueFqns()
-						}
-					}
-				}
-
-				// call access-pdp
-				accessPDP := access.NewPdp(as.logger)
-				decisions, err := accessPDP.DetermineAccess(
-					ctx,
-					attrVals,
-					subjectEntityAttrValues,
-					attrDefs,
-				)
-				if err != nil {
-					// TODO: should all decisions in a request fail if one entity entitlement lookup fails?
-					return nil, db.StatusifyError(errors.New("could not determine access"), "could not determine access", slog.String("error", err.Error()))
-				}
-				// check the decisions
-				decision := authorization.DecisionResponse_DECISION_PERMIT
-				for entityID, d := range decisions {
-					// Set overall decision as well as individual entity decision
-					entityDecision := authorization.DecisionResponse_DECISION_PERMIT
-					if !d.Access {
-						entityDecision = authorization.DecisionResponse_DECISION_DENY
-						decision = authorization.DecisionResponse_DECISION_DENY
-					}
-
-					// Add entity decision to audit list
-					entityEntitlementFqns := subjectEntityAttrValues[entityID]
-					if entityEntitlementFqns == nil {
-						entityEntitlementFqns = []string{}
-					}
-					auditEntityDecisions = append(auditEntityDecisions, audit.EntityDecision{
-						EntityID:     entityID,
-						Decision:     entityDecision.String(),
-						Entitlements: entityEntitlementFqns,
-					})
-				}
-
-				decisionResp := &authorization.DecisionResponse{
-					Decision:      decision,
-					EntityChainId: ec.GetId(),
-					Action: &policy.Action{
-						Value: &policy.Action_Standard{
-							Standard: policy.Action_STANDARD_ACTION_TRANSMIT,
-						},
-					},
-				}
-				if ra.GetResourceAttributesId() != "" {
-					decisionResp.ResourceAttributesId = ra.GetResourceAttributesId()
-				} else if len(ra.GetAttributeValueFqns()) > 0 {
-					decisionResp.ResourceAttributesId = ra.GetAttributeValueFqns()[0]
-				}
-
-				auditDecision := audit.GetDecisionResultDeny
-				if decision == authorization.DecisionResponse_DECISION_PERMIT {
-					auditDecision = audit.GetDecisionResultPermit
-				}
-				as.logger.Audit.GetDecision(ctx, audit.GetDecisionEventParams{
-					Decision:                auditDecision,
-					EntityChainEntitlements: auditECEntitlements,
-					EntityChainID:           decisionResp.GetEntityChainId(),
-					EntityDecisions:         auditEntityDecisions,
-					FQNs:                    fqns,
-					ResourceAttributeID:     decisionResp.GetResourceAttributesId(),
-				})
-				rsp.DecisionResponses = append(rsp.DecisionResponses, decisionResp)
-			}
+		resp, err := as.getDecisions(ctx, dr)
+		if err != nil {
+			return nil, err
 		}
+		rsp.DecisionResponses = append(rsp.DecisionResponses, resp...)
 	}
+
 	return connect.NewResponse(rsp), nil
 }
 
-func getAllPertinentAttributeFQNSFromRAS(ras []*authorization.ResourceAttribute) []string {
-	attributeFQNsSet := make(map[string]bool)
-	for _, ra := range ras {
-		for _, fqn := range ra.AttributeValueFqns {
-			attributeFQNsSet[fqn] = true
+func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorization.DecisionRequest) ([]*authorization.DecisionResponse, error) {
+	var attrDefsReqs [][]*policy.Attribute
+	var attrValsReqs [][]*policy.Value
+	var fqnsReqs [][]string
+	allPertinentFQNS := &authorization.ResourceAttribute{AttributeValueFqns: make([]string, 0)}
+	response := make([]*authorization.DecisionResponse, len(dr.ResourceAttributes))
+	for idx, ra := range dr.GetResourceAttributes() {
+		as.logger.DebugContext(ctx, "getting resource attributes", slog.String("FQNs", strings.Join(ra.GetAttributeValueFqns(), ", ")))
+
+		// get attribute definition/value combinations
+		dataAttrDefsAndVals, err := retrieveAttributeDefinitions(ctx, ra, as.sdk)
+		if err != nil {
+			// if attribute an FQN does not exist
+			// return deny for all entity chains aginst this RA set and continue to next
+			if errors.Is(err, db.StatusifyError(db.ErrNotFound, "")) {
+				for ecIdx, ec := range dr.GetEntityChains() {
+					decisionResp := &authorization.DecisionResponse{
+						Decision:      authorization.DecisionResponse_DECISION_DENY,
+						EntityChainId: ec.GetId(),
+						Action: &policy.Action{
+							Value: &policy.Action_Standard{
+								Standard: policy.Action_STANDARD_ACTION_TRANSMIT,
+							},
+						},
+					}
+					if ra.GetResourceAttributesId() != "" {
+						decisionResp.ResourceAttributesId = ra.GetResourceAttributesId()
+					} else if len(ra.GetAttributeValueFqns()) > 0 {
+						decisionResp.ResourceAttributesId = ra.GetAttributeValueFqns()[0]
+					}
+					response[(idx*len(dr.EntityChains))+ecIdx] = decisionResp
+				}
+				continue
+			}
+			return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("fqns", strings.Join(ra.GetAttributeValueFqns(), ", ")))
+		}
+
+		var attrDefs []*policy.Attribute
+		var attrVals []*policy.Value
+		var fqns []string
+
+		for fqn, v := range dataAttrDefsAndVals {
+			attrDefs = append(attrDefs, v.GetAttribute())
+			attrVal := v.GetValue()
+			fqns = append(fqns, fqn)
+			attrVal.Fqn = fqn
+			attrVals = append(attrVals, attrVal)
+		}
+
+		attrDefs, err = populateAttrDefValueFqns(attrDefs)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		allPertinentFQNS.AttributeValueFqns = append(allPertinentFQNS.AttributeValueFqns, ra.AttributeValueFqns...)
+
+		// get the relevant resource attribute fqns
+		for _, attrDef := range attrDefs {
+			if attrDef.GetRule() == policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY {
+				for _, value := range attrDef.GetValues() {
+					allPertinentFQNS.AttributeValueFqns = append(allPertinentFQNS.AttributeValueFqns, value.GetFqn())
+				}
+			}
+		}
+		attrDefsReqs = append(attrDefsReqs, attrDefs)
+		attrValsReqs = append(attrValsReqs, attrVals)
+		fqnsReqs = append(fqnsReqs, fqns)
+	}
+
+	var ecChainEntitlementsResponse []*connect.Response[authorization.GetEntitlementsResponse]
+	for _, ec := range dr.GetEntityChains() {
+		entities := ec.GetEntities()
+		if len(entities) == 0 {
+			ecChainEntitlementsResponse = append(ecChainEntitlementsResponse, nil)
+			continue
+		}
+		req := connect.Request[authorization.GetEntitlementsRequest]{
+			Msg: &authorization.GetEntitlementsRequest{
+				Entities: entities,
+				Scope:    allPertinentFQNS,
+			},
+		}
+		ecEntitlements, err := as.GetEntitlements(ctx, &req)
+		if err != nil {
+			// TODO: should all decisions in a request fail if one entity entitlement lookup fails?
+			return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("extra", "getEntitlements request failed"))
+		}
+		ecChainEntitlementsResponse = append(ecChainEntitlementsResponse, ecEntitlements)
+	}
+
+	for reqIdx, ra := range dr.GetResourceAttributes() {
+		for idx, ec := range dr.GetEntityChains() {
+			attrVals := attrValsReqs[reqIdx]
+			attrDefs := attrDefsReqs[reqIdx]
+			fqns := fqnsReqs[reqIdx]
+
+			//
+			// TODO: we should already have the subject mappings here and be able to just use OPA to trim down the known data attr values to the ones matched up with the entities
+			//
+			entities := ec.GetEntities()
+			auditECEntitlements := make([]audit.EntityChainEntitlement, 0)
+			auditEntityDecisions := make([]audit.EntityDecision, 0)
+
+			// Entitlements for environment entites in chain
+			envEntityAttrValues := make(map[string][]string)
+			// Entitlementsfor sbuject entities in chain
+			subjectEntityAttrValues := make(map[string][]string)
+
+			//nolint:nestif // handle empty entity / attr list
+			if len(entities) == 0 || len(ra.AttributeValueFqns) == 0 {
+				as.logger.WarnContext(ctx, "empty entity list and/or entity data attribute list")
+			} else {
+				ecEntitlements := ecChainEntitlementsResponse[idx]
+				for idx, e := range ecEntitlements.Msg.GetEntitlements() {
+					entityID := e.GetEntityId()
+					if entityID == "" {
+						entityID = EntityIDPrefix + fmt.Sprint(idx)
+					}
+					entityCategory := entities[idx].GetCategory()
+					auditECEntitlements = append(auditECEntitlements, audit.EntityChainEntitlement{
+						EntityID:                 entityID,
+						EntityCatagory:           entityCategory.String(),
+						AttributeValueReferences: e.GetAttributeValueFqns(),
+					})
+
+					// If entity type unspecified, include in access decision to err on the side of caution
+					if entityCategory == authorization.Entity_CATEGORY_SUBJECT || entityCategory == authorization.Entity_CATEGORY_UNSPECIFIED {
+						subjectEntityAttrValues[entityID] = e.GetAttributeValueFqns()
+					} else {
+						envEntityAttrValues[entityID] = e.GetAttributeValueFqns()
+					}
+				}
+			}
+
+			// call access-pdp
+			accessPDP := access.NewPdp(as.logger)
+			decisions, err := accessPDP.DetermineAccess(
+				ctx,
+				attrVals,
+				subjectEntityAttrValues,
+				attrDefs,
+			)
+			if err != nil {
+				// TODO: should all decisions in a request fail if one entity entitlement lookup fails?
+				return nil, db.StatusifyError(errors.New("could not determine access"), "could not determine access", slog.String("error", err.Error()))
+			}
+			// check the decisions
+			decision := authorization.DecisionResponse_DECISION_PERMIT
+			for entityID, d := range decisions {
+				// Set overall decision as well as individual entity decision
+				entityDecision := authorization.DecisionResponse_DECISION_PERMIT
+				if !d.Access {
+					entityDecision = authorization.DecisionResponse_DECISION_DENY
+					decision = authorization.DecisionResponse_DECISION_DENY
+				}
+
+				// Add entity decision to audit list
+				entityEntitlementFqns := subjectEntityAttrValues[entityID]
+				if entityEntitlementFqns == nil {
+					entityEntitlementFqns = []string{}
+				}
+				auditEntityDecisions = append(auditEntityDecisions, audit.EntityDecision{
+					EntityID:     entityID,
+					Decision:     entityDecision.String(),
+					Entitlements: entityEntitlementFqns,
+				})
+			}
+
+			decisionResp := &authorization.DecisionResponse{
+				Decision:      decision,
+				EntityChainId: ec.GetId(),
+				Action: &policy.Action{
+					Value: &policy.Action_Standard{
+						Standard: policy.Action_STANDARD_ACTION_TRANSMIT,
+					},
+				},
+			}
+			if ra.GetResourceAttributesId() != "" {
+				decisionResp.ResourceAttributesId = ra.GetResourceAttributesId()
+			} else if len(ra.GetAttributeValueFqns()) > 0 {
+				decisionResp.ResourceAttributesId = ra.GetAttributeValueFqns()[0]
+			}
+
+			auditDecision := audit.GetDecisionResultDeny
+			if decision == authorization.DecisionResponse_DECISION_PERMIT {
+				auditDecision = audit.GetDecisionResultPermit
+			}
+			as.logger.Audit.GetDecision(ctx, audit.GetDecisionEventParams{
+				Decision:                auditDecision,
+				EntityChainEntitlements: auditECEntitlements,
+				EntityChainID:           decisionResp.GetEntityChainId(),
+				EntityDecisions:         auditEntityDecisions,
+				FQNs:                    fqns,
+				ResourceAttributeID:     decisionResp.GetResourceAttributesId(),
+			})
+			response[(reqIdx*len(dr.EntityChains) + idx)] = decisionResp
 		}
 	}
-	return maps.Keys(attributeFQNsSet)
-
-
+	return response, nil
 }
 
 // makeSubMapsByValLookup creates a lookup map of subject mappings by attribute value ID.

--- a/service/authorization/authorization.go
+++ b/service/authorization/authorization.go
@@ -200,7 +200,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 	var attrValsReqs [][]*policy.Value
 	var fqnsReqs [][]string
 	allPertinentFQNS := &authorization.ResourceAttribute{AttributeValueFqns: make([]string, 0)}
-	response := make([]*authorization.DecisionResponse, len(dr.ResourceAttributes))
+	response := make([]*authorization.DecisionResponse, len(dr.GetResourceAttributes()))
 	for idx, ra := range dr.GetResourceAttributes() {
 		as.logger.DebugContext(ctx, "getting resource attributes", slog.String("FQNs", strings.Join(ra.GetAttributeValueFqns(), ", ")))
 
@@ -225,7 +225,8 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 					} else if len(ra.GetAttributeValueFqns()) > 0 {
 						decisionResp.ResourceAttributesId = ra.GetAttributeValueFqns()[0]
 					}
-					response[(idx*len(dr.EntityChains))+ecIdx] = decisionResp
+					responseIdx := (idx * len(dr.GetEntityChains())) + ecIdx
+					response[responseIdx] = decisionResp
 				}
 				continue
 			}
@@ -248,7 +249,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
-		allPertinentFQNS.AttributeValueFqns = append(allPertinentFQNS.AttributeValueFqns, ra.AttributeValueFqns...)
+		allPertinentFQNS.AttributeValueFqns = append(allPertinentFQNS.GetAttributeValueFqns(), ra.GetAttributeValueFqns()...)
 
 		// get the relevant resource attribute fqns
 		for _, attrDef := range attrDefs {
@@ -302,8 +303,8 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 			// Entitlementsfor sbuject entities in chain
 			subjectEntityAttrValues := make(map[string][]string)
 
-			//nolint:nestif // handle empty entity / attr list
-			if len(entities) == 0 || len(ra.AttributeValueFqns) == 0 {
+			// handle empty entity / attr list
+			if len(entities) == 0 || len(ra.GetAttributeValueFqns()) == 0 {
 				as.logger.WarnContext(ctx, "empty entity list and/or entity data attribute list")
 			} else {
 				ecEntitlements := ecChainEntitlementsResponse[idx]
@@ -389,7 +390,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 				FQNs:                    fqns,
 				ResourceAttributeID:     decisionResp.GetResourceAttributesId(),
 			})
-			response[(reqIdx*len(dr.EntityChains) + idx)] = decisionResp
+			response[(reqIdx*len(dr.GetEntityChains()) + idx)] = decisionResp
 		}
 	}
 	return response, nil


### PR DESCRIPTION
### Proposed Changes

* `GetEntitlements` is an expensive call. `GetDecisions` is calling `GetEntitlements` repetitively, despite no change in entities, but different Resource Attribute Policies. This can cause an unnecessary heavy load on the IDaP when a bulk amount Decisions are being made on one entity chain. 
* By getting all pertinent FAQs from the per Decision, and calling `GetEntitlements` per Decision will reduce IDaP load and have a huge performance win.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions
Compare the newly added benchmark test `benchmark-decision` result in commit `c9215db` before the benchmark test was made to the `HEAD` of this PR (`e903758`)
Follow the Platform Quickstart, and run `go run ./examples benchmark-decision --insecurePlaintextConn` for a quick test.

Locally, on PR changes
```
Benchmark Results:
Result: DECISION_PERMIT
Total Time: 227.609ms
```

Locally, before PR changes 
```
Benchmark Results:
Result: DECISION_PERMIT
Total Time: 2.143040292s
```
