### PR TITLE
fix(sdk): adds connection options to getPlatformConfiguration

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -413,7 +413,7 @@ func validateHealthyPlatformConnection(platformEndpoint string, httpClient *http
 
 func getPlatformConfiguration(conn *ConnectRPCConnection) (PlatformConfiguration, error) {
 	req := wellknownconfiguration.GetWellKnownConfigurationRequest{}
-	wellKnownConfig := wellknownconfigurationconnect.NewWellKnownServiceClient(conn.Client, conn.Endpoint)
+	wellKnownConfig := wellknownconfigurationconnect.NewWellKnownServiceClient(conn.Client, conn.Endpoint, conn.Options...)
 
 	response, err := wellKnownConfig.GetWellKnownConfiguration(context.Background(), connect.NewRequest(&req))
 	if err != nil {


### PR DESCRIPTION
### Proposed Changes

* connection options should be passed to `getPlatformConfiguration`.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

