### PR TITLE
fix(core): Fix DPoP with grpc-gateway

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -276,7 +276,7 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 
 func (a Authentication) lookupOrigins(header http.Header) []string {
 	result := make([]string, 0)
-	for _, m := range []string{"Origin", "Grpcgateway-Origin", "Grpcgateway-Referer"} {
+	for _, m := range []string{"Grpcgateway-Origin", "Grpcgateway-Referer", "Origin"} {
 		origins := header.Values(m)
 		if len(origins) == 0 {
 			continue

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -746,6 +746,16 @@ func (s *AuthSuite) Test_LookupGatewayPaths() {
 			expected: []string{s.server.URL + "/kas/v2/rewrap"},
 		},
 		{
+			name: "Multiple Origins",
+			path: "/kas.AccessService/Rewrap",
+			header: http.Header{
+				"Grpcgateway-Origin": []string{s.server.URL, "https://origin.1.com"},
+				"Origin":             []string{"https://origin.com"},
+			},
+			expected: []string{s.server.URL + "/kas/v2/rewrap",
+				"https://origin.1.com/kas/v2/rewrap", "https://origin.com/kas/v2/rewrap"},
+		},
+		{
 			name: "Unknown Path with Pattern",
 			path: "/unknown/path",
 			header: http.Header{


### PR DESCRIPTION
### Proposed Changes

- Lets IPC middleware share DPoP htu resolution logic with the existing middleware
- This fixes an issue where the htu fail when set to the gateway path (like /v2/rewrap) but the IPC only expects the new connect path (the name of the rpc procedure)


### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

