### PR TITLE
chore: Add security for reviewing dependency updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,8 +11,8 @@
 ## General
 
 .gitignore    @opentdf/maintainers
-go.mod        @opentdf/maintainers
-*.sum         @opentdf/maintainers
+*go.mod       @opentdf/maintainers @opentdf/security
+*.sum         @opentdf/maintainers @opentdf/security
 
 ### Documentation
 


### PR DESCRIPTION
### Proposed Changes

This changes CODEOWNERS to fix the `go.mod` definition to handle the fact that go.mod exists within subdirectories.

In addition `@opentdf/security` is being added as possible reviewers for these files so they we can help assist with safe dependency updates.  For example:
* https://github.com/opentdf/platform/pull/1852
* https://github.com/opentdf/platform/security/dependabot/31
* https://github.com/opentdf/platform/security/dependabot/32
* https://github.com/opentdf/platform/security/dependabot/29
* https://github.com/opentdf/platform/security/dependabot/36
* https://github.com/opentdf/platform/security/dependabot/35
* https://github.com/opentdf/platform/security/dependabot/34
* https://github.com/opentdf/platform/security/dependabot/33

### Testing Instructions

N/A