### PR TITLE
fix(core): Let legacy KAOs use new trust plugins

### DIFF
--- a/service/internal/security/crypto_provider.go
+++ b/service/internal/security/crypto_provider.go
@@ -1,34 +1,8 @@
 package security
 
-import (
-	"crypto"
-	"crypto/elliptic"
-)
-
 const (
 	// Key agreement along P-256
 	AlgorithmECP256R1 = "ec:secp256r1"
 	// Used for encryption with RSA of the KAO
 	AlgorithmRSA2048 = "rsa:2048"
 )
-
-type CryptoProvider interface {
-	// Gets some KID associated with a given algorithm.
-	// Returns empty string if none are found.
-	FindKID(alg string) string
-
-	// Gets all KIDs associated with a given algorithm.
-	ListKeysByAlg(alg string) ([]string, error)
-
-	RSAPublicKey(keyID string) (string, error)
-	RSAPublicKeyAsJSON(keyID string) (string, error)
-	RSADecrypt(hash crypto.Hash, keyID string, keyLabel string, ciphertext []byte) ([]byte, error)
-	ECDecrypt(keyID string, ephemeralPublicKey, ciphertext []byte) ([]byte, error)
-
-	ECPublicKey(keyID string) (string, error)
-	ECCertificate(keyID string) (string, error)
-	GenerateNanoTDFSymmetricKey(kasKID string, ephemeralPublicKeyBytes []byte, curve elliptic.Curve) ([]byte, error)
-	GenerateEphemeralKasKeys() (any, []byte, error)
-	GenerateNanoTDFSessionKey(privateKeyHandle any, ephemeralPublicKey []byte) ([]byte, error)
-	Close()
-}

--- a/service/internal/security/crypto_provider.go
+++ b/service/internal/security/crypto_provider.go
@@ -16,6 +16,10 @@ type CryptoProvider interface {
 	// Gets some KID associated with a given algorithm.
 	// Returns empty string if none are found.
 	FindKID(alg string) string
+
+	// Gets all KIDs associated with a given algorithm.
+	ListKeysByAlg(alg string) ([]string, error)
+
 	RSAPublicKey(keyID string) (string, error)
 	RSAPublicKeyAsJSON(keyID string) (string, error)
 	RSADecrypt(hash crypto.Hash, keyID string, keyLabel string, ciphertext []byte) ([]byte, error)

--- a/service/internal/security/standard_crypto.go
+++ b/service/internal/security/standard_crypto.go
@@ -95,6 +95,18 @@ func NewStandardCrypto(cfg StandardConfig) (*StandardCrypto, error) {
 	}
 }
 
