### PR TITLE
feat(core): consume RPC interceptor request context metadata in logging

### DIFF
--- a/service/authorization/authorization.go
+++ b/service/authorization/authorization.go
@@ -543,7 +543,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 			}
 			return response, nil
 		}
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("fqns", strings.Join(allPertinentFQNS.GetAttributeValueFqns(), ", ")))
+		return nil, db.StatusifyError(ctx, as.logger, err, db.ErrTextGetRetrievalFailed, slog.String("fqns", strings.Join(allPertinentFQNS.GetAttributeValueFqns(), ", ")))
 	}
 
 	var allAttrDefs []*policy.Attribute
@@ -579,7 +579,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 		ecEntitlements, err := as.GetEntitlements(ctx, &req)
 		if err != nil {
 			// TODO: should all decisions in a request fail if one entity entitlement lookup fails?
-			return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("extra", "getEntitlements request failed"))
+			return nil, db.StatusifyError(ctx, as.logger, err, db.ErrTextGetRetrievalFailed, slog.String("extra", "getEntitlements request failed"))
 		}
 		ecChainEntitlementsResponse = append(ecChainEntitlementsResponse, ecEntitlements)
 	}
@@ -662,7 +662,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 				)
 				if err != nil {
 					// TODO: should all decisions in a request fail if one entity entitlement lookup fails?
-					return nil, db.StatusifyError(errors.New("could not determine access"), "could not determine access", slog.String("error", err.Error()))
+					return nil, db.StatusifyError(ctx, as.logger, errors.New("could not determine access"), "could not determine access", slog.String("error", err.Error()))
 				}
 				// check the decisions
 				decision = authorization.DecisionResponse_DECISION_PERMIT

--- a/service/logger/contextHandler.go
+++ b/service/logger/contextHandler.go
@@ -1,0 +1,45 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/opentdf/platform/service/logger/audit"
+)
+
+// ContextHandler is a custom slog.Handler that adds context attributes to log records from values set to the
+// context by the RPC interceptor. It is used to enrich log records with request-specific metadata such as
+// request ID, user agent, request IP, and actor ID.
+type ContextHandler struct {
+	handler slog.Handler
+}
+
+// Handle overrides the default Handle method to add context values set by RPC interceptor.
+func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error {
+	contextData := audit.GetAuditDataFromContext(ctx)
+
+	// Only add context attributes if RequestID is present, indicating this is part of a request
+	if contextData.RequestID != uuid.Nil {
+		r.AddAttrs(
+			slog.String("request-id", contextData.RequestID.String()),
+			slog.String("user-agent", contextData.UserAgent),
+			slog.String("request-ip", contextData.RequestIP),
+			slog.String("actor-id", contextData.ActorID),
+		)
+	}
+
+	return h.handler.Handle(ctx, r)
+}
+
+func (h *ContextHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.handler.Enabled(ctx, level)
+}
+
+func (h *ContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &ContextHandler{handler: h.handler.WithAttrs(attrs)}
+}
+
+func (h *ContextHandler) WithGroup(name string) slog.Handler {
+	return &ContextHandler{handler: h.handler.WithGroup(name)}
+}

--- a/service/logger/contextHandler.go
+++ b/service/logger/contextHandler.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/google/uuid"
+	sdkAudit "github.com/opentdf/platform/sdk/audit"
 	"github.com/opentdf/platform/service/logger/audit"
 )
 
