### PR TITLE
fix(deps): bump toolchain in /lib/fixtures and /examples to resolve CVE GO-2025-3563

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/examples
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	github.com/opentdf/platform/lib/ocrypto v0.1.9

--- a/lib/fixtures/go.mod
+++ b/lib/fixtures/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/lib/fixtures
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require github.com/Nerzal/gocloak/v13 v13.9.0
 


### PR DESCRIPTION
bumps toolchain from go 1.24.1 to patch increment 1.24.2

