### PR TITLE
feat(authz): Add caching to keycloak ERS

### DIFF
--- a/service/entityresolution/keycloak/v2/entity_resolution.go
+++ b/service/entityresolution/keycloak/v2/entity_resolution.go
@@ -441,9 +441,7 @@ func getEntitiesFromToken(ctx context.Context, kcConfig Config, connector *Conne
 func getServiceAccountClient(ctx context.Context, username string, kcConfig Config, connector *Connector, logger *logger.Logger, svcCache *cache.Cache) (string, error) {
 	expectedClientName := strings.TrimPrefix(username, serviceAccountUsernamePrefix)
 
-	clients, err := connector.client.GetClients(ctx, connector.token.AccessToken, kcConfig.Realm, gocloak.GetClientsParams{
-		ClientID: &expectedClientName,
-	})
+	clients, err := retrieveClients(ctx, logger, expectedClientName, kcConfig.Realm, svcCache, connector)
 	switch {
 	case err != nil:
 		logger.Error(err.Error())

--- a/service/entityresolution/keycloak/v2/entity_resolution_test.go
+++ b/service/entityresolution/keycloak/v2/entity_resolution_test.go
@@ -207,7 +207,7 @@ func Test_KCEntityResolutionByClientId(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 	_ = json.NewEncoder(os.Stdout).Encode(&resp)
@@ -236,7 +236,7 @@ func Test_KCEntityResolutionByEmail(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -276,7 +276,7 @@ func Test_KCEntityResolutionByUsername(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -321,7 +321,7 @@ func Test_KCEntityResolutionByGroupEmail(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -362,7 +362,7 @@ func Test_KCEntityResolutionNotFoundError(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.Error(t, reserr)
 	assert.Equal(t, &entityresolutionV2.ResolveEntitiesResponse{}, &resp)
@@ -385,7 +385,7 @@ func Test_JwtClientAndUsernameClientCredentials(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -408,7 +408,7 @@ func Test_JwtClientAndUsernamePasswordPub(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -431,7 +431,7 @@ func Test_JwtClientAndUsernamePasswordPriv(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -454,7 +454,7 @@ func Test_JwtClientAndUsernameAuthPub(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -477,7 +477,7 @@ func Test_JwtClientAndUsernameAuthPriv(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -500,7 +500,7 @@ func Test_JwtClientAndUsernameImplicitPub(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -523,7 +523,7 @@ func Test_JwtClientAndUsernameImplicitPriv(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -549,7 +549,7 @@ func Test_JwtClientAndClientTokenExchange(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -575,7 +575,7 @@ func Test_JwtMultiple(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := CreateEntityChainsFromTokens(t.Context(), &entityresolutionV2.CreateEntityChainsFromTokensRequest{Tokens: validBody}, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -617,7 +617,7 @@ func Test_KCEntityResolutionNotFoundInferEmail(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -651,7 +651,7 @@ func Test_KCEntityResolutionNotFoundInferClientId(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.NoError(t, reserr)
 
@@ -684,7 +684,7 @@ func Test_KCEntityResolutionNotFoundNotInferUsername(t *testing.T) {
 		token:  &gocloak.JWT{AccessToken: "dummy_token"},
 		client: gocloak.NewClient(server.URL),
 	}
-	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger())
+	resp, reserr := EntityResolution(t.Context(), &req, kcconfig, connector, logger.CreateTestLogger(), nil)
 
 	require.Error(t, reserr)
 	assert.Equal(t, &entityresolutionV2.ResolveEntitiesResponse{}, &resp)

--- a/service/entityresolution/keycloak/v2/retrieve.go
+++ b/service/entityresolution/keycloak/v2/retrieve.go
@@ -1,0 +1,119 @@
+package keycloak
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/Nerzal/gocloak/v13"
+	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/pkg/cache"
+)
+
+// Cache Key formats
+// Client: {realm}::client::{clientid}
+// User: {realm}::user::{emailaddress or username}
+// Group: {realm}::group::{emailaddress or id}
+// Group members: {realm}::group::{groupid}::members
+
+func retrieveClients(ctx context.Context, logger *logger.Logger, clientID string, realm string, svcCache *cache.Cache, connector *Connector) ([]*gocloak.Client, error) {
+	cacheKey := fmt.Sprintf("%s::client::%s", realm, clientID)
+	retrievalFunc := func() ([]*gocloak.Client, error) {
+		return connector.client.GetClients(ctx, connector.token.AccessToken, realm, gocloak.GetClientsParams{
+			ClientID: &clientID,
+		})
+	}
+	clients, err := retrieveWithKey[[]*gocloak.Client](ctx, cacheKey, svcCache, logger, retrievalFunc)
+	if err != nil {
+		return nil, err
+	}
+	return clients.([]*gocloak.Client), nil
+}
+
+func retrieveUsers(ctx context.Context, logger *logger.Logger, getUserParams gocloak.GetUsersParams, realm string, svcCache *cache.Cache, connector *Connector) ([]*gocloak.User, error) {
+	var cacheKey string
+	if getUserParams.Email != nil {
+		cacheKey = fmt.Sprintf("%s::user::%s", realm, *getUserParams.Email)
+	} else if getUserParams.Username != nil {
+		cacheKey = fmt.Sprintf("%s::user::%s", realm, *getUserParams.Username)
+	} else {
+		return nil, errors.New("either email or username must be provided")
+	}
+
+	retrievalFunc := func() ([]*gocloak.User, error) {
+		return connector.client.GetUsers(ctx, connector.token.AccessToken, realm, getUserParams)
+	}
+	users, err := retrieveWithKey[[]*gocloak.User](ctx, cacheKey, svcCache, logger, retrievalFunc)
+	if err != nil {
+		return nil, err
+	}
+	return users.([]*gocloak.User), nil
+}
+
+func retrieveGroupsByEmail(ctx context.Context, logger *logger.Logger, groupEmail string, realm string, svcCache *cache.Cache, connector *Connector) ([]*gocloak.Group, error) {
+	cacheKey := fmt.Sprintf("%s::group::%s", realm, groupEmail)
+	retrievalFunc := func() ([]*gocloak.Group, error) {
+		return connector.client.GetGroups(
+			ctx,
+			connector.token.AccessToken,
+			realm,
+			gocloak.GetGroupsParams{Search: func() *string { t := groupEmail; return &t }()},
+		)
+	}
+	group, err := retrieveWithKey[[]*gocloak.Group](ctx, cacheKey, svcCache, logger, retrievalFunc)
+	if err != nil {
+		return nil, err
+	}
+	return group.([]*gocloak.Group), nil
+}
+
+func retrieveGroupByID(ctx context.Context, logger *logger.Logger, groupID string, realm string, svcCache *cache.Cache, connector *Connector) (*gocloak.Group, error) {
+	cacheKey := fmt.Sprintf("%s::group::%s", realm, groupID)
+	retrievalFunc := func() (*gocloak.Group, error) {
+		return connector.client.GetGroup(ctx, connector.token.AccessToken, realm, groupID)
+	}
+	group, err := retrieveWithKey[*gocloak.Group](ctx, cacheKey, svcCache, logger, retrievalFunc)
+	if err != nil {
+		return nil, err
+	}
+	return group.(*gocloak.Group), nil
+}
+
+func retrieveGroupMembers(ctx context.Context, logger *logger.Logger, groupID string, realm string, svcCache *cache.Cache, connector *Connector) ([]*gocloak.User, error) {
+	cacheKey := fmt.Sprintf("%s::group::%s::members", realm, groupID)
+	retrievalFunc := func() ([]*gocloak.User, error) {
+		return connector.client.GetGroupMembers(ctx, connector.token.AccessToken, realm, groupID, gocloak.GetGroupsParams{})
+	}
+	members, err := retrieveWithKey[[]*gocloak.User](ctx, cacheKey, svcCache, logger, retrievalFunc)
+	if err != nil {
+		return nil, err
+	}
+	return members.([]*gocloak.User), nil
+}
+
+func retrieveWithKey[T any](ctx context.Context, cacheKey string, svcCache *cache.Cache, logger *logger.Logger, retrieveFunc func() (T, error)) (any, error) {
+	if svcCache != nil {
+		cachedData, err := svcCache.Get(ctx, cacheKey)
+		switch {
+		case err == nil:
+			if retrieved, ok := cachedData.(T); ok {
+				return retrieved, nil
+			} else {
+				logger.Error("cache data type assertion failed")
+			}
+		case errors.Is(err, cache.ErrCacheMiss):
+			logger.Debug("cache miss", slog.String("key", cacheKey))
+		default:
+			return nil, err
+		}
+	}
+	retrieved, err := retrieveFunc()
+	if svcCache != nil && err == nil {
+		cacheErr := svcCache.Set(ctx, cacheKey, retrieved, []string{})
+		if cacheErr != nil {
+			logger.Error("error setting cache", slog.String("error", cacheErr.Error()))
+		}
+	}
+	return retrieved, err
+}

--- a/service/entityresolution/keycloak/v2/retrieve.go
+++ b/service/entityresolution/keycloak/v2/retrieve.go
@@ -83,9 +83,8 @@ func retrieveWithKey[T any](ctx context.Context, cacheKey string, svcCache *cach
 		if err == nil {
 			if retrieved, ok := cachedData.(T); ok {
 				return retrieved, nil
-			} else {
-				logger.Error("cache data type assertion failed")
 			}
+			logger.Error("cache data type assertion failed")
 		} else if !errors.Is(err, cache.ErrCacheMiss) {
 			var zero T
 			return zero, err

--- a/service/entityresolution/keycloak/v2/retrieve_test.go
+++ b/service/entityresolution/keycloak/v2/retrieve_test.go
@@ -1,0 +1,283 @@
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Nerzal/gocloak/v13"
+	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/pkg/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCache(t *testing.T) (*cache.Manager, *cache.Cache) {
+	// Use a short expiration for test
+	cacheManager, err := cache.NewCacheManager(1000)
+	require.NoError(t, err, "Failed to create cache manager")
+	c, err := cacheManager.NewCache("test", logger.CreateTestLogger(), cache.Options{
+		Expiration: 5 * time.Second,
+	})
+	require.NoError(t, err, "Failed to create test cache")
+	return cacheManager, c
+}
+
+func TestRetrieveClients_CacheIntegration(t *testing.T) {
+	clientID := "myclient"
+	realm := "tdf"
+	cacheKey := fmt.Sprintf("%s::client::%s", realm, clientID)
+	clientsResp := []*gocloak.Client{{ID: gocloak.StringP(clientID)}}
+
+	var called int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// slog.Info("Server called", "path", r.URL.Path, "query", r.URL.RawQuery)
+		called++
+		assert.Equal(t, "/admin/realms/tdf/clients", r.URL.Path)
+		assert.Contains(t, r.URL.RawQuery, "clientId=myclient")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(clientsResp)
+	}))
+	defer server.Close()
+
+	kc := &Connector{
+		token:  &gocloak.JWT{AccessToken: "dummy"},
+		client: gocloak.NewClient(server.URL),
+	}
+	l := logger.CreateTestLogger()
+	_, c := newTestCache(t)
+
+	// First call: cache miss, should hit server
+	got, err := retrieveClients(context.Background(), l, clientID, realm, c, kc)
+	require.NoError(t, err)
+	assert.Equal(t, clientsResp, got)
+	assert.Equal(t, 1, called)
+
+	// Wait
+	time.Sleep(200 * time.Millisecond)
+
+	// Second call: cache hit, should NOT hit server
+	called = 0
+	got2, err := retrieveClients(context.Background(), l, clientID, realm, c, kc)
+	require.NoError(t, err)
+	assert.Equal(t, clientsResp, got2)
+	assert.Equal(t, 0, called, "server should not be called on cache hit")
+
+	// Optionally, check cache directly
+	val, err := c.Get(context.Background(), cacheKey)
+	require.NoError(t, err)
+	assert.Equal(t, clientsResp, val)
+
+	// Wait for cache expiration
+	time.Sleep(6 * time.Second)
+	// After expiration, cache should be empty
+	_, err = c.Get(context.Background(), cacheKey)
+	require.Error(t, err, "Cache should be empty after expiration")
+}
+
+func TestRetrieveUsers_CacheIntegration(t *testing.T) {
+	email := "foo@bar.com"
+	realm := "tdf"
+	cacheKey := fmt.Sprintf("%s::user::%s", realm, email)
+	usersResp := []*gocloak.User{{Email: gocloak.StringP(email)}}
+
+	var called int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		assert.Equal(t, "/admin/realms/tdf/users", r.URL.Path)
+		assert.Contains(t, r.URL.RawQuery, "email=foo%40bar.com")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(usersResp)
+	}))
+	defer server.Close()
+
+	kc := &Connector{
+		token:  &gocloak.JWT{AccessToken: "dummy"},
+		client: gocloak.NewClient(server.URL),
+	}
+	l := logger.CreateTestLogger()
+	_, c := newTestCache(t)
+
+	// First call: cache miss, should hit server
+	params := gocloak.GetUsersParams{Email: &email}
+	got, err := retrieveUsers(context.Background(), l, params, realm, c, kc)
+	require.NoError(t, err)
+	assert.Equal(t, usersResp, got)
+	assert.Equal(t, 1, called)
+
+	// Wait
+	time.Sleep(200 * time.Millisecond)
+
+	called = 0
+	// Second call: cache hit, should NOT hit server
+	got2, err := retrieveUsers(context.Background(), l, params, realm, c, kc)
+	require.NoError(t, err)
+	assert.Equal(t, usersResp, got2)
+	assert.Equal(t, 0, called)
+
+	// Optionally, check cache directly
+	val, err := c.Get(context.Background(), cacheKey)
+	require.NoError(t, err)
+	assert.Equal(t, usersResp, val)
+
+	// Wait for cache expiration
+	time.Sleep(6 * time.Second)
+	// After expiration, cache should be empty
+	_, err = c.Get(context.Background(), cacheKey)
+	require.Error(t, err, "Cache should be empty after expiration")
+}
+
+func TestRetrieveGroupsByEmail_CacheIntegration(t *testing.T) {
+	groupEmail := "group@bar.com"
+	realm := "tdf"
+	cacheKey := fmt.Sprintf("%s::group::%s", realm, groupEmail)
+	groupsResp := []*gocloak.Group{{ID: gocloak.StringP("gid")}}
+
+	var called int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		assert.Equal(t, "/admin/realms/tdf/groups", r.URL.Path)
+		assert.Contains(t, r.URL.RawQuery, "search=group%40bar.com")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(groupsResp)
+	}))
+	defer server.Close()
+
+	kc := &Connector{
+		token:  &gocloak.JWT{AccessToken: "dummy"},
+		client: gocloak.NewClient(server.URL),
+	}
+	l := logger.CreateTestLogger()
+	_, c := newTestCache(t)
+
+	// First call: cache miss, should hit server
+	got, err := retrieveGroupsByEmail(context.Background(), l, groupEmail, realm, c, kc)
+	require.NoError(t, err)
+	assert.Equal(t, groupsResp, got)
+	assert.Equal(t, 1, called)
+
+	// Wait
+	time.Sleep(200 * time.Millisecond)
+
+	// Second call: cache hit, should NOT hit server
+	called = 0
+	got2, err := retrieveGroupsByEmail(context.Background(), l, groupEmail, realm, c, kc)
+	require.NoError(t, err)
+	assert.Equal(t, groupsResp, got2)
+	assert.Equal(t, 0, called)
+
+	// Optionally, check cache directly
+	val, err := c.Get(context.Background(), cacheKey)
+	require.NoError(t, err)
+	assert.Equal(t, groupsResp, val)
+
+	// Wait for cache expiration
+	time.Sleep(6 * time.Second)
+	// After expiration, cache should be empty
+	_, err = c.Get(context.Background(), cacheKey)
+	require.Error(t, err, "Cache should be empty after expiration")
+}
+
+func TestRetrieveGroupByID_CacheIntegration(t *testing.T) {
+	groupID := "gid"
+	realm := "tdf"
+	cacheKey := fmt.Sprintf("%s::group::%s", realm, groupID)
+	groupResp := &gocloak.Group{ID: gocloak.StringP(groupID)}
+
+	var called int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		assert.Equal(t, "/admin/realms/tdf/groups/gid", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(groupResp)
+	}))
+	defer server.Close()
+
+	kc := &Connector{
+		token:  &gocloak.JWT{AccessToken: "dummy"},
+		client: gocloak.NewClient(server.URL),
+	}
+	l := logger.CreateTestLogger()
+	_, c := newTestCache(t)
+
+	// First call: cache miss, should hit server
+	got, err := retrieveGroupByID(context.Background(), l, groupID, realm, c, kc)
+	require.NoError(t, err)
+	assert.Equal(t, groupResp, got)
+	assert.Equal(t, 1, called)
+
+	// Wait
+	time.Sleep(200 * time.Millisecond)
+
+	// Second call: cache hit, should NOT hit server
+	called = 0
+	got2, err := retrieveGroupByID(context.Background(), l, groupID, realm, c, kc)
+	require.NoError(t, err)
+	assert.Equal(t, groupResp, got2)
+	assert.Equal(t, 0, called)
+
+	// Optionally, check cache directly
+	val, err := c.Get(context.Background(), cacheKey)
+	require.NoError(t, err)
+	assert.Equal(t, groupResp, val)
+
+	// Wait for cache expiration
+	time.Sleep(6 * time.Second)
+	// After expiration, cache should be empty
+	_, err = c.Get(context.Background(), cacheKey)
+	require.Error(t, err, "Cache should be empty after expiration")
+}
+
+func TestRetrieveGroupMembers_CacheIntegration(t *testing.T) {
+	groupID := "gid"
+	realm := "tdf"
+	cacheKey := fmt.Sprintf("%s::group::%s::members", realm, groupID)
+	membersResp := []*gocloak.User{{ID: gocloak.StringP("uid")}}
+
+	var called int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		assert.Equal(t, "/admin/realms/tdf/groups/gid/members", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(membersResp)
+	}))
+	defer server.Close()
+
+	kc := &Connector{
+		token:  &gocloak.JWT{AccessToken: "dummy"},
+		client: gocloak.NewClient(server.URL),
+	}
+	l := logger.CreateTestLogger()
+	_, c := newTestCache(t)
+
+	// First call: cache miss, should hit server
+	got, err := retrieveGroupMembers(context.Background(), l, groupID, realm, c, kc)
+	require.NoError(t, err)
+	assert.Equal(t, membersResp, got)
+	assert.Equal(t, 1, called)
+
+	// Wait
+	time.Sleep(200 * time.Millisecond)
+
+	// Second call: cache hit, should NOT hit server
+	called = 0
+	got2, err := retrieveGroupMembers(context.Background(), l, groupID, realm, c, kc)
+	require.NoError(t, err)
+	assert.Equal(t, membersResp, got2)
+	assert.Equal(t, 0, called)
+
+	// Optionally, check cache directly
+	val, err := c.Get(context.Background(), cacheKey)
+	require.NoError(t, err)
+	assert.Equal(t, membersResp, val)
+
+	// Wait for cache expiration
+	time.Sleep(6 * time.Second)
+	// After expiration, cache should be empty
+	_, err = c.Get(context.Background(), cacheKey)
+	require.Error(t, err, "Cache should be empty after expiration")
+}

--- a/service/entityresolution/keycloak/v2/retrieve_test.go
+++ b/service/entityresolution/keycloak/v2/retrieve_test.go
@@ -51,7 +51,7 @@ func TestRetrieveClients_CacheIntegration(t *testing.T) {
 	}
 	l := logger.CreateTestLogger()
 	cm, c := newTestCache(t)
-	cm.Close() // Ensure cache manager is closed after test
+	defer cm.Close() // Ensure cache manager is closed after test
 
 	// First call: cache miss, should hit server
 	got, err := retrieveClients(t.Context(), l, clientID, realm, c, kc)
@@ -103,7 +103,7 @@ func TestRetrieveUsers_CacheIntegration(t *testing.T) {
 	}
 	l := logger.CreateTestLogger()
 	cm, c := newTestCache(t)
-	cm.Close() // Ensure cache manager is closed after test
+	defer cm.Close() // Ensure cache manager is closed after test
 
 	// First call: cache miss, should hit server
 	params := gocloak.GetUsersParams{Email: &email}
@@ -156,7 +156,7 @@ func TestRetrieveGroupsByEmail_CacheIntegration(t *testing.T) {
 	}
 	l := logger.CreateTestLogger()
 	cm, c := newTestCache(t)
-	cm.Close() // Ensure cache manager is closed after test
+	defer cm.Close() // Ensure cache manager is closed after test
 
 	// First call: cache miss, should hit server
 	got, err := retrieveGroupsByEmail(t.Context(), l, groupEmail, realm, c, kc)
@@ -207,7 +207,7 @@ func TestRetrieveGroupByID_CacheIntegration(t *testing.T) {
 	}
 	l := logger.CreateTestLogger()
 	cm, c := newTestCache(t)
-	cm.Close() // Ensure cache manager is closed after test
+	defer cm.Close() // Ensure cache manager is closed after test
 
 	// First call: cache miss, should hit server
 	got, err := retrieveGroupByID(t.Context(), l, groupID, realm, c, kc)
@@ -258,7 +258,7 @@ func TestRetrieveGroupMembers_CacheIntegration(t *testing.T) {
 	}
 	l := logger.CreateTestLogger()
 	cm, c := newTestCache(t)
-	cm.Close() // Ensure cache manager is closed after test
+	defer cm.Close() // Ensure cache manager is closed after test
 
 	// First call: cache miss, should hit server
 	got, err := retrieveGroupMembers(t.Context(), l, groupID, realm, c, kc)

--- a/service/entityresolution/keycloak/v2/retrieve_test.go
+++ b/service/entityresolution/keycloak/v2/retrieve_test.go
@@ -50,7 +50,8 @@ func TestRetrieveClients_CacheIntegration(t *testing.T) {
 		client: gocloak.NewClient(server.URL),
 	}
 	l := logger.CreateTestLogger()
-	_, c := newTestCache(t)
+	cm, c := newTestCache(t)
+	cm.Close() // Ensure cache manager is closed after test
 
 	// First call: cache miss, should hit server
 	got, err := retrieveClients(t.Context(), l, clientID, realm, c, kc)
@@ -101,7 +102,8 @@ func TestRetrieveUsers_CacheIntegration(t *testing.T) {
 		client: gocloak.NewClient(server.URL),
 	}
 	l := logger.CreateTestLogger()
-	_, c := newTestCache(t)
+	cm, c := newTestCache(t)
+	cm.Close() // Ensure cache manager is closed after test
 
 	// First call: cache miss, should hit server
 	params := gocloak.GetUsersParams{Email: &email}
@@ -153,7 +155,8 @@ func TestRetrieveGroupsByEmail_CacheIntegration(t *testing.T) {
 		client: gocloak.NewClient(server.URL),
 	}
 	l := logger.CreateTestLogger()
-	_, c := newTestCache(t)
+	cm, c := newTestCache(t)
+	cm.Close() // Ensure cache manager is closed after test
 
 	// First call: cache miss, should hit server
 	got, err := retrieveGroupsByEmail(t.Context(), l, groupEmail, realm, c, kc)
@@ -203,7 +206,8 @@ func TestRetrieveGroupByID_CacheIntegration(t *testing.T) {
 		client: gocloak.NewClient(server.URL),
 	}
 	l := logger.CreateTestLogger()
-	_, c := newTestCache(t)
+	cm, c := newTestCache(t)
+	cm.Close() // Ensure cache manager is closed after test
 
 	// First call: cache miss, should hit server
 	got, err := retrieveGroupByID(t.Context(), l, groupID, realm, c, kc)
@@ -253,7 +257,8 @@ func TestRetrieveGroupMembers_CacheIntegration(t *testing.T) {
 		client: gocloak.NewClient(server.URL),
 	}
 	l := logger.CreateTestLogger()
-	_, c := newTestCache(t)
+	cm, c := newTestCache(t)
+	cm.Close() // Ensure cache manager is closed after test
 
 	// First call: cache miss, should hit server
 	got, err := retrieveGroupMembers(t.Context(), l, groupID, realm, c, kc)

--- a/service/pkg/cache/cache.go
+++ b/service/pkg/cache/cache.go
@@ -88,14 +88,14 @@ func (c *Cache) Get(ctx context.Context, key string) (any, error) {
 	val, err := c.manager.cache.Get(ctx, c.getKey(key))
 	if err != nil {
 		// All errors are a cache miss in the gocache library.
-		c.logger.DebugContext(ctx,
+		c.logger.TraceContext(ctx,
 			"cache miss",
 			slog.Any("key", key),
 			slog.Any("error", err),
 		)
 		return nil, ErrCacheMiss
 	}
-	c.logger.DebugContext(ctx,
+	c.logger.TraceContext(ctx,
 		"cache hit",
 		slog.Any("key", key),
 	)
@@ -118,7 +118,7 @@ func (c *Cache) Set(ctx context.Context, key string, object any, tags []string) 
 		)
 		return err
 	}
-	c.logger.DebugContext(ctx, "set cache", slog.Any("key", key))
+	c.logger.TraceContext(ctx, "set cache", slog.Any("key", key))
 	return nil
 }
 


### PR DESCRIPTION
### Proposed Changes

- Centralizes Keycloak entity retrieval logic into helper functions (retrieve.go)
- Adds caching for Keycloak lookups (clients, users, groups, group members)
- Updates entity resolution code to use cached helpers
- Improves performance by reducing redundant Keycloak requests
- No API changes; internal refactor only
- Adds tests for cache integration and expiration

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