@@ -22,10 +23,10 @@ func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error {
 	// Only add context attributes if RequestID is present, indicating this is part of a request
 	if contextData.RequestID != uuid.Nil {
 		r.AddAttrs(
-			slog.String("request-id", contextData.RequestID.String()),
-			slog.String("user-agent", contextData.UserAgent),
-			slog.String("request-ip", contextData.RequestIP),
-			slog.String("actor-id", contextData.ActorID),
+			slog.String(string(sdkAudit.RequestIDContextKey), contextData.RequestID.String()),
+			slog.String(string(sdkAudit.UserAgentContextKey), contextData.UserAgent),
+			slog.String(string(sdkAudit.RequestIPContextKey), contextData.RequestIP),
+			slog.String(string(sdkAudit.ActorIDContextKey), contextData.ActorID),
 		)
 	}
 

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -58,22 +58,23 @@ func NewLogger(config Config) (*Logger, error) {
 		return nil, err
 	}
 
+	var handler slog.Handler
 	switch config.Type {
 	case "json":
-		j := slog.NewJSONHandler(w, &slog.HandlerOptions{
+		handler = slog.NewJSONHandler(w, &slog.HandlerOptions{
 			Level:       level,
 			ReplaceAttr: logger.replaceAttrChain,
 		})
-		sLogger = slog.New(j)
 	case "text":
-		t := slog.NewTextHandler(w, &slog.HandlerOptions{
+		handler = slog.NewTextHandler(w, &slog.HandlerOptions{
 			Level:       level,
 			ReplaceAttr: logger.replaceAttrChain,
 		})
-		sLogger = slog.New(t)
 	default:
 		return nil, fmt.Errorf("invalid logger type: %s", config.Type)
 	}
+
+	sLogger = slog.New(&ContextHandler{handler})
 
 	// Audit logger will always log at the AUDIT level and be JSON formatted
 	auditLoggerHandler := slog.NewJSONHandler(w, &slog.HandlerOptions{

--- a/service/pkg/db/errors.go
+++ b/service/pkg/db/errors.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -10,6 +11,7 @@ import (
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/opentdf/platform/service/logger"
 )
 
 var (
@@ -120,60 +122,60 @@ const (
 	ErrorTextNamespaceMismatch          = "namespace mismatch"
 )
 
-func StatusifyError(err error, fallbackErr string, log ...any) error {
-	l := append([]any{"error", err}, log...)
+func StatusifyError(ctx context.Context, l *logger.Logger, err error, fallbackErr string, logs ...any) error {
+	l = l.With("error", err.Error())
 	if errors.Is(err, ErrUniqueConstraintViolation) {
-		slog.Error(ErrTextConflict, l...)
+		l.ErrorContext(ctx, ErrTextConflict, logs...)
 		return connect.NewError(connect.CodeAlreadyExists, errors.New(ErrTextConflict))
 	}
 	if errors.Is(err, ErrNotFound) {
-		slog.Error(ErrTextNotFound, l...)
+		l.ErrorContext(ctx, ErrTextNotFound, logs...)
 		return connect.NewError(connect.CodeNotFound, errors.New(ErrTextNotFound))
 	}
 	if errors.Is(err, ErrForeignKeyViolation) {
-		slog.Error(ErrTextRelationInvalid, l...)
+		l.ErrorContext(ctx, ErrTextRelationInvalid, logs...)
 		return connect.NewError(connect.CodeInvalidArgument, errors.New(ErrTextRelationInvalid))
 	}
 	if errors.Is(err, ErrEnumValueInvalid) {
-		slog.Error(ErrTextEnumValueInvalid, l...)
+		l.ErrorContext(ctx, ErrTextEnumValueInvalid, logs...)
 		return connect.NewError(connect.CodeInvalidArgument, errors.New(ErrTextEnumValueInvalid))
 	}
 	if errors.Is(err, ErrUUIDInvalid) {
-		slog.Error(ErrTextUUIDInvalid, l...)
+		l.ErrorContext(ctx, ErrTextUUIDInvalid, logs...)
 		return connect.NewError(connect.CodeInvalidArgument, errors.New(ErrTextUUIDInvalid))
 	}
 	if errors.Is(err, ErrRestrictViolation) {
-		slog.Error(ErrTextRestrictViolation, l...)
+		l.ErrorContext(ctx, ErrTextRestrictViolation, logs...)
 		return connect.NewError(connect.CodeInvalidArgument, errors.New(ErrTextRestrictViolation))
 	}
 	if errors.Is(err, ErrListLimitTooLarge) {
-		slog.Error(ErrTextListLimitTooLarge, l...)
+		l.ErrorContext(ctx, ErrTextListLimitTooLarge, logs...)
 		return connect.NewError(connect.CodeInvalidArgument, errors.New(ErrTextListLimitTooLarge))
 	}
 	if errors.Is(err, ErrSelectIdentifierInvalid) {
-		slog.Error(ErrTextInvalidIdentifier, l...)
+		l.ErrorContext(ctx, ErrTextInvalidIdentifier, logs...)
 		return connect.NewError(connect.CodeInvalidArgument, errors.New(ErrTextInvalidIdentifier))
 	}
 	if errors.Is(err, ErrUnknownSelectIdentifier) {
-		slog.Error(ErrorTextUnknownIdentifier, l...)
+		l.ErrorContext(ctx, ErrorTextUnknownIdentifier, logs...)
 		return connect.NewError(connect.CodeInvalidArgument, errors.New(ErrorTextUnknownIdentifier))
 	}
 	if errors.Is(err, ErrCannotUpdateToUnspecified) {
-		slog.Error(ErrorTextUpdateToUnspecified, l...)
+		l.ErrorContext(ctx, ErrorTextUpdateToUnspecified, logs...)
 		return connect.NewError(connect.CodeInvalidArgument, errors.New(ErrorTextUpdateToUnspecified))
 	}
 	if errors.Is(err, ErrKeyRotationFailed) {
-		slog.Error(ErrTextKeyRotationFailed, l...)
+		l.ErrorContext(ctx, ErrTextKeyRotationFailed, logs...)
 		return connect.NewError(connect.CodeInternal, errors.New(ErrTextKeyRotationFailed))
 	}
 	if errors.Is(err, ErrExpectedBase64EncodedValue) {
-		slog.Error(ErrorTextExpectedBase64EncodedValue, l...)
+		l.ErrorContext(ctx, ErrorTextExpectedBase64EncodedValue, logs...)
 		return connect.NewError(connect.CodeInvalidArgument, errors.New(ErrorTextExpectedBase64EncodedValue))
 	}
 	if errors.Is(err, ErrMarshalValueFailed) {
-		slog.Error(ErrorTextMarshalFailed, l...)
+		l.ErrorContext(ctx, ErrorTextMarshalFailed, logs...)
 		return connect.NewError(connect.CodeInvalidArgument, errors.New(ErrorTextMarshalFailed))
 	}
-	slog.Error(err.Error(), l...)
+	l.ErrorContext(ctx, err.Error(), logs...)
 	return connect.NewError(connect.CodeInternal, errors.New(fallbackErr))
 }

--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -141,7 +141,7 @@ func startServices(ctx context.Context, cfg *config.Config, otdf *server.OpenTDF
 			continue
 		}
 
-		var svcLogger *logging.Logger = logger.With("namespace", ns)
+		svcLogger := logger.With("namespace", ns)
 		extractedLogLevel, err := extractServiceLoggerConfig(cfg.Services[ns])
 
 		// If ns has log_level in config, create new logger with that level

--- a/service/policy/actions/actions.go
+++ b/service/policy/actions/actions.go
@@ -93,7 +93,7 @@ func (a *ActionService) GetAction(ctx context.Context, req *connect.Request[acti
 
 	action, err := a.dbClient.GetAction(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.Any("identifier", req.Msg.GetIdentifier()))
+		return nil, db.StatusifyError(ctx, a.logger, err, db.ErrTextGetRetrievalFailed, slog.Any("identifier", req.Msg.GetIdentifier()))
 	}
 	rsp.Action = action
 
@@ -104,7 +104,7 @@ func (a *ActionService) ListActions(ctx context.Context, req *connect.Request[ac
 	a.logger.DebugContext(ctx, "listing actions")
 	rsp, err := a.dbClient.ListActions(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, a.logger, err, db.ErrTextListRetrievalFailed)
 	}
 	a.logger.DebugContext(ctx, "listed actions")
 	return connect.NewResponse(rsp), nil
@@ -133,7 +133,7 @@ func (a *ActionService) CreateAction(ctx context.Context, req *connect.Request[a
 	})
 	if err != nil {
 		a.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("action", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, a.logger, err, db.ErrTextCreationFailed, slog.String("action", req.Msg.String()))
 	}
 	return connect.NewResponse(rsp), nil
 }
@@ -173,7 +173,7 @@ func (a *ActionService) UpdateAction(ctx context.Context, req *connect.Request[a
 	})
 	if err != nil {
 		a.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("action", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, a.logger, err, db.ErrTextUpdateFailed, slog.String("action", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -193,7 +193,7 @@ func (a *ActionService) DeleteAction(ctx context.Context, req *connect.Request[a
 	deleted, err := a.dbClient.DeleteAction(ctx, req.Msg)
 	if err != nil {
 		a.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("action", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, a.logger, err, db.ErrTextDeletionFailed, slog.String("action", req.Msg.String()))
 	}
 
 	a.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)

--- a/service/policy/attributes/attributes.go
+++ b/service/policy/attributes/attributes.go
@@ -105,7 +105,7 @@ func (s *AttributesService) CreateAttribute(ctx context.Context,
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("attribute", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("attribute", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -122,7 +122,7 @@ func (s *AttributesService) ListAttributes(ctx context.Context,
 
 	rsp, err := s.dbClient.ListAttributes(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -146,7 +146,7 @@ func (s *AttributesService) GetAttribute(ctx context.Context,
 
 	item, err := s.dbClient.GetAttribute(ctx, identifier)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.Any("id", identifier))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.Any("id", identifier))
 	}
 	rsp.Attribute = item
 
@@ -163,7 +163,7 @@ func (s *AttributesService) GetAttributeValuesByFqns(ctx context.Context,
 
 	fqnsToAttributes, err := s.dbClient.GetAttributesByValueFqns(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("fqns", fmt.Sprintf("%v", req.Msg.GetFqns())))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("fqns", fmt.Sprintf("%v", req.Msg.GetFqns())))
 	}
 	rsp.FqnAttributeValues = fqnsToAttributes
 
@@ -185,13 +185,13 @@ func (s *AttributesService) UpdateAttribute(ctx context.Context,
 	original, err := s.dbClient.GetAttribute(ctx, attributeID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", attributeID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", attributeID))
 	}
 
 	updated, err := s.dbClient.UpdateAttribute(ctx, attributeID, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("id", req.Msg.GetId()), slog.String("attribute", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", req.Msg.GetId()), slog.String("attribute", req.Msg.String()))
 	}
 
 	auditParams.Original = original
@@ -220,13 +220,13 @@ func (s *AttributesService) DeactivateAttribute(ctx context.Context,
 	original, err := s.dbClient.GetAttribute(ctx, attributeID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", attributeID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", attributeID))
 	}
 
 	updated, err := s.dbClient.DeactivateAttribute(ctx, attributeID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeactivationFailed, slog.String("id", attributeID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeactivationFailed, slog.String("id", attributeID))
 	}
 
 	auditParams.Original = original
@@ -267,7 +267,7 @@ func (s *AttributesService) CreateAttributeValue(ctx context.Context, req *conne
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("value", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -278,7 +278,7 @@ func (s *AttributesService) ListAttributeValues(ctx context.Context, req *connec
 	s.logger.DebugContext(ctx, "listing attribute values", slog.String("attributeId", req.Msg.GetAttributeId()), slog.String("state", state))
 	rsp, err := s.dbClient.ListAttributeValues(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed, slog.String("attributeId", req.Msg.GetAttributeId()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed, slog.String("attributeId", req.Msg.GetAttributeId()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -297,7 +297,7 @@ func (s *AttributesService) GetAttributeValue(ctx context.Context, req *connect.
 
 	item, err := s.dbClient.GetAttributeValue(ctx, identifier)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.Any("id", identifier))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.Any("id", identifier))
 	}
 
 	rsp.Value = item
@@ -318,13 +318,13 @@ func (s *AttributesService) UpdateAttributeValue(ctx context.Context, req *conne
 	original, err := s.dbClient.GetAttributeValue(ctx, attributeID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", attributeID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", attributeID))
 	}
 
 	updated, err := s.dbClient.UpdateAttributeValue(ctx, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("id", req.Msg.GetId()), slog.String("value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", req.Msg.GetId()), slog.String("value", req.Msg.String()))
 	}
 
 	auditParams.Original = original
@@ -351,13 +351,13 @@ func (s *AttributesService) DeactivateAttributeValue(ctx context.Context, req *c
 	original, err := s.dbClient.GetAttributeValue(ctx, attributeID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", attributeID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", attributeID))
 	}
 
 	updated, err := s.dbClient.DeactivateAttributeValue(ctx, attributeID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeactivationFailed, slog.String("id", attributeID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeactivationFailed, slog.String("id", attributeID))
 	}
 
 	auditParams.Original = original
@@ -380,7 +380,7 @@ func (s *AttributesService) AssignKeyAccessServerToAttribute(ctx context.Context
 	attributeKas, err := s.dbClient.AssignKeyAccessServerToAttribute(ctx, req.Msg.GetAttributeKeyAccessServer())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("attributeKas", req.Msg.GetAttributeKeyAccessServer().String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("attributeKas", req.Msg.GetAttributeKeyAccessServer().String()))
 	}
 
 	auditParams.ObjectID = attributeKas.GetAttributeId()
@@ -403,7 +403,7 @@ func (s *AttributesService) RemoveKeyAccessServerFromAttribute(ctx context.Conte
 	attributeKas, err := s.dbClient.RemoveKeyAccessServerFromAttribute(ctx, req.Msg.GetAttributeKeyAccessServer())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("attributeKas", req.Msg.GetAttributeKeyAccessServer().String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("attributeKas", req.Msg.GetAttributeKeyAccessServer().String()))
 	}
 
 	auditParams.ObjectID = attributeKas.GetAttributeId()
@@ -427,7 +427,7 @@ func (s *AttributesService) AssignKeyAccessServerToValue(ctx context.Context, re
 	valueKas, err := s.dbClient.AssignKeyAccessServerToValue(ctx, req.Msg.GetValueKeyAccessServer())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("attributeValueKas", req.Msg.GetValueKeyAccessServer().String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("attributeValueKas", req.Msg.GetValueKeyAccessServer().String()))
 	}
 
 	auditParams.ObjectID = valueKas.GetValueId()
@@ -450,7 +450,7 @@ func (s *AttributesService) RemoveKeyAccessServerFromValue(ctx context.Context, 
 	valueKas, err := s.dbClient.RemoveKeyAccessServerFromValue(ctx, req.Msg.GetValueKeyAccessServer())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("attributeValueKas", req.Msg.GetValueKeyAccessServer().String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("attributeValueKas", req.Msg.GetValueKeyAccessServer().String()))
 	}
 
 	auditParams.ObjectID = valueKas.GetValueId()
@@ -473,7 +473,7 @@ func (s *AttributesService) AssignPublicKeyToAttribute(ctx context.Context, r *c
 	ak, err := s.dbClient.AssignPublicKeyToAttribute(ctx, r.Msg.GetAttributeKey())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("attributeKey", r.Msg.GetAttributeKey().String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("attributeKey", r.Msg.GetAttributeKey().String()))
 	}
 
 	auditParams.ObjectID = ak.GetAttributeId()
@@ -495,7 +495,7 @@ func (s *AttributesService) RemovePublicKeyFromAttribute(ctx context.Context, r 
 	ak, err := s.dbClient.RemovePublicKeyFromAttribute(ctx, r.Msg.GetAttributeKey())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("attributeKey", r.Msg.GetAttributeKey().String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("attributeKey", r.Msg.GetAttributeKey().String()))
 	}
 
 	auditParams.ObjectID = ak.GetAttributeId()
@@ -516,7 +516,7 @@ func (s *AttributesService) AssignPublicKeyToValue(ctx context.Context, r *conne
 	vk, err := s.dbClient.AssignPublicKeyToValue(ctx, r.Msg.GetValueKey())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("attributeKey", r.Msg.GetValueKey().String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("attributeKey", r.Msg.GetValueKey().String()))
 	}
 
 	auditParams.ObjectID = vk.GetValueId()
@@ -538,7 +538,7 @@ func (s *AttributesService) RemovePublicKeyFromValue(ctx context.Context, r *con
 	vk, err := s.dbClient.RemovePublicKeyFromValue(ctx, r.Msg.GetValueKey())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("attributeKey", r.Msg.GetValueKey().String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("attributeKey", r.Msg.GetValueKey().String()))
 	}
 
 	auditParams.ObjectID = vk.GetValueId()

--- a/service/policy/attributes/attributes.go
+++ b/service/policy/attributes/attributes.go
@@ -80,7 +80,7 @@ func (s *AttributesService) Close() {
 func (s *AttributesService) CreateAttribute(ctx context.Context,
 	req *connect.Request[attributes.CreateAttributeRequest],
 ) (*connect.Response[attributes.CreateAttributeResponse], error) {
-	s.logger.Debug("creating new attribute definition", slog.String("name", req.Msg.GetName()))
+	s.logger.DebugContext(ctx, "creating new attribute definition", slog.String("name", req.Msg.GetName()))
 	rsp := &attributes.CreateAttributeResponse{}
 
 	auditParams := audit.PolicyEventParams{
@@ -95,7 +95,7 @@ func (s *AttributesService) CreateAttribute(ctx context.Context,
 			return err
 		}
 
-		s.logger.Debug("created new attribute definition", slog.String("name", req.Msg.GetName()))
+		s.logger.DebugContext(ctx, "created new attribute definition", slog.String("name", req.Msg.GetName()))
 
 		auditParams.ObjectID = item.GetId()
 		auditParams.Original = item
@@ -118,7 +118,7 @@ func (s *AttributesService) ListAttributes(ctx context.Context,
 	defer span.End()
 
 	state := req.Msg.GetState().String()
-	s.logger.Debug("listing attribute definitions", slog.String("state", state))
+	s.logger.DebugContext(ctx, "listing attribute definitions", slog.String("state", state))
 
 	rsp, err := s.dbClient.ListAttributes(ctx, req.Msg)
 	if err != nil {
@@ -275,7 +275,7 @@ func (s *AttributesService) CreateAttributeValue(ctx context.Context, req *conne
 
 func (s *AttributesService) ListAttributeValues(ctx context.Context, req *connect.Request[attributes.ListAttributeValuesRequest]) (*connect.Response[attributes.ListAttributeValuesResponse], error) {
 	state := req.Msg.GetState().String()
-	s.logger.Debug("listing attribute values", slog.String("attributeId", req.Msg.GetAttributeId()), slog.String("state", state))
+	s.logger.DebugContext(ctx, "listing attribute values", slog.String("attributeId", req.Msg.GetAttributeId()), slog.String("state", state))
 	rsp, err := s.dbClient.ListAttributeValues(ctx, req.Msg)
 	if err != nil {
 		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed, slog.String("attributeId", req.Msg.GetAttributeId()))

--- a/service/policy/db/namespaces.go
+++ b/service/policy/db/namespaces.go
@@ -56,7 +56,7 @@ func (c PolicyDBClient) GetNamespace(ctx context.Context, identifier any) (*poli
 	if ns.Grants != nil {
 		grants, err = db.KeyAccessServerProtoJSON(ns.Grants)
 		if err != nil {
-			c.logger.Error("could not unmarshal grants", slog.String("error", err.Error()))
+			c.logger.ErrorContext(ctx, "could not unmarshal grants", slog.String("error", err.Error()))
 			return nil, err
 		}
 	}
@@ -65,7 +65,7 @@ func (c PolicyDBClient) GetNamespace(ctx context.Context, identifier any) (*poli
 	if len(ns.Keys) > 0 {
 		keys, err = db.SimpleKasKeysProtoJSON(ns.Keys)
 		if err != nil {
-			c.logger.Error("could not unmarshal keys", slog.String("error", err.Error()))
+			c.logger.ErrorContext(ctx, "could not unmarshal keys", slog.String("error", err.Error()))
 			return nil, err
 		}
 	}

--- a/service/policy/db/registered_resources.go
+++ b/service/policy/db/registered_resources.go
@@ -325,7 +325,7 @@ func (c PolicyDBClient) GetRegisteredResourceValuesByFQNs(ctx context.Context, r
 			},
 		})
 		if err != nil {
-			c.logger.Error("registered resource value for FQN not found", slog.String("fqn", fqn), slog.Any("err", err))
+			c.logger.ErrorContext(ctx, "registered resource value for FQN not found", slog.String("fqn", fqn), slog.Any("err", err))
 			return nil, db.WrapIfKnownInvalidQueryErr(err)
 		}
 

--- a/service/policy/kasregistry/key_access_server_registry.go
+++ b/service/policy/kasregistry/key_access_server_registry.go
@@ -97,7 +97,7 @@ func (s KeyAccessServerRegistry) CreateKeyAccessServer(ctx context.Context,
 ) (*connect.Response[kasr.CreateKeyAccessServerResponse], error) {
 	rsp := &kasr.CreateKeyAccessServerResponse{}
 
-	s.logger.Debug("creating key access server")
+	s.logger.DebugContext(ctx, "creating key access server")
 
 	auditParams := audit.PolicyEventParams{
 		ActionType: audit.ActionTypeCreate,
@@ -227,7 +227,7 @@ func (s KeyAccessServerRegistry) ListKeyAccessServerGrants(ctx context.Context,
 }
 
 func (s KeyAccessServerRegistry) CreateKey(ctx context.Context, r *connect.Request[kasr.CreateKeyRequest]) (*connect.Response[kasr.CreateKeyResponse], error) {
-	s.logger.Debug("creating key", slog.String("keyAccessServer Keys", r.Msg.GetKasId()))
+	s.logger.DebugContext(ctx, "creating key", slog.String("keyAccessServer Keys", r.Msg.GetKasId()))
 
 	resp := &kasr.CreateKeyResponse{}
 	auditParams := audit.PolicyEventParams{
@@ -275,7 +275,7 @@ func (s KeyAccessServerRegistry) CreateKey(ctx context.Context, r *connect.Reque
 
 func (s KeyAccessServerRegistry) UpdateKey(ctx context.Context, req *connect.Request[kasr.UpdateKeyRequest]) (*connect.Response[kasr.UpdateKeyResponse], error) {
 	rsp := &kasr.UpdateKeyResponse{}
-	s.logger.Debug("updating key", slog.String("keyAccessServer Keys", req.Msg.GetId()))
+	s.logger.DebugContext(ctx, "updating key", slog.String("keyAccessServer Keys", req.Msg.GetId()))
 
 	auditParams := audit.PolicyEventParams{
 		ActionType: audit.ActionTypeUpdate,
@@ -326,9 +326,9 @@ func (s KeyAccessServerRegistry) GetKey(ctx context.Context, r *connect.Request[
 
 	switch i := r.Msg.GetIdentifier().(type) {
 	case *kasr.GetKeyRequest_Id:
-		s.logger.Debug("Getting keyAccessServer key by ID", slog.String("ID", i.Id))
+		s.logger.DebugContext(ctx, "Getting keyAccessServer key by ID", slog.String("ID", i.Id))
 	case *kasr.GetKeyRequest_Key:
-		s.logger.Debug("Getting keyAccessServer by Key", slog.String("Key Id", i.Key.GetKid()))
+		s.logger.DebugContext(ctx, "Getting keyAccessServer by Key", slog.String("Key Id", i.Key.GetKid()))
 	default:
 		return nil, connect.NewError(connect.CodeInvalidArgument, nil)
 	}
@@ -353,7 +353,7 @@ func (s KeyAccessServerRegistry) GetKey(ctx context.Context, r *connect.Request[
 }
 
 func (s KeyAccessServerRegistry) ListKeys(ctx context.Context, r *connect.Request[kasr.ListKeysRequest]) (*connect.Response[kasr.ListKeysResponse], error) {
-	s.logger.Debug("Listing KAS Keys")
+	s.logger.DebugContext(ctx, "Listing KAS Keys")
 	resp, err := s.dbClient.ListKeys(ctx, r.Msg)
 	if err != nil {
 		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed, slog.String("keyAccessServer Keys", r.Msg.String()))
@@ -369,13 +369,13 @@ func (s KeyAccessServerRegistry) RotateKey(ctx context.Context, r *connect.Reque
 
 	switch i := r.Msg.GetActiveKey().(type) {
 	case *kasr.RotateKeyRequest_Id:
-		s.logger.Debug("Rotating key by ID", slog.String("ID", i.Id))
+		s.logger.DebugContext(ctx, "Rotating key by ID", slog.String("ID", i.Id))
 		objectID = i.Id
 		identifier = &kasr.GetKeyRequest_Id{
 			Id: i.Id,
 		}
 	case *kasr.RotateKeyRequest_Key:
-		s.logger.Debug("Rotating key by Kas Key", slog.String("Active Key ID", i.Key.GetKid()), slog.String("New Key ID", r.Msg.GetNewKey().GetKeyId()))
+		s.logger.DebugContext(ctx, "Rotating key by Kas Key", slog.String("Active Key ID", i.Key.GetKid()), slog.String("New Key ID", r.Msg.GetNewKey().GetKeyId()))
 		objectID = i.Key.GetKid()
 		identifier = &kasr.GetKeyRequest_Key{
 			Key: i.Key,
@@ -450,10 +450,10 @@ func (s KeyAccessServerRegistry) SetBaseKey(ctx context.Context, r *connect.Requ
 	var objectID string
 	switch i := r.Msg.GetActiveKey().(type) {
 	case *kasr.SetBaseKeyRequest_Id:
-		s.logger.Debug("Setting base key by ID", slog.String("ID", i.Id))
+		s.logger.DebugContext(ctx, "Setting base key by ID", slog.String("ID", i.Id))
 		objectID = i.Id
 	case *kasr.SetBaseKeyRequest_Key:
-		s.logger.Debug("Setting base key by Key ID", slog.String("Active Key ID", i.Key.GetKid()))
+		s.logger.DebugContext(ctx, "Setting base key by Key ID", slog.String("Active Key ID", i.Key.GetKid()))
 		objectID = i.Key.GetKid()
 	default:
 		return nil, connect.NewError(connect.CodeInvalidArgument, nil)
@@ -469,7 +469,7 @@ func (s KeyAccessServerRegistry) SetBaseKey(ctx context.Context, r *connect.Requ
 		var err error
 		resp, err = txClient.SetBaseKey(ctx, r.Msg)
 		if err != nil {
-			s.logger.Error("failed to set default key", slog.String("error", err.Error()))
+			s.logger.ErrorContext(ctx, "failed to set default key", slog.String("error", err.Error()))
 			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 			return err
 		}
@@ -488,7 +488,7 @@ func (s KeyAccessServerRegistry) SetBaseKey(ctx context.Context, r *connect.Requ
 }
 
 func (s KeyAccessServerRegistry) GetBaseKey(ctx context.Context, _ *connect.Request[kasr.GetBaseKeyRequest]) (*connect.Response[kasr.GetBaseKeyResponse], error) {
-	s.logger.Debug("Getting Base Key")
+	s.logger.DebugContext(ctx, "Getting Base Key")
 	resp := &kasr.GetBaseKeyResponse{}
 
 	key, err := s.dbClient.GetBaseKey(ctx)

--- a/service/policy/kasregistry/key_access_server_registry.go
+++ b/service/policy/kasregistry/key_access_server_registry.go
@@ -107,7 +107,7 @@ func (s KeyAccessServerRegistry) CreateKeyAccessServer(ctx context.Context,
 	ks, err := s.dbClient.CreateKeyAccessServer(ctx, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("keyAccessServer", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("keyAccessServer", req.Msg.String()))
 	}
 
 	auditParams.ObjectID = ks.GetId()
@@ -124,7 +124,7 @@ func (s KeyAccessServerRegistry) ListKeyAccessServers(ctx context.Context,
 ) (*connect.Response[kasr.ListKeyAccessServersResponse], error) {
 	rsp, err := s.dbClient.ListKeyAccessServers(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -145,7 +145,7 @@ func (s KeyAccessServerRegistry) GetKeyAccessServer(ctx context.Context,
 
 	keyAccessServer, err := s.dbClient.GetKeyAccessServer(ctx, identifier)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.Any("id", identifier))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.Any("id", identifier))
 	}
 
 	rsp.KeyAccessServer = keyAccessServer
@@ -169,13 +169,13 @@ func (s KeyAccessServerRegistry) UpdateKeyAccessServer(ctx context.Context,
 	original, err := s.dbClient.GetKeyAccessServer(ctx, kasID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", kasID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", kasID))
 	}
 
 	updated, err := s.dbClient.UpdateKeyAccessServer(ctx, kasID, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("id", kasID), slog.String("keyAccessServer", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", kasID), slog.String("keyAccessServer", req.Msg.String()))
 	}
 
 	auditParams.Original = original
@@ -204,7 +204,7 @@ func (s KeyAccessServerRegistry) DeleteKeyAccessServer(ctx context.Context,
 	_, err := s.dbClient.DeleteKeyAccessServer(ctx, req.Msg.GetId())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("id", req.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", req.Msg.GetId()))
 	}
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
 
@@ -220,7 +220,7 @@ func (s KeyAccessServerRegistry) ListKeyAccessServerGrants(ctx context.Context,
 ) (*connect.Response[kasr.ListKeyAccessServerGrantsResponse], error) {
 	rsp, err := s.dbClient.ListKeyAccessServerGrants(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -267,7 +267,7 @@ func (s KeyAccessServerRegistry) CreateKey(ctx context.Context, r *connect.Reque
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("keyAccessServer Keys", r.Msg.GetKasId()), slog.String("key id", r.Msg.GetKeyId()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("keyAccessServer Keys", r.Msg.GetKasId()), slog.String("key id", r.Msg.GetKeyId()))
 	}
 
 	return connect.NewResponse(resp), nil
@@ -288,7 +288,7 @@ func (s KeyAccessServerRegistry) UpdateKey(ctx context.Context, req *connect.Req
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("keyAccessServer Keys", req.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("keyAccessServer Keys", req.Msg.GetId()))
 	}
 
 	err = s.dbClient.RunInTx(ctx, func(txClient *policydb.PolicyDBClient) error {
@@ -315,7 +315,7 @@ func (s KeyAccessServerRegistry) UpdateKey(ctx context.Context, req *connect.Req
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("keyAccessServer Keys", req.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("keyAccessServer Keys", req.Msg.GetId()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -341,7 +341,7 @@ func (s KeyAccessServerRegistry) GetKey(ctx context.Context, r *connect.Request[
 	key, err := s.dbClient.GetKey(ctx, r.Msg.GetIdentifier())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("keyAccessServer Keys", r.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("keyAccessServer Keys", r.Msg.String()))
 	}
 
 	auditParams.ObjectID = key.GetKey().GetKeyId()
@@ -356,7 +356,7 @@ func (s KeyAccessServerRegistry) ListKeys(ctx context.Context, r *connect.Reques
 	s.logger.DebugContext(ctx, "Listing KAS Keys")
 	resp, err := s.dbClient.ListKeys(ctx, r.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed, slog.String("keyAccessServer Keys", r.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed, slog.String("keyAccessServer Keys", r.Msg.String()))
 	}
 
 	return connect.NewResponse(resp), nil
@@ -393,7 +393,7 @@ func (s KeyAccessServerRegistry) RotateKey(ctx context.Context, r *connect.Reque
 	original, err := s.dbClient.GetKey(ctx, identifier)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("keyAccessServer Keys", objectID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("keyAccessServer Keys", objectID))
 	}
 
 	auditParams.Original = &policy.KasKey{
@@ -437,7 +437,7 @@ func (s KeyAccessServerRegistry) RotateKey(ctx context.Context, r *connect.Reque
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextKeyRotationFailed, slog.String("Active Key ID", objectID), slog.String("New Key ID", r.Msg.GetNewKey().GetKeyId()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextKeyRotationFailed, slog.String("Active Key ID", objectID), slog.String("New Key ID", r.Msg.GetNewKey().GetKeyId()))
 	}
 
 	// Implementation for RotateKey
@@ -481,7 +481,7 @@ func (s KeyAccessServerRegistry) SetBaseKey(ctx context.Context, r *connect.Requ
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("SetDefaultKey", r.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("SetDefaultKey", r.Msg.GetId()))
 	}
 
 	return connect.NewResponse(resp), nil
@@ -493,7 +493,7 @@ func (s KeyAccessServerRegistry) GetBaseKey(ctx context.Context, _ *connect.Requ
 
 	key, err := s.dbClient.GetBaseKey(ctx)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed)
 	}
 	resp.BaseKey = key
 	return connect.NewResponse(resp), nil

--- a/service/policy/keymanagement/key_management.go
+++ b/service/policy/keymanagement/key_management.go
@@ -74,7 +74,7 @@ func (ksvc *Service) Close() {
 func (ksvc Service) CreateProviderConfig(ctx context.Context, req *connect.Request[keyMgmtProto.CreateProviderConfigRequest]) (*connect.Response[keyMgmtProto.CreateProviderConfigResponse], error) {
 	rsp := &keyMgmtProto.CreateProviderConfigResponse{}
 
-	ksvc.logger.Debug("Creating Provider Config")
+	ksvc.logger.DebugContext(ctx, "Creating Provider Config")
 
 	auditParams := audit.PolicyEventParams{
 		ActionType: audit.ActionTypeCreate,
@@ -111,9 +111,9 @@ func (ksvc Service) GetProviderConfig(ctx context.Context, req *connect.Request[
 
 	switch req := req.Msg.GetIdentifier().(type) {
 	case *keyMgmtProto.GetProviderConfigRequest_Id:
-		ksvc.logger.Debug("Getting Provider config by ID", slog.String("ID", req.Id))
+		ksvc.logger.DebugContext(ctx, "Getting Provider config by ID", slog.String("ID", req.Id))
 	case *keyMgmtProto.GetProviderConfigRequest_Name:
-		ksvc.logger.Debug("Getting Provider config by Name", slog.String("Name", req.Name))
+		ksvc.logger.DebugContext(ctx, "Getting Provider config by Name", slog.String("Name", req.Name))
 	default:
 		return nil, connect.NewError(connect.CodeInvalidArgument, nil)
 	}
@@ -128,7 +128,7 @@ func (ksvc Service) GetProviderConfig(ctx context.Context, req *connect.Request[
 }
 
 func (ksvc Service) ListProviderConfigs(ctx context.Context, req *connect.Request[keyMgmtProto.ListProviderConfigsRequest]) (*connect.Response[keyMgmtProto.ListProviderConfigsResponse], error) {
-	ksvc.logger.Debug("Listing Provider Configs")
+	ksvc.logger.DebugContext(ctx, "Listing Provider Configs")
 
 	resp, err := ksvc.dbClient.ListProviderConfigs(ctx, req.Msg.GetPagination())
 	if err != nil {
@@ -142,7 +142,7 @@ func (ksvc Service) UpdateProviderConfig(ctx context.Context, req *connect.Reque
 	rsp := &keyMgmtProto.UpdateProviderConfigResponse{}
 	providerConfigID := req.Msg.GetId()
 
-	ksvc.logger.Debug("Updating Provider Config", slog.String("id", req.Msg.GetId()))
+	ksvc.logger.DebugContext(ctx, "Updating Provider Config", slog.String("id", req.Msg.GetId()))
 
 	auditParams := audit.PolicyEventParams{
 		ActionType: audit.ActionTypeUpdate,
@@ -192,7 +192,7 @@ func (ksvc Service) UpdateProviderConfig(ctx context.Context, req *connect.Reque
 func (ksvc Service) DeleteProviderConfig(ctx context.Context, req *connect.Request[keyMgmtProto.DeleteProviderConfigRequest]) (*connect.Response[keyMgmtProto.DeleteProviderConfigResponse], error) {
 	rsp := &keyMgmtProto.DeleteProviderConfigResponse{}
 
-	ksvc.logger.Debug("Deleting Provider Config", slog.String("id", req.Msg.GetId()))
+	ksvc.logger.DebugContext(ctx, "Deleting Provider Config", slog.String("id", req.Msg.GetId()))
 
 	auditParams := audit.PolicyEventParams{
 		ActionType: audit.ActionTypeDelete,

--- a/service/policy/keymanagement/key_management.go
+++ b/service/policy/keymanagement/key_management.go
@@ -100,7 +100,7 @@ func (ksvc Service) CreateProviderConfig(ctx context.Context, req *connect.Reque
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("keyManagementService", req.Msg.GetName()))
+		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextCreationFailed, slog.String("keyManagementService", req.Msg.GetName()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -120,7 +120,7 @@ func (ksvc Service) GetProviderConfig(ctx context.Context, req *connect.Request[
 
 	pc, err := ksvc.dbClient.GetProviderConfig(ctx, req.Msg.GetIdentifier())
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("keyManagementService", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextGetRetrievalFailed, slog.String("keyManagementService", req.Msg.String()))
 	}
 
 	rsp.ProviderConfig = pc
@@ -132,7 +132,7 @@ func (ksvc Service) ListProviderConfigs(ctx context.Context, req *connect.Reques
 
 	resp, err := ksvc.dbClient.ListProviderConfigs(ctx, req.Msg.GetPagination())
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("keyManagementService", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextGetRetrievalFailed, slog.String("keyManagementService", req.Msg.String()))
 	}
 
 	return connect.NewResponse(resp), nil
@@ -155,7 +155,7 @@ func (ksvc Service) UpdateProviderConfig(ctx context.Context, req *connect.Reque
 	})
 	if err != nil {
 		ksvc.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", providerConfigID))
+		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", providerConfigID))
 	}
 
 	err = ksvc.dbClient.RunInTx(ctx, func(txClient *policydb.PolicyDBClient) error {
@@ -183,7 +183,7 @@ func (ksvc Service) UpdateProviderConfig(ctx context.Context, req *connect.Reque
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("keyManagementService", req.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextUpdateFailed, slog.String("keyManagementService", req.Msg.GetId()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -202,7 +202,7 @@ func (ksvc Service) DeleteProviderConfig(ctx context.Context, req *connect.Reque
 	pc, err := ksvc.dbClient.DeleteProviderConfig(ctx, req.Msg.GetId())
 	if err != nil {
 		ksvc.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("keyManagementService", req.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextDeletionFailed, slog.String("keyManagementService", req.Msg.GetId()))
 	}
 
 	auditParams.ObjectID = pc.GetId()

--- a/service/policy/namespaces/namespaces.go
+++ b/service/policy/namespaces/namespaces.go
@@ -88,14 +88,14 @@ func (ns *NamespacesService) Close() {
 
 func (ns NamespacesService) ListNamespaces(ctx context.Context, req *connect.Request[namespaces.ListNamespacesRequest]) (*connect.Response[namespaces.ListNamespacesResponse], error) {
 	state := req.Msg.GetState().String()
-	ns.logger.Debug("listing namespaces", slog.String("state", state))
+	ns.logger.DebugContext(ctx, "listing namespaces", slog.String("state", state))
 
 	rsp, err := ns.dbClient.ListNamespaces(ctx, req.Msg)
 	if err != nil {
 		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
 	}
 
-	ns.logger.Debug("listed namespaces")
+	ns.logger.DebugContext(ctx, "listed namespaces")
 
 	return connect.NewResponse(rsp), nil
 }
@@ -111,7 +111,7 @@ func (ns NamespacesService) GetNamespace(ctx context.Context, req *connect.Reque
 		identifier = req.Msg.GetIdentifier()
 	}
 
-	ns.logger.Debug("getting namespace", slog.Any("id", identifier))
+	ns.logger.DebugContext(ctx, "getting namespace", slog.Any("id", identifier))
 
 	namespace, err := ns.dbClient.GetNamespace(ctx, identifier)
 	if err != nil {
@@ -124,7 +124,7 @@ func (ns NamespacesService) GetNamespace(ctx context.Context, req *connect.Reque
 }
 
 func (ns NamespacesService) CreateNamespace(ctx context.Context, req *connect.Request[namespaces.CreateNamespaceRequest]) (*connect.Response[namespaces.CreateNamespaceResponse], error) {
-	ns.logger.Debug("creating new namespace", slog.String("name", req.Msg.GetName()))
+	ns.logger.DebugContext(ctx, "creating new namespace", slog.String("name", req.Msg.GetName()))
 	auditParams := audit.PolicyEventParams{
 		ActionType: audit.ActionTypeCreate,
 		ObjectType: audit.ObjectTypeNamespace,
@@ -142,7 +142,7 @@ func (ns NamespacesService) CreateNamespace(ctx context.Context, req *connect.Re
 		auditParams.Original = n
 		ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
 
-		ns.logger.Debug("created new namespace", slog.String("name", req.Msg.GetName()))
+		ns.logger.DebugContext(ctx, "created new namespace", slog.String("name", req.Msg.GetName()))
 		rsp.Namespace = n
 
 		return nil
@@ -156,7 +156,7 @@ func (ns NamespacesService) CreateNamespace(ctx context.Context, req *connect.Re
 
 func (ns NamespacesService) UpdateNamespace(ctx context.Context, req *connect.Request[namespaces.UpdateNamespaceRequest]) (*connect.Response[namespaces.UpdateNamespaceResponse], error) {
 	namespaceID := req.Msg.GetId()
-	ns.logger.Debug("updating namespace", slog.String("name", namespaceID))
+	ns.logger.DebugContext(ctx, "updating namespace", slog.String("name", namespaceID))
 	rsp := &namespaces.UpdateNamespaceResponse{}
 
 	auditParams := audit.PolicyEventParams{
@@ -181,7 +181,7 @@ func (ns NamespacesService) UpdateNamespace(ctx context.Context, req *connect.Re
 	auditParams.Updated = updated
 
 	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
-	ns.logger.Debug("updated namespace", slog.String("id", namespaceID))
+	ns.logger.DebugContext(ctx, "updated namespace", slog.String("id", namespaceID))
 
 	rsp.Namespace = &policy.Namespace{
 		Id: namespaceID,
@@ -192,7 +192,7 @@ func (ns NamespacesService) UpdateNamespace(ctx context.Context, req *connect.Re
 func (ns NamespacesService) DeactivateNamespace(ctx context.Context, req *connect.Request[namespaces.DeactivateNamespaceRequest]) (*connect.Response[namespaces.DeactivateNamespaceResponse], error) {
 	namespaceID := req.Msg.GetId()
 
-	ns.logger.Debug("deactivating namespace", slog.String("id", namespaceID))
+	ns.logger.DebugContext(ctx, "deactivating namespace", slog.String("id", namespaceID))
 	rsp := &namespaces.DeactivateNamespaceResponse{}
 
 	auditParams := audit.PolicyEventParams{
@@ -216,7 +216,7 @@ func (ns NamespacesService) DeactivateNamespace(ctx context.Context, req *connec
 	auditParams.Original = original
 	auditParams.Updated = updated
 	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
-	ns.logger.Debug("soft-deleted namespace", slog.String("id", namespaceID))
+	ns.logger.DebugContext(ctx, "soft-deleted namespace", slog.String("id", namespaceID))
 
 	return connect.NewResponse(rsp), nil
 }

--- a/service/policy/namespaces/namespaces.go
+++ b/service/policy/namespaces/namespaces.go
@@ -92,7 +92,7 @@ func (ns NamespacesService) ListNamespaces(ctx context.Context, req *connect.Req
 
 	rsp, err := ns.dbClient.ListNamespaces(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	ns.logger.DebugContext(ctx, "listed namespaces")
@@ -115,7 +115,7 @@ func (ns NamespacesService) GetNamespace(ctx context.Context, req *connect.Reque
 
 	namespace, err := ns.dbClient.GetNamespace(ctx, identifier)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.Any("id", identifier))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextGetRetrievalFailed, slog.Any("id", identifier))
 	}
 
 	rsp.Namespace = namespace
@@ -148,7 +148,7 @@ func (ns NamespacesService) CreateNamespace(ctx context.Context, req *connect.Re
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("namespace", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextCreationFailed, slog.String("namespace", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -168,13 +168,13 @@ func (ns NamespacesService) UpdateNamespace(ctx context.Context, req *connect.Re
 	original, err := ns.dbClient.GetNamespace(ctx, namespaceID)
 	if err != nil {
 		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", namespaceID))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", namespaceID))
 	}
 
 	updated, err := ns.dbClient.UpdateNamespace(ctx, namespaceID, req.Msg)
 	if err != nil {
 		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("id", namespaceID))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextUpdateFailed, slog.String("id", namespaceID))
 	}
 
 	auditParams.Original = original
@@ -204,13 +204,13 @@ func (ns NamespacesService) DeactivateNamespace(ctx context.Context, req *connec
 	original, err := ns.dbClient.GetNamespace(ctx, namespaceID)
 	if err != nil {
 		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", namespaceID))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", namespaceID))
 	}
 
 	updated, err := ns.dbClient.DeactivateNamespace(ctx, namespaceID)
 	if err != nil {
 		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("id", namespaceID))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextDeletionFailed, slog.String("id", namespaceID))
 	}
 
 	auditParams.Original = original
@@ -234,7 +234,7 @@ func (ns NamespacesService) AssignKeyAccessServerToNamespace(ctx context.Context
 	namespaceKas, err := ns.dbClient.AssignKeyAccessServerToNamespace(ctx, grant)
 	if err != nil {
 		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("namespaceKas", grant.String()))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextCreationFailed, slog.String("namespaceKas", grant.String()))
 	}
 	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
 
@@ -256,7 +256,7 @@ func (ns NamespacesService) RemoveKeyAccessServerFromNamespace(ctx context.Conte
 	namespaceKas, err := ns.dbClient.RemoveKeyAccessServerFromNamespace(ctx, grant)
 	if err != nil {
 		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("namespaceKas", grant.String()))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextDeletionFailed, slog.String("namespaceKas", grant.String()))
 	}
 	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
 
@@ -278,7 +278,7 @@ func (ns NamespacesService) AssignPublicKeyToNamespace(ctx context.Context, r *c
 	namespaceKey, err := ns.dbClient.AssignPublicKeyToNamespace(ctx, key)
 	if err != nil {
 		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("namespaceKey", key.String()))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextCreationFailed, slog.String("namespaceKey", key.String()))
 	}
 	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
 
@@ -300,7 +300,7 @@ func (ns NamespacesService) RemovePublicKeyFromNamespace(ctx context.Context, r 
 	_, err := ns.dbClient.RemovePublicKeyFromNamespace(ctx, key)
 	if err != nil {
 		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("namespaceKey", key.String()))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextDeletionFailed, slog.String("namespaceKey", key.String()))
 	}
 	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
 

--- a/service/policy/registeredresources/registered_resources.go
+++ b/service/policy/registeredresources/registered_resources.go
@@ -109,7 +109,7 @@ func (s *RegisteredResourcesService) CreateRegisteredResource(ctx context.Contex
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("registered resource", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("registered resource", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -122,7 +122,7 @@ func (s *RegisteredResourcesService) GetRegisteredResource(ctx context.Context, 
 
 	resource, err := s.dbClient.GetRegisteredResource(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.Any("identifier", req.Msg.GetIdentifier()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.Any("identifier", req.Msg.GetIdentifier()))
 	}
 	rsp.Resource = resource
 
@@ -134,7 +134,7 @@ func (s *RegisteredResourcesService) ListRegisteredResources(ctx context.Context
 
 	rsp, err := s.dbClient.ListRegisteredResources(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	s.logger.DebugContext(ctx, "listed registered resources")
@@ -179,7 +179,7 @@ func (s *RegisteredResourcesService) UpdateRegisteredResource(ctx context.Contex
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("registered resource", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("registered resource", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -201,7 +201,7 @@ func (s *RegisteredResourcesService) DeleteRegisteredResource(ctx context.Contex
 	deleted, err := s.dbClient.DeleteRegisteredResource(ctx, resourceID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("registered resource", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("registered resource", req.Msg.String()))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
@@ -238,7 +238,7 @@ func (s *RegisteredResourcesService) CreateRegisteredResourceValue(ctx context.C
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("registered resource value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("registered resource value", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -251,7 +251,7 @@ func (s *RegisteredResourcesService) GetRegisteredResourceValue(ctx context.Cont
 
 	value, err := s.dbClient.GetRegisteredResourceValue(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.Any("identifier", req.Msg.GetIdentifier()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.Any("identifier", req.Msg.GetIdentifier()))
 	}
 	rsp.Value = value
 
@@ -265,7 +265,7 @@ func (s *RegisteredResourcesService) GetRegisteredResourceValuesByFQNs(ctx conte
 
 	fqnValueMap, err := s.dbClient.GetRegisteredResourceValuesByFQNs(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.Any("fqns", req.Msg.GetFqns()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.Any("fqns", req.Msg.GetFqns()))
 	}
 	rsp.FqnValueMap = fqnValueMap
 
@@ -277,7 +277,7 @@ func (s *RegisteredResourcesService) ListRegisteredResourceValues(ctx context.Co
 
 	rsp, err := s.dbClient.ListRegisteredResourceValues(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	s.logger.DebugContext(ctx, "listed registered resource values")
@@ -323,7 +323,7 @@ func (s *RegisteredResourcesService) UpdateRegisteredResourceValue(ctx context.C
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("registered resource value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("registered resource value", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -345,7 +345,7 @@ func (s *RegisteredResourcesService) DeleteRegisteredResourceValue(ctx context.C
 	deleted, err := s.dbClient.DeleteRegisteredResourceValue(ctx, valueID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("registered resource value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("registered resource value", req.Msg.String()))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)

--- a/service/policy/resourcemapping/resource_mapping.go
+++ b/service/policy/resourcemapping/resource_mapping.go
@@ -234,7 +234,7 @@ func (s ResourceMappingService) CreateResourceMapping(ctx context.Context,
 ) (*connect.Response[resourcemapping.CreateResourceMappingResponse], error) {
 	rsp := &resourcemapping.CreateResourceMappingResponse{}
 
-	s.logger.Debug("creating resource mapping")
+	s.logger.DebugContext(ctx, "creating resource mapping")
 
 	auditParams := audit.PolicyEventParams{
 		ActionType: audit.ActionTypeCreate,

--- a/service/policy/resourcemapping/resource_mapping.go
+++ b/service/policy/resourcemapping/resource_mapping.go
@@ -81,7 +81,7 @@ func (s *ResourceMappingService) Close() {
 func (s ResourceMappingService) ListResourceMappingGroups(ctx context.Context, req *connect.Request[resourcemapping.ListResourceMappingGroupsRequest]) (*connect.Response[resourcemapping.ListResourceMappingGroupsResponse], error) {
 	rsp, err := s.dbClient.ListResourceMappingGroups(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -92,7 +92,7 @@ func (s ResourceMappingService) GetResourceMappingGroup(ctx context.Context, req
 
 	rmGroup, err := s.dbClient.GetResourceMappingGroup(ctx, req.Msg.GetId())
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", req.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", req.Msg.GetId()))
 	}
 
 	rsp.ResourceMappingGroup = rmGroup
@@ -111,7 +111,7 @@ func (s ResourceMappingService) CreateResourceMappingGroup(ctx context.Context, 
 	rmGroup, err := s.dbClient.CreateResourceMappingGroup(ctx, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("resourceMappingGroup", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("resourceMappingGroup", req.Msg.String()))
 	}
 
 	auditParams.ObjectID = rmGroup.GetId()
@@ -137,13 +137,13 @@ func (s ResourceMappingService) UpdateResourceMappingGroup(ctx context.Context, 
 	originalRmGroup, err := s.dbClient.GetResourceMappingGroup(ctx, id)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	updatedRmGroup, err := s.dbClient.UpdateResourceMappingGroup(ctx, id, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", id))
 	}
 
 	auditParams.Original = originalRmGroup
@@ -172,7 +172,7 @@ func (s ResourceMappingService) DeleteResourceMappingGroup(ctx context.Context, 
 	_, err := s.dbClient.DeleteResourceMappingGroup(ctx, id)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", id))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
@@ -193,7 +193,7 @@ func (s ResourceMappingService) ListResourceMappings(ctx context.Context,
 ) (*connect.Response[resourcemapping.ListResourceMappingsResponse], error) {
 	rsp, err := s.dbClient.ListResourceMappings(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -206,7 +206,7 @@ func (s ResourceMappingService) ListResourceMappingsByGroupFqns(ctx context.Cont
 
 	fqnRmGroupMap, err := s.dbClient.ListResourceMappingsByGroupFqns(ctx, fqns)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed, slog.Any("fqns", fqns))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed, slog.Any("fqns", fqns))
 	}
 
 	rsp.FqnResourceMappingGroups = fqnRmGroupMap
@@ -221,7 +221,7 @@ func (s ResourceMappingService) GetResourceMapping(ctx context.Context,
 
 	rm, err := s.dbClient.GetResourceMapping(ctx, req.Msg.GetId())
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", req.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", req.Msg.GetId()))
 	}
 
 	rsp.ResourceMapping = rm
@@ -244,7 +244,7 @@ func (s ResourceMappingService) CreateResourceMapping(ctx context.Context,
 	rm, err := s.dbClient.CreateResourceMapping(ctx, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("resourceMapping", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("resourceMapping", req.Msg.String()))
 	}
 
 	auditParams.ObjectID = rm.GetId()
@@ -272,13 +272,13 @@ func (s ResourceMappingService) UpdateResourceMapping(ctx context.Context,
 	originalRM, err := s.dbClient.GetResourceMapping(ctx, resourceMappingID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	updatedRM, err := s.dbClient.UpdateResourceMapping(ctx, resourceMappingID, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed,
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed,
 			slog.String("id", req.Msg.GetId()),
 			slog.String("resourceMapping", req.Msg.String()),
 		)
@@ -311,7 +311,7 @@ func (s ResourceMappingService) DeleteResourceMapping(ctx context.Context,
 	_, err := s.dbClient.DeleteResourceMapping(ctx, resourceMappingID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("id", resourceMappingID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", resourceMappingID))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)

--- a/service/policy/subjectmapping/subject_mapping.go
+++ b/service/policy/subjectmapping/subject_mapping.go
@@ -106,7 +106,7 @@ func (s SubjectMappingService) CreateSubjectMapping(ctx context.Context,
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("subjectMapping", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("subjectMapping", req.Msg.String()))
 	}
 	return connect.NewResponse(rsp), nil
 }
@@ -118,7 +118,7 @@ func (s SubjectMappingService) ListSubjectMappings(ctx context.Context,
 
 	rsp, err := s.dbClient.ListSubjectMappings(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -132,7 +132,7 @@ func (s SubjectMappingService) GetSubjectMapping(ctx context.Context,
 
 	mapping, err := s.dbClient.GetSubjectMapping(ctx, req.Msg.GetId())
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", req.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", req.Msg.GetId()))
 	}
 
 	rsp.SubjectMapping = mapping
@@ -158,13 +158,13 @@ func (s SubjectMappingService) UpdateSubjectMapping(ctx context.Context,
 		original, err := txClient.GetSubjectMapping(ctx, subjectMappingID)
 		if err != nil {
 			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-			return db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", subjectMappingID))
+			return db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", subjectMappingID))
 		}
 
 		updated, err := txClient.UpdateSubjectMapping(ctx, req.Msg)
 		if err != nil {
 			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-			return db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("id", req.Msg.GetId()), slog.String("subjectMapping fields", req.Msg.String()))
+			return db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", req.Msg.GetId()), slog.String("subjectMapping fields", req.Msg.String()))
 		}
 
 		auditParams.Original = original
@@ -198,7 +198,7 @@ func (s SubjectMappingService) DeleteSubjectMapping(ctx context.Context,
 	_, err := s.dbClient.DeleteSubjectMapping(ctx, subjectMappingID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("id", subjectMappingID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", subjectMappingID))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
@@ -217,7 +217,7 @@ func (s SubjectMappingService) MatchSubjectMappings(ctx context.Context,
 
 	smList, err := s.dbClient.GetMatchedSubjectMappings(ctx, req.Msg.GetSubjectProperties())
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.Any("subjectProperties", req.Msg.GetSubjectProperties()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.Any("subjectProperties", req.Msg.GetSubjectProperties()))
 	}
 
 	rsp.SubjectMappings = smList
@@ -236,7 +236,7 @@ func (s SubjectMappingService) GetSubjectConditionSet(ctx context.Context,
 
 	conditionSet, err := s.dbClient.GetSubjectConditionSet(ctx, req.Msg.GetId())
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", req.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", req.Msg.GetId()))
 	}
 
 	rsp.SubjectConditionSet = conditionSet
@@ -250,7 +250,7 @@ func (s SubjectMappingService) ListSubjectConditionSets(ctx context.Context,
 
 	rsp, err := s.dbClient.ListSubjectConditionSets(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextListRetrievalFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -270,7 +270,7 @@ func (s SubjectMappingService) CreateSubjectConditionSet(ctx context.Context,
 	conditionSet, err := s.dbClient.CreateSubjectConditionSet(ctx, req.Msg.GetSubjectConditionSet())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextCreationFailed, slog.String("subjectConditionSet", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("subjectConditionSet", req.Msg.String()))
 	}
 
 	auditParams.ObjectID = conditionSet.GetId()
@@ -297,13 +297,13 @@ func (s SubjectMappingService) UpdateSubjectConditionSet(ctx context.Context,
 	original, err := s.dbClient.GetSubjectConditionSet(ctx, subjectConditionSetID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", subjectConditionSetID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", subjectConditionSetID))
 	}
 
 	updated, err := s.dbClient.UpdateSubjectConditionSet(ctx, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("id", req.Msg.GetId()), slog.String("subjectConditionSet fields", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", req.Msg.GetId()), slog.String("subjectConditionSet fields", req.Msg.String()))
 	}
 
 	auditParams.Original = original
@@ -332,7 +332,7 @@ func (s SubjectMappingService) DeleteSubjectConditionSet(ctx context.Context,
 	_, err := s.dbClient.DeleteSubjectConditionSet(ctx, conditionSetID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("id", conditionSetID))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", conditionSetID))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
@@ -357,7 +357,7 @@ func (s SubjectMappingService) DeleteAllUnmappedSubjectConditionSets(ctx context
 	deleted, err := s.dbClient.DeleteAllUnmappedSubjectConditionSets(ctx)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed)
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed)
 	}
 
 	// Log each pruned subject condition set to audit

--- a/service/policy/subjectmapping/subject_mapping.go
+++ b/service/policy/subjectmapping/subject_mapping.go
@@ -82,7 +82,7 @@ func (s SubjectMappingService) CreateSubjectMapping(ctx context.Context,
 	req *connect.Request[sm.CreateSubjectMappingRequest],
 ) (*connect.Response[sm.CreateSubjectMappingResponse], error) {
 	rsp := &sm.CreateSubjectMappingResponse{}
-	s.logger.Debug("creating subject mapping")
+	s.logger.DebugContext(ctx, "creating subject mapping")
 
 	auditParams := audit.PolicyEventParams{
 		ActionType: audit.ActionTypeCreate,
@@ -114,7 +114,7 @@ func (s SubjectMappingService) CreateSubjectMapping(ctx context.Context,
 func (s SubjectMappingService) ListSubjectMappings(ctx context.Context,
 	req *connect.Request[sm.ListSubjectMappingsRequest],
 ) (*connect.Response[sm.ListSubjectMappingsResponse], error) {
-	s.logger.Debug("listing subject mappings")
+	s.logger.DebugContext(ctx, "listing subject mappings")
 
 	rsp, err := s.dbClient.ListSubjectMappings(ctx, req.Msg)
 	if err != nil {
@@ -128,7 +128,7 @@ func (s SubjectMappingService) GetSubjectMapping(ctx context.Context,
 	req *connect.Request[sm.GetSubjectMappingRequest],
 ) (*connect.Response[sm.GetSubjectMappingResponse], error) {
 	rsp := &sm.GetSubjectMappingResponse{}
-	s.logger.Debug("getting subject mapping", slog.String("id", req.Msg.GetId()))
+	s.logger.DebugContext(ctx, "getting subject mapping", slog.String("id", req.Msg.GetId()))
 
 	mapping, err := s.dbClient.GetSubjectMapping(ctx, req.Msg.GetId())
 	if err != nil {
@@ -145,7 +145,7 @@ func (s SubjectMappingService) UpdateSubjectMapping(ctx context.Context,
 	rsp := &sm.UpdateSubjectMappingResponse{}
 	subjectMappingID := req.Msg.GetId()
 
-	s.logger.Debug("updating subject mapping", slog.String("subjectMapping", req.Msg.String()))
+	s.logger.DebugContext(ctx, "updating subject mapping", slog.String("subjectMapping", req.Msg.String()))
 
 	auditParams := audit.PolicyEventParams{
 		ActionType: audit.ActionTypeUpdate,
@@ -186,7 +186,7 @@ func (s SubjectMappingService) DeleteSubjectMapping(ctx context.Context,
 	req *connect.Request[sm.DeleteSubjectMappingRequest],
 ) (*connect.Response[sm.DeleteSubjectMappingResponse], error) {
 	rsp := &sm.DeleteSubjectMappingResponse{}
-	s.logger.Debug("deleting subject mapping", slog.String("id", req.Msg.GetId()))
+	s.logger.DebugContext(ctx, "deleting subject mapping", slog.String("id", req.Msg.GetId()))
 
 	subjectMappingID := req.Msg.GetId()
 	auditParams := audit.PolicyEventParams{
@@ -213,7 +213,7 @@ func (s SubjectMappingService) MatchSubjectMappings(ctx context.Context,
 	req *connect.Request[sm.MatchSubjectMappingsRequest],
 ) (*connect.Response[sm.MatchSubjectMappingsResponse], error) {
 	rsp := &sm.MatchSubjectMappingsResponse{}
-	s.logger.Debug("matching subject mappings", slog.Any("subjectProperties", req.Msg.GetSubjectProperties()))
+	s.logger.DebugContext(ctx, "matching subject mappings", slog.Any("subjectProperties", req.Msg.GetSubjectProperties()))
 
 	smList, err := s.dbClient.GetMatchedSubjectMappings(ctx, req.Msg.GetSubjectProperties())
 	if err != nil {
@@ -232,7 +232,7 @@ func (s SubjectMappingService) GetSubjectConditionSet(ctx context.Context,
 	req *connect.Request[sm.GetSubjectConditionSetRequest],
 ) (*connect.Response[sm.GetSubjectConditionSetResponse], error) {
 	rsp := &sm.GetSubjectConditionSetResponse{}
-	s.logger.Debug("getting subject condition set", slog.String("id", req.Msg.GetId()))
+	s.logger.DebugContext(ctx, "getting subject condition set", slog.String("id", req.Msg.GetId()))
 
 	conditionSet, err := s.dbClient.GetSubjectConditionSet(ctx, req.Msg.GetId())
 	if err != nil {
@@ -246,7 +246,7 @@ func (s SubjectMappingService) GetSubjectConditionSet(ctx context.Context,
 func (s SubjectMappingService) ListSubjectConditionSets(ctx context.Context,
 	req *connect.Request[sm.ListSubjectConditionSetsRequest],
 ) (*connect.Response[sm.ListSubjectConditionSetsResponse], error) {
-	s.logger.Debug("listing subject condition sets")
+	s.logger.DebugContext(ctx, "listing subject condition sets")
 
 	rsp, err := s.dbClient.ListSubjectConditionSets(ctx, req.Msg)
 	if err != nil {
@@ -260,7 +260,7 @@ func (s SubjectMappingService) CreateSubjectConditionSet(ctx context.Context,
 	req *connect.Request[sm.CreateSubjectConditionSetRequest],
 ) (*connect.Response[sm.CreateSubjectConditionSetResponse], error) {
 	rsp := &sm.CreateSubjectConditionSetResponse{}
-	s.logger.Debug("creating subject condition set", slog.String("subjectConditionSet", req.Msg.String()))
+	s.logger.DebugContext(ctx, "creating subject condition set", slog.String("subjectConditionSet", req.Msg.String()))
 
 	auditParams := audit.PolicyEventParams{
 		ActionType: audit.ActionTypeCreate,
@@ -285,7 +285,7 @@ func (s SubjectMappingService) UpdateSubjectConditionSet(ctx context.Context,
 	req *connect.Request[sm.UpdateSubjectConditionSetRequest],
 ) (*connect.Response[sm.UpdateSubjectConditionSetResponse], error) {
 	rsp := &sm.UpdateSubjectConditionSetResponse{}
-	s.logger.Debug("updating subject condition set", slog.String("subjectConditionSet", req.Msg.String()))
+	s.logger.DebugContext(ctx, "updating subject condition set", slog.String("subjectConditionSet", req.Msg.String()))
 
 	subjectConditionSetID := req.Msg.GetId()
 	auditParams := audit.PolicyEventParams{
@@ -320,7 +320,7 @@ func (s SubjectMappingService) DeleteSubjectConditionSet(ctx context.Context,
 	req *connect.Request[sm.DeleteSubjectConditionSetRequest],
 ) (*connect.Response[sm.DeleteSubjectConditionSetResponse], error) {
 	rsp := &sm.DeleteSubjectConditionSetResponse{}
-	s.logger.Debug("deleting subject condition set", slog.String("id", req.Msg.GetId()))
+	s.logger.DebugContext(ctx, "deleting subject condition set", slog.String("id", req.Msg.GetId()))
 
 	conditionSetID := req.Msg.GetId()
 	auditParams := audit.PolicyEventParams{
@@ -347,7 +347,7 @@ func (s SubjectMappingService) DeleteAllUnmappedSubjectConditionSets(ctx context
 	_ *connect.Request[sm.DeleteAllUnmappedSubjectConditionSetsRequest],
 ) (*connect.Response[sm.DeleteAllUnmappedSubjectConditionSetsResponse], error) {
 	rsp := &sm.DeleteAllUnmappedSubjectConditionSetsResponse{}
-	s.logger.Debug("deleting all unmapped subject condition sets")
+	s.logger.DebugContext(ctx, "deleting all unmapped subject condition sets")
 
 	auditParams := audit.PolicyEventParams{
 		ActionType: audit.ActionTypeDelete,

--- a/service/policy/unsafe/unsafe.go
+++ b/service/policy/unsafe/unsafe.go
@@ -114,7 +114,7 @@ func (s *UnsafeService) UnsafeUpdateNamespace(ctx context.Context, req *connect.
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("namespace", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("namespace", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -134,13 +134,13 @@ func (s *UnsafeService) UnsafeReactivateNamespace(ctx context.Context, req *conn
 	original, err := s.dbClient.GetNamespace(ctx, id)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	updated, err := s.dbClient.UnsafeReactivateNamespace(ctx, id)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", id))
 	}
 
 	auditParams.Original = original
@@ -169,13 +169,13 @@ func (s *UnsafeService) UnsafeDeleteNamespace(ctx context.Context, req *connect.
 	existing, err := s.dbClient.GetNamespace(ctx, id)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	_, err = s.dbClient.UnsafeDeleteNamespace(ctx, existing, req.Msg.GetFqn())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", id))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
@@ -227,7 +227,7 @@ func (s *UnsafeService) UnsafeUpdateAttribute(ctx context.Context, req *connect.
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("attribute", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("attribute", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -247,13 +247,13 @@ func (s *UnsafeService) UnsafeReactivateAttribute(ctx context.Context, req *conn
 	original, err := s.dbClient.GetAttribute(ctx, id)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	updated, err := s.dbClient.UnsafeReactivateAttribute(ctx, id)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", id))
 	}
 
 	auditParams.Original = original
@@ -282,13 +282,13 @@ func (s *UnsafeService) UnsafeDeleteAttribute(ctx context.Context, req *connect.
 	existing, err := s.dbClient.GetAttribute(ctx, id)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	_, err = s.dbClient.UnsafeDeleteAttribute(ctx, existing, req.Msg.GetFqn())
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", id))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
@@ -340,7 +340,7 @@ func (s *UnsafeService) UnsafeUpdateAttributeValue(ctx context.Context, req *con
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("value", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -360,13 +360,13 @@ func (s *UnsafeService) UnsafeReactivateAttributeValue(ctx context.Context, req 
 	original, err := s.dbClient.GetAttributeValue(ctx, id)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	updated, err := s.dbClient.UnsafeReactivateAttributeValue(ctx, id)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextUpdateFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", id))
 	}
 
 	auditParams.Original = original
@@ -394,13 +394,13 @@ func (s *UnsafeService) UnsafeDeleteAttributeValue(ctx context.Context, req *con
 	existing, err := s.dbClient.GetAttributeValue(ctx, id)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	_, err = s.dbClient.UnsafeDeleteAttributeValue(ctx, existing, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(err, db.ErrTextDeletionFailed, slog.String("id", id))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", id))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)


### PR DESCRIPTION
### Proposed Changes

* Pulls context values into logs that are set to contexts within RPC requests by our interceptors
* Improves correlation by better propagating request IDs throughout all logs within the RPC handlers
* Updates `db.StatusifyError` to take in context and a service logger so error logs are correlated with services and contextualized requests

```shell
time=2025-06-13T14:01:04.501-07:00 level=DEBUG msg="creating new attribute definition" namespace=policy name=testing5 request-id=771749b3-a1fb-488e-9710-b94c30cf3d5d user-agent="connect-go/1.18.1 (go1.24.2)" request-ip=None actor-id=80ff2bda-e446-4b3c-8197-ba980540d293
```

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

