### PR TITLE
fix(policy): all policy services should gracefully close

### DIFF
--- a/service/policy/actions/actions.go
+++ b/service/policy/actions/actions.go
@@ -79,6 +79,12 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 	}
 }
 
+// Close gracefully shuts down the actions service, closing the database client.
+func (s *ActionService) Close() {
+	s.logger.Info("gracefully shutting down")
+	s.dbClient.Close()
+}
+
 func (a *ActionService) GetAction(ctx context.Context, req *connect.Request[actions.GetActionRequest]) (*connect.Response[actions.GetActionResponse], error) {
 	rsp := &actions.GetActionResponse{}
 

--- a/service/policy/actions/actions.go
+++ b/service/policy/actions/actions.go
@@ -81,9 +81,9 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 }
 
 // Close gracefully shuts down the actions service, closing the database client.
-func (s *ActionService) Close() {
-	s.logger.Info("gracefully shutting down actions service")
-	s.dbClient.Close()
+func (a *ActionService) Close() {
+	a.logger.Info("gracefully shutting down actions service")
+	a.dbClient.Close()
 }
 
 func (a *ActionService) GetAction(ctx context.Context, req *connect.Request[actions.GetActionRequest]) (*connect.Response[actions.GetActionResponse], error) {

--- a/service/policy/actions/actions.go
+++ b/service/policy/actions/actions.go
@@ -56,6 +56,7 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 	onUpdateConfigHook := OnConfigUpdate(actionsSvc)
 
 	return &serviceregistry.Service[actionsconnect.ActionServiceHandler]{
+		Close: actionsSvc.Close,
 		ServiceOptions: serviceregistry.ServiceOptions[actionsconnect.ActionServiceHandler]{
 			Namespace:      ns,
 			DB:             dbRegister,
@@ -81,7 +82,7 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 
 // Close gracefully shuts down the actions service, closing the database client.
 func (s *ActionService) Close() {
-	s.logger.Info("gracefully shutting down")
+	s.logger.Info("gracefully shutting down actions service")
 	s.dbClient.Close()
 }
 

--- a/service/policy/attributes/attributes.go
+++ b/service/policy/attributes/attributes.go
@@ -44,7 +44,9 @@ func OnConfigUpdate(as *AttributesService) serviceregistry.OnConfigUpdateHook {
 func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *serviceregistry.Service[attributesconnect.AttributesServiceHandler] {
 	as := new(AttributesService)
 	onUpdateConfigHook := OnConfigUpdate(as)
+
 	return &serviceregistry.Service[attributesconnect.AttributesServiceHandler]{
+		Close: as.Close,
 		ServiceOptions: serviceregistry.ServiceOptions[attributesconnect.AttributesServiceHandler]{
 			Namespace:       ns,
 			DB:              dbRegister,
@@ -71,7 +73,7 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 
 // Close gracefully shuts down the service, closing the database client.
 func (s *AttributesService) Close() {
-	s.logger.Info("gracefully shutting down")
+	s.logger.Info("gracefully shutting down attributes service")
 	s.dbClient.Close()
 }
 

--- a/service/policy/attributes/attributes.go
+++ b/service/policy/attributes/attributes.go
@@ -69,7 +69,13 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 	}
 }
 
-func (s AttributesService) CreateAttribute(ctx context.Context,
+// Close gracefully shuts down the service, closing the database client.
+func (s *AttributesService) Close() {
+	s.logger.Info("gracefully shutting down")
+	s.dbClient.Close()
+}
+
+func (s *AttributesService) CreateAttribute(ctx context.Context,
 	req *connect.Request[attributes.CreateAttributeRequest],
 ) (*connect.Response[attributes.CreateAttributeResponse], error) {
 	s.logger.Debug("creating new attribute definition", slog.String("name", req.Msg.GetName()))

--- a/service/policy/kasregistry/key_access_server_registry.go
+++ b/service/policy/kasregistry/key_access_server_registry.go
@@ -84,6 +84,12 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 	}
 }
 
+// Close gracefully shuts down the service, closing the database client.
+func (s *KeyAccessServerRegistry) Close() {
+	s.logger.Info("gracefully shutting down")
+	s.dbClient.Close()
+}
+
 func (s KeyAccessServerRegistry) CreateKeyAccessServer(ctx context.Context,
 	req *connect.Request[kasr.CreateKeyAccessServerRequest],
 ) (*connect.Response[kasr.CreateKeyAccessServerResponse], error) {

--- a/service/policy/kasregistry/key_access_server_registry.go
+++ b/service/policy/kasregistry/key_access_server_registry.go
@@ -54,7 +54,9 @@ func OnConfigUpdate(kasrSvc *KeyAccessServerRegistry) serviceregistry.OnConfigUp
 func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *serviceregistry.Service[kasregistryconnect.KeyAccessServerRegistryServiceHandler] {
 	kasrSvc := new(KeyAccessServerRegistry)
 	onUpdateConfigHook := OnConfigUpdate(kasrSvc)
+
 	return &serviceregistry.Service[kasregistryconnect.KeyAccessServerRegistryServiceHandler]{
+		Close: kasrSvc.Close,
 		ServiceOptions: serviceregistry.ServiceOptions[kasregistryconnect.KeyAccessServerRegistryServiceHandler]{
 			Namespace:       ns,
 			DB:              dbRegister,
@@ -86,7 +88,7 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 
 // Close gracefully shuts down the service, closing the database client.
 func (s *KeyAccessServerRegistry) Close() {
-	s.logger.Info("gracefully shutting down")
+	s.logger.Info("gracefully shutting down key access server registry service")
 	s.dbClient.Close()
 }
 

--- a/service/policy/keymanagement/key_management.go
+++ b/service/policy/keymanagement/key_management.go
@@ -61,6 +61,12 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 	}
 }
 
+// Close gracefully shuts down the service, closing the database client.
+func (ksvc Service) Close() {
+	ksvc.logger.Info("gracefully shutting down")
+	ksvc.dbClient.Close()
+}
+
 func (ksvc Service) CreateProviderConfig(ctx context.Context, req *connect.Request[keyMgmtProto.CreateProviderConfigRequest]) (*connect.Response[keyMgmtProto.CreateProviderConfigResponse], error) {
 	rsp := &keyMgmtProto.CreateProviderConfigResponse{}
 

--- a/service/policy/namespaces/namespaces.go
+++ b/service/policy/namespaces/namespaces.go
@@ -42,7 +42,9 @@ func OnConfigUpdate(ns *NamespacesService) serviceregistry.OnConfigUpdateHook {
 func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *serviceregistry.Service[namespacesconnect.NamespaceServiceHandler] {
 	nsService := new(NamespacesService)
 	onUpdateConfigHook := OnConfigUpdate(nsService)
+
 	return &serviceregistry.Service[namespacesconnect.NamespaceServiceHandler]{
+		Close: nsService.Close,
 		ServiceOptions: serviceregistry.ServiceOptions[namespacesconnect.NamespaceServiceHandler]{
 			Namespace:       ns,
 			DB:              dbRegister,
@@ -61,6 +63,7 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 				nsService.logger = logger
 				nsService.dbClient = policydb.NewClient(srp.DBClient, logger, int32(cfg.ListRequestLimitMax), int32(cfg.ListRequestLimitDefault))
 				nsService.config = cfg
+
 				return nsService, nil
 			},
 		},
@@ -79,8 +82,8 @@ func (ns NamespacesService) IsReady(ctx context.Context) error {
 }
 
 // Close gracefully shuts down the service, closing the database client.
-func (ns NamespacesService) Close() {
-	ns.logger.Info("gracefully shutting down")
+func (ns *NamespacesService) Close() {
+	ns.logger.Info("gracefully shutting down namespaces service")
 	ns.dbClient.Close()
 }
 

--- a/service/policy/namespaces/namespaces.go
+++ b/service/policy/namespaces/namespaces.go
@@ -78,6 +78,12 @@ func (ns NamespacesService) IsReady(ctx context.Context) error {
 	return nil
 }
 
+// Close gracefully shuts down the service, closing the database client.
+func (ns NamespacesService) Close() {
+	ns.logger.Info("gracefully shutting down")
+	ns.dbClient.Close()
+}
+
 func (ns NamespacesService) ListNamespaces(ctx context.Context, req *connect.Request[namespaces.ListNamespacesRequest]) (*connect.Response[namespaces.ListNamespacesResponse], error) {
 	state := req.Msg.GetState().String()
 	ns.logger.Debug("listing namespaces", slog.String("state", state))

--- a/service/policy/registeredresources/registered_resources.go
+++ b/service/policy/registeredresources/registered_resources.go
@@ -75,6 +75,12 @@ func (s *RegisteredResourcesService) IsReady(ctx context.Context) error {
 	return nil
 }
 
+// Close gracefully shuts down the service, closing the database client.
+func (s *RegisteredResourcesService) Close() {
+	s.logger.Info("gracefully shutting down")
+	s.dbClient.Close()
+}
+
 /// Registered Resources Handlers
 
 func (s *RegisteredResourcesService) CreateRegisteredResource(ctx context.Context, req *connect.Request[registeredresources.CreateRegisteredResourceRequest]) (*connect.Response[registeredresources.CreateRegisteredResourceResponse], error) {

--- a/service/policy/registeredresources/registered_resources.go
+++ b/service/policy/registeredresources/registered_resources.go
@@ -43,6 +43,7 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 	onUpdateConfigHook := OnConfigUpdate(rrService)
 
 	return &serviceregistry.Service[registeredresourcesconnect.RegisteredResourcesServiceHandler]{
+		Close: rrService.Close,
 		ServiceOptions: serviceregistry.ServiceOptions[registeredresourcesconnect.RegisteredResourcesServiceHandler]{
 			Namespace:      ns,
 			DB:             dbRegister,
@@ -77,7 +78,7 @@ func (s *RegisteredResourcesService) IsReady(ctx context.Context) error {
 
 // Close gracefully shuts down the service, closing the database client.
 func (s *RegisteredResourcesService) Close() {
-	s.logger.Info("gracefully shutting down")
+	s.logger.Info("gracefully shutting down registered resources service")
 	s.dbClient.Close()
 }
 

--- a/service/policy/resourcemapping/resource_mapping.go
+++ b/service/policy/resourcemapping/resource_mapping.go
@@ -67,6 +67,12 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 	}
 }
 
+// Close gracefully shuts down the service, closing the database client.
+func (s ResourceMappingService) Close() {
+	s.logger.Info("gracefully shutting down")
+	s.dbClient.Close()
+}
+
 /*
 	Resource Mapping Groups
 */

--- a/service/policy/resourcemapping/resource_mapping.go
+++ b/service/policy/resourcemapping/resource_mapping.go
@@ -42,7 +42,9 @@ func OnConfigUpdate(rmSvc *ResourceMappingService) serviceregistry.OnConfigUpdat
 func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *serviceregistry.Service[resourcemappingconnect.ResourceMappingServiceHandler] {
 	rmSvc := new(ResourceMappingService)
 	onUpdateConfigHook := OnConfigUpdate(rmSvc)
+
 	return &serviceregistry.Service[resourcemappingconnect.ResourceMappingServiceHandler]{
+		Close: rmSvc.Close,
 		ServiceOptions: serviceregistry.ServiceOptions[resourcemappingconnect.ResourceMappingServiceHandler]{
 			Namespace:       ns,
 			DB:              dbRegister,
@@ -68,8 +70,8 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 }
 
 // Close gracefully shuts down the service, closing the database client.
-func (s ResourceMappingService) Close() {
-	s.logger.Info("gracefully shutting down")
+func (s *ResourceMappingService) Close() {
+	s.logger.Info("gracefully shutting down resource mapping service")
 	s.dbClient.Close()
 }
 

--- a/service/policy/subjectmapping/subject_mapping.go
+++ b/service/policy/subjectmapping/subject_mapping.go
@@ -67,6 +67,12 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 	}
 }
 
+// Close gracefully shuts down the service, closing the database client.
+func (s SubjectMappingService) Close() {
+	s.logger.Info("gracefully shutting down")
+	s.dbClient.Close()
+}
+
 /* ---------------------------------------------------
  * ----------------- SubjectMappings -----------------
  * --------------------------------------------------*/

--- a/service/policy/subjectmapping/subject_mapping.go
+++ b/service/policy/subjectmapping/subject_mapping.go
@@ -42,7 +42,9 @@ func OnConfigUpdate(smSvc *SubjectMappingService) serviceregistry.OnConfigUpdate
 func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *serviceregistry.Service[subjectmappingconnect.SubjectMappingServiceHandler] {
 	smSvc := new(SubjectMappingService)
 	onUpdateConfigHook := OnConfigUpdate(smSvc)
+
 	return &serviceregistry.Service[subjectmappingconnect.SubjectMappingServiceHandler]{
+		Close: smSvc.Close,
 		ServiceOptions: serviceregistry.ServiceOptions[subjectmappingconnect.SubjectMappingServiceHandler]{
 			Namespace:       ns,
 			DB:              dbRegister,
@@ -68,8 +70,8 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 }
 
 // Close gracefully shuts down the service, closing the database client.
-func (s SubjectMappingService) Close() {
-	s.logger.Info("gracefully shutting down")
+func (s *SubjectMappingService) Close() {
+	s.logger.Info("gracefully shutting down subject mapping service")
 	s.dbClient.Close()
 }
 

--- a/service/policy/unsafe/unsafe.go
+++ b/service/policy/unsafe/unsafe.go
@@ -41,7 +41,9 @@ func OnConfigUpdate(unsafeSvc *UnsafeService) serviceregistry.OnConfigUpdateHook
 func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *serviceregistry.Service[unsafeconnect.UnsafeServiceHandler] {
 	unsafeSvc := new(UnsafeService)
 	onUpdateConfigHook := OnConfigUpdate(unsafeSvc)
+
 	return &serviceregistry.Service[unsafeconnect.UnsafeServiceHandler]{
+		Close: unsafeSvc.Close,
 		ServiceOptions: serviceregistry.ServiceOptions[unsafeconnect.UnsafeServiceHandler]{
 			Namespace:      ns,
 			DB:             dbRegister,
@@ -67,7 +69,7 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 
 // Close gracefully shuts down the service, closing the database client.
 func (s *UnsafeService) Close() {
-	s.logger.Info("gracefully shutting down")
+	s.logger.Info("gracefully shutting down unsafe service")
 	s.dbClient.Close()
 }
 

--- a/service/policy/unsafe/unsafe.go
+++ b/service/policy/unsafe/unsafe.go
@@ -65,6 +65,12 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 	}
 }
 
+// Close gracefully shuts down the service, closing the database client.
+func (s *UnsafeService) Close() {
+	s.logger.Info("gracefully shutting down")
+	s.dbClient.Close()
+}
+
 //
 // Unsafe Namespace RPCs
 //


### PR DESCRIPTION
### Proposed Changes

* Each policy service should gracefully close its db client connections on shutdown

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

