### PR TITLE
feat(sdk): adds seeker interface to TDF Reader

### DIFF
--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -814,6 +814,7 @@ func (r *Reader) WriteTo(writer io.Writer) (int64, error) {
 	for _, seg := range r.manifest.EncryptionInformation.IntegrityInformation.Segments {
 		if decryptedDataOffset+seg.Size < r.cursor {
 			decryptedDataOffset += seg.Size
+			payloadReadOffset += seg.EncryptedSize
 			continue
 		}
 

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -775,6 +775,7 @@ func (r *Reader) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// Seek updates cursor to `Read` or `WriteTo` at an offset.
 func (r *Reader) Seek(offset int64, whence int) (int64, error) {
 	var newPos int64
 	switch whence {
@@ -791,7 +792,7 @@ func (r *Reader) Seek(offset int64, whence int) (int64, error) {
 	if newPos < 0 || newPos >= r.payloadSize {
 		return 0, fmt.Errorf("reader.Seek failed: index if out of range %d", newPos)
 	}
-	r.cursor += offset
+	r.cursor = newPos
 	return r.cursor, nil
 }
 

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -789,7 +789,7 @@ func (r *Reader) Seek(offset int64, whence int) (int64, error) {
 		return 0, fmt.Errorf("reader.Seek failed: unknown whence: %d", whence)
 	}
 	newPos += offset
-	if newPos < 0 || newPos >= r.payloadSize {
+	if newPos < 0 || newPos > r.payloadSize {
 		return 0, fmt.Errorf("reader.Seek failed: index if out of range %d", newPos)
 	}
 	r.cursor = newPos

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -797,7 +796,7 @@ func (r *Reader) WriteTo(writer io.Writer) (int64, error) {
 
 	isLegacyTDF := r.manifest.TDFVersion == ""
 	defaultSegmentSize := r.manifest.EncryptionInformation.IntegrityInformation.DefaultSegmentSize
-	start := int(math.Floor(float64(r.cursor) / float64(defaultSegmentSize)))
+	start := r.cursor / defaultSegmentSize
 
 	var totalBytes int64
 	var payloadReadOffset int64
@@ -866,8 +865,8 @@ func (r *Reader) ReadAt(buf []byte, offset int64) (int, error) { //nolint:funlen
 	}
 
 	defaultSegmentSize := r.manifest.EncryptionInformation.IntegrityInformation.DefaultSegmentSize
-	start := math.Floor(float64(offset) / float64(defaultSegmentSize))
-	end := math.Ceil(float64(offset+int64(len(buf))) / float64(defaultSegmentSize))
+	start := offset / defaultSegmentSize
+	end := (offset + int64(len(buf)) + defaultSegmentSize - 1) / defaultSegmentSize // rounds up
 
 	firstSegment := int64(start)
 	lastSegment := int64(end)

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -853,6 +853,7 @@ func (r *Reader) WriteTo(writer io.Writer) (int64, error) {
 			writeBuf = writeBuf[offset:]
 		}
 		n, err := writer.Write(writeBuf)
+		totalBytes += int64(n)
 		if err != nil {
 			return totalBytes, fmt.Errorf("io.writer.write failed: %w", err)
 		}
@@ -862,7 +863,6 @@ func (r *Reader) WriteTo(writer io.Writer) (int64, error) {
 		}
 
 		payloadReadOffset += seg.EncryptedSize
-		totalBytes += int64(n)
 		r.cursor += int64(n)
 		decryptedDataOffset += seg.Size
 	}

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -483,122 +483,6 @@ func (s *TDFSuite) Test_SimpleTDF() {
 	}
 }
 
-func (s *TDFSuite) Test_TDFReader() { //nolint:gocognit // requires for testing tdf
-	for _, test := range []partialReadTdfTest{ //nolint:gochecknoglobals // requires for testing tdf
-		{
-			payload: payload, // len: 62
-			kasInfoList: []KASInfo{
-				{
-					URL:       s.kasTestURLLookup["http://localhost:65432/"],
-					PublicKey: mockRSAPublicKey1,
-				},
-				{
-					URL:       s.kasTestURLLookup["http://localhost:65432/"],
-					PublicKey: mockRSAPublicKey1,
-				},
-			},
-			readAtTests: []TestReadAt{
-				{
-					segmentSize:     2,
-					dataOffset:      26,
-					dataLength:      26,
-					expectedPayload: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-
-					whence:       io.SeekStart,
-					writerOffset: 26,
-				},
-				{
-					segmentSize:     2 * oneMB,
-					dataOffset:      61,
-					dataLength:      1,
-					expectedPayload: "9",
-
-					whence:       io.SeekEnd,
-					writerOffset: -1,
-				},
-				{
-					segmentSize:     2,
-					dataOffset:      0,
-					dataLength:      62,
-					expectedPayload: payload,
-
-					whence:       io.SeekCurrent,
-					writerOffset: 0,
-				},
-				{
-					segmentSize:     int64(len(payload)),
-					dataOffset:      0,
-					dataLength:      len(payload),
-					expectedPayload: payload,
-
-					whence:       io.SeekStart,
-					writerOffset: 0,
-				},
-				{
-					segmentSize:     1,
-					dataOffset:      26,
-					dataLength:      26,
-					expectedPayload: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-
-					whence:       io.SeekCurrent,
-					writerOffset: 26,
-				},
-			},
-		},
-	} { // create .txt file
-		kasInfoList := test.kasInfoList
-
-		// reset public keys so we have to get them from the service
-		for index := range kasInfoList {
-			kasInfoList[index].PublicKey = ""
-		}
-
-		for _, readAtTest := range test.readAtTests {
-			tdfBuf := bytes.Buffer{}
-			readSeeker := bytes.NewReader([]byte(test.payload))
-			_, err := s.sdk.CreateTDF(
-				io.Writer(&tdfBuf),
-				readSeeker,
-				WithKasInformation(kasInfoList...),
-				WithSegmentSize(readAtTest.segmentSize),
-			)
-			s.Require().NoError(err)
-
-			// test reader
-			tdfReadSeeker := bytes.NewReader(tdfBuf.Bytes())
-			r, err := s.sdk.LoadTDF(tdfReadSeeker)
-			s.Require().NoError(err)
-
-			rbuf := make([]byte, readAtTest.dataLength)
-			n, err := r.ReadAt(rbuf, readAtTest.dataOffset)
-			s.Require().NoError(err)
-
-			s.Equal(readAtTest.dataLength, n)
-			s.Equal(readAtTest.expectedPayload, string(rbuf))
-
-			// Test Read
-			{
-				fmt.Println()
-				buf := bytes.NewBuffer(make([]byte, 0))
-
-				pos, err := r.Seek(int64(readAtTest.writerOffset), readAtTest.whence)
-				s.Require().NoError(err)
-				s.Equal(readAtTest.dataOffset, pos)
-
-				n, err := r.WriteTo(buf)
-				s.Require().NoError(err)
-
-				offset := readAtTest.writerOffset
-				if offset < 0 {
-					offset = len(payload) + offset
-				}
-				s.Equal(payload[offset:], string(buf.Bytes()))
-				s.Equal(int64(len(buf.Bytes())), n)
-			}
-		}
-	}
-}
-
 func (s *TDFSuite) Test_TDF_KAS_Allowlist() {
 	type TestConfig struct {
 		tdfOptions     []TDFOption
@@ -1320,6 +1204,121 @@ func (s *TDFSuite) Test_TDFWithAssertionNegativeTests() {
 			s.Require().NotErrorIs(err, io.EOF)
 		}
 		_ = os.Remove(tdfFilename)
+	}
+}
+
+func (s *TDFSuite) Test_TDFReader() { //nolint:gocognit // requires for testing tdf
+	for _, test := range []partialReadTdfTest{ //nolint:gochecknoglobals // requires for testing tdf
+		{
+			payload: payload, // len: 62
+			kasInfoList: []KASInfo{
+				{
+					URL:       s.kasTestURLLookup["http://localhost:65432/"],
+					PublicKey: mockRSAPublicKey1,
+				},
+				{
+					URL:       s.kasTestURLLookup["http://localhost:65432/"],
+					PublicKey: mockRSAPublicKey1,
+				},
+			},
+			readAtTests: []TestReadAt{
+				{
+					segmentSize:     2,
+					dataOffset:      26,
+					dataLength:      26,
+					expectedPayload: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+
+					whence:       io.SeekStart,
+					writerOffset: 26,
+				},
+				{
+					segmentSize:     2 * oneMB,
+					dataOffset:      61,
+					dataLength:      1,
+					expectedPayload: "9",
+
+					whence:       io.SeekEnd,
+					writerOffset: -1,
+				},
+				{
+					segmentSize:     2,
+					dataOffset:      0,
+					dataLength:      62,
+					expectedPayload: payload,
+
+					whence:       io.SeekCurrent,
+					writerOffset: 0,
+				},
+				{
+					segmentSize:     int64(len(payload)),
+					dataOffset:      0,
+					dataLength:      len(payload),
+					expectedPayload: payload,
+
+					whence:       io.SeekStart,
+					writerOffset: 0,
+				},
+				{
+					segmentSize:     1,
+					dataOffset:      26,
+					dataLength:      26,
+					expectedPayload: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+
+					whence:       io.SeekCurrent,
+					writerOffset: 26,
+				},
+			},
+		},
+	} { // create .txt file
+		kasInfoList := test.kasInfoList
+
+		// reset public keys so we have to get them from the service
+		for index := range kasInfoList {
+			kasInfoList[index].PublicKey = ""
+		}
+
+		for _, readAtTest := range test.readAtTests {
+			tdfBuf := bytes.Buffer{}
+			readSeeker := bytes.NewReader([]byte(test.payload))
+			_, err := s.sdk.CreateTDF(
+				io.Writer(&tdfBuf),
+				readSeeker,
+				WithKasInformation(kasInfoList...),
+				WithSegmentSize(readAtTest.segmentSize),
+			)
+			s.Require().NoError(err)
+
+			// test reader
+			tdfReadSeeker := bytes.NewReader(tdfBuf.Bytes())
+			r, err := s.sdk.LoadTDF(tdfReadSeeker)
+			s.Require().NoError(err)
+
+			rbuf := make([]byte, readAtTest.dataLength)
+			n, err := r.ReadAt(rbuf, readAtTest.dataOffset)
+			s.Require().NoError(err)
+
+			s.Equal(readAtTest.dataLength, n)
+			s.Equal(readAtTest.expectedPayload, string(rbuf))
+
+			// Test Read
+			{
+				buf := bytes.NewBuffer(make([]byte, 0))
+
+				pos, err := r.Seek(int64(readAtTest.writerOffset), readAtTest.whence)
+				s.Require().NoError(err)
+				s.Equal(readAtTest.dataOffset, pos)
+
+				n, err := r.WriteTo(buf)
+				s.Require().NoError(err)
+
+				offset := readAtTest.writerOffset
+				if offset < 0 {
+					offset = len(payload) + offset
+				}
+				s.Equal(payload[offset:], string(buf.Bytes()))
+				s.Equal(int64(len(buf.Bytes())), n)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
### Proposed Changes

* Adds Seeking to SDK so write can have offset when using `WriteTo`. This is useful when the TDF is large but only want a specific segment from the data. 
* Also `ReadAt` had an off by one error decrypting one extra segment when it was not required to do so.

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation

### Testing Instructions

