### PR TITLE
feat(sdk): expose AccessTokenSource

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -497,3 +497,7 @@ func (s *SDK) StoreKASKeys(url string, keys *policy.KasPublicKeySet) error {
 	}
 	return nil
 }
+
+func (s *SDK) TokenSource() auth.AccessTokenSource {
+	return s.tokenSource
+}


### PR DESCRIPTION
### Proposed Changes

Expose `AccessTokenSource` from SDK instance.
This would allow me to reuse an existing `IDPTokenExchangeTokenSource` instance.

### Context
I'm retrieving the entitlements for a user while using the `ClaimsEntityResolutionService`.
For that I'm retrieving an `EntityChain` via `client.EntityResoution.CreateEntityChainFromJwt` and pass that to  `client.Authorization.GetEntitlements`.

I would like to avoid implementing the token exchange myself when there's already an implementation available through the sdk. Unfortunately it's a bit cumbersome to setup, so I would like to reuse the existing instance from the sdk, which currently is not exposed.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

