### PR TITLE
fix(core): remove generics on new platform cache manager and client

### DIFF
--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -134,7 +134,7 @@ type OpenTDFServer struct {
 	HTTPServer          *http.Server
 	ConnectRPCInProcess *inProcessServer
 	ConnectRPC          *ConnectRPC
-	CacheManager        *cache.Manager[any]
+	CacheManager        *cache.Manager
 
 	// To Deprecate: Use the TrustKeyIndex and TrustKeyManager instead
 	CryptoProvider *security.StandardCrypto
@@ -158,7 +158,7 @@ type inProcessServer struct {
 	*ConnectRPC
 }
 
-func NewOpenTDFServer(config Config, logger *logger.Logger, cacheManager *cache.Manager[any]) (*OpenTDFServer, error) {
+func NewOpenTDFServer(config Config, logger *logger.Logger, cacheManager *cache.Manager) (*OpenTDFServer, error) {
 	var (
 		authN *auth.Authentication
 		err   error

--- a/service/pkg/cache/cache.go
+++ b/service/pkg/cache/cache.go
@@ -15,12 +15,12 @@ import (
 
 var ErrCacheMiss = errors.New("cache miss")
 
-// Manager is a generic cache manager for any value type T.
+// Manager is a cache manager for any value.
 type Manager struct {
 	cache *cache.Cache[any]
 }
 
-// Cache is a generic cache implementation using gocache for any value type T.
+// Cache is a cache implementation using gocache for any value type.
 type Cache struct {
 	manager      *Manager
 	serviceName  string
@@ -33,7 +33,7 @@ type Options struct {
 	Cost       int64
 }
 
-// NewCacheManager creates a new generic cache manager using Ristretto as the backend.
+// NewCacheManager creates a new cache manager using Ristretto as the backend.
 func NewCacheManager(maxCost int64) (*Manager, error) {
 	numCounters, bufferItems, err := EstimateRistrettoConfigParams(maxCost)
 	if err != nil {
@@ -54,7 +54,7 @@ func NewCacheManager(maxCost int64) (*Manager, error) {
 	}, nil
 }
 
-// NewCache creates a new generic Cache instance with the given service name and options.
+// NewCache creates a new Cache client instance with the given service name and options.
 // The purpose of this function is to create a new cache for a specific service.
 // Because caching can be expensive we want to make sure there are some strict controls with
 // how it is used.
@@ -76,7 +76,7 @@ func (c *Manager) NewCache(serviceName string, log *logger.Logger, options Optio
 	return cache, nil
 }
 
-// Get retrieves a value from the cache and type asserts it to T.
+// Get retrieves a value from the cache
 func (c *Cache) Get(ctx context.Context, key string) (any, error) {
 	val, err := c.manager.cache.Get(ctx, c.getKey(key))
 	if err != nil {

--- a/service/pkg/cache/cache_test.go
+++ b/service/pkg/cache/cache_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewCacheManager_ValidMaxCost(t *testing.T) {
 	maxCost := int64(1024 * 1024) // 1MB
-	manager, err := NewCacheManager[any](maxCost)
+	manager, err := NewCacheManager(maxCost)
 	require.NoError(t, err)
 	require.NotNil(t, manager)
 	require.NotNil(t, manager.cache)
@@ -18,16 +18,16 @@ func TestNewCacheManager_ValidMaxCost(t *testing.T) {
 
 func TestNewCacheManager_InvalidMaxCost(t *testing.T) {
 	// Ristretto requires MaxCost > 0, so use 0 or negative
-	_, err := NewCacheManager[any](0)
+	_, err := NewCacheManager(0)
 	require.Error(t, err)
 
-	_, err = NewCacheManager[any](-100)
+	_, err = NewCacheManager(-100)
 	require.Error(t, err)
 }
 
 func TestNewCacheManager_NewCacheIntegration(t *testing.T) {
 	maxCost := int64(1024 * 1024)
-	manager, err := NewCacheManager[any](maxCost)
+	manager, err := NewCacheManager(maxCost)
 	require.NoError(t, err)
 	require.NotNil(t, manager)
 

--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -124,7 +124,7 @@ type startServicesParams struct {
 	client       *sdk.SDK
 	logger       *logging.Logger
 	reg          serviceregistry.Registry
-	cacheManager *cache.Manager[any]
+	cacheManager *cache.Manager
 	keyManagers  []trust.KeyManager
 }
 
@@ -195,7 +195,7 @@ func startServices(ctx context.Context, params startServicesParams) (func(), err
 			}
 
 			// Check if the service supports and needs a cache
-			var cacheClient *cache.Cache[any]
+			var cacheClient *cache.Cache
 			if cacheSvc, ok := svc.(serviceregistry.CacheSupportedService); ok {
 				cacheClient, err = cacheManager.NewCache(ns, svcLogger, *cacheSvc.CacheOptions())
 				if err != nil {

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -92,7 +92,7 @@ func Start(f ...StartOptions) error {
 	if cfg.Server.Cache.Driver != "ristretto" {
 		return fmt.Errorf("unsupported cache driver: %s", cfg.Server.Cache.Driver)
 	}
-	cacheManager, err := cache.NewCacheManager[any](cfg.Server.Cache.RistrettoCache.MaxCostBytes())
+	cacheManager, err := cache.NewCacheManager(cfg.Server.Cache.RistrettoCache.MaxCostBytes())
 	if err != nil {
 		return fmt.Errorf("could not create cache manager: %w", err)
 	}

--- a/service/pkg/server/start_test.go
+++ b/service/pkg/server/start_test.go
@@ -153,7 +153,7 @@ func mockOpenTDFServer() (*server.OpenTDFServer, error) {
 		&logger.Logger{
 			Logger: slog.New(slog.Default().Handler()),
 		},
-		&cache.Manager[any]{},
+		&cache.Manager{},
 	)
 }
 
@@ -367,7 +367,7 @@ func (s *StartTestSuite) Test_Start_When_Extra_Service_Registered() {
 				keyManagers:  []trust.KeyManager{},
 				logger:       logger,
 				reg:          registry,
-				cacheManager: &cache.Manager[any]{},
+				cacheManager: &cache.Manager{},
 			})
 			require.NoError(t, err)
 			defer cleanup()

--- a/service/pkg/serviceregistry/serviceregistry.go
+++ b/service/pkg/serviceregistry/serviceregistry.go
@@ -45,7 +45,7 @@ type RegistrationParams struct {
 	trace.Tracer
 
 	// Cache is the cache that can be used to cache data. This cache is scoped to the service
-	Cache *cache.Cache[any]
+	Cache *cache.Cache
 
 	KeyManagers []trust.KeyManager
 


### PR DESCRIPTION
### Proposed Changes

* Current implementation allows one type per cache client
* Cannot genericize `cache.Set` easily as Go does not support method generics
* Allows consumers to get/set `any` type and do their own assertion on retrieved cache hits

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

