### PR TITLE
chore(ci): Stops dependabot for 3rd party go mods

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,21 +13,6 @@ updates:
     commit-message:
       prefix: "chore(ci)"
 
-  # Dependabot for third party deps
-  - package-ecosystem: gomod
-    directories:
-      - /examples
-      - /lib/*
-      - /protocol/go
-      - /sdk
-      - /service
-    groups:
-      external:
-        exclude-patterns:
-          - "github.com/opentdf/*"
-    schedule:
-      interval: weekly
-
   # Dependabot for internal deps
   # Add explicit entry as any go.mods need internal dep checks
   - package-ecosystem: gomod


### PR DESCRIPTION
### Proposed Changes

* These will have to be added back to each separate go.mod if we want them, since the current dependabot.yaml is failing with the message:

> Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'gomod' has overlapping directories.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

