### PR TITLE
fix(sdk): Fixed token expiration time

### DIFF
--- a/sdk/auth/oauth/oauth.go
+++ b/sdk/auth/oauth/oauth.go
@@ -187,7 +187,7 @@ func processResponse(resp *http.Response) (*Token, error) {
 		return nil, fmt.Errorf("error unmarshaling token from response: %w", err)
 	}
 
-	token.received = time.Now()
+	token.received = time.Now().Round(0)
 
 	return token, nil
 }


### PR DESCRIPTION
### Issue

In Platform SDK, there is a corner case which is not handled by current logic which checks token expiration date. Currently, platform SDK uses monotonic clock for checking token expiration, but this clock is not running while PC sleeps/hibernates, thus causing wrong calculations of token expiration date and leading to sending of expired token to DSP.

From Go documentation (https://pkg.go.dev/time):

> **On some systems the monotonic clock will stop if the computer goes to sleep.** On such a system, t.Sub(u) may not accurately reflect the actual time that passed between t and u. The same applies to other functions and methods that subtract times, such as [Since](https://pkg.go.dev/time#Since), [Until](https://pkg.go.dev/time#Until), [Before], [After](https://pkg.go.dev/time#After), [Add], [Sub], [Equal] and [Compare]. In some cases, you may need to strip the monotonic clock to get accurate results.

> **The Time returned by time.Now contains a monotonic clock reading.** If Time t has a monotonic clock reading, t.Add adds the same duration to both the wall clock and monotonic clock readings to compute the result. Because t.AddDate(y, m, d), t.Round(d), and t.Truncate(d) are wall time computations, they always strip any monotonic clock reading from their results. Because t.In, t.Local, and t.UTC are used for their effect on the interpretation of the wall time, they also strip any monotonic clock reading from their results. **The canonical way to strip a monotonic clock reading is to use t = t.Round(0)**.

### Proposed Changes

Switched to wall-time clock by stripping monotonic clock.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

