### PR TITLE
chore(sdk): Fixes future linter error

### DIFF
--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -1145,7 +1145,11 @@ func (s *TDFSuite) Test_ValidateSchema() {
 					return err
 				}
 
-				(data["payload"].(map[string]interface{}))["tdf_spec_version"] = nil //nolint:forcetypeassert // testonly code
+				if m, ok := data["payload"].(map[string]interface{}); ok {
+					m["tdf_spec_version"] = nil
+				} else {
+					s.Fail("payload type invalid")
+				}
 
 				err = json.NewEncoder(dst).Encode(data)
 				return err


### PR DESCRIPTION

### Proposed Changes

- Validates a cast is `ok` in a test function for a known value
- Newer versions of golangci-lint will fail on this line with `errcheck`

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

