### PR TITLE
chore(examples): Lint fixes

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -77,8 +77,6 @@ jobs:
           version: v2.1
           working-directory: ${{ matrix.directory }}
           skip-cache: true
-          only-new-issues: true
-          # args: --out-format=colored-line-number
       - if: matrix.directory == 'service'
         run: .github/scripts/init-temp-keys.sh
       - run: go test ./... -short

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ go-lint:
 	status=0; \
 	for m in $(HAND_MODS); do \
 		echo "Linting module: $$m"; \
-		(cd "$$m" && golangci-lint run $(LINT_OPTIONS) --path-prefix="$$m" ) || status=1; \
+		(cd "$$m" && golangci-lint run $(LINT_OPTIONS) ) || status=1; \
 	done; \
 	exit $$status
 

--- a/examples/cmd/attributes.go
+++ b/examples/cmd/attributes.go
@@ -116,7 +116,7 @@ func listAttributes(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		slog.Info(fmt.Sprintf("found %d namespaces", len(listResp.Namespaces)))
+		slog.Info(fmt.Sprintf("found %d namespaces", len(listResp.GetNamespaces())))
 		for _, n := range listResp.GetNamespaces() {
 			nsuris = append(nsuris, n.GetFqn())
 		}
@@ -215,7 +215,7 @@ func addNamespace(ctx context.Context, s *sdk.SDK, u string) (string, error) {
 		slog.Error("CreateNamespace", "err", err)
 		return "", errors.Join(err, ErrInvalidArgument)
 	}
-	return resp.Namespace.GetId(), nil
+	return resp.GetNamespace().GetId(), nil
 }
 
 func addAttribute(cmd *cobra.Command) error {
@@ -369,19 +369,19 @@ func assignAttribute(cmd *cobra.Command, assign bool) error {
 			kasById[kasid] = kas
 		}
 	case assign:
-		return fmt.Errorf("assign must take a `--kas` parameter")
+		return errors.New("assign must take a `--kas` parameter")
 	case len(values) == 0:
 		// look up all kasids associated with the attribute
 		ar, err := s.Attributes.GetAttribute(cmd.Context(), &attributes.GetAttributeRequest{Id: auuid})
 		if err != nil {
 			return err
 		}
-		for _, b := range ar.Attribute.GetGrants() {
+		for _, b := range ar.GetAttribute().GetGrants() {
 			kasids = append(kasids, b.GetId())
 			kasById[b.GetId()] = b.GetUri()
 		}
 	case len(values) > 1:
-		return fmt.Errorf("TODO: unassign from multiple values at a time")
+		return errors.New("TODO: unassign from multiple values at a time")
 	default:
 		// look up all kasids associated with the value
 		avu, err := avuuid(cmd.Context(), s, auuid, values[0])
@@ -482,5 +482,5 @@ func upsertAttr(ctx context.Context, s *sdk.SDK, auth, name string, values []str
 		slog.Error("CreateAttribute", "err", err, "auth", auth, "name", name, "values", values, "rule", ruler())
 		return "", err
 	}
-	return av.Attribute.GetId(), nil
+	return av.GetAttribute().GetId(), nil
 }

--- a/examples/cmd/attributes.go
+++ b/examples/cmd/attributes.go
@@ -472,13 +472,12 @@ func ruler() policy.AttributeRuleTypeEnum {
 }
 
 func upsertAttr(ctx context.Context, s *sdk.SDK, auth, name string, values []string) (string, error) {
-	av, err :=
-		s.Attributes.CreateAttribute(ctx, &attributes.CreateAttributeRequest{
-			NamespaceId: auth,
-			Name:        name,
-			Rule:        ruler(),
-			Values:      values,
-		})
+	av, err := s.Attributes.CreateAttribute(ctx, &attributes.CreateAttributeRequest{
+		NamespaceId: auth,
+		Name:        name,
+		Rule:        ruler(),
+		Values:      values,
+	})
 	if err != nil {
 		slog.Error("CreateAttribute", "err", err, "auth", auth, "name", name, "values", values, "rule", ruler())
 		return "", err

--- a/examples/cmd/attributes.go
+++ b/examples/cmd/attributes.go
@@ -1,3 +1,4 @@
+//nolint:forbidigo,nestif // We use Println here extensively because we are printing markdown.
 package cmd
 
 import (
@@ -37,7 +38,7 @@ func init() {
 	add := &cobra.Command{
 		Use:  "add",
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return addAttribute(cmd)
 		},
 	}
@@ -49,7 +50,7 @@ func init() {
 	assign := &cobra.Command{
 		Use:  "assign",
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return assignAttribute(cmd, true)
 		},
 	}
@@ -63,7 +64,7 @@ func init() {
 		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "list available policy attributes",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return listAttributes(cmd)
 		},
 	}
@@ -75,7 +76,7 @@ func init() {
 		Use:     "remove",
 		Aliases: []string{"rm"},
 		Args:    cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return removeAttribute(cmd)
 		},
 	}
@@ -87,7 +88,7 @@ func init() {
 	unassign := &cobra.Command{
 		Use:  "unassign",
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return assignAttribute(cmd, false)
 		},
 	}
@@ -240,16 +241,16 @@ func addAttribute(cmd *cobra.Command) error {
 		slog.Error("upsertNamespace", "err", err)
 		return err
 	}
-	attr, err := url.PathUnescape(m[2])
+	attrEl, err := url.PathUnescape(m[2])
 	if err != nil {
 		slog.Error("url.PathUnescape(attr)", "err", err, "attr", m[2])
 		return err
 	}
-	aid, err := upsertAttr(cmd.Context(), s, nsu, attr, values)
+	aid, err := upsertAttr(cmd.Context(), s, nsu, attrEl, values)
 	if err != nil {
 		return err
 	}
-	slog.Info("created attribute", "passedin", attr, "id", aid)
+	slog.Info("created attribute", "passedin", attrEl, "id", aid)
 	return nil
 }
 
@@ -297,32 +298,32 @@ func removeAttribute(cmd *cobra.Command) error {
 		}
 		slog.Info("deactivated attribute", "attr", attr, "resp", resp)
 		return nil
-	} else {
-		for _, v := range values {
-			avu, err := avuuid(cmd.Context(), s, auuid, v)
+	}
+
+	for _, v := range values {
+		avu, err := avuuid(cmd.Context(), s, auuid, v)
+		if err != nil {
+			return err
+		}
+		if unsafeBool {
+			r, err := s.Unsafe.UnsafeDeleteAttributeValue(cmd.Context(), &unsafe.UnsafeDeleteAttributeValueRequest{
+				Id:  avu,
+				Fqn: strings.ToLower(attr + "/value/" + url.PathEscape(v)),
+			})
 			if err != nil {
+				slog.Error("UnsafeDeleteAttributeValue", "err", err, "id", avu)
 				return err
 			}
-			if unsafeBool {
-				r, err := s.Unsafe.UnsafeDeleteAttributeValue(cmd.Context(), &unsafe.UnsafeDeleteAttributeValueRequest{
-					Id:  avu,
-					Fqn: strings.ToLower(attr + "/value/" + url.PathEscape(v)),
-				})
-				if err != nil {
-					slog.Error("UnsafeDeleteAttributeValue", "err", err, "id", avu)
-					return err
-				}
-				slog.Info("deactivated attribute value", "attr", attr, "value", v, "resp", r)
-			} else {
-				r, err := s.Attributes.DeactivateAttributeValue(cmd.Context(), &attributes.DeactivateAttributeValueRequest{
-					Id: avu,
-				})
-				if err != nil {
-					slog.Error("DeactivateAttributeValue", "err", err, "id", avu)
-					return err
-				}
-				slog.Info("deactivated attribute value", "attr", attr, "value", v, "resp", r)
+			slog.Info("deactivated attribute value", "attr", attr, "value", v, "resp", r)
+		} else {
+			r, err := s.Attributes.DeactivateAttributeValue(cmd.Context(), &attributes.DeactivateAttributeValueRequest{
+				Id: avu,
+			})
+			if err != nil {
+				slog.Error("DeactivateAttributeValue", "err", err, "id", avu)
+				return err
 			}
+			slog.Info("deactivated attribute value", "attr", attr, "value", v, "resp", r)
 		}
 	}
 	return nil
@@ -355,7 +356,7 @@ func assignAttribute(cmd *cobra.Command, assign bool) error {
 		return err
 	}
 
-	kasById := make(map[string]string)
+	kasByID := make(map[string]string)
 
 	var kasids []string
 	switch {
@@ -366,7 +367,7 @@ func assignAttribute(cmd *cobra.Command, assign bool) error {
 				return err
 			}
 			kasids = append(kasids, kasid)
-			kasById[kasid] = kas
+			kasByID[kasid] = kas
 		}
 	case assign:
 		return errors.New("assign must take a `--kas` parameter")
@@ -378,7 +379,7 @@ func assignAttribute(cmd *cobra.Command, assign bool) error {
 		}
 		for _, b := range ar.GetAttribute().GetGrants() {
 			kasids = append(kasids, b.GetId())
-			kasById[b.GetId()] = b.GetUri()
+			kasByID[b.GetId()] = b.GetUri()
 		}
 	case len(values) > 1:
 		return errors.New("TODO: unassign from multiple values at a time")
@@ -394,7 +395,7 @@ func assignAttribute(cmd *cobra.Command, assign bool) error {
 		}
 		for _, b := range ar.GetValue().GetGrants() {
 			kasids = append(kasids, b.GetId())
-			kasById[b.GetId()] = b.GetUri()
+			kasByID[b.GetId()] = b.GetUri()
 		}
 	}
 
@@ -410,7 +411,7 @@ func assignAttribute(cmd *cobra.Command, assign bool) error {
 				if err != nil {
 					return err
 				}
-				cmd.Printf("successfully assigned all of [%s] to [%s] (binding [%v])\n", attr, kasById[kasid], *r.GetAttributeKeyAccessServer())
+				cmd.Printf("successfully assigned all of [%s] to [%s] (binding [%v])\n", attr, kasByID[kasid], *r.GetAttributeKeyAccessServer())
 			} else {
 				r, err := s.Attributes.RemoveKeyAccessServerFromAttribute(cmd.Context(), &attributes.RemoveKeyAccessServerFromAttributeRequest{
 					AttributeKeyAccessServer: &attributes.AttributeKeyAccessServer{
@@ -421,7 +422,7 @@ func assignAttribute(cmd *cobra.Command, assign bool) error {
 				if err != nil {
 					return err
 				}
-				cmd.Printf("successfully unassigned [%s] from [%s] (binding %v)\n", attr, kasById[kasid], *r.GetAttributeKeyAccessServer())
+				cmd.Printf("successfully unassigned [%s] from [%s] (binding %v)\n", attr, kasByID[kasid], *r.GetAttributeKeyAccessServer())
 			}
 		} else {
 			for _, v := range values {
@@ -439,7 +440,7 @@ func assignAttribute(cmd *cobra.Command, assign bool) error {
 					if err != nil {
 						return err
 					}
-					cmd.Printf("successfully assigned [%s] to [%s] (binding [%v])\n", attr, kasById[kasid], *r.GetValueKeyAccessServer())
+					cmd.Printf("successfully assigned [%s] to [%s] (binding [%v])\n", attr, kasByID[kasid], *r.GetValueKeyAccessServer())
 				} else {
 					r, err := s.Attributes.RemoveKeyAccessServerFromValue(cmd.Context(), &attributes.RemoveKeyAccessServerFromValueRequest{
 						ValueKeyAccessServer: &attributes.ValueKeyAccessServer{
@@ -450,7 +451,7 @@ func assignAttribute(cmd *cobra.Command, assign bool) error {
 					if err != nil {
 						return err
 					}
-					cmd.Printf("successfully unassigned [%s] from [%s] (binding [%v])\n", attr, kasById[kasid], *r.GetValueKeyAccessServer())
+					cmd.Printf("successfully unassigned [%s] from [%s] (binding [%v])\n", attr, kasByID[kasid], *r.GetValueKeyAccessServer())
 				}
 			}
 		}
@@ -463,11 +464,11 @@ func ruler() policy.AttributeRuleTypeEnum {
 	case "allof":
 		return policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
 	case "anyof":
-		return policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
+		return policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
 	case "hierarchy":
-		return policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
+		return policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
 	default:
-		return policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
+		return policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
 	}
 }
 

--- a/examples/cmd/authorization.go
+++ b/examples/cmd/authorization.go
@@ -65,21 +65,21 @@ func authorizationExamples() error {
 	})
 
 	decisionRequest := &authorization.GetDecisionsRequest{DecisionRequests: drs}
-	slog.Info(fmt.Sprintf("Submitting decision request: %s", protojson.Format(decisionRequest)))
+	slog.Info("Submitting decision request: " + protojson.Format(decisionRequest))
 	decisionResponse, err := s.Authorization.GetDecisions(context.Background(), decisionRequest)
 	if err != nil {
 		return err
 	}
-	slog.Info(fmt.Sprintf("Received decision response: %s", protojson.Format(decisionResponse)))
+	slog.Info("Received decision response: " + protojson.Format(decisionResponse))
 
 	// map response back to entity chain id
 	decisionsByEntityChain := make(map[string]*authorization.DecisionResponse)
-	for _, dr := range decisionResponse.DecisionResponses {
-		decisionsByEntityChain[dr.EntityChainId] = dr
+	for _, dr := range decisionResponse.GetDecisionResponses() {
+		decisionsByEntityChain[dr.GetEntityChainId()] = dr
 	}
 
-	slog.Info(fmt.Sprintf("decision for bob: %s", protojson.Format(decisionsByEntityChain["ec1"])))
-	slog.Info(fmt.Sprintf("decision for alice: %s", protojson.Format(decisionsByEntityChain["ec2"])))
+	slog.Info("decision for bob: " + protojson.Format(decisionsByEntityChain["ec1"]))
+	slog.Info("decision for alice: " + protojson.Format(decisionsByEntityChain["ec2"]))
 	return nil
 }
 

--- a/examples/cmd/authorization.go
+++ b/examples/cmd/authorization.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/opentdf/platform/protocol/go/authorization"
@@ -15,7 +14,7 @@ import (
 var AuthorizationExampleCmd = &cobra.Command{
 	Use:   "authorization",
 	Short: "Example usage for authorization service",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return authorizationExamples()
 	},
 }
@@ -48,8 +47,7 @@ func authorizationExamples() error {
 		}},
 	}}
 
-	// TODO Get attribute value ids
-	tradeSecretAttributeValueFqn := "https://namespace.com/attr/attr_name/value/replaceme"
+	tradeSecretAttributeValueFqn := "https://namespace.com/attr/attr_name/value/replaceme" //nolint: gosec // TODO Get attribute value ids
 	openAttributeValueFqn := "https://open.io/attr/attr_name/value/open"
 
 	slog.Info("Getting decision for bob and alice for transmit action on resource set with trade secret and resource" +

--- a/examples/cmd/authorization.go
+++ b/examples/cmd/authorization.go
@@ -36,12 +36,16 @@ func authorizationExamples() error {
 	// model two groups of entities; user bob and user alice
 	entityChains := []*authorization.EntityChain{{
 		Id: "ec1", // ec1 is an arbitrary tracking id to match results to request
-		Entities: []*authorization.Entity{{EntityType: &authorization.Entity_EmailAddress{EmailAddress: "bob@example.org"},
-			Category: authorization.Entity_CATEGORY_SUBJECT}},
+		Entities: []*authorization.Entity{{
+			EntityType: &authorization.Entity_EmailAddress{EmailAddress: "bob@example.org"},
+			Category:   authorization.Entity_CATEGORY_SUBJECT,
+		}},
 	}, {
 		Id: "ec2", // ec2 is an arbitrary tracking id to match results to request
-		Entities: []*authorization.Entity{{EntityType: &authorization.Entity_UserName{UserName: "alice@example.org"},
-			Category: authorization.Entity_CATEGORY_SUBJECT}},
+		Entities: []*authorization.Entity{{
+			EntityType: &authorization.Entity_UserName{UserName: "alice@example.org"},
+			Category:   authorization.Entity_CATEGORY_SUBJECT,
+		}},
 	}}
 
 	// TODO Get attribute value ids

--- a/examples/cmd/benchmark.go
+++ b/examples/cmd/benchmark.go
@@ -94,7 +94,7 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	var dataAttributes = []string{"https://example.com/attr/attr1/value/value1"}
+	dataAttributes := []string{"https://example.com/attr/attr1/value/value1"}
 	if config.TDFFormat == NanoTDF {
 		nanoTDFConfig, err := client.NewNanoTDFConfig()
 		if err != nil {
@@ -119,16 +119,15 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		// 	}
 		// }
 	} else {
-		tdf, err :=
-			client.CreateTDF(
-				out, in,
-				sdk.WithDataAttributes(dataAttributes...),
-				sdk.WithKasInformation(
-					sdk.KASInfo{
-						URL:       fmt.Sprintf("http://%s", "localhost:8080"),
-						PublicKey: "",
-					}),
-				sdk.WithAutoconfigure(false))
+		tdf, err := client.CreateTDF(
+			out, in,
+			sdk.WithDataAttributes(dataAttributes...),
+			sdk.WithKasInformation(
+				sdk.KASInfo{
+					URL:       fmt.Sprintf("http://%s", "localhost:8080"),
+					PublicKey: "",
+				}),
+			sdk.WithAutoconfigure(false))
 		if err != nil {
 			return err
 		}

--- a/examples/cmd/benchmark.go
+++ b/examples/cmd/benchmark.go
@@ -124,7 +124,7 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 			sdk.WithDataAttributes(dataAttributes...),
 			sdk.WithKasInformation(
 				sdk.KASInfo{
-					URL:       fmt.Sprintf("http://%s", "localhost:8080"),
+					URL:       "http://" + "localhost:8080",
 					PublicKey: "",
 				}),
 			sdk.WithAutoconfigure(false))
@@ -151,7 +151,7 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 
 		file, err := os.Open("sensitive.txt.tdf")
 		if err != nil {
-			errors <- fmt.Errorf("file open error: %v", err)
+			errors <- fmt.Errorf("file open error: %w", err)
 			return
 		}
 		defer file.Close()
@@ -159,19 +159,19 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		if config.TDFFormat == NanoTDF {
 			_, err = client.ReadNanoTDF(io.Discard, file)
 			if err != nil {
-				errors <- fmt.Errorf("ReadNanoTDF error: %v", err)
+				errors <- fmt.Errorf("ReadNanoTDF error: %w", err)
 				return
 			}
 		} else {
 			tdfreader, err := client.LoadTDF(file)
 			if err != nil {
-				errors <- fmt.Errorf("LoadTDF error: %v", err)
+				errors <- fmt.Errorf("LoadTDF error: %w", err)
 				return
 			}
 
 			_, err = io.Copy(io.Discard, tdfreader)
-			if err != nil && err != io.EOF {
-				errors <- fmt.Errorf("read error: %v", err)
+			if err != nil && !errors.Is(err, io.EOF) {
+				errors <- fmt.Errorf("read error: %w", err)
 				return
 			}
 		}

--- a/examples/cmd/benchmark_bulk.go
+++ b/examples/cmd/benchmark_bulk.go
@@ -79,7 +79,7 @@ func runBenchmarkBulk(cmd *cobra.Command, args []string) error {
 			sdk.WithDataAttributes(dataAttributes...),
 			sdk.WithKasInformation(
 				sdk.KASInfo{
-					URL:       fmt.Sprintf("http://%s", "localhost:8080"),
+					URL:       "http://" + "localhost:8080",
 					PublicKey: "",
 				}),
 			sdk.WithAutoconfigure(false))
@@ -101,7 +101,7 @@ func runBenchmarkBulk(cmd *cobra.Command, args []string) error {
 	operation := func() {
 		file, err := os.Open("sensitive.txt.tdf")
 		if err != nil {
-			requestFailure = fmt.Errorf("file open error: %v", err)
+			requestFailure = fmt.Errorf("file open error: %w", err)
 			return
 		}
 		defer file.Close()

--- a/examples/cmd/benchmark_bulk.go
+++ b/examples/cmd/benchmark_bulk.go
@@ -1,3 +1,4 @@
+//nolint:forbidigo,nestif // We use Println here extensively because we are printing markdown.
 package cmd
 
 import (
@@ -22,12 +23,12 @@ func init() {
 		RunE:  runBenchmarkBulk,
 	}
 
-	benchmarkCmd.Flags().IntVar(&config.RequestCount, "count", 100, "Total number of requests")
+	benchmarkCmd.Flags().IntVar(&config.RequestCount, "count", 100, "Total number of requests") //nolint: mnd // This is output to the help with explanation
 	benchmarkCmd.Flags().Var(&config.TDFFormat, "tdf", "TDF format (tdf3 or nanotdf)")
 	ExamplesCmd.AddCommand(benchmarkCmd)
 }
 
-func runBenchmarkBulk(cmd *cobra.Command, args []string) error {
+func runBenchmarkBulk(cmd *cobra.Command, _ []string) error {
 	in := strings.NewReader("Hello, World!")
 
 	// Create new offline client
@@ -55,7 +56,10 @@ func runBenchmarkBulk(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		nanoTDFConfig.SetAttributes(dataAttributes)
+		err = nanoTDFConfig.SetAttributes(dataAttributes)
+		if err != nil {
+			return err
+		}
 		nanoTDFConfig.EnableECDSAPolicyBinding()
 		err = nanoTDFConfig.SetKasURL(fmt.Sprintf("http://%s/kas", "localhost:8080"))
 		if err != nil {
@@ -107,7 +111,10 @@ func runBenchmarkBulk(cmd *cobra.Command, args []string) error {
 		defer file.Close()
 		cipher, _ := io.ReadAll(file)
 
-		file.Seek(0, 0)
+		if _, err := file.Seek(0, 0); err != nil {
+			requestFailure = fmt.Errorf("file seek error: %w", err)
+		}
+
 		format := sdk.Nano
 		var bulkTdfs []*sdk.BulkTDF
 		if config.TDFFormat == "tdf3" {
@@ -145,7 +152,7 @@ func runBenchmarkBulk(cmd *cobra.Command, args []string) error {
 
 	errorMsgs := make(map[string]int)
 	for _, err := range errors {
-		errorMsgs[err.Error()] += 1
+		errorMsgs[err.Error()]++
 	}
 
 	// Print results

--- a/examples/cmd/benchmark_bulk.go
+++ b/examples/cmd/benchmark_bulk.go
@@ -74,16 +74,15 @@ func runBenchmarkBulk(cmd *cobra.Command, args []string) error {
 			}
 		}
 	} else {
-		tdf, err :=
-			client.CreateTDF(
-				out, in,
-				sdk.WithDataAttributes(dataAttributes...),
-				sdk.WithKasInformation(
-					sdk.KASInfo{
-						URL:       fmt.Sprintf("http://%s", "localhost:8080"),
-						PublicKey: "",
-					}),
-				sdk.WithAutoconfigure(false))
+		tdf, err := client.CreateTDF(
+			out, in,
+			sdk.WithDataAttributes(dataAttributes...),
+			sdk.WithKasInformation(
+				sdk.KASInfo{
+					URL:       fmt.Sprintf("http://%s", "localhost:8080"),
+					PublicKey: "",
+				}),
+			sdk.WithAutoconfigure(false))
 		if err != nil {
 			return err
 		}
@@ -125,7 +124,6 @@ func runBenchmarkBulk(cmd *cobra.Command, args []string) error {
 				requestFailure = err
 			}
 		}
-
 	}
 
 	// Start the benchmark
@@ -134,7 +132,7 @@ func runBenchmarkBulk(cmd *cobra.Command, args []string) error {
 	totalTime := time.Since(startTime)
 
 	// Count errors and collect error messages
-	errorCount := 0
+	var errorCount int
 	successCount := 0
 	if requestFailure != nil {
 		errorCount = config.RequestCount

--- a/examples/cmd/benchmark_decision.go
+++ b/examples/cmd/benchmark_decision.go
@@ -44,7 +44,8 @@ func runDecisionBenchmark(cmd *cobra.Command, args []string) error {
 					{Id: "rewrap-tok", Entities: []*authorization.Entity{
 						{Id: "jwtentity-0-clientid-opentdf-public", EntityType: &authorization.Entity_ClientId{ClientId: "opentdf-public"}, Category: authorization.Entity_CATEGORY_ENVIRONMENT},
 						{Id: "jwtentity-1-username-sample-user", EntityType: &authorization.Entity_UserName{UserName: "sample-user"}, Category: authorization.Entity_CATEGORY_SUBJECT},
-					}}},
+					}},
+				},
 				ResourceAttributes: ras,
 			},
 		},
@@ -61,7 +62,6 @@ func runDecisionBenchmark(cmd *cobra.Command, args []string) error {
 			} else {
 				numberDenied += 1
 			}
-
 		}
 	}
 

--- a/examples/cmd/benchmark_decision.go
+++ b/examples/cmd/benchmark_decision.go
@@ -57,7 +57,7 @@ func runDecisionBenchmark(cmd *cobra.Command, args []string) error {
 	numberDenied := 0
 	if err == nil {
 		for _, dr := range res.GetDecisionResponses() {
-			if dr.Decision == authorization.DecisionResponse_DECISION_PERMIT {
+			if dr.GetDecision() == authorization.DecisionResponse_DECISION_PERMIT {
 				numberApproved += 1
 			} else {
 				numberDenied += 1

--- a/examples/cmd/benchmark_decision.go
+++ b/examples/cmd/benchmark_decision.go
@@ -1,3 +1,4 @@
+//nolint:forbidigo // We use Println here extensively because we are printing markdown.
 package cmd
 
 import (
@@ -17,11 +18,11 @@ func init() {
 		Long:  `A OpenTDF benchmark tool to measure throughput and latency with configurable concurrency.`,
 		RunE:  runDecisionBenchmark,
 	}
-	benchmarkCmd.Flags().IntVar(&config.RequestCount, "count", 100, "Total number of requests")
+	benchmarkCmd.Flags().IntVar(&config.RequestCount, "count", 100, "Total number of requests") //nolint: mnd // This is output to the help with explanation
 	ExamplesCmd.AddCommand(benchmarkCmd)
 }
 
-func runDecisionBenchmark(cmd *cobra.Command, args []string) error {
+func runDecisionBenchmark(_ *cobra.Command, _ []string) error {
 	// Create new offline client
 	client, err := newSDK()
 	if err != nil {
@@ -58,9 +59,9 @@ func runDecisionBenchmark(cmd *cobra.Command, args []string) error {
 	if err == nil {
 		for _, dr := range res.GetDecisionResponses() {
 			if dr.GetDecision() == authorization.DecisionResponse_DECISION_PERMIT {
-				numberApproved += 1
+				numberApproved++
 			} else {
-				numberDenied += 1
+				numberDenied++
 			}
 		}
 	}

--- a/examples/cmd/decrypt.go
+++ b/examples/cmd/decrypt.go
@@ -99,7 +99,7 @@ func decrypt(cmd *cobra.Command, args []string) error {
 
 		// Print decrypted string
 		_, err = io.Copy(os.Stdout, tdfreader)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return err
 		}
 	} else {

--- a/examples/cmd/decrypt.go
+++ b/examples/cmd/decrypt.go
@@ -1,3 +1,4 @@
+//nolint:forbidigo,nestif // Sample code
 package cmd
 
 import (
@@ -71,7 +72,7 @@ func decrypt(cmd *cobra.Command, args []string) error {
 	switch {
 	case err != nil:
 		return err
-	case n < 3:
+	case n < 3: //nolint: mnd // All TDFs are more than 2 bytes
 		return errors.New("file too small; no magic number found")
 	case bytes.HasPrefix(magic[:], []byte("L1L")):
 		isNano = true

--- a/examples/cmd/decrypt.go
+++ b/examples/cmd/decrypt.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	var decryptCmd = &cobra.Command{
+	decryptCmd := &cobra.Command{
 		Use:   "decrypt",
 		Short: "Decrypt TDF file",
 		RunE:  decrypt,
@@ -97,7 +97,7 @@ func decrypt(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		//Print decrypted string
+		// Print decrypted string
 		_, err = io.Copy(os.Stdout, tdfreader)
 		if err != nil && err != io.EOF {
 			return err

--- a/examples/cmd/docs.go
+++ b/examples/cmd/docs.go
@@ -8,7 +8,7 @@ import (
 var GenDocsCmd = &cobra.Command{
 	Use:   "docs",
 	Short: "Generates docs for the example commands",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		println("Generating Docs")
 		err := doc.GenMarkdownTree(ExamplesCmd, "./docs")
 		return err

--- a/examples/cmd/docs.go
+++ b/examples/cmd/docs.go
@@ -9,7 +9,6 @@ var GenDocsCmd = &cobra.Command{
 	Use:   "docs",
 	Short: "Generates docs for the example commands",
 	RunE: func(_ *cobra.Command, _ []string) error {
-		println("Generating Docs")
 		err := doc.GenMarkdownTree(ExamplesCmd, "./docs")
 		return err
 	},

--- a/examples/cmd/encrypt.go
+++ b/examples/cmd/encrypt.go
@@ -75,7 +75,7 @@ func encrypt(cmd *cobra.Command, args []string) error {
 
 	out := os.Stdout
 	if outputName == "-" && collection > 0 {
-		return fmt.Errorf("cannot use stdout for collection")
+		return errors.New("cannot use stdout for collection")
 	}
 
 	var writer []io.Writer
@@ -103,7 +103,7 @@ func encrypt(cmd *cobra.Command, args []string) error {
 
 	baseKasURL := platformEndpoint
 	if !strings.HasPrefix(baseKasURL, "http://") && !strings.HasPrefix(baseKasURL, "https://") {
-		baseKasURL = fmt.Sprintf("http://%s", baseKasURL)
+		baseKasURL = "http://" + baseKasURL
 	}
 
 	if !nanoFormat {
@@ -144,7 +144,7 @@ func encrypt(cmd *cobra.Command, args []string) error {
 		if collection > 0 {
 			nanoTDFConfig.EnableCollection()
 		}
-		err = nanoTDFConfig.SetKasURL(fmt.Sprintf("%s/kas", baseKasURL))
+		err = nanoTDFConfig.SetKasURL(baseKasURL + "/kas")
 		if err != nil {
 			return err
 		}

--- a/examples/cmd/encrypt.go
+++ b/examples/cmd/encrypt.go
@@ -101,9 +101,9 @@ func encrypt(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	baseKasUrl := platformEndpoint
-	if !strings.HasPrefix(baseKasUrl, "http://") && !strings.HasPrefix(baseKasUrl, "https://") {
-		baseKasUrl = fmt.Sprintf("http://%s", baseKasUrl)
+	baseKasURL := platformEndpoint
+	if !strings.HasPrefix(baseKasURL, "http://") && !strings.HasPrefix(baseKasURL, "https://") {
+		baseKasURL = fmt.Sprintf("http://%s", baseKasURL)
 	}
 
 	if !nanoFormat {
@@ -113,7 +113,7 @@ func encrypt(cmd *cobra.Command, args []string) error {
 			opts = append(opts, sdk.WithWrappingKeyAlg(ocrypto.EC256Key))
 			opts = append(opts, sdk.WithKasInformation(
 				sdk.KASInfo{
-					URL:       baseKasUrl,
+					URL:       baseKasURL,
 					PublicKey: "",
 				}))
 		}
@@ -144,7 +144,7 @@ func encrypt(cmd *cobra.Command, args []string) error {
 		if collection > 0 {
 			nanoTDFConfig.EnableCollection()
 		}
-		err = nanoTDFConfig.SetKasURL(fmt.Sprintf("%s/kas", baseKasUrl))
+		err = nanoTDFConfig.SetKasURL(fmt.Sprintf("%s/kas", baseKasURL))
 		if err != nil {
 			return err
 		}
@@ -172,7 +172,6 @@ func encrypt(cmd *cobra.Command, args []string) error {
 			_, err = client.CreateNanoTDF(writer, in, *nanoTDFConfig)
 			if err != nil {
 				return err
-
 			}
 		}
 
@@ -198,7 +197,7 @@ func keyTypeForKeyType(alg string) (ocrypto.KeyType, error) {
 	}
 }
 
-func cat(cmd *cobra.Command, nTdfFile string) error {
+func cat(_ *cobra.Command, nTdfFile string) error {
 	f, err := os.Open(nTdfFile)
 	if err != nil {
 		return err

--- a/examples/cmd/encrypt.go
+++ b/examples/cmd/encrypt.go
@@ -1,8 +1,10 @@
+//nolint:forbidigo,nestif // Sample code
 package cmd
 
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -53,19 +55,6 @@ func encrypt(cmd *cobra.Command, args []string) error {
 
 	plainText := args[0]
 	in := strings.NewReader(plainText)
-
-	opts := []sdk.Option{
-		sdk.WithInsecurePlaintextConn(),
-		sdk.WithClientCredentials("opentdf-sdk", "secret", nil),
-	}
-
-	if noKIDInKAO {
-		opts = append(opts, sdk.WithNoKIDInKAO())
-	}
-	// double negative always gets me
-	if !noKIDInNano {
-		opts = append(opts, sdk.WithNoKIDInNano())
-	}
 
 	// Create new offline client
 	client, err := newSDK()
@@ -139,7 +128,10 @@ func encrypt(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		nanoTDFConfig.SetAttributes(dataAttributes)
+		err = nanoTDFConfig.SetAttributes(dataAttributes)
+		if err != nil {
+			return err
+		}
 		nanoTDFConfig.EnableECDSAPolicyBinding()
 		if collection > 0 {
 			nanoTDFConfig.EnableCollection()

--- a/examples/cmd/examples.go
+++ b/examples/cmd/examples.go
@@ -51,7 +51,7 @@ func newSDK() (*sdk.SDK, error) {
 	if clientCredentials != "" {
 		i := strings.Index(clientCredentials, ":")
 		if i < 0 {
-			return nil, fmt.Errorf("invalid client id/secret pair")
+			return nil, errors.New("invalid client id/secret pair")
 		}
 		opts = append(opts, sdk.WithClientCredentials(clientCredentials[:i], clientCredentials[i+1:], nil))
 	}

--- a/examples/cmd/examples.go
+++ b/examples/cmd/examples.go
@@ -1,9 +1,8 @@
 package cmd
 
 import (
-	"fmt"
+	"errors"
 	"log"
-	"os"
 	"strings"
 
 	"google.golang.org/grpc/resolver"
@@ -58,12 +57,18 @@ func newSDK() (*sdk.SDK, error) {
 	if tokenEndpoint != "" {
 		opts = append(opts, sdk.WithTokenEndpoint(tokenEndpoint))
 	}
+	if noKIDInKAO {
+		opts = append(opts, sdk.WithNoKIDInKAO())
+	}
+	// double negative always gets me
+	if !noKIDInNano {
+		opts = append(opts, sdk.WithNoKIDInNano())
+	}
 	return sdk.New(platformEndpoint, opts...)
 }
 
 func Execute() {
 	if err := ExamplesCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatalf("Error executing command: %v", err)
 	}
 }

--- a/examples/cmd/isvalid.go
+++ b/examples/cmd/isvalid.go
@@ -13,9 +13,7 @@ func init() {
 	isValidCmd := &cobra.Command{
 		Use:   "isvalid [files...]",
 		Short: "Check validity of a TDF",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return areValid(cmd, args)
-		},
+		RunE:  areValid,
 	}
 
 	ExamplesCmd.AddCommand(isValidCmd)
@@ -50,7 +48,7 @@ func areValid(cmd *cobra.Command, files []string) error {
 		}
 		defer in.Close()
 
-		fmt.Printf("File: [%s], TypeInfo: %v\n", file, isValid(cmd, in))
+		cmd.Printf("File: [%s], TypeInfo: %v\n", file, isValid(cmd, in))
 	}
 	return nil
 }

--- a/examples/cmd/isvalid.go
+++ b/examples/cmd/isvalid.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	var isValidCmd = &cobra.Command{
+	isValidCmd := &cobra.Command{
 		Use:   "isvalid [files...]",
 		Short: "Check validity of a TDF",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/examples/cmd/isvalid_test.go
+++ b/examples/cmd/isvalid_test.go
@@ -16,11 +16,11 @@ type mockReadSeeker struct {
 	pos  int
 }
 
-func (m *mockReadSeeker) Read(p []byte) (n int, err error) {
+func (m *mockReadSeeker) Read(p []byte) (int, error) {
 	if m.pos >= len(m.data) {
 		return 0, io.EOF
 	}
-	n = copy(p, m.data[m.pos:])
+	n := copy(p, m.data[m.pos:])
 	m.pos += n
 	return n, nil
 }

--- a/examples/cmd/kas.go
+++ b/examples/cmd/kas.go
@@ -105,7 +105,7 @@ func upsertKasRegistration(ctx context.Context, s *sdk.SDK, uri string, pk *poli
 			oldpk := ki.GetPublicKey()
 			recreate := false
 			switch {
-			case pk != nil && len(pk.GetCached().Keys) == 0 && len(oldpk.GetCached().Keys) == 0:
+			case pk != nil && len(pk.GetCached().GetKeys()) == 0 && len(oldpk.GetCached().GetKeys()) == 0:
 				recreate = pk.GetRemote() != oldpk.GetRemote()
 			case pk != nil:
 				// previously remote, now local, or local and changed
@@ -138,7 +138,7 @@ func upsertKasRegistration(ctx context.Context, s *sdk.SDK, uri string, pk *poli
 		slog.Error("CreateKeyAccessServer", "uri", uri, "publicKey", uri+"/v2/kas_public_key")
 		return "", err
 	}
-	return ur.KeyAccessServer.GetId(), nil
+	return ur.GetKeyAccessServer().GetId(), nil
 }
 
 func algString2Proto(a string) policy.KasPublicKeyAlgEnum {
@@ -163,7 +163,7 @@ func updateKas(cmd *cobra.Command) error {
 	switch {
 	case keyIdentifier != "":
 		if key == "" || algorithm == "" {
-			err := fmt.Errorf("if --kid is found, --public-key and --algorithm must also be specified")
+			err := errors.New("if --kid is found, --public-key and --algorithm must also be specified")
 			return err
 		}
 		pk = new(policy.PublicKey)

--- a/examples/cmd/kas.go
+++ b/examples/cmd/kas.go
@@ -1,7 +1,9 @@
+//nolint:forbidigo // Sample code
 package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"

--- a/examples/cmd/kas.go
+++ b/examples/cmd/kas.go
@@ -24,7 +24,7 @@ func init() {
 		Use:     "update",
 		Aliases: []string{"add"},
 		Args:    cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return updateKas(cmd)
 		},
 	}
@@ -41,7 +41,7 @@ func init() {
 		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Short:   "list stored kas information",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return listKases(cmd)
 		},
 	}
@@ -53,7 +53,7 @@ func init() {
 		Args:    cobra.NoArgs,
 		Aliases: []string{"rm"},
 		Short:   "remove kas by uri",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return removeKas(cmd)
 		},
 	}
@@ -226,8 +226,8 @@ func removeKas(cmd *cobra.Command) error {
 	}
 	if !deletedSomething {
 		return fmt.Errorf("nothing deleted; [%s] not found", kas)
-	} else {
-		slog.Info("deleted kas registration", "kas", kas)
 	}
+
+	slog.Info("deleted kas registration", "kas", kas)
 	return nil
 }

--- a/examples/cmd/metrics.go
+++ b/examples/cmd/metrics.go
@@ -1,3 +1,4 @@
+//nolint:forbidigo // Markdown output
 package cmd
 
 import (
@@ -42,7 +43,7 @@ func init() {
 }
 
 func formatDuration(nanos int64) string {
-	ms := float64(nanos) / 1_000_000.0 // Convert to milliseconds
+	ms := float64(nanos) / 1_000_000.0 //nolint:mnd // Convert to milliseconds
 	return fmt.Sprintf("%.3f ms", ms)
 }
 

--- a/examples/cmd/metrics.go
+++ b/examples/cmd/metrics.go
@@ -48,7 +48,7 @@ func formatDuration(nanos int64) string {
 
 func runMetrics(cmd *cobra.Command, _ []string) error {
 	// Ensure the directory exists
-	if err := os.MkdirAll(folderPath, 0755); err != nil {
+	if err := os.MkdirAll(folderPath, 0o755); err != nil {
 		return fmt.Errorf("error creating directory '%s': %w", folderPath, err)
 	}
 

--- a/service/entityresolution/claims/entity_resolution.go
+++ b/service/entityresolution/claims/entity_resolution.go
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-type ClaimsEntityResolutionService struct {
+type ClaimsEntityResolutionService struct { //nolint:revive // Too late! Already exported
 	entityresolution.UnimplementedEntityResolutionServiceServer
 	logger *logger.Logger
 	trace.Tracer

--- a/service/entityresolution/keycloak/entity_resolution.go
+++ b/service/entityresolution/keycloak/entity_resolution.go
@@ -38,14 +38,14 @@ const (
 
 const serviceAccountUsernamePrefix = "service-account-"
 
-type KeycloakEntityResolutionService struct {
+type KeycloakEntityResolutionService struct { //nolint:revive // Too late! Already exported
 	entityresolution.UnimplementedEntityResolutionServiceServer
 	idpConfig KeycloakConfig
 	logger    *logger.Logger
 	trace.Tracer
 }
 
-type KeycloakConfig struct {
+type KeycloakConfig struct { //nolint:revive // yeah but what if we want to embed multiple configs?
 	URL            string                 `mapstructure:"url" json:"url"`
 	Realm          string                 `mapstructure:"realm" json:"realm"`
 	ClientID       string                 `mapstructure:"clientid" json:"clientid"`
@@ -103,7 +103,7 @@ type EntityImpliedFrom struct {
 	Username bool `mapstructure:"username,omitempty" json:"username,omitempty"`
 }
 
-type KeyCloakConnector struct {
+type KeyCloakConnector struct { //nolint:revive // Too late! Already exported
 	token  *gocloak.JWT
 	client *gocloak.GoCloak
 }


### PR DESCRIPTION
### Proposed Changes

* Some fixes for example code in the linter / formatter
* Suppresses a lot of revive (unnecessary or dangerous renames) and things like nestif (unneeded refactor of code only lightly covered by tests) and forbidigo (yeah, sample code often uses Println, why make such a big deal over it)
* Get rid of 'only changes', as we are now 100% green. We can add it back whenever we upgrade/change lint settings as needed
* Fix makefile so links are clickable in vscode again

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

