### PR TITLE
fix(sdk): Allow reuse of session key

### DIFF
--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -646,6 +646,10 @@ func (s SDK) LoadTDF(reader io.ReadSeeker, opts ...TDFReaderOption) (*Reader, er
 		return nil, fmt.Errorf("archive.NewTDFReader failed: %w", err)
 	}
 
+	if s.kasSessionKey != nil {
+		opts = append([]TDFReaderOption{withSessionKey(s.kasSessionKey)}, opts...)
+	}
+
 	config, err := newTDFReaderConfig(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("newAssertionConfig failed: %w", err)

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -255,14 +255,11 @@ type TDFReaderConfig struct {
 
 	schemaValidationIntensity SchemaValidationIntensity
 	kasSessionKey             ocrypto.KeyPair
-	keyType                   ocrypto.KeyType
 }
 
 func newTDFReaderConfig(opt ...TDFReaderOption) (*TDFReaderConfig, error) {
-	var err error
 	c := &TDFReaderConfig{
 		disableAssertionVerification: false,
-		keyType:                      ocrypto.RSA2048Key,
 	}
 
 	for _, o := range opt {
@@ -272,9 +269,12 @@ func newTDFReaderConfig(opt ...TDFReaderOption) (*TDFReaderConfig, error) {
 		}
 	}
 
-	c.kasSessionKey, err = ocrypto.NewKeyPair(c.keyType)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create RSA key pair: %w", err)
+	if c.kasSessionKey == nil {
+		// Default to RSA 2048
+		err := WithSessionKeyType(ocrypto.RSA2048Key)(c)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return c, nil
@@ -303,10 +303,18 @@ func WithDisableAssertionVerification(disable bool) TDFReaderOption {
 
 func WithSessionKeyType(keyType ocrypto.KeyType) TDFReaderOption {
 	return func(c *TDFReaderConfig) error {
-		if c.keyType == "" {
-			return errors.New("key type missing")
+		kasSessionKey, err := ocrypto.NewKeyPair(keyType)
+		if err != nil {
+			return fmt.Errorf("failed to create RSA key pair: %w", err)
 		}
-		c.keyType = keyType
+		c.kasSessionKey = kasSessionKey
+		return nil
+	}
+}
+
+func withSessionKey(k ocrypto.KeyPair) TDFReaderOption {
+	return func(c *TDFReaderConfig) error {
+		c.kasSessionKey = k
 		return nil
 	}
 }


### PR DESCRIPTION

### Proposed Changes

- This was dropped during merging in the support for EC session keys

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

