### PR TITLE
fix(core): Correct length of GetDecision response array

### DIFF
--- a/service/authorization/authorization.go
+++ b/service/authorization/authorization.go
@@ -204,7 +204,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 	var attrValsReqs [][]*policy.Value
 	var fqnsReqs [][]string
 	allPertinentFQNS := &authorization.ResourceAttribute{AttributeValueFqns: make([]string, 0)}
-	response := make([]*authorization.DecisionResponse, len(dr.GetResourceAttributes()))
+	response := make([]*authorization.DecisionResponse, len(dr.GetResourceAttributes())*len(dr.GetEntityChains()))
 	for raIdx, ra := range dr.GetResourceAttributes() {
 		as.logger.DebugContext(ctx, "getting resource attributes", slog.String("FQNs", strings.Join(ra.GetAttributeValueFqns(), ", ")))
 

--- a/service/authorization/authorization_test.go
+++ b/service/authorization/authorization_test.go
@@ -1347,6 +1347,7 @@ func Test_GetDecisionsAllOf_Pass_EC_RA_Length_Mismatch(t *testing.T) {
 			},
 		},
 	}}
+	errGetAttributesByValueFqns = nil
 	userRepresentation := map[string]interface{}{
 		"A": "B",
 		"C": "D",


### PR DESCRIPTION
### Proposed Changes

* the length of the decision response array should be len(RAs) * len(ECs)
* add tests to catch future errors

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

