### PR TITLE
chore(ci): actionlint fix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       - id: todo
         if: fromJson(steps.release-please.outputs.releases_created)
         run: |
-          for x in ${{join(fromJson(steps.release-please.outputs.paths_released), ' ')}}; do
+          <<<"$RELEASED_PATHS" jq -r '.[]'| while IFS= read -r x; do
             case "$x" in
               lib/ocrypto)
                 echo "TO_UPDATE=['examples','sdk','service']">>"$GITHUB_OUTPUT"
@@ -60,7 +60,8 @@ jobs:
                 ;;
             esac
           done
-
+        env:
+          RELEASED_PATHS: ${{ toJson(steps.release-please.outputs.paths_released) }}
   update-go-mods:
     runs-on: ubuntu-latest
     needs: 
@@ -78,15 +79,15 @@ jobs:
       - run: |
           git checkout -b update-go-mods-for-${{matrix.path}}
           git push -f -u origin update-go-mods-for-${{matrix.path}}
-          cd ${{matrix.path}}
-          for x in ${{join(fromJson(needs.release-please.outputs.paths_released), ' ')}}; do
-            export pkg=github.com/opentdf/platform/${x}
+          cd ${{matrix.path}} || exit 1
+          <<<"$RELEASED_PATHS" jq -r '.[]'| while IFS= read -r x; do
+            export pkg="github.com/opentdf/platform/${x}"
             if go mod edit --json | jq -e '.Replace[] | select(.Old.Path == env.pkg)'; then
-              go mod edit --dropreplace=$pkg
+              go mod edit --dropreplace="$pkg"
             fi
             echo "Should we update [${pkg}] in [${{ matrix.path }}]?"
             if go mod edit --json | jq -e '.Require[] | select(.Path == env.pkg)'; then
-              ver=$(jq -r .\[\"${x}\"\] < "${GITHUB_WORKSPACE}/.release-please-manifest.json")
+              ver="$(jq -r --arg x "$x" '.[$x]' <"${GITHUB_WORKSPACE}"/.release-please-manifest.json)"
               echo "go get ${pkg}@v${ver}"
               go get "${pkg}@v${ver}"
             fi
@@ -99,6 +100,7 @@ jobs:
           git diff
         env:
           GONOSUMDB: github.com/opentdf/platform/${{join(fromJson(needs.release-please.outputs.paths_released), ',github.com/opentdf/platform/')}}
+          RELEASED_PATHS: ${{ toJson(needs.release-please.outputs.paths_released) }}
       - uses: planetscale/ghcommit-action@d4176bfacef926cc2db351eab20398dfc2f593b5
         with:
           commit_message: "fix(core): Autobump ${{ matrix.path }}"


### PR DESCRIPTION
### Proposed Changes

* This shouldn't matter, since go package names cannot contain spaces, but this fixes an issue where spaces in the release paths would cause the for loop to fail.


### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

