### PR TITLE
fix(core): fix service go.mod

### DIFF
--- a/service/go.mod
+++ b/service/go.mod
@@ -51,12 +51,9 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/mitchellh/mapstructure v1.5.0 // indirect
-
 require (
 	cel.dev/expr v0.19.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.1 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 )
 
 require (


### PR DESCRIPTION
### Proposed Changes

`go mod tidy` was not run after migrating the mapstructure dependency to use the viper fork

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

