### PR TITLE
chore: Add security to CODEOWNERS for docs/go.*

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,10 +16,10 @@
 
 ### Documentation
 
-*.md          @opentdf/maintainers
-/docs/        @opentdf/maintainers
-/examples/    @opentdf/maintainers
-/examples/    @opentdf/maintainers @opentdf/security
+*.md            @opentdf/maintainers
+/docs/          @opentdf/maintainers
+/examples/      @opentdf/maintainers
+/examples/go.*  @opentdf/maintainers @opentdf/security
 
 ## Services
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,6 +19,7 @@
 *.md          @opentdf/maintainers
 /docs/        @opentdf/maintainers
 /examples/    @opentdf/maintainers
+/examples/    @opentdf/maintainers @opentdf/security
 
 ## Services
 


### PR DESCRIPTION
### Proposed Changes

This adds the security team to CODEOWNERS to `docs/go.*` so that we can assist with dependency updates.  This was missed as a go directory in PR #1878, discovered through the update needed in PR https://github.com/opentdf/platform/pull/1882

### Testing Instructions

N/A