### PR TITLE
fix(ci): Use dockerhub keycloak image in init-temp-keys scripts

### DIFF
--- a/.github/scripts/init-temp-keys.cmd
+++ b/.github/scripts/init-temp-keys.cmd
@@ -21,4 +21,4 @@ set hostKeyDir=%hostKeyDir%/keys
 set "hostKeyDir=%hostKeyDir:\=/%"
 
 openssl pkcs12 -export -in keys/keycloak-ca.pem -inkey keys/keycloak-ca-private.pem -out keys/ca.p12 -nodes -passout pass:password
-docker run -v %hostKeyDir%:/keys --entrypoint keytool cgr.dev/chainguard/keycloak@sha256:37895558d2e0e93ffff75da5900f9ae7e79ec6d1c390b18b2ecea6cee45ec26f -importkeystore -srckeystore /keys/ca.p12 -srcstoretype PKCS12 -destkeystore /keys/ca.jks -deststoretype JKS -srcstorepass "password" -deststorepass "password" -noprompt
+docker run -v %hostKeyDir%:/keys --entrypoint keytool keycloak/keycloak:25.0 -importkeystore -srckeystore /keys/ca.p12 -srcstoretype PKCS12 -destkeystore /keys/ca.jks -deststoretype JKS -srcstorepass "password" -deststorepass "password" -noprompt

--- a/.github/scripts/init-temp-keys.sh
+++ b/.github/scripts/init-temp-keys.sh
@@ -59,7 +59,7 @@ docker run \
     -v $(pwd)/keys:/keys \
     --entrypoint keytool \
     --user $(id -u):$(id -g) \
-    cgr.dev/chainguard/keycloak@sha256:37895558d2e0e93ffff75da5900f9ae7e79ec6d1c390b18b2ecea6cee45ec26f \
+    keycloak/keycloak:25.0 \
     -importkeystore \
     -srckeystore /keys/ca.p12 \
     -srcstoretype PKCS12 \

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -284,7 +284,7 @@ jobs:
     name: otdfctl e2e tests
     runs-on: ubuntu-latest
     steps:
-      - uses: opentdf/platform/test/start-up-with-containers@use-dockerhub-keycloak-image
+      - uses: opentdf/platform/test/start-up-with-containers@main
         with:
           platform-ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: opentdf/otdfctl/e2e@main

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -284,7 +284,7 @@ jobs:
     name: otdfctl e2e tests
     runs-on: ubuntu-latest
     steps:
-      - uses: opentdf/platform/test/start-up-with-containers@main
+      - uses: opentdf/platform/test/start-up-with-containers@use-dockerhub-keycloak-image
         with:
           platform-ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: opentdf/otdfctl/e2e@main


### PR DESCRIPTION
### Proposed Changes

* fixes issue with pull errors from chainguard

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

