### PR TITLE
fix: Service utilize `httputil.SafeHttpClient`

### DIFF
--- a/sdk/auth/token_adding_interceptor.go
+++ b/sdk/auth/token_adding_interceptor.go
@@ -25,6 +25,8 @@ const (
 	JTILength = 14
 )
 
+// Deprecated: NewTokenAddingInterceptor is deprecated, use NewTokenAddingInterceptorWithClient instead. A http client
+// can be constructed using httputil.SafeHTTPClientWithTLSConfig, but should be reused as much as possible.
 func NewTokenAddingInterceptor(t AccessTokenSource, c *tls.Config) TokenAddingInterceptor {
 	return NewTokenAddingInterceptorWithClient(t, httputil.SafeHTTPClientWithTLSConfig(c))
 }

--- a/sdk/auth/token_adding_interceptor_test.go
+++ b/sdk/auth/token_adding_interceptor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/opentdf/platform/protocol/go/kas"
+	"github.com/opentdf/platform/sdk/httputil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -42,9 +43,9 @@ func TestAddingTokensToOutgoingRequest(t *testing.T) {
 		accessToken: "thisisafakeaccesstoken",
 	}
 	server := FakeAccessServiceServer{}
-	oo := NewTokenAddingInterceptor(&ts, &tls.Config{
+	oo := NewTokenAddingInterceptorWithClient(&ts, httputil.SafeHTTPClientWithTLSConfig(&tls.Config{
 		MinVersion: tls.VersionTLS12,
-	})
+	}))
 
 	client, stop := runServer(&server, oo)
 	defer stop()
@@ -97,9 +98,9 @@ func TestAddingTokensToOutgoingRequest(t *testing.T) {
 func Test_InvalidCredentials_DoesNotSendMessage(t *testing.T) {
 	ts := FakeTokenSource{key: nil, accessToken: ""}
 	server := FakeAccessServiceServer{}
-	oo := NewTokenAddingInterceptor(&ts, &tls.Config{
+	oo := NewTokenAddingInterceptorWithClient(&ts, httputil.SafeHTTPClientWithTLSConfig(&tls.Config{
 		MinVersion: tls.VersionTLS12,
-	})
+	}))
 
 	client, stop := runServer(&server, oo)
 	defer stop()

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opentdf/platform/sdk"
 	sdkauth "github.com/opentdf/platform/sdk/auth"
 	"github.com/opentdf/platform/sdk/auth/oauth"
+	"github.com/opentdf/platform/sdk/httputil"
 	"github.com/opentdf/platform/service/internal/auth"
 	"github.com/opentdf/platform/service/internal/config"
 	"github.com/opentdf/platform/service/internal/server"
@@ -231,7 +232,8 @@ func Start(f ...StartOptions) error {
 					return fmt.Errorf("error creating ERS tokensource: %w", err)
 				}
 
-				interceptor := sdkauth.NewTokenAddingInterceptor(ts, tlsConfig)
+				interceptor := sdkauth.NewTokenAddingInterceptorWithClient(ts,
+					httputil.SafeHTTPClientWithTLSConfig(tlsConfig))
 
 				ersDialOptions = append(ersDialOptions, grpc.WithChainUnaryInterceptor(interceptor.AddCredentials))
 			}


### PR DESCRIPTION
### Proposed Changes

This PR follows #1910 by updating `service` to utilize the new `httputil` helper for constructing a client which wont follow redirects, and has sensible timeouts. To quote that description:
> This change switches us from maintaining a tls config which we then on-demand initialize an http.Client with to instead maintain and reuse an http.Client instance. This enables us to utilize the connection pooling which occurs within the http.Transport to reduce ssl handshakes and thus reduce latency.
>
> In addition this change provides us a central place to configure out http.Client (httputil). Allowing us to easily set configuration options to reduce the security risks of using an unconfigured http.Client. Notably timeouts to reduce DoS risks, and control around following redirects to prevent blind SSRF's.

The prior auth API was marked as deprecated. There is no remaining use within this repo, so it may be able to be removed.

Merging this should fully resolve #1891.

### Checklist

- [X] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

