### PR TITLE
feat(sdk): sdk.New should validate platform connectivity and provide precise error

### DIFF
--- a/sdk/options.go
+++ b/sdk/options.go
@@ -39,6 +39,9 @@ type config struct {
 	coreConn                *grpc.ClientConn
 	entityResolutionConn    *grpc.ClientConn
 	collectionStore         *collectionStore
+
+	// For testing purposes only
+	testSkipValidatePlatformConnectivity bool
 }
 
 // Options specific to TDF protocol features
@@ -114,6 +117,13 @@ func WithTokenEndpoint(tokenEndpoint string) Option {
 func withCustomAccessTokenSource(a auth.AccessTokenSource) Option {
 	return func(c *config) {
 		c.customAccessTokenSource = a
+	}
+}
+
+// For test purposes only, allows skipping the validation of platform connectivity
+func withTestSkipValidatePlatformConnectivity() Option {
+	return func(c *config) {
+		c.testSkipValidatePlatformConnectivity = true
 	}
 }
 

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -20,28 +20,26 @@ type Option func(*config)
 // Internal config struct for building SDK options.
 type config struct {
 	// Platform configuration structure is subject to change. Consume via accessor methods.
-	PlatformConfiguration   PlatformConfiguration
-	dialOption              grpc.DialOption
-	httpClient              *http.Client
-	clientCredentials       *oauth.ClientCredentials
-	tokenExchange           *oauth.TokenExchangeInfo
-	tokenEndpoint           string
-	scopes                  []string
-	extraDialOptions        []grpc.DialOption
-	certExchange            *oauth.CertExchangeInfo
-	kasSessionKey           *ocrypto.RsaKeyPair
-	dpopKey                 *ocrypto.RsaKeyPair
-	ipc                     bool
-	tdfFeatures             tdfFeatures
-	nanoFeatures            nanoFeatures
-	customAccessTokenSource auth.AccessTokenSource
-	oauthAccessTokenSource  oauth2.TokenSource
-	coreConn                *grpc.ClientConn
-	entityResolutionConn    *grpc.ClientConn
-	collectionStore         *collectionStore
-
-	// For testing purposes only
-	testSkipValidatePlatformConnectivity bool
+	PlatformConfiguration              PlatformConfiguration
+	dialOption                         grpc.DialOption
+	httpClient                         *http.Client
+	clientCredentials                  *oauth.ClientCredentials
+	tokenExchange                      *oauth.TokenExchangeInfo
+	tokenEndpoint                      string
+	scopes                             []string
+	extraDialOptions                   []grpc.DialOption
+	certExchange                       *oauth.CertExchangeInfo
+	kasSessionKey                      *ocrypto.RsaKeyPair
+	dpopKey                            *ocrypto.RsaKeyPair
+	ipc                                bool
+	tdfFeatures                        tdfFeatures
+	nanoFeatures                       nanoFeatures
+	customAccessTokenSource            auth.AccessTokenSource
+	oauthAccessTokenSource             oauth2.TokenSource
+	coreConn                           *grpc.ClientConn
+	entityResolutionConn               *grpc.ClientConn
+	collectionStore                    *collectionStore
+	shouldValidatePlatformConnectivity bool
 }
 
 // Options specific to TDF protocol features
@@ -120,13 +118,6 @@ func withCustomAccessTokenSource(a auth.AccessTokenSource) Option {
 	}
 }
 
-// For test purposes only, allows skipping the validation of platform connectivity
-func withTestSkipValidatePlatformConnectivity() Option {
-	return func(c *config) {
-		c.testSkipValidatePlatformConnectivity = true
-	}
-}
-
 // WithOAuthAccessTokenSource directs the SDK to use a standard OAuth2 token source for authentication
 func WithOAuthAccessTokenSource(t oauth2.TokenSource) Option {
 	return func(c *config) {
@@ -202,6 +193,13 @@ func WithCustomWellknownConnection(conn *grpc.ClientConn) Option {
 func WithPlatformConfiguration(platformConfiguration PlatformConfiguration) Option {
 	return func(c *config) {
 		c.PlatformConfiguration = platformConfiguration
+	}
+}
+
+// WithConnectionValidation will validate connection to a healthy, running platform
+func WithConnectionValidation() Option {
+	return func(c *config) {
+		c.shouldValidatePlatformConnectivity = true
 	}
 }
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -120,7 +120,7 @@ func New(platformEndpoint string, opts ...Option) (*SDK, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%w [%v]: %w", ErrPlatformEndpointMalformed, platformEndpoint, err)
 		}
-		
+
 		// TODO: to support an offline SDK, we would need to remove the connection requirement
 		// For now we will only skip for test purposes
 		if !cfg.testSkipValidatePlatformConnectivity {

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -3,7 +3,6 @@ package sdk
 import (
 	"bytes"
 	"encoding/base64"
-	"errors"
 	"reflect"
 	"testing"
 
@@ -263,7 +262,7 @@ func Test_New_ShouldFailWithDisconnectedPlatform(t *testing.T) {
 	// When
 	s, err := New(badPlatformEndpoint)
 	// Then
-	require.True(t, errors.Is(err, ErrPlatformUnreachable))
+	require.ErrorIs(t, err, ErrPlatformUnreachable)
 	assert.Nil(t, s)
 }
 


### PR DESCRIPTION
### Proposed Changes

* Validates healthy platform is available within `sdk.New` when triggered
* Provides precise error if error connecting to provided `platformEndpoint` or status is unhealthy
* Exposes validation function from SDK module for DX

Resolves https://github.com/opentdf/platform/issues/1935

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

