### PR TITLE
chore(main): update labels for repo metrics

### DIFF
--- a/.github/workflows/traffic.yaml
+++ b/.github/workflows/traffic.yaml
@@ -13,11 +13,10 @@ jobs:
       matrix:
         repo-values:
           - {repo: platform, event: ""}
-          - {repo: otdfctl, event: backend-}
-          - {repo: spec, event: frontend-}
+          - {repo: otdfctl, event: otdfctl-}
+          - {repo: spec, event: spec-}
           - {repo: tests, event: tests-}
-          - {repo: client-web, event: clientweb-}
-          - {repo: client-cpp, event: cpp-sdk-}
+          - {repo: web-sdk, event: web-sdk-}
           - {repo: java-sdk, event: java-sdk-}
           - {repo: charts, event: charts-}
           - {repo: nifi, event: nifi-}


### PR DESCRIPTION
### Proposed Changes

* the labels on the metrics we are pulling for the repos need to be updated, they are still the names of the old repos. this is making reporting confusing. this pr updates the labels to match the repos they are reporting about. 

### Checklist

- [ ] I have added or updated unit tests  
- [ ] I have added or updated integration tests (if appropriate) 
- [ ] I have added or updated documentation 

### Testing Instructions

* you can trigger this workflow manually and view the json output to have the correct labels. 
