### PR TITLE
chore(ci): Fix git-town on empty PR bodies

### DIFF
--- a/.github/workflows/git-town.yaml
+++ b/.github/workflows/git-town.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: git-town/action@8a1ec345d5e6181d108d189ad0b2ff262b3155f4
+      - uses: git-town/action@379e52b8a5c26c8350c75b45597b3ca7316683d7
         with:
           skip-single-stacks: true
           main-branch: main


### PR DESCRIPTION
The 'autobump' PRs currently don't have a description, so they fail the git-town/action.

Sample Failure: https://github.com/opentdf/platform/pull/1849

This updates past git-town/action 1.0.7, which fixes an NPE when the PR description is empty

### Proposed Changes

*

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

