### PR TITLE
fix(main): add ipc auth extensibility

### DIFF
--- a/service/internal/auth/config.go
+++ b/service/internal/auth/config.go
@@ -12,7 +12,9 @@ import (
 type Config struct {
 	Enabled      bool     `mapstructure:"enabled" json:"enabled" default:"true" `
 	PublicRoutes []string `mapstructure:"-"`
-	AuthNConfig  `mapstructure:",squash"`
+	// Used for re-authentication of IPC connections
+	IPCReauthRoutes []string `mapstructure:"-"`
+	AuthNConfig     `mapstructure:",squash"`
 }
 
 // AuthNConfig is the configuration need for the platform to validate tokens

--- a/service/pkg/server/options.go
+++ b/service/pkg/server/options.go
@@ -12,6 +12,7 @@ type StartConfig struct {
 	ConfigFile            string
 	WaitForShutdownSignal bool
 	PublicRoutes          []string
+	IPCReauthRoutes       []string
 	bultinPolicyOverride  string
 	extraCoreServices     []serviceregistry.IService
 	extraServices         []serviceregistry.IService
@@ -57,6 +58,15 @@ func WithWaitForShutdownSignal() StartOptions {
 func WithPublicRoutes(routes []string) StartOptions {
 	return func(c StartConfig) StartConfig {
 		c.PublicRoutes = routes
+		return c
+	}
+}
+
+// WithIPCReauthRoutes option sets the IPC reauthorization routes for the server.
+// It enables the server to reauthorize IPC routes and embed the token on the context.
+func WithIPCReauthRoutes(routes []string) StartOptions {
+	return func(c StartConfig) StartConfig {
+		c.IPCReauthRoutes = routes
 		return c
 	}
 }


### PR DESCRIPTION
This pull request introduces changes to add IPC reauthorization routes and improve the testing of the authentication service. The most important changes include adding new routes for IPC reauthorization, modifying the `Authentication` struct and its methods, and updating the test suite to include tests for the new functionality.

### Proposed Changes

*

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

