### PR TITLE
chore(ci): policy bot diff calc should ignore test files

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -168,6 +168,7 @@ approval_rules:
       paths:
         - ".*"  # This will match any file
       ignore:
+        - ".*_test/.go$" # Ignore test files
         - "^protocol/.*" # Ignore files in the protocol directory
         - "^docs/.*"     # Ignore files in the docs directory
   options:


### PR DESCRIPTION
### Proposed Changes

* Policy bot calculation to require multiple reviewers should ignore diff calculations from test files.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

