### PR TITLE
chore(ci): add label workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,27 @@
+docs:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'docs/**/*'
+comp:sdk:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'sdk/**/*'
+comp:ci:
+- changed-files:
+  - any-glob-to-any-file:
+    - '.github/**/*'
+comp:db:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'service/policy/db/**/*'
+comp:kas:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'service/kas/**'
+comp:policy:
+- all:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'service/policy/**/*'
+    - all-globs-to-all-files:
+      - '!service/policy/db/**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,9 +19,30 @@ comp:kas:
   - any-glob-to-any-file:
     - 'service/kas/**'
 comp:policy:
-- all:
   - changed-files:
     - any-glob-to-any-file:
       - 'service/policy/**/*'
-    - all-globs-to-all-files:
-      - '!service/policy/db/**/*'
+comp:authorization:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'service/authorization/**/*'
+comp:examples:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'examples/**/*'
+comp:lib:fixtures:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'lib/fixtures/**/*'
+comp:lib:flattening:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'lib/flattening/**/*'
+comp:lib:ocrypto:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'lib/ocrypto/**/*'
+comp:middleware:auth:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'service/internal/auth/**/*'

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,0 +1,82 @@
+name: Label Pull Requests
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - unlabeled
+
+permissions:
+  pull-requests: write
+
+jobs:
+  external-contributor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Author Association and Label PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              console.log("Could not get PR from context");
+              return;
+            }
+
+            // Define associations considered "internal"
+            const internalAssociations = ["MEMBER"];
+
+            // Label to add if the author is external
+            const externalLabel = "external-contributor";
+
+            const authorAssociation = pr.author_association;
+            const isExternal = !internalAssociations.includes(authorAssociation);
+
+            const prLabels = pr.labels.map(label => label.name);
+            const hasExternalLabel = prLabels.includes(externalLabel);
+
+            console.log(`Event: ${context.eventName}, Action: ${context.payload.action}`);
+            console.log(`Author: ${pr.user.login}, Association: ${authorAssociation}, Is External: ${isExternal}`);
+            console.log(`Current PR Labels: ${prLabels.join(', ')}`);
+
+            // Logic for 'unlabeled' event: only re-add if *our* label was removed and author is still external
+            if (context.eventName === 'pull_request_target' && context.payload.action === 'unlabeled') {
+              const removedLabel = context.payload.label.name;
+              console.log(`Label removed: ${removedLabel}`);
+              if (removedLabel === externalLabel && isExternal) {
+                console.log(`External label was removed, author is still external. Re-adding label: ${externalLabel}`);
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: [externalLabel]
+                });
+                console.log(`Label "${externalLabel}" re-added successfully.`);
+              } else {
+                console.log(`Removed label was not the external label or author is not external. No action needed for unlabeled event.`);
+              }
+            }
+            // Logic for 'opened' or 'reopened' events: add label if external and not already present
+            else if (['opened', 'reopened'].includes(context.payload.action)) {
+              if (isExternal && !hasExternalLabel) {
+                console.log(`Author association "${authorAssociation}" is external and label is missing. Adding label: ${externalLabel}`);
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: [externalLabel]
+                });
+                console.log(`Label "${externalLabel}" added successfully.`);
+              } else if (isExternal && hasExternalLabel) {
+                 console.log(`Author is external, but label "${externalLabel}" is already present.`);
+              } else {
+                console.log(`Author association "${authorAssociation}" is internal or label already present. No label added.`);
+              }
+            }
+            // Optional: Add logic for 'synchronize' if you uncomment it in the 'on:' section
+            // else if (context.payload.action === 'synchronize') { ... }
+            else {
+              console.log(`Unhandled action type: ${context.payload.action}. No labeling action taken.`);
+            }

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -18,6 +18,19 @@ jobs:
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
 
