### PR TITLE
feat(sdk): Allow schema validation during TDF decrypt

### DIFF
--- a/sdk/schema/manifest-lax.schema.json
+++ b/sdk/schema/manifest-lax.schema.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/manifest.schema.json",
+  "title": "manifest",
+  "description": "TDF manifest in JSON",
+  "type": "object",
+  "properties": {
+    "payload": {
+      "type": "object",
+      "description": "An object which contains information describing the payload.",
+      "properties": {
+        "type": {
+          "description": "Describes the type of payload is associated with the TDF.",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL which points to payload. For reference types, with the default ZIP protocol, the URL would point to a local file within the zip.",
+          "type": "string"
+        },
+        "protocol": {
+          "description": "The payload protocol. Default is zip."
+        },
+        "isEncrypted": {
+          "description": "Designates whether or not the payload is encrypted, or cleartext.",
+          "type": "boolean"
+        },
+        "mimeType": {
+          "description": "Specifies the type of file that is encrypted. Default is `application/octet-stream`.",
+          "type": "string"
+        },
+        "tdf_spec_version": {
+          "description": "Semver version number of the TDF spec.",
+          "type": ["string", "null"]
+        }
+      },
+      "required": ["type", "url", "protocol", "isEncrypted"]
+    },
+    "encryptionInformation": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Designates the type of key access protocol was used. Default, is split.",
+          "type": "string"
+        },
+        "keyAccess": {
+          "description": "An array of keyAccess objects which are used to retrieve keys from one, or more Key Access Services",
+          "type": "array",
+          "items": {
+            "description": "A key access object",
+            "type": "object",
+            "properties": {
+              "type": {
+                "description": "The type of key access object.",
+                "type": "string",
+                "enum": ["wrapped", "remote"]
+              },
+              "url": {
+                "description": "A fully qualified URL pointing to a key access service responsible for managing access to the encryption keys.",
+                "type": "string"
+              },
+              "protocol": {
+                "description": "The protocol to be used for managing key access.",
+                "type": "string",
+                "enum": ["kas"]
+              },
+              "wrappedKey": {
+                "description": "The symmetric key used to encrypt the payload. It has been encrypted using the public key of the KAS, then base64 encoded.",
+                "type": "string"
+              },
+              "sid": {
+                "description": "A unique identifier for a single key split. In some complex policies, multiple key access objects may exist that share a specific key split. Using a splitId allows software to more efficiently operate by not reusing key material unnecessarily. ",
+                "type": ["string", "null"]
+              },
+              "kid": {
+                "description": "A UUID for the specific keypair used for wrapping the symmetric key.",
+                "type": "string"
+              },
+              "policyBinding": {
+                "description": "Object describing the policyBinding. Contains a hash, and an algorithm used. May also be a string, with just the hash. In that case default to HS256.",
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },{
+                    "type": "object",
+                    "properties": {
+                      "alg": {
+                        "description": "The policy binding algorithm used to generate the hash.",
+                        "type": "string"
+                      },
+                      "hash": {
+                        "description": "This contains a keyed hash that will provide cryptographic integrity on the policy object, such that it cannot be modified or copied to another TDF, without invalidating the binding. Specifically, you would have to have access to the key in order to overwrite the policy.",
+                        "type": "string"
+                      }
+                    }
+                    ,"required": ["alg", "hash"]
+                  }
+                ]
+              },
+              "encryptedMetadata": {
+                "description": "Metadata associated with the TDF, and the request. The contents of the metadata are freeform, and are used to pass information from the client, and any plugins that may be in use by the KAS. The metadata stored here should not be used for primary access decisions. Base64.",
+                "type": ["string", "null"]
+              }
+            }
+          },
+          "required": ["type", "url", "protocol", "wrappedKey","sid", "kid", "policyBinding"]
+        },
+        "method": {
+          "type": "object",
+          "properties": {
+            "algorithm": {
+              "description": "Algorithm used to encrypt the payload",
+              "type": "string"
+            },
+            "isStreamable": {
+              "description": "Designates whether or not the payload is streamable.",
+              "type": "boolean"
+            }
+          },
+          "required": ["algorithm", "isStreamable"]
+        },
+        "integrityInformation": {
+          "type": "object",
+          "properties": {
+            "rootSignature": {
+              "type": "object",
+              "properties": {
+                "alg": {
+                  "description": "Algorithm used to generate the root signature of the payload",
+                  "type": "string"
+                },
+                "sig": {
+                  "description": "The payload signature",
+                  "type": "string"
+                }
+              }
+            },
+            "segmentSizeDefault": {
+              "description": "Default size of a encryption segment",
+              "type": "number"
+            },
+            "segmentHashAlg": {
+              "description": "Algorithm used to generate segment hashes",
+              "type": "string"
+            },
+            "segments": {
+              "description": "An array of segment objects. Allows for the possibility of assuring integrity over file segments, in addition to the entire payload. Useful for streaming.",
+              "type": "array",
+              "items": {
+                "description": "Segment object. Contains information necessary to validate integrity over a specific byte range of a payload.",
+                "type": "object",
+                "properties": {
+                  "hash": {
+                    "description": "Generated hash using the segment hashing algorithm specified in the parent object.",
+                    "type": "string"
+                  },
+                  "segmentSize": {
+                    "description": "The size of the segment prior to its encryption. Optional field only specified if it differs from the 'segmentSizeDefault', specified above.",
+                    "type": "number"
+                  },
+                  "encryptedSegmentSize": {
+                    "description": "The size of the segment once it has been encrypted.",
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            "encryptedSegmentSizeDefault": {
+              "description": "Default size of an encrypted segment. TODO: Is this necessary??",
+              "type": "number"
+            }
+          },
+          "required": ["rootSignature", "segmentSizeDefault", "segments", "encryptedSegmentSizeDefault"]
+        },
+        "policy": {
+          "description": "Base64 encoded policy object",
+          "type": "string"
+        }
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "description": "An array of objects used to express metadata about the objects in the scope attribute of the assertion. An assertion also supports metadata about the assertion statement for the purposes of indicating any handling instructions pertinent to the statement itself. Also supports encrypted statements and binding the statement with objects in its scope.",
+      "items": {
+        "type": "object",
+        "description": "A single assertion",
+        "properties": {
+          "id": {
+            "description": "A unique local identifier used for binding and signing purposes. Not guaranteed to be unique across multiple TDOs but must be unique within a single instance.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Describes the type of assertion ('handling' or 'other').",
+            "type": "string"
+          },
+          "scope": {
+            "description": "An enumeration of the object to which the assertion applies ('tdo' or 'payload').",
+            "type": "string"
+          },
+          "appliesToState": {
+            "description": "Used to indicate if the statement metadata applies to 'encrypted' or 'unencrypted' data.",
+            "type": ["string", "null"]
+          },
+          "statement": {
+            "description": "Intended for access, rights, and/or handling instructions that apply to the scope of the assertion.",
+            "type": "object",
+            "properties": {
+              "format": {
+                "description": "Describes the payload content encoding format ('xml-structured', 'base64binary', 'string').",
+                "type": "string"
+              },
+              "value": {
+                "description": "Payload content encoded in the format specified.",
+                "type": ["string", "object"]
+              }
+            }
+          },
+          "binding": {
+            "description": "Object describing the assertionBinding. Contains a hash, and an algorithm used.",
+            "type": "object",
+            "properties": {
+              "method": {
+                "description": "The assertion binding method used encode the signature. Default is 'jws'",
+                "type": "string"
+              },
+              "signature": {
+                "description": "This contains a keyed hash that will provide cryptographic integrity on the assertion object, such that it cannot be modified or copied to another TDF, without invalidating the binding. Specifically, you would have to have access to the key in order to overwrite the policy.",
+                "type": "string"
+              }
+            },
+            "required": ["method", "signature"]
+          }
+        },
+        "required": ["id", "type", "scope", "appliesToState", "statement"]
+      }
+    }
+  },
+  "required": ["payload", "encryptionInformation"]
+}

--- a/sdk/schema/manifest.schema.json
+++ b/sdk/schema/manifest.schema.json
@@ -30,7 +30,7 @@
           },
           "tdf_spec_version": {
             "description": "Semver version number of the TDF spec.",
-            "type": ["string", "null"]
+            "type": "string"
           }
         },
         "required": ["type", "url", "protocol", "isEncrypted"]
