### PR TITLE
chore(ci): Use GitHub app token for checkout action

### DIFF
--- a/.github/workflows/reusable_backport.yaml
+++ b/.github/workflows/reusable_backport.yaml
@@ -26,10 +26,6 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: true
 
       - name: "Generate a GitHub app token"
         id: generate-token
@@ -37,6 +33,12 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.AUTOMATION_KEY }}
+
+      - name: "Checkout"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: true
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: "Create backport pull requests"
         id: backport


### PR DESCRIPTION
### Proposed Changes

Persist credentials from the app token instead of the `github.token`

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

