### PR TITLE
feat: add custom json marshaler for sdk.Statement

### DIFF
--- a/sdk/assertion.go
+++ b/sdk/assertion.go
@@ -108,6 +108,16 @@ func (a Assertion) GetHash() ([]byte, error) {
 	// Remove the binding key
 	delete(jsonObject, "binding")
 
+	// Deep patch: fix "value" inside "statement" if it is a string
+	if statement, ok := jsonObject["statement"].(map[string]interface{}); ok {
+		if valueStr, ok := statement["value"].(string); ok {
+			var valueObj interface{}
+			if err := json.Unmarshal([]byte(valueStr), &valueObj); err == nil {
+				statement["value"] = valueObj // replace the string with parsed object
+			}
+		}
+	}
+
 	// Marshal the map back to JSON
 	assertionJSON, err = json.Marshal(jsonObject)
 	if err != nil {

--- a/sdk/assertion.go
+++ b/sdk/assertion.go
@@ -123,6 +123,32 @@ func (a Assertion) GetHash() ([]byte, error) {
 	return ocrypto.SHA256AsHex(transformedJSON), nil
 }
 
+func (s *Statement) MarshalJSON() ([]byte, error) {
+	// Define a custom struct for serialization
+	type Alias Statement
+	aux := &struct {
+		Value interface{} `json:"value,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+	}
+
+	if s.Format == "json-structured" {
+		raw := json.RawMessage(s.Value)
+		var tmp interface{}
+		// Attempt to decode Value to validate it's actual json
+		if err := json.Unmarshal(raw, &tmp); err == nil {
+			aux.Value = raw
+		} else {
+			aux.Value = s.Value
+		}
+	} else {
+		aux.Value = s.Value
+	}
+
+	return json.Marshal(aux)
+}
+
 func (s *Statement) UnmarshalJSON(data []byte) error {
 	// Define a custom struct for deserialization
 	type Alias Statement


### PR DESCRIPTION
### Proposed Changes

* add a custom json Marshaler for sdk.Statement that works similar to the  Unmarshaler and handles json structured values

If you agree with this change, I'm happy to add tests.

I assume it's a good idea to try to decode the value to make sure it's actual json. I just wasn't sure whether we should return an error if not or if we should just use the value as string.
Opinions?

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

