### PR TITLE
fix(core): Fixes for ec-wrapped from js client

### DIFF
--- a/service/kas/access/keyaccess.go
+++ b/service/kas/access/keyaccess.go
@@ -1,14 +1,15 @@
 package access
 
 type KeyAccess struct {
-	EncryptedMetadata string      `json:"encryptedMetadata,omitempty"`
-	PolicyBinding     interface{} `json:"policyBinding,omitempty"`
-	Protocol          string      `json:"protocol"`
-	Type              string      `json:"type"`
-	URL               string      `json:"url"`
-	KID               string      `json:"kid,omitempty"`
-	SID               string      `json:"sid,omitempty"`
-	WrappedKey        []byte      `json:"wrappedKey,omitempty"`
-	Header            []byte      `json:"header,omitempty"`
-	Algorithm         string      `json:"algorithm,omitempty"`
+	EncryptedMetadata  string      `json:"encryptedMetadata,omitempty"`
+	PolicyBinding      interface{} `json:"policyBinding,omitempty"`
+	Protocol           string      `json:"protocol"`
+	Type               string      `json:"type"`
+	URL                string      `json:"url"`
+	KID                string      `json:"kid,omitempty"`
+	SID                string      `json:"sid,omitempty"`
+	WrappedKey         []byte      `json:"wrappedKey,omitempty"`
+	Header             []byte      `json:"header,omitempty"`
+	Algorithm          string      `json:"algorithm,omitempty"`
+	EphemeralPublicKey string      `json:"ephemeralPublicKey,omitempty"`
 }


### PR DESCRIPTION
### Proposed Changes

* Javascript still uses the old, non-bulk request object format for rewrap
* As such, the logic for upgrading the request body needs to support the ec wrapped kao type

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

