### PR TITLE
fix(core): GetDecisions should handle empty string and non-existent attributes

### DIFF
--- a/service/authorization/authorization.go
+++ b/service/authorization/authorization.go
@@ -29,9 +29,13 @@ import (
 	"github.com/opentdf/platform/service/pkg/db"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
 	"github.com/opentdf/platform/service/policies"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const EntityIDPrefix string = "entity_idx_"
+
+var ErrEmptyStringAttribute = errors.New("resource attributes must have at least one attribute value fqn")
 
 type AuthorizationService struct { //nolint:revive // AuthorizationService is a valid name for this struct
 	sdk    *otdf.SDK
@@ -206,10 +210,11 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 
 		// get attribute definition/value combinations
 		dataAttrDefsAndVals, err := retrieveAttributeDefinitions(ctx, ra, as.sdk)
+		as.logger.Debug("attr defts and vals", slog.Any("dataAttrDefsAndVals", dataAttrDefsAndVals))
 		if err != nil {
 			// if attribute an FQN does not exist
 			// return deny for all entity chains aginst this RA set and continue to next
-			if errors.Is(err, db.StatusifyError(db.ErrNotFound, "")) {
+			if errors.Is(err, status.Error(codes.NotFound, db.ErrTextNotFound)) || errors.Is(err, ErrEmptyStringAttribute) {
 				for ecIdx, ec := range dr.GetEntityChains() {
 					decisionResp := &authorization.DecisionResponse{
 						Decision:      authorization.DecisionResponse_DECISION_DENY,
@@ -227,6 +232,10 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 					}
 					responseIdx := (raIdx * len(dr.GetEntityChains())) + ecIdx
 					response[responseIdx] = decisionResp
+					// append empty values to keep the order of the requests
+					attrDefsReqs = append(attrDefsReqs, []*policy.Attribute{})
+					attrValsReqs = append(attrValsReqs, []*policy.Value{})
+					fqnsReqs = append(fqnsReqs, []string{})
 				}
 				continue
 			}
@@ -287,6 +296,11 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 
 	for raIdx, ra := range dr.GetResourceAttributes() {
 		for ecIdx, ec := range dr.GetEntityChains() {
+			// check if we already have a decision for this entity chain
+			responseIdx := (raIdx * len(dr.GetEntityChains())) + ecIdx
+			if response[responseIdx] != nil {
+				continue
+			}
 			attrVals := attrValsReqs[raIdx]
 			attrDefs := attrDefsReqs[raIdx]
 			fqns := fqnsReqs[raIdx]
@@ -390,7 +404,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 				FQNs:                    fqns,
 				ResourceAttributeID:     decisionResp.GetResourceAttributesId(),
 			})
-			response[(raIdx*len(dr.GetEntityChains()) + ecIdx)] = decisionResp
+			response[responseIdx] = decisionResp
 		}
 	}
 	return response, nil
@@ -639,11 +653,22 @@ func retrieveAttributeDefinitions(ctx context.Context, ra *authorization.Resourc
 	if len(attrFqns) == 0 {
 		return make(map[string]*attr.GetAttributeValuesByFqnsResponse_AttributeAndValue), nil
 	}
+	// remove empty strings
+	attrFqnsNoEmpty := attrFqns[:0] // Use the same backing array to avoid allocation
+	for _, str := range attrFqns {
+		if str != "" {
+			attrFqnsNoEmpty = append(attrFqnsNoEmpty, str)
+		}
+	}
+	// if no attribute value FQNs after removal, return error
+	if len(attrFqnsNoEmpty) == 0 {
+		return nil, ErrEmptyStringAttribute
+	}
 	resp, err := sdk.Attributes.GetAttributeValuesByFqns(ctx, &attr.GetAttributeValuesByFqnsRequest{
 		WithValue: &policy.AttributeValueSelector{
 			WithSubjectMaps: false,
 		},
-		Fqns: attrFqns,
+		Fqns: attrFqnsNoEmpty,
 	})
 	if err != nil {
 		return nil, err

--- a/service/authorization/authorization.go
+++ b/service/authorization/authorization.go
@@ -210,7 +210,6 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 
 		// get attribute definition/value combinations
 		dataAttrDefsAndVals, err := retrieveAttributeDefinitions(ctx, ra, as.sdk)
-		as.logger.Debug("attr defts and vals", slog.Any("dataAttrDefsAndVals", dataAttrDefsAndVals))
 		if err != nil {
 			// if attribute an FQN does not exist
 			// return deny for all entity chains aginst this RA set and continue to next

--- a/service/authorization/authorization_test.go
+++ b/service/authorization/authorization_test.go
@@ -28,9 +28,9 @@ import (
 
 var (
 	getAttributesByValueFqnsResponse attr.GetAttributeValuesByFqnsResponse
-	getAttributesByValueFqnsError    error
+	errGetAttributesByValueFqns      error
 	listAttributeResp                attr.ListAttributesResponse
-	listAttributesError              error
+	errListAttributes                error
 	listSubjectMappings              sm.ListSubjectMappingsResponse
 	createEntityChainResp            entityresolution.CreateEntityChainFromJwtResponse
 	resolveEntitiesResp              entityresolution.ResolveEntitiesResponse
@@ -47,11 +47,11 @@ type myAttributesClient struct {
 }
 
 func (*myAttributesClient) ListAttributes(_ context.Context, _ *attr.ListAttributesRequest, _ ...grpc.CallOption) (*attr.ListAttributesResponse, error) {
-	return &listAttributeResp, listAttributesError
+	return &listAttributeResp, errListAttributes
 }
 
 func (*myAttributesClient) GetAttributeValuesByFqns(_ context.Context, _ *attr.GetAttributeValuesByFqnsRequest, _ ...grpc.CallOption) (*attr.GetAttributeValuesByFqnsResponse, error) {
-	return &getAttributesByValueFqnsResponse, getAttributesByValueFqnsError
+	return &getAttributesByValueFqnsResponse, errGetAttributesByValueFqns
 }
 
 type myERSClient struct {
@@ -1212,7 +1212,7 @@ func Test_GetDecisions_RA_FQN_Edge_Cases(t *testing.T) {
 
 	// should not hit get attributes by value fqns
 	getAttributesByValueFqnsResponse = attr.GetAttributeValuesByFqnsResponse{}
-	getAttributesByValueFqnsError = errors.New("should not hit")
+	errGetAttributesByValueFqns = errors.New("should not hit")
 
 	// set the request
 	req := connect.Request[authorization.GetDecisionsRequest]{
@@ -1249,7 +1249,7 @@ func Test_GetDecisions_RA_FQN_Edge_Cases(t *testing.T) {
 
 	// will hit getAttributesByValueFqns but will get error
 	getAttributesByValueFqnsResponse = attr.GetAttributeValuesByFqnsResponse{}
-	getAttributesByValueFqnsError = status.Error(codes.NotFound, db.ErrTextNotFound)
+	errGetAttributesByValueFqns = status.Error(codes.NotFound, db.ErrTextNotFound)
 
 	// set the request
 	req = connect.Request[authorization.GetDecisionsRequest]{
@@ -1286,7 +1286,7 @@ func Test_GetDecisions_RA_FQN_Edge_Cases(t *testing.T) {
 
 	// should not hit get attributes by value fqns
 	getAttributesByValueFqnsResponse = attr.GetAttributeValuesByFqnsResponse{}
-	getAttributesByValueFqnsError = errors.New("should not hit")
+	errGetAttributesByValueFqns = errors.New("should not hit")
 
 	// set the request
 	req = connect.Request[authorization.GetDecisionsRequest]{


### PR DESCRIPTION
### Proposed Changes

* if a resouce attribute fqn list only has "", DENY
* if a resource attribute fqn list has "" and other attributes, ignore the ""
* if a resource attribute fqn list has a non existent attribute, DENY

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

