### PR TITLE
fix(sdk): bump lib/ocrypto to 0.1.8

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/opentdf/platform/lib/fixtures v0.2.10
-	github.com/opentdf/platform/lib/ocrypto v0.1.7
+	github.com/opentdf/platform/lib/ocrypto v0.1.8
 	github.com/opentdf/platform/protocol/go v0.2.26
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.32.0

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -116,6 +116,8 @@ github.com/opentdf/platform/lib/fixtures v0.2.10 h1:R688b98ctsEiDRlQSvLxmAWT7bXv
 github.com/opentdf/platform/lib/fixtures v0.2.10/go.mod h1:wGhclxDeDXf8bp5VAWztT1nY2gWVNGQLd8rWs5wtXV0=
 github.com/opentdf/platform/lib/ocrypto v0.1.7 h1:IcCYRrwmMqntqUE8frmUDg5EZ0WMdldpGeGhbv9+/A8=
 github.com/opentdf/platform/lib/ocrypto v0.1.7/go.mod h1:4bhKPbRFzURMerH5Vr/LlszHvcoXQbfJXa0bpY7/7yg=
+github.com/opentdf/platform/lib/ocrypto v0.1.8 h1:FUKMHsVCjU4NmgaXgS1RFstl19tkX/7USTIubAuUBlA=
+github.com/opentdf/platform/lib/ocrypto v0.1.8/go.mod h1:UTtqh8mvhAYA+sEnaMxpr/406e84L5Q1sAxtKGIXfu4=
 github.com/opentdf/platform/protocol/go v0.2.26 h1:22ugJFhAjlz7BRAky3eBljIQrsLzmsdkKVM+pjuG09k=
 github.com/opentdf/platform/protocol/go v0.2.26/go.mod h1:eldxqX2oF2ADtG8ivhfwn1lALVMX4aaUM+Lp9ynOJXs=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=


### PR DESCRIPTION
### Proposed Changes

* CI pipeline failed to bump `lib/ocrypto` in `sdk` when recently released: https://github.com/opentdf/platform/actions/runs/13525675363/job/37796239649

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

