### PR TITLE
fix(sdk): everything is `mixedSplits` now

### DIFF
--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -812,8 +812,9 @@ func (r *Reader) doPayloadKeyUnwrap(ctx context.Context) error { //nolint:gocogn
 			} else if strings.Contains(err.Error(), codes.PermissionDenied.String()) {
 				skippedSplits[ss] = fmt.Errorf("%w: %w", errRewrapForbidden, errToReturn)
 			} else {
-			skippedSplits[ss] = errToReturn
-			continue
+				skippedSplits[ss] = errToReturn
+				continue
+			}
 		}
 
 		for keyByteIndex, keyByte := range wrappedKey {

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -856,7 +856,7 @@ func (r *Reader) doPayloadKeyUnwrap(ctx context.Context) error { //nolint:gocogn
 		for _, e := range skippedSplits {
 			v = append(v, e)
 		}
-		return v[0]
+		return v[1]
 	}
 
 	aggregateHash := &bytes.Buffer{}

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -807,10 +807,10 @@ func (r *Reader) doPayloadKeyUnwrap(ctx context.Context) error { //nolint:gocogn
 		wrappedKey, err = client.unwrap(ctx, keyAccessObj, r.manifest.EncryptionInformation.Policy)
 		if err != nil {
 			errToReturn := fmt.Errorf("kao unwrap failed for split %v: %w", ss, err)
-			if !strings.Contains(err.Error(), codes.InvalidArgument.String()) {
+			if strings.Contains(err.Error(), codes.InvalidArgument.String()) {
 				skippedSplits[ss] = fmt.Errorf("%w: %w", ErrRewrapBadRequest, errToReturn)
 			}
-			if !strings.Contains(err.Error(), codes.PermissionDenied.String()) {
+			if strings.Contains(err.Error(), codes.PermissionDenied.String()) {
 				skippedSplits[ss] = fmt.Errorf("%w: %w", errRewrapForbidden, errToReturn)
 			}
 			skippedSplits[ss] = errToReturn

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -809,10 +809,9 @@ func (r *Reader) doPayloadKeyUnwrap(ctx context.Context) error { //nolint:gocogn
 			errToReturn := fmt.Errorf("kao unwrap failed for split %v: %w", ss, err)
 			if strings.Contains(err.Error(), codes.InvalidArgument.String()) {
 				skippedSplits[ss] = fmt.Errorf("%w: %w", ErrRewrapBadRequest, errToReturn)
-			}
-			if strings.Contains(err.Error(), codes.PermissionDenied.String()) {
+			} else if strings.Contains(err.Error(), codes.PermissionDenied.String()) {
 				skippedSplits[ss] = fmt.Errorf("%w: %w", errRewrapForbidden, errToReturn)
-			}
+			} else {
 			skippedSplits[ss] = errToReturn
 			continue
 		}

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -856,7 +856,7 @@ func (r *Reader) doPayloadKeyUnwrap(ctx context.Context) error { //nolint:gocogn
 		for _, e := range skippedSplits {
 			v = append(v, e)
 		}
-		return errors.Join(v...)
+		return v[0]
 	}
 
 	aggregateHash := &bytes.Buffer{}

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -791,7 +791,6 @@ func (r *Reader) doPayloadKeyUnwrap(ctx context.Context) error { //nolint:gocogn
 	knownSplits := make(map[string]bool)
 	foundSplits := make(map[string]bool)
 	skippedSplits := make(map[keySplitStep]error)
-	mixedSplits := len(r.manifest.KeyAccessObjs) > 1 && r.manifest.KeyAccessObjs[0].SplitID != ""
 
 	for _, keyAccessObj := range r.manifest.EncryptionInformation.KeyAccessObjs {
 		client := newKASClient(r.dialOptions, r.tokenSource, &r.kasSessionKey)
@@ -800,36 +799,22 @@ func (r *Reader) doPayloadKeyUnwrap(ctx context.Context) error { //nolint:gocogn
 
 		var err error
 		var wrappedKey []byte
-		if !mixedSplits { //nolint:nestif // todo: subfunction
-			wrappedKey, err = client.unwrap(ctx, keyAccessObj, r.manifest.EncryptionInformation.Policy)
-			if err != nil {
-				errToReturn := fmt.Errorf("doPayloadKeyUnwrap splitKey.rewrap failed: %w", err)
-				if strings.Contains(err.Error(), codes.InvalidArgument.String()) {
-					return fmt.Errorf("%w: %w", ErrRewrapBadRequest, errToReturn)
-				}
-				if strings.Contains(err.Error(), codes.PermissionDenied.String()) {
-					return fmt.Errorf("%w: %w", errRewrapForbidden, errToReturn)
-				}
-				return errToReturn
+		knownSplits[ss.SplitID] = true
+		if foundSplits[ss.SplitID] {
+			// already found
+			continue
+		}
+		wrappedKey, err = client.unwrap(ctx, keyAccessObj, r.manifest.EncryptionInformation.Policy)
+		if err != nil {
+			errToReturn := fmt.Errorf("kao unwrap failed for split %v: %w", ss, err)
+			if !strings.Contains(err.Error(), codes.InvalidArgument.String()) {
+				skippedSplits[ss] = fmt.Errorf("%w: %w", ErrRewrapBadRequest, errToReturn)
 			}
-		} else {
-			knownSplits[ss.SplitID] = true
-			if foundSplits[ss.SplitID] {
-				// already found
-				continue
+			if !strings.Contains(err.Error(), codes.PermissionDenied.String()) {
+				skippedSplits[ss] = fmt.Errorf("%w: %w", errRewrapForbidden, errToReturn)
 			}
-			wrappedKey, err = client.unwrap(ctx, keyAccessObj, r.manifest.EncryptionInformation.Policy)
-			if err != nil {
-				errToReturn := fmt.Errorf("kao unwrap failed for split %v: %w", ss, err)
-				if !strings.Contains(err.Error(), codes.InvalidArgument.String()) {
-					skippedSplits[ss] = fmt.Errorf("%w: %w", ErrRewrapBadRequest, errToReturn)
-				}
-				if !strings.Contains(err.Error(), codes.PermissionDenied.String()) {
-					skippedSplits[ss] = fmt.Errorf("%w: %w", errRewrapForbidden, errToReturn)
-				}
-				skippedSplits[ss] = errToReturn
-				continue
-			}
+			skippedSplits[ss] = errToReturn
+			continue
 		}
 
 		for keyByteIndex, keyByte := range wrappedKey {
@@ -865,7 +850,7 @@ func (r *Reader) doPayloadKeyUnwrap(ctx context.Context) error { //nolint:gocogn
 		}
 	}
 
-	if mixedSplits && len(knownSplits) > len(foundSplits) {
+	if len(knownSplits) > len(foundSplits) {
 		v := make([]error, 1, len(skippedSplits))
 		v[0] = fmt.Errorf("splitKey.unable to reconstruct split key: %v", skippedSplits)
 		for _, e := range skippedSplits {


### PR DESCRIPTION
### Proposed Changes

Previously we handled TDFs with missing split IDs as if each key split with no split ID should be
part of a different split. This was incompatible with the way that FileWatcher created TDFs; multiple
KAOs with no split IDs are part of a single split.
 
This removes this special-casing that groups splits with no IDs separately.

Tests for this case are [in a new xtest](https://github.com/opentdf/tests/pull/240)

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

