### PR TITLE
fix(sdk): Display proper error on kas rewrap failure

### DIFF
--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -1221,13 +1221,14 @@ func (r *Reader) doPayloadKeyUnwrap(ctx context.Context) error { //nolint:gocogn
 		policyRes, err := kasClient.unwrap(ctx, req)
 		if err != nil {
 			reqFail(err, req)
+		} else {
+			result, ok := policyRes["policy"]
+			if !ok {
+				err = errors.New("could not find policy in rewrap response")
+				reqFail(err, req)
+			}
+			kaoResults = append(kaoResults, result...)
 		}
-		result, ok := policyRes["policy"]
-		if !ok {
-			err = errors.New("could not find policy in rewrap response")
-			reqFail(err, req)
-		}
-		kaoResults = append(kaoResults, result...)
 	}
 
 	return r.buildKey(ctx, kaoResults)


### PR DESCRIPTION
### Proposed Changes

* Previously, the error was always "could not find policy in rewrap response" even if error was that it couldnt connect to the provided kas url. With this change it will properly return the error from the kas request if one is present. 

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

