### PR TITLE
fix: Allow parsing IPs as hostnames

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -211,7 +211,7 @@ func SanitizePlatformEndpoint(e string) (string, error) {
 		e = "https://" + e
 	}
 
-	if !regexp.MustCompile(`^(https?:\/\/)?(([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(:\d+)?|(localhost)(:\d+)?)\/?$`).MatchString(e) {
+	if !regexp.MustCompile(`^(https?:\/\/)?((([a-zA-Z0-9-]+\.)+[a-zA-Z-]{2,})|(([0-9]+\.){3}[0-9]+)|(localhost))(:\d+)?\/?$`).MatchString(e) {
 		return "", errors.New("platform endpoint is not valid")
 	}
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -218,22 +218,21 @@ func SanitizePlatformEndpoint(e string) (string, error) {
 		if err != nil {
 			return "", errors.Join(fmt.Errorf("cannot parse platform endpoint [%s]", newE), err)
 		}
+		if u.Host == "" {
+			return "", fmt.Errorf("invalid URL [%s], got empty hostname", newE)
+		}
 	}
-
-	if u.Host == "" {
-		return "", fmt.Errorf("invalid URL [%s], got empty hostname", e)
-	}
-
+	
 	if strings.Contains(u.Hostname(), ":") {
 		return "", fmt.Errorf("invalid hostname [%s]. IPv6 addresses are not supported", u.Hostname())
 	}
 
 	p := u.Port()
 	if p == "" {
-		if u.Scheme == "https" {
-			p = "443"
-		} else {
+		if u.Scheme == "http" {
 			p = "80"
+		} else {
+			p = "443"
 		}
 	}
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -213,12 +213,11 @@ func SanitizePlatformEndpoint(e string) (string, error) {
 	}
 	if u.Host == "" {
 		// if the schema is missing add https. when the schema is missing the host is parsed as the scheme
-		e = "https://" + e
-		u, err = url.ParseRequestURI(e)
-	}
-
-	if err != nil {
-		return "", errors.Join(fmt.Errorf("cannot parse platform endpoint [%s]", e), err)
+		newE := "https://" + e
+		u, err = url.ParseRequestURI(newE)
+		if err != nil {
+			return "", errors.Join(fmt.Errorf("cannot parse platform endpoint [%s]", newE), err)
+		}
 	}
 
 	if u.Host == "" {

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -222,7 +222,7 @@ func SanitizePlatformEndpoint(e string) (string, error) {
 			return "", fmt.Errorf("invalid URL [%s], got empty hostname", newE)
 		}
 	}
-	
+
 	if strings.Contains(u.Hostname(), ":") {
 		return "", fmt.Errorf("invalid hostname [%s]. IPv6 addresses are not supported", u.Hostname())
 	}

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -304,6 +304,16 @@ func Test_ShouldSanitizePlatformEndpoint(t *testing.T) {
 			expected: "localhost:443",
 		},
 		{
+			name:     "HTTPS scheme port (IP)",
+			endpoint: "https://192.168.1.1:8080",
+			expected: "192.168.1.1:8080",
+		},
+		{
+			name:     "HTTPS scheme no port (IP)",
+			endpoint: "https://192.168.1.1",
+			expected: "192.168.1.1:443",
+		},
+		{
 			name:     "Malformed url",
 			endpoint: "http://localhost:8080:8080",
 			expected: "",


### PR DESCRIPTION
### Proposed Changes

* Also rely more on parsing using `net` and `url` libraries as opposed to regex

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

