### PR TITLE
feat(main): Add Close() method to cache manager

### DIFF
--- a/service/pkg/cache/cache.go
+++ b/service/pkg/cache/cache.go
@@ -17,6 +17,7 @@ var ErrCacheMiss = errors.New("cache miss")
 // Manager is a cache manager for any value.
 type Manager struct {
 	cache *cache.Cache[any]
+	raw   *ristretto.Cache
 }
 
 // Cache is a cache implementation using gocache for any value type.
@@ -50,6 +51,7 @@ func NewCacheManager(maxCost int64) (*Manager, error) {
 	ristrettoStore := ristretto_store.NewRistretto(store)
 	return &Manager{
 		cache: cache.New[any](ristrettoStore),
+		raw:   store,
 	}, nil
 }
 
@@ -72,6 +74,12 @@ func (c *Manager) NewCache(serviceName string, log *logger.Logger, options Optio
 		With("expiration", options.Expiration.String())
 	cache.logger.Info("created cache")
 	return cache, nil
+}
+
+func (m *Manager) Close() {
+	if m.raw != nil {
+		m.raw.Close()
+	}
 }
 
 // Get retrieves a value from the cache

--- a/service/pkg/cache/cache.go
+++ b/service/pkg/cache/cache.go
@@ -16,8 +16,8 @@ var ErrCacheMiss = errors.New("cache miss")
 
 // Manager is a cache manager for any value.
 type Manager struct {
-	cache *cache.Cache[any]
-	raw   *ristretto.Cache
+	cache           *cache.Cache[any]
+	underlyingStore *ristretto.Cache
 }
 
 // Cache is a cache implementation using gocache for any value type.
@@ -50,8 +50,8 @@ func NewCacheManager(maxCost int64) (*Manager, error) {
 	}
 	ristrettoStore := ristretto_store.NewRistretto(store)
 	return &Manager{
-		cache: cache.New[any](ristrettoStore),
-		raw:   store,
+		cache:           cache.New[any](ristrettoStore),
+		underlyingStore: store,
 	}, nil
 }
 
@@ -77,8 +77,8 @@ func (c *Manager) NewCache(serviceName string, log *logger.Logger, options Optio
 }
 
 func (c *Manager) Close() {
-	if c.raw != nil {
-		c.raw.Close()
+	if c.underlyingStore != nil {
+		c.underlyingStore.Close()
 	}
 }
 

--- a/service/pkg/cache/cache.go
+++ b/service/pkg/cache/cache.go
@@ -76,9 +76,9 @@ func (c *Manager) NewCache(serviceName string, log *logger.Logger, options Optio
 	return cache, nil
 }
 
-func (m *Manager) Close() {
-	if m.raw != nil {
-		m.raw.Close()
+func (c *Manager) Close() {
+	if c.raw != nil {
+		c.raw.Close()
 	}
 }
 

--- a/service/pkg/cache/cache_test.go
+++ b/service/pkg/cache/cache_test.go
@@ -43,3 +43,20 @@ func TestNewCacheManager_NewCacheIntegration(t *testing.T) {
 	require.Equal(t, "testService", cache.serviceName)
 	require.Equal(t, options, cache.cacheOptions)
 }
+
+func TestCacheManagerClose(t *testing.T) {
+	// Create a cache manager
+	manager, err := NewCacheManager(1024 * 1024) // 1 MB max cost
+	require.NoError(t, err)
+	require.NotNil(t, manager)
+
+	// Ensure Close does not panic
+	require.NotPanics(t, func() {
+		manager.Close()
+	})
+
+	// Calling Close twice should also be safe (defensive test)
+	require.NotPanics(t, func() {
+		manager.Close()
+	})
+}

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -96,6 +96,7 @@ func Start(f ...StartOptions) error {
 	if err != nil {
 		return fmt.Errorf("could not create cache manager: %w", err)
 	}
+	defer cacheManager.Close()
 
 	logger.Info("starting opentdf services")
 
@@ -312,8 +313,6 @@ func Start(f ...StartOptions) error {
 		return fmt.Errorf("issue starting services: %w", err)
 	}
 	defer gatewayCleanup()
-
-	defer cacheManager.Close()
 
 	// Start watching the configuration for changes with registered config change service hooks
 	if err := cfg.Watch(ctx); err != nil {

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -313,6 +313,8 @@ func Start(f ...StartOptions) error {
 	}
 	defer gatewayCleanup()
 
+	defer cacheManager.Close()
+
 	// Start watching the configuration for changes with registered config change service hooks
 	if err := cfg.Watch(ctx); err != nil {
 		return fmt.Errorf("failed to watch configuration: %w", err)


### PR DESCRIPTION
### Proposed Changes

Add cleanup for underlying Ristretto cache by tracking and explicitly closing it to avoid goroutine leaks and ensure proper resource release.

Details:
Modified cache.Manager to store a reference to the underlying *ristretto.Cache.
Added a Close() method to Manager that calls .Close() on the underlying Ristretto cache.

Why:
Ristretto starts background goroutines and allocates internal buffers that aren't automatically cleaned up. Explicitly calling .Close() ensures proper shutdown, especially important in tests and long-running services

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

