### PR TITLE
feat(policy): Restrict deletion of pc with used key.

### DIFF
--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -97,7 +97,7 @@ func (s *KasRegistryKeySuite) Test_CreateKasKey_ProviderConfigInvalid_Fail() {
 	resp, err := s.db.PolicyClient.CreateKey(s.ctx, &req)
 	s.Require().Error(err)
 	s.Nil(resp)
-	s.Require().ErrorContains(err, db.ErrTextNotFound)
+	s.Require().ErrorContains(err, db.ErrForeignKeyViolation.Error())
 }
 
 func (s *KasRegistryKeySuite) Test_CreateKasKey_NonBase64Ctx_Fail() {

--- a/service/policy/db/key_access_server_registry.go
+++ b/service/policy/db/key_access_server_registry.go
@@ -12,7 +12,6 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/attributes"
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
-	"github.com/opentdf/platform/protocol/go/policy/keymanagement"
 	"github.com/opentdf/platform/protocol/go/policy/namespaces"
 	"github.com/opentdf/platform/service/pkg/db"
 	"github.com/opentdf/platform/service/wellknownconfiguration"
@@ -374,17 +373,6 @@ func (c PolicyDBClient) CreateKey(ctx context.Context, r *kasregistry.CreateKeyR
 		return nil, errors.Join(errors.New("private key ctx"), db.ErrExpectedBase64EncodedValue)
 	}
 
-	// Especially if we need to verify the connection and get the public key.
-	// Need provider logic to validate connection to remote provider.
-	var pc *policy.KeyProviderConfig
-	var err error
-	if providerConfigID != "" {
-		pc, err = c.GetProviderConfig(ctx, &keymanagement.GetProviderConfigRequest_Id{Id: providerConfigID})
-		if err != nil {
-			return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, kasID)
-		}
-	}
-
 	// Marshal private key and public key context
 	pubCtx, err := json.Marshal(r.GetPublicKeyCtx())
 	if err != nil {
@@ -412,7 +400,7 @@ func (c PolicyDBClient) CreateKey(ctx context.Context, r *kasregistry.CreateKeyR
 		Metadata:          metadataJSON,
 		PrivateKeyCtx:     privateCtx,
 		PublicKeyCtx:      pubCtx,
-		ProviderConfigID:  pgtypeUUID(pc.GetId()),
+		ProviderConfigID:  pgtypeUUID(providerConfigID),
 	})
 	if err != nil {
 		return nil, db.WrapIfKnownInvalidQueryErr(err)

--- a/service/policy/db/migrations/20250609000000_restrict_provider_deletion.md
+++ b/service/policy/db/migrations/20250609000000_restrict_provider_deletion.md
@@ -18,4 +18,3 @@ erDiagram
 
     key_access_server_keys }o--|| provider_config : "provider_config_id"
 ```
-<style>div.mermaid{overflow-x:scroll;}div.mermaid>svg{width:250rem;}</style>

--- a/service/policy/db/migrations/20250609000000_restrict_provider_deletion.md
+++ b/service/policy/db/migrations/20250609000000_restrict_provider_deletion.md
@@ -1,0 +1,21 @@
+```mermaid
+erDiagram
+    key_access_server_keys {
+            timestamp_with_time_zone created_at 
+            timestamp_with_time_zone expiration 
+            uuid id PK 
+            uuid key_access_server_id FK,UK 
+            integer key_algorithm 
+            character_varying key_id UK 
+            integer key_mode 
+            integer key_status 
+            jsonb metadata 
+            jsonb private_key_ctx 
+            uuid provider_config_id FK 
+            jsonb public_key_ctx 
+            timestamp_with_time_zone updated_at 
+    }
+
+    key_access_server_keys }o--|| provider_config : "provider_config_id"
+```
+<style>div.mermaid{overflow-x:scroll;}div.mermaid>svg{width:250rem;}</style>

--- a/service/policy/db/migrations/20250609000000_restrict_provider_deletion.sql
+++ b/service/policy/db/migrations/20250609000000_restrict_provider_deletion.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Do not delete provider configurations when they are referenced by asym_key
+ ALTER TABLE key_access_server_keys
+ DROP CONSTRAINT IF EXISTS key_access_server_keys_provider_config_fk;
+ 
+ ALTER TABLE key_access_server_keys
+ ADD CONSTRAINT key_access_server_keys_provider_config_fk 
+ FOREIGN KEY (provider_config_id) 
+ REFERENCES provider_config (id) 
+ ON DELETE RESTRICT;
+
+
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Revert changes for asym_key
+ ALTER TABLE key_access_server_keys
+ DROP CONSTRAINT IF EXISTS key_access_server_keys_provider_config_fk;
+ 
+ ALTER TABLE key_access_server_keys
+ ADD CONSTRAINT key_access_server_keys_provider_config_fk 
+ FOREIGN KEY (provider_config_id) 
+ REFERENCES provider_config (id);
+
+-- +goose StatementEnd

--- a/service/policy/db/schema_erd.md
+++ b/service/policy/db/schema_erd.md
@@ -116,7 +116,7 @@ erDiagram
         integer key_status 
         jsonb metadata 
         jsonb private_key_ctx 
-        uuid provider_config_id 
+        uuid provider_config_id FK 
         jsonb public_key_ctx 
         timestamp_with_time_zone updated_at 
     }
@@ -249,6 +249,7 @@ erDiagram
     subject_mappings }o--|| attribute_values : "attribute_value_id"
     base_keys }o--|| key_access_server_keys : "key_access_server_key_id"
     key_access_server_keys }o--|| key_access_servers : "key_access_server_id"
+    key_access_server_keys }o--|| provider_config : "provider_config_id"
     sym_key }o--|| provider_config : "provider_config_id"
     registered_resource_action_attribute_values }o--|| registered_resource_values : "registered_resource_value_id"
     registered_resource_values }o--|| registered_resources : "registered_resource_id"


### PR DESCRIPTION
### Proposed Changes

1.) Update **key_access_server_keys** table to not allow deletion of in-use provider configurations
2.) Remove application level check for provider_configuration, in-favor or db level

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

