### PR TITLE
chore(ci): updates ci to go 1.22.11

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,7 +23,7 @@ jobs:
       - name: 'Setup Go'
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
         with:
-          go-version: '1.22.5'
+          go-version: '1.22.11'
           check-latest: false
           cache-dependency-path: |
             service/go.sum

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -22,5 +22,5 @@ jobs:
       - name: govluncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
         with:
-          go-version-input: "1.22.5"
+          go-version-input: "1.22.11"
           work-dir: ${{ matrix.directory }}


### PR DESCRIPTION
This should fix the failing vulncheck

### Proposed Changes

*

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

