### PR TITLE
chore(ci): Fix nightlies

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -176,6 +176,8 @@ jobs:
       contents: read
       pull-requests: write
     name: benchmark tests
+    outputs:
+      markdown: ${{ steps.save-benchmark.outputs.BENCHMARK_MARKDOWN }}
     runs-on: ubuntu-22.04
     env:
       TLS_ENABLED: "true"
@@ -299,29 +301,33 @@ jobs:
             echo "EOO"
           } >> "$GITHUB_ENV"
 
-      - name: save benchmark results as a comment
-        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const decisionOutput = process.env.BENCHMARK_DECISION_OUTPUT || '## Decision Benchmark Skipped or Failed';
-            const decisionV2Output = process.env.BENCHMARK_DECISION_V2_OUTPUT || '## Decision Benchmark v2 Skipped or Failed';
-            const metricsOutput = process.env.BENCHMARK_METRICS_OUTPUT || '## Standard Benchmark Metrics Skipped or Failed';
-            const bulkOutput = process.env.BENCHMARK_BULK_OUTPUT || '## Bulk Benchmark Skipped or Failed';
-            const tdf3Output = process.env.BENCHMARK_TDF3_OUTPUT || '## TDF3 Benchmark Skipped or Failed';
-            const nanoOutput = process.env.BENCHMARK_NANO_OUTPUT || '## Nano Benchmark Skipped or Failed';
+      - name: save benchmark results as an output variable
+        id: save-benchmark
+        run: |
+          # helper functions
+          h2() {
+            if [ -z "$1" ]; then
+              echo "## ${2} Skipped or Failed"
+            else 
+              echo "$1"
+            fi
+          }
 
-            const body = `<details><summary>Benchmark results, click to expand</summary>\n\n${decisionOutput}\n\n${decisionV2Output}\n\n${bulkOutput}\n\n${tdf3Output}\n\n${nanoOutput}\n\n${metricsOutput}</details>`;
+          {
+            echo "BENCHMARK_MARKDOWN<<EOO"
 
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
+            h2 "${BENCHMARK_DECISION_OUTPUT}" "Decision Benchmark"
+            h2 "${BENCHMARK_DECISION_V2_OUTPUT}" "Decision Benchmark v2"
+            h2 "${BENCHMARK_METRICS_OUTPUT}" "Standard Benchmark Metrics"
+            h2 "${BENCHMARK_BULK_OUTPUT}" "Bulk Benchmark"
+            h2 "${BENCHMARK_TDF3_OUTPUT}" "TDF3 Benchmark"
+            h2 "${BENCHMARK_NANO_OUTPUT}" "Nano Benchmark"
+
+            echo EOO
+          } >>"$GITHUB_OUTPUT"
 
       - name: save benchmark results as a step summary
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
@@ -330,6 +336,35 @@ jobs:
             const bulkOutput = process.env.BENCHMARK_BULK_OUTPUT || '## Bulk Benchmark Skipped or Failed';
             const summaryContent = `${metricsOutput}\n\n${bulkOutput}`;
             fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summaryContent + '\n');
+
+  comment-benchmark:
+    if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+    permissions:
+      contents: read
+      pull-requests: write
+    name: benchmark tests
+    needs: benchmark
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.4.2
+        with:
+          persist-credentials: false
+
+      - name: save benchmark results as a comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const decisionOutput = process.env.BENCHMARK_MARKDOWN;
+            const body = `<details><summary>Benchmark results, click to expand</summary>\n\n${decisionOutput}</details>`;
+
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+        env:
+          BENCHMARK_MARKDOWN: ${{ needs.benchmark.outputs.markdown }}
 
   image:
     permissions:

--- a/.github/workflows/nightly-checks.yaml
+++ b/.github/workflows/nightly-checks.yaml
@@ -5,6 +5,7 @@ on:
     # Run at 12:15 AM UTC (Scheduled actions are not guaranteed during times of high load like the top of the
     # hour or 00:00. See discussion: https://github.com/orgs/community/discussions/27130)
     - cron: "15 0 * * *"
+  workflow_dispatch:
 
 permissions: {}
 
@@ -78,5 +79,7 @@ jobs:
         working-directory: platform
   ci-checks:
     permissions:
+      checks: write
       contents: read
+      pull-requests: read
     uses: opentdf/platform/.github/workflows/checks.yaml@main


### PR DESCRIPTION
### Proposed Changes

- checks currently can write to PRs, which nightlies can't
  - See the failures here: https://github.com/opentdf/platform/actions/workflows/nightly-checks.yaml
- I'm gonna try to be nice and reduce the required permissions in checks. let's see if this works...
- Adds `workflow_dispatch` for manual testing (probably should do this for all scheduled ci test jobs tbh)

This should fix the error:

> Invalid workflow file: .github/workflows/nightly-checks.yaml#L79The workflow is not valid. .github/workflows/nightly-checks.yaml (Line: 79, Col: 3): Error calling workflow 'opentdf/platform/.github/workflows/checks.yaml@main'. The nested job 'go' is requesting 'checks: write, pull-requests: read', but is only allowed 'checks: none, pull-requests: none'. .github/workflows/nightly-checks.yaml (Line: 79, Col: 3): Error calling workflow 'opentdf/platform/.github/workflows/checks.yaml@main'. The nested job 'benchmark' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

<img width="1031" alt="image" src="https://github.com/user-attachments/assets/200ede7d-f40e-4e09-b0ba-990d5c703aa9" />
