### PR TITLE
chore(ci): Collapse external dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,25 +17,31 @@ updates:
   # Add explicit entry as any go.mods need internal dep checks
   - package-ecosystem: gomod
     directory: "/examples"
+    commit-message:
+      prefix: "fix(deps)"
     groups:
-      internal:
-        patterns:
+      external:
+        exclude-patterns:
           - "github.com/opentdf/*"
     schedule:
       interval: daily
   - package-ecosystem: gomod
     directory: "/sdk"
+    commit-message:
+      prefix: "fix(deps)"
     groups:
-      internal:
-        patterns:
+      external:
+        exclude-patterns:
           - "github.com/opentdf/*"
     schedule:
       interval: daily
   - package-ecosystem: gomod
     directory: "/service"
+    commit-message:
+      prefix: "fix(deps)"
     groups:
-      internal:
-        patterns:
+      external:
+        exclude-patterns:
           - "github.com/opentdf/*"
     schedule:
       interval: daily


### PR DESCRIPTION
### Proposed Changes

* Groups *external* go dep updates, not internal ones.
  * I had it backward - the groups will only group explicitly listed items; others remain individual. This will group external ones.
  * Example of the current internal PR: https://github.com/opentdf/platform/pull/2265
* Adds back `fix(deps)` commit title
* Updates `lib/identifier` to version 0.0.2 in the vain hope this will fix the 'downloading' error, which maybe due to our deps on buf.build or something else :-/


### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

