### PR TITLE
feat(sdk): CreateTDF option to run with specific target schema version

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -24,6 +24,7 @@ require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
+	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Nerzal/gocloak/v13 v13.9.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -6,6 +6,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nerzal/gocloak/v13 v13.9.0 h1:YWsJsdM5b0yhM2Ba3MLydiOlujkBry4TtdzfIzSVZhw=

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/opentdf/platform/protocol/go/kas"
 
 	"github.com/google/uuid"
@@ -54,6 +55,7 @@ const (
 	kPolicy                 = "policy"
 	kHmacIntegrityAlgorithm = "HS256"
 	kGmacIntegrityAlgorithm = "GMAC"
+	hexSemverThreshold      = "4.3.0"
 )
 
 // Loads and reads ZTDF files
@@ -243,7 +245,7 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 		}
 
 		segmentSig, err := calculateSignature(cipherData, tdfObject.payloadKey[:],
-			tdfConfig.segmentIntegrityAlgorithm, false)
+			tdfConfig.segmentIntegrityAlgorithm, tdfConfig.useHex)
 		if err != nil {
 			return nil, fmt.Errorf("splitKey.GetSignaturefailed: %w", err)
 		}
@@ -262,7 +264,7 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 	}
 
 	rootSignature, err := calculateSignature([]byte(aggregateHash), tdfObject.payloadKey[:],
-		tdfConfig.integrityAlgorithm, false)
+		tdfConfig.integrityAlgorithm, tdfConfig.useHex)
 	if err != nil {
 		return nil, fmt.Errorf("splitKey.GetSignaturefailed: %w", err)
 	}
@@ -322,7 +324,11 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 
 		var completeHashBuilder strings.Builder
 		completeHashBuilder.WriteString(aggregateHash)
-		completeHashBuilder.Write(hashOfAssertion)
+		if tdfConfig.useHex {
+			completeHashBuilder.Write(hashOfAssertionAsHex)
+		} else {
+			completeHashBuilder.Write(hashOfAssertion)
+		}
 
 		encoded := ocrypto.Base64Encode([]byte(completeHashBuilder.String()))
 
@@ -375,7 +381,10 @@ func (r *Reader) Manifest() Manifest {
 func (s SDK) prepareManifest(ctx context.Context, t *TDFObject, tdfConfig TDFConfig) error { //nolint:funlen,gocognit // Better readability keeping it as is
 	manifest := Manifest{}
 
-	manifest.TDFVersion = TDFSpecVersion
+	if !tdfConfig.excludeVersionFromManifest {
+		manifest.TDFVersion = TDFSpecVersion
+	}
+
 	if len(tdfConfig.splitPlan) == 0 && len(tdfConfig.kasInfoList) == 0 {
 		return fmt.Errorf("%w: no key access template specified or inferred", errInvalidKasInfo)
 	}
@@ -1264,4 +1273,18 @@ func validateRootSignature(manifest Manifest, aggregateHash, secret []byte) (boo
 	}
 
 	return false, nil
+}
+
+// check if the provided semver is less than the target
+func isLessThanSemver(version, target string) (bool, error) {
+	v1, err := semver.NewVersion(version)
+	if err != nil {
+		return false, fmt.Errorf("semver.NewVersion failed for version %s: %w", version, err)
+	}
+	v2, err := semver.NewVersion(target)
+	if err != nil {
+		return false, fmt.Errorf("semver.NewVersion failed for version %s: %w", target, err)
+	}
+	// Check if the provided version is less than the target version based on semantic versioning rules.
+	return v1.LessThan(v2), nil
 }

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -53,22 +53,24 @@ type TDFOption func(*TDFConfig) error
 
 // TDFConfig Internal config struct for building TDF options.
 type TDFConfig struct {
-	autoconfigure             bool
-	defaultSegmentSize        int64
-	enableEncryption          bool
-	tdfFormat                 TDFFormat
-	tdfPublicKey              string // TODO: Remove it
-	tdfPrivateKey             string
-	metaData                  string
-	mimeType                  string
-	integrityAlgorithm        IntegrityAlgorithm
-	segmentIntegrityAlgorithm IntegrityAlgorithm
-	assertions                []AssertionConfig
-	attributes                []AttributeValueFQN
-	attributeValues           []*policy.Value
-	kasInfoList               []KASInfo
-	splitPlan                 []keySplitStep
-	keyType                   ocrypto.KeyType
+	autoconfigure              bool
+	defaultSegmentSize         int64
+	enableEncryption           bool
+	tdfFormat                  TDFFormat
+	tdfPublicKey               string // TODO: Remove it
+	tdfPrivateKey              string
+	metaData                   string
+	mimeType                   string
+	integrityAlgorithm         IntegrityAlgorithm
+	segmentIntegrityAlgorithm  IntegrityAlgorithm
+	assertions                 []AssertionConfig
+	attributes                 []AttributeValueFQN
+	attributeValues            []*policy.Value
+	kasInfoList                []KASInfo
+	splitPlan                  []keySplitStep
+	keyType                    ocrypto.KeyType
+	useHex                     bool
+	excludeVersionFromManifest bool
 }
 
 func newTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
@@ -233,6 +235,24 @@ func WithWrappingKeyAlg(keyType ocrypto.KeyType) TDFOption {
 			return errors.New("key type missing")
 		}
 		c.keyType = keyType
+		return nil
+	}
+}
+
+// WithTargetMode sets the target schema mode for the TDF
+func WithTargetMode(mode string) TDFOption {
+	return func(c *TDFConfig) error {
+		if mode != "" {
+			lessThan, err := isLessThanSemver(mode, hexSemverThreshold)
+			if err != nil {
+				return fmt.Errorf("isLessThanSemver failed: %w", err)
+			}
+			c.useHex = lessThan
+			c.excludeVersionFromManifest = lessThan
+		} else {
+			c.useHex = false
+			c.excludeVersionFromManifest = false
+		}
 		return nil
 	}
 }

--- a/sdk/tdf_config_test.go
+++ b/sdk/tdf_config_test.go
@@ -95,3 +95,21 @@ func TestWithAssertions(t *testing.T) {
 	assert.Equal(t, id1, cfg.assertions[0].ID)
 	assert.Equal(t, id2, cfg.assertions[1].ID)
 }
+
+func TestWithTargetMode(t *testing.T) {
+	cfg := makeConfig(t, WithTargetMode("0.0.0"))
+	assert.True(t, cfg.useHex)
+	assert.True(t, cfg.excludeVersionFromManifest)
+
+	cfg = makeConfig(t, WithTargetMode("v0.0.0"))
+	assert.True(t, cfg.useHex)
+	assert.True(t, cfg.excludeVersionFromManifest)
+
+	cfg = makeConfig(t, WithTargetMode("4.3.0"))
+	assert.False(t, cfg.useHex)
+	assert.False(t, cfg.excludeVersionFromManifest)
+
+	cfg = makeConfig(t, WithTargetMode("v4.3.1"))
+	assert.False(t, cfg.useHex)
+	assert.False(t, cfg.excludeVersionFromManifest)
+}


### PR DESCRIPTION
### Proposed Changes

* Supports creating tdfs with hex encoded hashes and without the schema version in the manifest

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

