### PR TITLE
fix(ci): Fix intermittent failures from auth tests

### DIFF
--- a/sdk/auth/token_adding_interceptor_test.go
+++ b/sdk/auth/token_adding_interceptor_test.go
@@ -95,7 +95,6 @@ func checkAccessAndDpopTokens(t *testing.T, accessToken []string, dpopToken []st
 }
 
 func TestAddingTokensToOutgoingRequest(t *testing.T) {
-
 	oo, key := setupTokenAddingInterceptor(t)
 
 	serverGrpc := FakeAccessServiceServer{}
@@ -109,7 +108,6 @@ func TestAddingTokensToOutgoingRequest(t *testing.T) {
 }
 
 func TestAddingTokensToOutgoingRequest_Connect(t *testing.T) {
-
 	oo, key := setupTokenAddingInterceptor(t)
 
 	serverConnect := FakeAccessServiceServerConnect{}


### PR DESCRIPTION
### Proposed Changes

* the auth tests have been failing intermittently since the addition of connect rpc due to what appears to be a race condition on the server close, separate the connect rpc and grpc tests for the auth interceptors

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