@@ -69,7 +69,7 @@
                 },
                 "sid": {
                   "description": "A unique identifier for a single key split. In some complex policies, multiple key access objects may exist that share a specific key split. Using a splitId allows software to more efficiently operate by not reusing key material unnecessarily. ",
-                  "type": ["string", "null"]
+                  "type": "string"
                 },
                 "kid": {
                   "description": "A UUID for the specific keypair used for wrapping the symmetric key.",
@@ -98,7 +98,7 @@
                 },
                 "encryptedMetadata": {
                   "description": "Metadata associated with the TDF, and the request. The contents of the metadata are freeform, and are used to pass information from the client, and any plugins that may be in use by the KAS. The metadata stored here should not be used for primary access decisions. Base64.",
-                  "type": ["string", "null"]
+                  "type": "string"
                 }
               }
             },
@@ -198,7 +198,7 @@
             },
             "appliesToState": {
               "description": "Used to indicate if the statement metadata applies to 'encrypted' or 'unencrypted' data.",
-              "type": ["string", "null"]
+              "type": "string"
             },
             "statement": {
               "description": "Intended for access, rights, and/or handling instructions that apply to the scope of the assertion.",

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -565,7 +565,7 @@ func (s SDK) LoadTDF(reader io.ReadSeeker, opts ...TDFReaderOption) (*Reader, er
 	}
 
 	if config.schemaValidationIntensity == Lax || config.schemaValidationIntensity == Strict {
-		valid, err := isValidManifest(manifest, Lax)
+		valid, err := isValidManifest(manifest, config.schemaValidationIntensity)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -564,6 +564,16 @@ func (s SDK) LoadTDF(reader io.ReadSeeker, opts ...TDFReaderOption) (*Reader, er
 		return nil, fmt.Errorf("tdfReader.Manifest failed: %w", err)
 	}
 
+	if config.schemaValidationIntensity == Lax || config.schemaValidationIntensity == Strict {
+		valid, err := isValidManifest(manifest, Lax)
+		if err != nil {
+			return nil, err
+		}
+		if !valid {
+			return nil, fmt.Errorf("manifest schema validation failed")
+		}
+	}
+
 	manifestObj := &Manifest{}
 	err = json.Unmarshal([]byte(manifest), manifestObj)
 	if err != nil {

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -1023,9 +1023,9 @@ func (r *Reader) buildKey(_ context.Context, results []kaoResult) error {
 		assertionKey.Alg = AssertionKeyAlgHS256
 		assertionKey.Key = payloadKey[:]
 
-		if !r.config.AssertionVerificationKeys.IsEmpty() {
+		if !r.config.verifiers.IsEmpty() {
 			// Look up the key for the assertion
-			foundKey, err := r.config.AssertionVerificationKeys.Get(assertion.ID)
+			foundKey, err := r.config.verifiers.Get(assertion.ID)
 
 			if err != nil {
 				return fmt.Errorf("%w: %w", ErrAssertionFailure{ID: assertion.ID}, err)

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -225,8 +225,7 @@ const (
 type TDFReaderOption func(*TDFReaderConfig) error
 
 type TDFReaderConfig struct {
-	// Optional Map of Assertion Verification Keys
-	AssertionVerificationKeys    AssertionVerificationKeys
+	verifiers                    AssertionVerificationKeys
 	disableAssertionVerification bool
 
 	schemaValidationIntensity SchemaValidationIntensity
@@ -248,7 +247,7 @@ func newTDFReaderConfig(opt ...TDFReaderOption) (*TDFReaderConfig, error) {
 
 func WithAssertionVerificationKeys(keys AssertionVerificationKeys) TDFReaderOption {
 	return func(c *TDFReaderConfig) error {
-		c.AssertionVerificationKeys = keys
+		c.verifiers = keys
 		return nil
 	}
 }

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -213,12 +213,23 @@ func WithAutoconfigure(enable bool) TDFOption {
 	}
 }
 
+// Schema Validation where 0 = none (skip), 1 = lax (allowing novel entries, 'falsy' values for unkowns), 2 = strict (rejecting novel entries, strict match to manifest schema)
+type SchemaValidationIntensity int
+
+const (
+	Skip SchemaValidationIntensity = iota
+	Lax
+	Strict
+)
+
 type TDFReaderOption func(*TDFReaderConfig) error
 
 type TDFReaderConfig struct {
 	// Optional Map of Assertion Verification Keys
 	AssertionVerificationKeys    AssertionVerificationKeys
 	disableAssertionVerification bool
+
+	schemaValidationIntensity SchemaValidationIntensity
 }
 
 func newTDFReaderConfig(opt ...TDFReaderOption) (*TDFReaderConfig, error) {
@@ -238,6 +249,13 @@ func newTDFReaderConfig(opt ...TDFReaderOption) (*TDFReaderConfig, error) {
 func WithAssertionVerificationKeys(keys AssertionVerificationKeys) TDFReaderOption {
 	return func(c *TDFReaderConfig) error {
 		c.AssertionVerificationKeys = keys
+		return nil
+	}
+}
+
+func WithSchemaValidation(intensity SchemaValidationIntensity) TDFReaderOption {
+	return func(c *TDFReaderConfig) eprror {
+		c.schemaValidationIntensity = intensity
 		return nil
 	}
 }

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -220,6 +220,7 @@ const (
 	Skip SchemaValidationIntensity = iota
 	Lax
 	Strict
+	unreasonable = 100
 )
 
 type TDFReaderOption func(*TDFReaderConfig) error
@@ -253,7 +254,7 @@ func WithAssertionVerificationKeys(keys AssertionVerificationKeys) TDFReaderOpti
 }
 
 func WithSchemaValidation(intensity SchemaValidationIntensity) TDFReaderOption {
-	return func(c *TDFReaderConfig) eprror {
+	return func(c *TDFReaderConfig) error {
 		c.schemaValidationIntensity = intensity
 		return nil
 	}

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -1145,7 +1145,7 @@ func (s *TDFSuite) Test_ValidateSchema() {
 					return err
 				}
 
-				(data["payload"].(map[string]interface{}))["tdf_spec_version"] = nil //nolint:errcheck,forcetypeassert // testonly code
+				(data["payload"].(map[string]interface{}))["tdf_spec_version"] = nil //nolint:forcetypeassert // testonly code
 
 				err = json.NewEncoder(dst).Encode(data)
 				return err

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -218,7 +218,7 @@ type partialReadTdfTest struct {
 
 type assertionTests struct {
 	assertions                   []AssertionConfig
-	assertionVerificationKeys    *AssertionVerificationKeys
+	verifiers                    *AssertionVerificationKeys
 	disableAssertionVerification bool
 	expectedSize                 int
 }
@@ -393,7 +393,7 @@ func (s *TDFSuite) Test_TDFWithAssertion() {
 					},
 				},
 			},
-			assertionVerificationKeys:    nil,
+			verifiers:                    nil,
 			disableAssertionVerification: false,
 			expectedSize:                 2689,
 		},
@@ -424,7 +424,7 @@ func (s *TDFSuite) Test_TDFWithAssertion() {
 					SigningKey: defaultKey,
 				},
 			},
-			assertionVerificationKeys: &AssertionVerificationKeys{
+			verifiers: &AssertionVerificationKeys{
 				DefaultKey: defaultKey,
 			},
 			disableAssertionVerification: false,
@@ -463,7 +463,7 @@ func (s *TDFSuite) Test_TDFWithAssertion() {
 					},
 				},
 			},
-			assertionVerificationKeys: &AssertionVerificationKeys{
+			verifiers: &AssertionVerificationKeys{
 				// defaultVerificationKey: nil,
 				Keys: map[string]AssertionKey{
 					"assertion1": {
@@ -508,7 +508,7 @@ func (s *TDFSuite) Test_TDFWithAssertion() {
 					},
 				},
 			},
-			assertionVerificationKeys: &AssertionVerificationKeys{
+			verifiers: &AssertionVerificationKeys{
 				Keys: map[string]AssertionKey{
 					"assertion1": {
 						Alg: AssertionKeyAlgHS256,
@@ -580,11 +580,11 @@ func (s *TDFSuite) Test_TDFWithAssertion() {
 			buf := make([]byte, 8)
 
 			var r *Reader
-			if test.assertionVerificationKeys == nil {
+			if test.verifiers == nil {
 				r, err = s.sdk.LoadTDF(readSeeker, WithDisableAssertionVerification(test.disableAssertionVerification))
 			} else {
 				r, err = s.sdk.LoadTDF(readSeeker,
-					WithAssertionVerificationKeys(*test.assertionVerificationKeys),
+					WithAssertionVerificationKeys(*test.verifiers),
 					WithDisableAssertionVerification(test.disableAssertionVerification))
 			}
 			s.Require().NoError(err)
@@ -678,7 +678,7 @@ func (s *TDFSuite) Test_TDFWithAssertionNegativeTests() {
 					},
 				},
 			},
-			assertionVerificationKeys: &AssertionVerificationKeys{
+			verifiers: &AssertionVerificationKeys{
 				// defaultVerificationKey: nil,
 				Keys: map[string]AssertionKey{
 					"assertion1": {
@@ -722,7 +722,7 @@ func (s *TDFSuite) Test_TDFWithAssertionNegativeTests() {
 					},
 				},
 			},
-			assertionVerificationKeys: &AssertionVerificationKeys{
+			verifiers: &AssertionVerificationKeys{
 				DefaultKey: defaultKey,
 			},
 			expectedSize: 2689,
@@ -771,10 +771,10 @@ func (s *TDFSuite) Test_TDFWithAssertionNegativeTests() {
 			buf := make([]byte, 8)
 
 			var r *Reader
-			if test.assertionVerificationKeys == nil {
+			if test.verifiers == nil {
 				r, err = s.sdk.LoadTDF(readSeeker)
 			} else {
-				r, err = s.sdk.LoadTDF(readSeeker, WithAssertionVerificationKeys(*test.assertionVerificationKeys))
+				r, err = s.sdk.LoadTDF(readSeeker, WithAssertionVerificationKeys(*test.verifiers))
 			}
 			s.Require().NoError(err)
 


### PR DESCRIPTION
### Proposed Changes

* Some users were gating on IsValidTDF, this makes that check an option for LoadTDF

Example usage:

```typescript
var s sdk.SDK
reader, err := s.LoadTDF(cipherText, s.WithSchemaValidation(sdk.Lax))
```

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

