### PR TITLE
chore(ci): Fix duplicate dependabot stanzas

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,15 +19,4 @@ updates:
       - /sdk
       - /service
     schedule:
-      interval: weekly
-  - package-ecosystem: gomod
-    directories:
-      - /examples
-      - /lib/*
-      - /protocol/go
-      - /sdk
-      - /service
-    allow:
-      - dependency-name: "github.com/opentdf/platform/*"
-    schedule:
       interval: daily


### PR DESCRIPTION
### Proposed Changes

- differing `allow` blocks is insufficient differentiation
- see: https://github.com/opentdf/platform/runs/41658077888

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

