### PR TITLE
fix: Improve http.Client usage for security and performance

### DIFF
--- a/sdk/auth/oauth/oauth_test.go
+++ b/sdk/auth/oauth/oauth_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/opentdf/platform/lib/fixtures"
+	"github.com/opentdf/platform/sdk/httputil"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	tc "github.com/testcontainers/testcontainers-go"
@@ -78,12 +79,15 @@ func (s *OAuthSuite) TestCertExchangeFromKeycloak() {
 	rootCAs, _ := x509.SystemCertPool()
 	rootCAs.AppendCertsFromPEM(ca)
 	s.Require().NoError(err)
-	tlsConfig := tls.Config{
+	tlsConfig := &tls.Config{
 		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      rootCAs,
 	}
-	exhcangeInfo := CertExchangeInfo{TLSConfig: &tlsConfig, Audience: []string{"opentdf-sdk"}}
+	exhcangeInfo := CertExchangeInfo{
+		HTTPClient: httputil.SafeHTTPClientWithTLSConfig(tlsConfig),
+		Audience:   []string{"opentdf-sdk"},
+	}
 
 	tok, err := DoCertExchange(
 		context.Background(),

--- a/sdk/httputil/http.go
+++ b/sdk/httputil/http.go
@@ -11,7 +11,7 @@ const (
 	// defaults to match DefaultTransport - defined to satisfy lint
 	maxIdleConns          = 100
 	idleConnTimeout       = 90 * time.Second
-	tLSHandshakeTimeout   = 10 * time.Second
+	tlsHandshakeTimeout   = 10 * time.Second
 	expectContinueTimeout = 1 * time.Second
 )
 
@@ -44,7 +44,7 @@ func SafeHTTPClientWithTLSConfig(cfg *tls.Config) *http.Client {
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          maxIdleConns,
 		IdleConnTimeout:       idleConnTimeout,
-		TLSHandshakeTimeout:   tLSHandshakeTimeout,
+		TLSHandshakeTimeout:   tlsHandshakeTimeout,
 		ExpectContinueTimeout: expectContinueTimeout,
 	})
 }

--- a/sdk/httputil/http.go
+++ b/sdk/httputil/http.go
@@ -1,0 +1,64 @@
+package httputil
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultTimeout = 120 * time.Second
+	// defaults to match DefaultTransport - defined to satisfy lint
+	maxIdleConns          = 100
+	idleConnTimeout       = 90 * time.Second
+	tLSHandshakeTimeout   = 10 * time.Second
+	expectContinueTimeout = 1 * time.Second
+)
+
+var preventRedirectCheck = func(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse // Prevent following redirects
+}
+
+var safeHTTPClient = &http.Client{
+	Transport:     http.DefaultTransport,
+	Timeout:       defaultTimeout,
+	CheckRedirect: preventRedirectCheck,
+}
+
+// SafeHTTPClient returns a default http client which has sensible timeouts, won't follow redirects, and enables idle
+// connection pooling.
+func SafeHTTPClient() *http.Client {
+	return safeHTTPClient
+}
+
+// SafeHTTPClientWithTLSConfig returns a http client which has sensible timeouts, won't follow redirects, and if
+// specified a http.Transport with the tls.Config provided.
+func SafeHTTPClientWithTLSConfig(cfg *tls.Config) *http.Client {
+	if cfg == nil {
+		return safeHTTPClient
+	}
+	return SafeHTTPClientWithTransport(&http.Transport{
+		TLSClientConfig: cfg,
+		// config below matches DefaultTransport
+		Proxy:                 http.ProxyFromEnvironment,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          maxIdleConns,
+		IdleConnTimeout:       idleConnTimeout,
+		TLSHandshakeTimeout:   tLSHandshakeTimeout,
+		ExpectContinueTimeout: expectContinueTimeout,
+	})
+}
+
+// SafeHTTPClientWithTransport returns a http client which has sensible timeouts, won't follow redirects, and if
+// specified the provided http.Transport.
+func SafeHTTPClientWithTransport(transport *http.Transport) *http.Client {
+	if transport == nil {
+		return safeHTTPClient
+	}
+	return &http.Client{
+		Transport: transport,
+		// config below matches our values for safeHttpClient
+		Timeout:       defaultTimeout,
+		CheckRedirect: preventRedirectCheck,
+	}
+}


### PR DESCRIPTION
### Proposed Changes
This change switches us from maintaining a tls config which we then on-demand initialize an `http.Client` with to instead maintain and reuse an `http.Client` instance. This enables us to utilize the connection pooling which occurs within the `http.Transport` to reduce ssl handshakes and thus reduce latency.

In addition this change provides us a central place to configure out `http.Client` (`httputil`). Allowing us to easily set configuration options to reduce the security risks of using an unconfigured `http.Client`. Notably timeouts to reduce DoS risks, and control around following redirects to prevent blind SSRF's.

This PR 3/4 addresses #1891.  After it's merged a small change will be made in the `service` to fully utilize the API being introduced in the SDK here.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

