### PR TITLE
fix(sdk): deduplicate attribute FQNss when adding to TDF manifest policy

### DIFF
--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -644,12 +644,18 @@ func createPolicyObject(attributes []AttributeValueFQN) (PolicyObject, error) {
 	policyObj := PolicyObject{}
 	policyObj.UUID = uuidObj.String()
 
+	// Deduplicate attributes
+	uniqueAttributes := make(map[string]struct{})
 	for _, attribute := range attributes {
-		attributeObj := attributeObject{}
-		attributeObj.Attribute = attribute.String()
-		policyObj.Body.DataAttributes = append(policyObj.Body.DataAttributes, attributeObj)
-		policyObj.Body.Dissem = make([]string, 0)
+		attributeStr := attribute.String()
+		if _, exists := uniqueAttributes[attributeStr]; !exists {
+			uniqueAttributes[attributeStr] = struct{}{}
+			attributeObj := attributeObject{Attribute: attributeStr}
+			policyObj.Body.DataAttributes = append(policyObj.Body.DataAttributes, attributeObj)
+		}
 	}
+
+	policyObj.Body.Dissem = make([]string, 0)
 
 	return policyObj, nil
 }

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -2276,3 +2276,27 @@ func TestIsLessThanSemver(t *testing.T) {
 		})
 	}
 }
+
+func TestCreatePolicyObjectDeduplication(t *testing.T) {
+	attributes := []AttributeValueFQN{}
+
+	attr1, err := NewAttributeValueFQN("https://example.com/attr/Classification/value/S")
+	require.NoError(t, err)
+	attributes = append(attributes, attr1)
+
+	attr2, err := NewAttributeValueFQN("https://example.com/attr/Classification/value/S")
+	require.NoError(t, err)
+	attributes = append(attributes, attr2)
+
+	attr3, err := NewAttributeValueFQN("https://example.com/attr/Classification/value/X")
+	require.NoError(t, err)
+	attributes = append(attributes, attr3)
+
+	policyObj, err := createPolicyObject(attributes)
+	require.NoError(t, err)
+
+	// Ensure deduplication occurred
+	assert.Len(t, policyObj.Body.DataAttributes, 2)
+	assert.Contains(t, policyObj.Body.DataAttributes, attributeObject{Attribute: "https://example.com/attr/Classification/value/S"})
+	assert.Contains(t, policyObj.Body.DataAttributes, attributeObject{Attribute: "https://example.com/attr/Classification/value/X"})
+}


### PR DESCRIPTION
### Proposed Changes

*

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

