### PR TITLE
chore(ci): Policy-bot ignore update merges

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -25,6 +25,7 @@ approval_rules:
   options:
     invalidate_on_push: true
     ignore_edited_comments: true
+    ignore_update_merges: true
   requires:
     count: 1
     conditions:
@@ -41,6 +42,7 @@ approval_rules:
   options:
     invalidate_on_push: true
     ignore_edited_comments: true
+    ignore_update_merges: true
   requires:
     count: 2
     conditions:
@@ -60,6 +62,7 @@ approval_rules:
   options:
     invalidate_on_push: true
     ignore_edited_comments: true
+    ignore_update_merges: true
   requires:
     count: 1
     conditions:
@@ -81,6 +84,7 @@ approval_rules:
   options:
     invalidate_on_push: true
     ignore_edited_comments: true
+    ignore_update_merges: true
   requires:
     count: 0
     conditions:
@@ -108,6 +112,7 @@ approval_rules:
   options:
     invalidate_on_push: true
     ignore_edited_comments: true
+    ignore_update_merges: true
   requires:
     count: 0
     conditions:
@@ -129,6 +134,7 @@ approval_rules:
   options:
     invalidate_on_push: true
     ignore_edited_comments: true
+    ignore_update_merges: true
   requires:
     count: 2
     conditions:
@@ -149,6 +155,7 @@ approval_rules:
   options:
     invalidate_on_push: true
     ignore_edited_comments: true
+    ignore_update_merges: true
   requires:
     count: 1
     conditions:
@@ -167,6 +174,7 @@ approval_rules:
   options:
     invalidate_on_push: true
     ignore_edited_comments: true
+    ignore_update_merges: true
   requires:
     count: 2
     conditions:


### PR DESCRIPTION
### Proposed Changes

* do not re-require review for update merges

https://github.com/palantir/policy-bot/blob/ee48493727855c4e14763250529f982d2d22ca63/README.md?plain=1#L486-L491
https://github.com/palantir/policy-bot/blob/develop/README.md#update-merges

there's certain caveats for updates with merge conflicts https://github.com/palantir/policy-bot/blob/develop/README.md#update-merge-conflicts- , is this enough of a security concern to not enable this feature?

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