+  size-pr:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@1c3422395d899286d5ee2c809fd5aed264d5eb9b # v1.10.2
+        with:
+          files_to_ignore: |
+            "protocol/**/*"
+            "docs/**/*"
+
   external-contributor:
     permissions:
       pull-requests: write

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,27 +1,36 @@
 name: Label Pull Requests
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
       - unlabeled
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+
   external-contributor:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check Author Association and Label PR
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
             if (!pr) {
-              console.log("Could not get PR from context");
+              core.error("Could not get PR from context");
               return;
             }
 
@@ -37,46 +46,45 @@ jobs:
             const prLabels = pr.labels.map(label => label.name);
             const hasExternalLabel = prLabels.includes(externalLabel);
 
-            console.log(`Event: ${context.eventName}, Action: ${context.payload.action}`);
-            console.log(`Author: ${pr.user.login}, Association: ${authorAssociation}, Is External: ${isExternal}`);
-            console.log(`Current PR Labels: ${prLabels.join(', ')}`);
+            core.info(`Event: ${context.eventName}, Action: ${context.payload.action}`);
+            core.info(`Author: ${pr.user.login}, Association: ${authorAssociation}, Is External: ${isExternal}`);
+            core.info(`Current PR Labels: ${prLabels.join(', ')}`);
 
             // Logic for 'unlabeled' event: only re-add if *our* label was removed and author is still external
             if (context.eventName === 'pull_request_target' && context.payload.action === 'unlabeled') {
               const removedLabel = context.payload.label.name;
-              console.log(`Label removed: ${removedLabel}`);
+              core.info(`Label removed: ${removedLabel}`);
               if (removedLabel === externalLabel && isExternal) {
-                console.log(`External label was removed, author is still external. Re-adding label: ${externalLabel}`);
+                core.info(`External label was removed, author is still external. Re-adding label: ${externalLabel}`);
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
                   labels: [externalLabel]
                 });
-                console.log(`Label "${externalLabel}" re-added successfully.`);
+                core.info(`Label "${externalLabel}" re-added successfully.`);
               } else {
-                console.log(`Removed label was not the external label or author is not external. No action needed for unlabeled event.`);
+                core.info(`Removed label was not the external label or author is not external. No action needed for unlabeled event.`);
               }
             }
             // Logic for 'opened' or 'reopened' events: add label if external and not already present
             else if (['opened', 'reopened'].includes(context.payload.action)) {
               if (isExternal && !hasExternalLabel) {
-                console.log(`Author association "${authorAssociation}" is external and label is missing. Adding label: ${externalLabel}`);
+                core.info(`Author association "${authorAssociation}" is external and label is missing. Adding label: ${externalLabel}`);
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
                   labels: [externalLabel]
                 });
-                console.log(`Label "${externalLabel}" added successfully.`);
+                core.info(`Label "${externalLabel}" added successfully.`);
               } else if (isExternal && hasExternalLabel) {
-                 console.log(`Author is external, but label "${externalLabel}" is already present.`);
+                 core.info(`Author is external, but label "${externalLabel}" is already present.`);
               } else {
-                console.log(`Author association "${authorAssociation}" is internal or label already present. No label added.`);
+                if (hasExternalLabel) {
+                  core.warning(`Author association "${authorAssociation}" is internal. However, external contributor label is present.`)
+                } else {
+                  core.info(`Author association "${authorAssociation}" is internal. No label added.`)
+                }
               }
-            }
-            // Optional: Add logic for 'synchronize' if you uncomment it in the 'on:' section
-            // else if (context.payload.action === 'synchronize') { ... }
-            else {
-              console.log(`Unhandled action type: ${context.payload.action}. No labeling action taken.`);
             }

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,7 +1,7 @@
 name: Label Pull Requests
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] this is needed to label PRs from forks
     types:
       - opened
       - reopened


### PR DESCRIPTION
### Proposed Changes

Adding label workflow which has one job at this time  and that is to label pull requests with `external-contributor` if  the user opening the pull request is not a member of the org. 

This workflow keys off of `author_associations` from the pull request context.  

Best [link](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation) that I could find to describe each association 

Also adds the following actions
- https://github.com/CodelyTV/pr-size-labeler
- https://github.com/actions/labeler

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

