### PR TITLE
fix(sdk): Removes unnecessary down-cast of `int`

### DIFF
--- a/sdk/kas_client.go
+++ b/sdk/kas_client.go
@@ -36,7 +36,7 @@ type kaoResult struct {
 
 type decryptor interface {
 	CreateRewrapRequest(ctx context.Context) (map[string]*kas.UnsignedRewrapRequest_WithPolicyRequest, error)
-	Decrypt(ctx context.Context, results []kaoResult) (uint32, error)
+	Decrypt(ctx context.Context, results []kaoResult) (int, error)
 }
 
 func newKASClient(dialOptions []grpc.DialOption, accessTokenSource auth.AccessTokenSource, sessionKey *ocrypto.RsaKeyPair) *KASClient {

--- a/sdk/nanotdf.go
+++ b/sdk/nanotdf.go
@@ -957,7 +957,7 @@ func (n *NanoTDFDecryptHandler) CreateRewrapRequest(_ context.Context) (map[stri
 	return map[string]*kas.UnsignedRewrapRequest_WithPolicyRequest{kasURL: req}, nil
 }
 
-func (n *NanoTDFDecryptHandler) Decrypt(_ context.Context, result []kaoResult) (uint32, error) {
+func (n *NanoTDFDecryptHandler) Decrypt(_ context.Context, result []kaoResult) (int, error) {
 	var err error
 	if len(result) != 1 {
 		return 0, fmt.Errorf("improper result from kas")
@@ -1013,16 +1013,16 @@ func (n *NanoTDFDecryptHandler) Decrypt(_ context.Context, result []kaoResult) (
 		return 0, err
 	}
 
-	return uint32(writeLen), nil
+	return writeLen, nil
 }
 
 // ReadNanoTDF - read the nano tdf and return the decrypted data from it
-func (s SDK) ReadNanoTDF(writer io.Writer, reader io.ReadSeeker) (uint32, error) {
+func (s SDK) ReadNanoTDF(writer io.Writer, reader io.ReadSeeker) (int, error) {
 	return s.ReadNanoTDFContext(context.Background(), writer, reader)
 }
 
 // ReadNanoTDFContext - allows cancelling the reader
-func (s SDK) ReadNanoTDFContext(ctx context.Context, writer io.Writer, reader io.ReadSeeker) (uint32, error) {
+func (s SDK) ReadNanoTDFContext(ctx context.Context, writer io.Writer, reader io.ReadSeeker) (int, error) {
 	handler := createNanoTDFDecryptHandler(reader, writer)
 
 	symmetricKey, err := s.getNanoRewrapKey(ctx, handler)

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -81,7 +81,7 @@ type tdf3DecryptHandler struct {
 	reader *Reader
 }
 
-func (r *tdf3DecryptHandler) Decrypt(ctx context.Context, results []kaoResult) (uint32, error) {
+func (r *tdf3DecryptHandler) Decrypt(ctx context.Context, results []kaoResult) (int, error) {
 	err := r.reader.buildKey(ctx, results)
 	if err != nil {
 		return 0, err
@@ -92,7 +92,7 @@ func (r *tdf3DecryptHandler) Decrypt(ctx context.Context, results []kaoResult) (
 	}
 
 	n, err := r.writer.Write(data)
-	return uint32(n), err
+	return n, err
 }
 
 func (r *tdf3DecryptHandler) CreateRewrapRequest(ctx context.Context) (map[string]*kas.UnsignedRewrapRequest_WithPolicyRequest, error) {


### PR DESCRIPTION
### Proposed Changes

* Removes some casts of io.Read responses of `int` to the less accurate `uint32`.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