+func (s StandardCrypto) ListKeysByAlg(alg string) ([]string, error) {
+	k, ok := s.keysByAlg[alg]
+	if !ok {
+		return nil, fmt.Errorf("no key found with algorithm [%s]: %w", alg, ErrCertNotFound)
+	}
+	keys := make([]string, 0, len(k))
+	for kid := range k {
+		keys = append(keys, kid)
+	}
+	return keys, nil
+}
+
 func loadKeys(ks []KeyPairInfo) (*StandardCrypto, error) {
 	keysByAlg := make(map[string]keylist)
 	keysByID := make(keylist)

--- a/service/internal/security/standard_only.go
+++ b/service/internal/security/standard_only.go
@@ -12,7 +12,7 @@ func (c Config) IsEmpty() bool {
 	return c.Type == "" && c.StandardConfig.IsEmpty()
 }
 
-func NewCryptoProvider(cfg Config) (CryptoProvider, error) {
+func NewCryptoProvider(cfg Config) (*StandardCrypto, error) {
 	switch cfg.Type {
 	case "hsm":
 		slog.Error("opentdf hsm mode has been removed")

--- a/service/internal/security/standard_only.go
+++ b/service/internal/security/standard_only.go
@@ -3,7 +3,7 @@ package security
 import "log/slog"
 
 type Config struct {
-	Type string `mapstructure:"type" json:"type" default:"standard"`
+	Type string `mapstructure:"type" json:"type"`
 	// StandardConfig is the configuration for the standard key provider
 	StandardConfig StandardConfig `mapstructure:"standard" json:"standard"`
 }

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -133,7 +133,7 @@ type OpenTDFServer struct {
 	TrustKeyManager trust.KeyManager
 
 	// To Deprecate: Use the TrustKeyIndex and TrustKeyManager instead
-	CryptoProvider security.CryptoProvider
+	CryptoProvider *security.StandardCrypto
 
 	logger *logger.Logger
 }

--- a/service/kas/access/provider.go
+++ b/service/kas/access/provider.go
@@ -26,7 +26,7 @@ type Provider struct {
 	KeyIndex     trust.KeyIndex
 	KeyManager   trust.KeyManager
 	// Deprecated: Use SecurityProvider instead
-	CryptoProvider security.CryptoProvider // Kept for backward compatibility
+	CryptoProvider *security.StandardCrypto // Kept for backward compatibility
 	Logger         *logger.Logger
 	Config         *config.ServiceConfig
 	KASConfig
@@ -73,7 +73,7 @@ func (p *Provider) IsReady(ctx context.Context) error {
 	return nil
 }
 
-func (kasCfg *KASConfig) UpgradeMapToKeyring(c security.CryptoProvider) {
+func (kasCfg *KASConfig) UpgradeMapToKeyring(c *security.StandardCrypto) {
 	switch {
 	case kasCfg.ECCertID != "" && len(kasCfg.Keyring) > 0:
 		panic("invalid kas cfg: please specify keyring or eccertid, not both")

--- a/service/kas/access/publicKey.go
+++ b/service/kas/access/publicKey.go
@@ -21,6 +21,12 @@ const (
 )
 
 func (p *Provider) lookupKid(ctx context.Context, algorithm string) (string, error) {
+	k, err := p.GetKeyIndex().FindKeyByAlgorithm(ctx, algorithm, false)
+	if err == nil {
+		return string(k.ID()), nil
+	}
+	p.Logger.WarnContext(ctx, "KeyIndex.FindKeyByAlgorithm failed", "err", err)
+
 	if len(p.Keyring) == 0 {
 		p.Logger.WarnContext(ctx, "no default keys found", "algorithm", algorithm)
 		return "", connect.NewError(connect.CodeNotFound, errors.Join(ErrConfig, errors.New("no default keys configured")))

--- a/service/kas/access/publicKey.go
+++ b/service/kas/access/publicKey.go
@@ -27,8 +27,8 @@ func (p *Provider) lookupKid(ctx context.Context, algorithm string) (string, err
 		if err == nil {
 			return string(k.ID()), nil
 		}
+		p.Logger.WarnContext(ctx, "KeyIndex.FindKeyByAlgorithm failed", "err", err)
 	}
-	p.Logger.WarnContext(ctx, "KeyIndex.FindKeyByAlgorithm failed", "err", err)
 
 	if len(p.Keyring) == 0 {
 		p.Logger.WarnContext(ctx, "no default keys found", "algorithm", algorithm)

--- a/service/kas/access/publicKey.go
+++ b/service/kas/access/publicKey.go
@@ -21,9 +21,12 @@ const (
 )
 
 func (p *Provider) lookupKid(ctx context.Context, algorithm string) (string, error) {
-	k, err := p.GetKeyIndex().FindKeyByAlgorithm(ctx, algorithm, false)
-	if err == nil {
-		return string(k.ID()), nil
+	keyIdx := p.GetKeyIndex()
+	if keyIdx != nil {
+		k, err := keyIdx.FindKeyByAlgorithm(ctx, algorithm, false)
+		if err == nil {
+			return string(k.ID()), nil
+		}
 	}
 	p.Logger.WarnContext(ctx, "KeyIndex.FindKeyByAlgorithm failed", "err", err)
 

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -335,7 +335,7 @@ func TestStandardCertificateHandlerEmpty(t *testing.T) {
 
 	kas := Provider{
 		URI:        *kasURI,
-		KeyManager: security.NewSecurityProviderAdapter(c),
+		KeyManager: security.NewSecurityProviderAdapter(c, nil, nil),
 		Logger:     logger.CreateTestLogger(),
 		Tracer:     noop.NewTracerProvider().Tracer(""),
 	}

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -345,7 +345,7 @@ func TestStandardCertificateHandlerEmpty(t *testing.T) {
 	assert.Nil(t, result)
 }
 
-func mustNewCryptoProvider(t *testing.T, configStandard security.Config) security.CryptoProvider {
+func mustNewCryptoProvider(t *testing.T, configStandard security.Config) *security.StandardCrypto {
 	c, err := security.NewCryptoProvider(configStandard)
 	require.NoError(t, err)
 	require.NotNil(t, c)

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -52,11 +52,11 @@ type fakeKeyIndex struct {
 }
 
 func (f *fakeKeyIndex) FindKeyByAlgorithm(context.Context, string, bool) (trust.KeyDetails, error) {
-	return nil, nil
+	return nil, errors.New("not implemented")
 }
 
 func (f *fakeKeyIndex) FindKeyByID(context.Context, trust.KeyIdentifier) (trust.KeyDetails, error) {
-	return nil, nil
+	return nil, errors.New("not implemented")
 }
 func (f *fakeKeyIndex) ListKeys(context.Context) ([]trust.KeyDetails, error) { return f.keys, f.err }
 
@@ -108,7 +108,6 @@ func TestListLegacyKeys_Empty(t *testing.T) {
 }
 
 func TestListLegacyKeys_KeyIndexError(t *testing.T) {
-	ctx := context.Background()
 	testLogger := logger.CreateTestLogger()
 	p := &Provider{
 		Logger: testLogger,
@@ -116,7 +115,7 @@ func TestListLegacyKeys_KeyIndexError(t *testing.T) {
 			err: errors.New("fail"),
 		},
 	}
-	kids := p.listLegacyKeys(ctx)
+	kids := p.listLegacyKeys(t.Context())
 	assert.Empty(t, kids)
 }
 

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"log/slog"
 	"net/http"
 	"testing"
@@ -21,6 +22,7 @@ import (
 	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/service/logger"
 	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
+	"github.com/opentdf/platform/service/trust"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -28,6 +30,95 @@ import (
 	kaspb "github.com/opentdf/platform/protocol/go/kas"
 	"google.golang.org/grpc/metadata"
 )
+
+type fakeKeyDetails struct {
+	id        trust.KeyIdentifier
+	algorithm string
+	legacy    bool
+}
+
+func (f *fakeKeyDetails) ID() trust.KeyIdentifier { return f.id }
+func (f *fakeKeyDetails) Algorithm() string       { return f.algorithm }
+func (f *fakeKeyDetails) IsLegacy() bool          { return f.legacy }
+func (f *fakeKeyDetails) ExportPublicKey(context.Context, trust.KeyType) (string, error) {
+	return "", nil
+}
+func (f *fakeKeyDetails) ExportCertificate(context.Context) (string, error) { return "", nil }
+func (f *fakeKeyDetails) System() string                                    { return "" }
+
+type fakeKeyIndex struct {
+	keys []trust.KeyDetails
+	err  error
+}
+
+func (f *fakeKeyIndex) FindKeyByAlgorithm(context.Context, string, bool) (trust.KeyDetails, error) {
+	return nil, nil
+}
+
+func (f *fakeKeyIndex) FindKeyByID(context.Context, trust.KeyIdentifier) (trust.KeyDetails, error) {
+	return nil, nil
+}
+func (f *fakeKeyIndex) ListKeys(context.Context) ([]trust.KeyDetails, error) { return f.keys, f.err }
+
+func TestListLegacyKeys_KeyringPopulated(t *testing.T) {
+	testLogger := logger.CreateTestLogger()
+	// Simulate a Provider with Keyring containing legacy RSA keys
+	p := &Provider{
+		Logger: testLogger,
+		KASConfig: KASConfig{
+			Keyring: []CurrentKeyFor{
+				{KID: "legacy1", Algorithm: "rsa:2048", Legacy: true},
+				{KID: "notlegacy", Algorithm: "rsa:2048", Legacy: false},
+				{KID: "legacy2", Algorithm: "rsa:2048", Legacy: true},
+				{KID: "legacy3", Algorithm: "ec:secp256r1", Legacy: true}, // not RSA
+			},
+		},
+	}
+
+	kids := p.listLegacyKeys(t.Context())
+	assert.ElementsMatch(t, []trust.KeyIdentifier{"legacy1", "legacy2"}, kids)
+}
+
+func TestListLegacyKeys_KeyIndexPopulated(t *testing.T) {
+	testLogger := logger.CreateTestLogger()
+	fakeKeys := []trust.KeyDetails{
+		&fakeKeyDetails{id: "id1", algorithm: "rsa:2048", legacy: true},
+		&fakeKeyDetails{id: "id2", algorithm: "rsa:2048", legacy: false},
+		&fakeKeyDetails{id: "id3", algorithm: "ec:secp256r1", legacy: true},
+		&fakeKeyDetails{id: "id4", algorithm: "rsa:2048", legacy: true},
+	}
+	p := &Provider{
+		Logger: testLogger,
+		KeyIndex: &fakeKeyIndex{
+			keys: fakeKeys,
+		},
+	}
+	kids := p.listLegacyKeys(t.Context())
+	assert.ElementsMatch(t, []trust.KeyIdentifier{"id1", "id4"}, kids)
+}
+
+func TestListLegacyKeys_Empty(t *testing.T) {
+	testLogger := logger.CreateTestLogger()
+	p := &Provider{
+		Logger:   testLogger,
+		KeyIndex: &fakeKeyIndex{},
+	}
+	kids := p.listLegacyKeys(t.Context())
+	assert.Empty(t, kids)
+}
+
+func TestListLegacyKeys_KeyIndexError(t *testing.T) {
+	ctx := context.Background()
+	testLogger := logger.CreateTestLogger()
+	p := &Provider{
+		Logger: testLogger,
+		KeyIndex: &fakeKeyIndex{
+			err: errors.New("fail"),
+		},
+	}
+	kids := p.listLegacyKeys(ctx)
+	assert.Empty(t, kids)
+}
 
 const (
 	ecCert = `-----BEGIN CERTIFICATE-----

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	kaspb "github.com/opentdf/platform/protocol/go/kas"
 	"github.com/opentdf/platform/protocol/go/kas/kasconnect"
-	"github.com/opentdf/platform/service/internal/security"
 	"github.com/opentdf/platform/service/kas/access"
 	"github.com/opentdf/platform/service/pkg/config"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
@@ -59,9 +58,6 @@ func NewRegistration() *serviceregistry.Service[kasconnect.AccessServiceHandler]
 
 				if srp.OTDF.TrustKeyIndex == nil {
 					// Set up both the legacy CryptoProvider and the new SecurityProvider
-					spa := security.NewSecurityProviderAdapter(srp.OTDF.CryptoProvider)
-					p.KeyIndex = spa
-					p.KeyManager = spa
 					kasCfg.UpgradeMapToKeyring(srp.OTDF.CryptoProvider)
 				} else {
 					p.KeyIndex = srp.OTDF.TrustKeyIndex

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -59,6 +59,7 @@ func NewRegistration() *serviceregistry.Service[kasconnect.AccessServiceHandler]
 				if srp.OTDF.TrustKeyIndex == nil {
 					// Set up both the legacy CryptoProvider and the new SecurityProvider
 					kasCfg.UpgradeMapToKeyring(srp.OTDF.CryptoProvider)
+					p.CryptoProvider = srp.OTDF.CryptoProvider
 				} else {
 					p.KeyIndex = srp.OTDF.TrustKeyIndex
 					p.KeyManager = srp.OTDF.TrustKeyManager

--- a/test/tdf-roundtrips.bats
+++ b/test/tdf-roundtrips.bats
@@ -128,6 +128,7 @@
   wait_for_green
 
   echo "[INFO] validating default key is r2"
+  echo "[INFO] default key result: $(grpcurl "localhost:8080" "kas.AccessService/PublicKey")"
   [ "$(grpcurl "localhost:8080" "kas.AccessService/PublicKey" | jq -e -r .kid)" = r2 ]
 
   echo "[INFO] decrypting after key rotation"
@@ -137,6 +138,7 @@
 
 @test "examples: legacy kas and service config format support" {
   echo "[INFO] validating default key is r1"
+  echo "[INFO] default key result: $(grpcurl "localhost:8080" "kas.AccessService/PublicKey")"
   [ "$(grpcurl "localhost:8080" "kas.AccessService/PublicKey" | jq -e -r .kid)" = r1 ]
 
   echo "[INFO] encrypting samples"
@@ -153,6 +155,7 @@
   wait_for_green
 
   echo "[INFO] validating default key is r1"
+  echo "[INFO] default key result: $(grpcurl "localhost:8080" "kas.AccessService/PublicKey")"
   [ $(grpcurl "localhost:8080" "kas.AccessService/PublicKey" | jq -e -r .kid) = r1 ]
 
   echo "[INFO] validating keys are correct by alg"

--- a/test/tdf-roundtrips.bats
+++ b/test/tdf-roundtrips.bats
@@ -110,6 +110,8 @@
 
 @test "examples: legacy key support Z-TDF" {
   echo "[INFO] validating default key is r1"
+  echo "[INFO] default key result: $(grpcurl "localhost:8080" "kas.AccessService/PublicKey")"
+  
   [ "$(grpcurl "localhost:8080" "kas.AccessService/PublicKey" | jq -e -r .kid)" = r1 ]
 
   echo "[INFO] encrypting samples"


### PR DESCRIPTION

### Proposed Changes

- The code path for KAOs that do not contain key identifier strings did not use the new trust.KeyIndex plugin, if one is provided
- Now the code will prefer to use the index, if it is available and the 'keyring' config is not set
- Also fixes an issue where defaulting to 'standard' in the config caused the 'in memory' crypto config (standard) to always be used, as `IsEmpty` would always return true

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

