### PR TITLE
fix(sdk): Allow tdfs with explicit 4.2.2 specver

### DIFF
--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -1256,7 +1256,16 @@ func calculateSignature(data []byte, secret []byte, alg IntegrityAlgorithm, isLe
 func validateRootSignature(manifest Manifest, aggregateHash, secret []byte) (bool, error) {
 	rootSigAlg := manifest.EncryptionInformation.IntegrityInformation.RootSignature.Algorithm
 	rootSigValue := manifest.EncryptionInformation.IntegrityInformation.RootSignature.Signature
-	isLegacyTDF := manifest.TDFVersion == ""
+	unknownTDFVersion := manifest.TDFVersion == ""
+	isLegacyTDF := unknownTDFVersion
+	if !unknownTDFVersion {
+		stillProfoundlyHexed, err := isLessThanSemver(manifest.TDFVersion, "4.3.0")
+		if err != nil {
+			// Who knows? Could be hexed.
+		} else {
+			isLegacyTDF = stillProfoundlyHexed
+		}
+	}
 
 	sigAlg := HS256
 	if strings.EqualFold(gmacIntegrityAlgorithm, rootSigAlg) {


### PR DESCRIPTION
### Proposed Changes

* javascript sdk sets this in compatiblity mode

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

