### PR TITLE
fix(sdk): Prefer KID and Algorithm selection from key maps

### DIFF
--- a/examples/cmd/encrypt.go
+++ b/examples/cmd/encrypt.go
@@ -99,7 +99,6 @@ func encrypt(cmd *cobra.Command, args []string) error {
 		opts := []sdk.TDFOption{sdk.WithDataAttributes(dataAttributes...)}
 		if !autoconfigure {
 			opts = append(opts, sdk.WithAutoconfigure(autoconfigure))
-			opts = append(opts, sdk.WithWrappingKeyAlg(ocrypto.EC256Key))
 			opts = append(opts, sdk.WithKasInformation(
 				sdk.KASInfo{
 					URL:       baseKasURL,
@@ -111,7 +110,7 @@ func encrypt(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			opts = append(opts, sdk.WithWrappingKeyAlg(kt))
+			opts = append(opts, sdk.WithPreferredKeyWrapAlg(kt))
 		}
 		tdf, err := client.CreateTDF(out, in, opts...)
 		if err != nil {

--- a/examples/cmd/encrypt.go
+++ b/examples/cmd/encrypt.go
@@ -110,7 +110,7 @@ func encrypt(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			opts = append(opts, sdk.WithPreferredKeyWrapAlg(kt))
+			opts = append(opts, sdk.WithWrappingKeyAlg(kt))
 		}
 		tdf, err := client.CreateTDF(out, in, opts...)
 		if err != nil {

--- a/sdk/basekey.go
+++ b/sdk/basekey.go
@@ -21,12 +21,14 @@ const (
 	wellKnownConfigKey = "configuration"
 )
 
+const RSA4096Key ocrypto.KeyType = "rsa:4096"
+
 // TODO: Move this function to ocrypto?
 func getKasKeyAlg(alg string) policy.Algorithm {
 	switch alg {
 	case string(ocrypto.RSA2048Key):
 		return policy.Algorithm_ALGORITHM_RSA_2048
-	case "rsa:4096":
+	case string(RSA4096Key):
 		return policy.Algorithm_ALGORITHM_RSA_4096
 	case string(ocrypto.EC256Key):
 		return policy.Algorithm_ALGORITHM_EC_P256
@@ -45,7 +47,7 @@ func formatAlg(alg policy.Algorithm) (string, error) {
 	case policy.Algorithm_ALGORITHM_RSA_2048:
 		return string(ocrypto.RSA2048Key), nil
 	case policy.Algorithm_ALGORITHM_RSA_4096:
-		return "rsa:4096", nil
+		return string(RSA4096Key), nil
 	case policy.Algorithm_ALGORITHM_EC_P256:
 		return string(ocrypto.EC256Key), nil
 	case policy.Algorithm_ALGORITHM_EC_P384:

--- a/sdk/basekey.go
+++ b/sdk/basekey.go
@@ -26,7 +26,7 @@ func getKasKeyAlg(alg string) policy.Algorithm {
 	switch alg {
 	case string(ocrypto.RSA2048Key):
 		return policy.Algorithm_ALGORITHM_RSA_2048
-	case rsa4096:
+	case "rsa:4096":
 		return policy.Algorithm_ALGORITHM_RSA_4096
 	case string(ocrypto.EC256Key):
 		return policy.Algorithm_ALGORITHM_EC_P256
@@ -45,7 +45,7 @@ func formatAlg(alg policy.Algorithm) (string, error) {
 	case policy.Algorithm_ALGORITHM_RSA_2048:
 		return string(ocrypto.RSA2048Key), nil
 	case policy.Algorithm_ALGORITHM_RSA_4096:
-		return rsa4096, nil
+		return "rsa:4096", nil
 	case policy.Algorithm_ALGORITHM_EC_P256:
 		return string(ocrypto.EC256Key), nil
 	case policy.Algorithm_ALGORITHM_EC_P384:

--- a/sdk/basekey_test.go
+++ b/sdk/basekey_test.go
@@ -15,10 +15,9 @@ import (
 )
 
 const (
-	testPem          = "a-pem"
-	testKasURI       = "https://test-kas.example.com"
-	testRSAAlgorithm = "rsa:2048"
-	testKid          = "test-key-id"
+	testPem    = "a-pem"
+	testKasURI = "https://test-kas.example.com"
+	testKid    = "test-key-id"
 )
 
 // Mock implementation of the WellKnownServiceClient for testing
@@ -192,7 +191,7 @@ func (s *BaseKeyTestSuite) TestGetBaseKeySuccess() {
 		baseKeyWellKnown: map[string]interface{}{
 			"kas_uri": "https://test-kas.example.com",
 			baseKeyPublicKey: map[string]interface{}{
-				baseKeyAlg: testRSAAlgorithm,
+				baseKeyAlg: "rsa:2048",
 				"kid":      testKid,
 				"pem":      testPem,
 			},

--- a/sdk/granter.go
+++ b/sdk/granter.go
@@ -293,16 +293,16 @@ func convertAlgEnum2Simple(a policy.KasPublicKeyAlgEnum) policy.Algorithm {
 
 // convertStringToAlgorithm converts a string algorithm representation to policy.Algorithm
 func convertStringToAlgorithm(alg string) policy.Algorithm {
-	switch strings.ToLower(alg) {
-	case "ec:secp256r1":
+	switch ocrypto.KeyType(strings.ToLower(alg)) {
+	case ocrypto.EC256Key:
 		return policy.Algorithm_ALGORITHM_EC_P256
-	case "ec:secp384r1":
+	case ocrypto.EC384Key:
 		return policy.Algorithm_ALGORITHM_EC_P384
-	case "ec:secp521r1":
+	case ocrypto.EC521Key:
 		return policy.Algorithm_ALGORITHM_EC_P521
-	case "rsa:2048":
+	case ocrypto.RSA2048Key:
 		return policy.Algorithm_ALGORITHM_RSA_2048
-	case "rsa:4096":
+	case RSA4096Key:
 		return policy.Algorithm_ALGORITHM_RSA_4096
 	default:
 		return policy.Algorithm_ALGORITHM_UNSPECIFIED
@@ -481,15 +481,15 @@ func newGranterFromService(ctx context.Context, keyCache *kasKeyCache, as sdkcon
 func algProto2String(e policy.KasPublicKeyAlgEnum) string {
 	switch e {
 	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1:
-		return "ec:secp256r1"
+		return string(ocrypto.EC256Key)
 	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1:
-		return "ec:secp384r1"
+		return string(ocrypto.EC384Key)
 	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1:
-		return "ec:secp521r1"
+		return string(ocrypto.EC521Key)
 	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048:
-		return "rsa:2048"
+		return string(ocrypto.RSA2048Key)
 	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096:
-		return "rsa:4096"
+		return string(RSA4096Key)
 	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED:
 		return ""
 	}
@@ -507,7 +507,7 @@ func algProto2OcryptoKeyType(e policy.Algorithm) ocrypto.KeyType {
 	case policy.Algorithm_ALGORITHM_RSA_2048:
 		return ocrypto.RSA2048Key
 	case policy.Algorithm_ALGORITHM_RSA_4096:
-		return ocrypto.KeyType("rsa:4096")
+		return RSA4096Key
 	case policy.Algorithm_ALGORITHM_UNSPECIFIED:
 		return ocrypto.KeyType("")
 	default:

--- a/sdk/granter.go
+++ b/sdk/granter.go
@@ -25,7 +25,6 @@ const (
 	anyOf       = "anyOf"
 	unspecified = "unspecified"
 	emptyTerm   = "DEFAULT"
-	rsa4096     = "rsa:4096"
 )
 
 // keySplitStep represents a which KAS a split with the associated ID should be shared with.

--- a/sdk/granter.go
+++ b/sdk/granter.go
@@ -698,7 +698,7 @@ func (r granter) plan(defaultKas []string, genSplitID func() string) ([]keySplit
 	return p, nil
 }
 
-func (r granter) resolveTemplate(ctx context.Context, genSplitID func() string) ([]kaoTpl, error) {
+func (r granter) resolveTemplate(ctx context.Context, kaoKeyAlg string, genSplitID func() string) ([]kaoTpl, error) {
 	b := r.constructAttributeBoolean()
 	k, err := r.assignKeysTo(*b)
 	if err != nil {
@@ -719,7 +719,7 @@ func (r granter) resolveTemplate(ctx context.Context, genSplitID func() string) 
 		for _, o := range v.values {
 			if o.ID() == "" && r.keyInfoFetcher != nil {
 				// No Key ID, guess what it should be.
-				kpub, err := r.keyInfoFetcher.getPublicKey(ctx, o.KASURI(), "", "")
+				kpub, err := r.keyInfoFetcher.getPublicKey(ctx, o.KASURI(), kaoKeyAlg, "")
 				if err != nil {
 					return nil, fmt.Errorf("failed to fetch public key for resource locator [%s]: %w", o, err)
 				}

--- a/sdk/granter.go
+++ b/sdk/granter.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/attributes"
 	"github.com/opentdf/platform/sdk/sdkconnect"
@@ -36,13 +37,20 @@ type keySplitStep struct {
 // It is filled in during manifest creation by splitting the key material (DEK) across each split ID,
 // then wrapping each split with the KAS public key identified by the KID at each element.
 type kaoTpl struct {
-	keySplitStep
-	kid string
+	KAS, SplitID string
+	kid          string
+	pem          string
+	algorithm    ocrypto.KeyType
 }
 
 // AttributeNameFQN represents the FQN for an attribute.
 type AttributeNameFQN struct {
 	url, key string
+}
+
+// Lookup Table for KAS keys, indexed by ResourceLocator.
+type rlKeyCache struct {
+	c map[ResourceLocator]*policy.SimpleKasKey
 }
 
 func attributeURLPartsValid(parts []string) error {
@@ -204,6 +212,12 @@ type granter struct {
 
 	// The types of grants or mapped keys found.
 	typ grantType
+
+	// The key cache to store KAS keys.
+	keyCache *rlKeyCache
+
+	// Key lookup for keys without a KID.
+	keyInfoFetcher KASKeyFetcher
 }
 
 type keyAccessGrant struct {
@@ -255,6 +269,7 @@ func (r *granter) addMappedKey(fqn AttributeValueFQN, sk *policy.SimpleKasKey) e
 	)
 	rls = append(rls, rl)
 	r.mapTable[fqn.key] = rls
+	r.keyCache.c[*rl] = sk
 	return nil
 }
 
@@ -272,6 +287,24 @@ func convertAlgEnum2Simple(a policy.KasPublicKeyAlgEnum) policy.Algorithm {
 		return policy.Algorithm_ALGORITHM_RSA_4096
 	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED:
 		return policy.Algorithm_ALGORITHM_UNSPECIFIED
+	default:
+		return policy.Algorithm_ALGORITHM_UNSPECIFIED
+	}
+}
+
+// convertStringToAlgorithm converts a string algorithm representation to policy.Algorithm
+func convertStringToAlgorithm(alg string) policy.Algorithm {
+	switch strings.ToLower(alg) {
+	case "ec:secp256r1":
+		return policy.Algorithm_ALGORITHM_EC_P256
+	case "ec:secp384r1":
+		return policy.Algorithm_ALGORITHM_EC_P384
+	case "ec:secp521r1":
+		return policy.Algorithm_ALGORITHM_EC_P521
+	case "rsa:2048":
+		return policy.Algorithm_ALGORITHM_RSA_2048
+	case "rsa:4096":
+		return policy.Algorithm_ALGORITHM_RSA_4096
 	default:
 		return policy.Algorithm_ALGORITHM_UNSPECIFIED
 	}
@@ -413,6 +446,7 @@ func newGranterFromService(ctx context.Context, keyCache *kasKeyCache, as sdkcon
 	grants := granter{
 		tags:       fqns,
 		grantTable: make(map[string]*keyAccessGrant),
+		keyCache:   &rlKeyCache{c: make(map[ResourceLocator]*policy.SimpleKasKey)},
 	}
 	for fqnstr, pair := range av.GetFqnAttributeValues() {
 		fqn, err := NewAttributeValueFQN(fqnstr)
@@ -422,23 +456,23 @@ func newGranterFromService(ctx context.Context, keyCache *kasKeyCache, as sdkcon
 		def := pair.GetAttribute()
 
 		if def != nil {
-			storeKeysToCache(def.GetGrants(), def.GetKasKeys(), keyCache)
+			storeKeysToCache(def.GetGrants(), def.GetKasKeys(), keyCache, grants.keyCache)
 		}
 		v := pair.GetValue()
 		gType := noKeysFound
 		if v != nil {
 			gType = grants.addAllGrants(fqn, v, def)
-			storeKeysToCache(v.GetGrants(), v.GetKasKeys(), keyCache)
+			storeKeysToCache(v.GetGrants(), v.GetKasKeys(), keyCache, grants.keyCache)
 		}
 
 		// If no more specific grant was found, then add the value grants
 		if gType == noKeysFound && def != nil {
 			gType = grants.addAllGrants(fqn, def, def)
-			storeKeysToCache(def.GetGrants(), def.GetKasKeys(), keyCache)
+			storeKeysToCache(def.GetGrants(), def.GetKasKeys(), keyCache, grants.keyCache)
 		}
 		if gType == noKeysFound && def.GetNamespace() != nil {
 			grants.addAllGrants(fqn, def.GetNamespace(), def)
-			storeKeysToCache(def.GetNamespace().GetGrants(), def.GetNamespace().GetKasKeys(), keyCache)
+			storeKeysToCache(def.GetNamespace().GetGrants(), def.GetNamespace().GetKasKeys(), keyCache, grants.keyCache)
 		}
 	}
 
@@ -463,7 +497,26 @@ func algProto2String(e policy.KasPublicKeyAlgEnum) string {
 	return ""
 }
 
-func storeKeysToCache(kases []*policy.KeyAccessServer, keys []*policy.SimpleKasKey, c *kasKeyCache) {
+func algProto2OcryptoKeyType(e policy.Algorithm) ocrypto.KeyType {
+	switch e {
+	case policy.Algorithm_ALGORITHM_EC_P256:
+		return ocrypto.EC256Key
+	case policy.Algorithm_ALGORITHM_EC_P384:
+		return ocrypto.EC384Key
+	case policy.Algorithm_ALGORITHM_EC_P521:
+		return ocrypto.EC521Key
+	case policy.Algorithm_ALGORITHM_RSA_2048:
+		return ocrypto.RSA2048Key
+	case policy.Algorithm_ALGORITHM_RSA_4096:
+		return ocrypto.KeyType("rsa:4096")
+	case policy.Algorithm_ALGORITHM_UNSPECIFIED:
+		return ocrypto.KeyType("")
+	default:
+		return ocrypto.KeyType("")
+	}
+}
+
+func storeKeysToCache(kases []*policy.KeyAccessServer, keys []*policy.SimpleKasKey, c *kasKeyCache, kc *rlKeyCache) {
 	for _, kas := range kases {
 		keys := kas.GetPublicKey().GetCached().GetKeys()
 		if len(keys) == 0 {
@@ -477,6 +530,29 @@ func storeKeysToCache(kases []*policy.KeyAccessServer, keys []*policy.SimpleKasK
 				Algorithm: algProto2String(ki.GetAlg()),
 				PublicKey: ki.GetPem(),
 			})
+
+			// Store in rlKeyCache if sufficient information is available
+			// (KID and PEM must not be empty)
+			if kc != nil && ki.GetKid() != "" && ki.GetPem() != "" {
+				rl, err := NewResourceLocator(kas.GetUri())
+				if err != nil {
+					slog.Debug("failed to create ResourceLocator",
+						slog.String("kas", kas.GetUri()),
+						slog.Any("error", err),
+					)
+					continue
+				}
+				rl.identifier = ki.GetKid()
+				kc.c[*rl] = &policy.SimpleKasKey{
+					KasUri: kas.GetUri(),
+					PublicKey: &policy.SimpleKasPublicKey{
+						Algorithm: convertAlgEnum2Simple(ki.GetAlg()),
+						Pem:       ki.GetPem(),
+						Kid:       ki.GetKid(),
+					},
+					KasId: kas.GetId(),
+				}
+			}
 		}
 	}
 	for _, key := range keys {
@@ -490,6 +566,20 @@ func storeKeysToCache(kases []*policy.KeyAccessServer, keys []*policy.SimpleKasK
 			Algorithm: alg,
 			PublicKey: key.GetPublicKey().GetPem(),
 		})
+
+		// Store in rlKeyCache if provided
+		if kc != nil && key.GetPublicKey().GetKid() != "" && key.GetPublicKey().GetPem() != "" {
+			rl, err := NewResourceLocator(key.GetKasUri())
+			if err != nil {
+				slog.Debug("failed to create ResourceLocator",
+					slog.String("kas", key.GetKasUri()),
+					slog.Any("error", err),
+				)
+				continue
+			}
+			rl.identifier = key.GetPublicKey().GetKid()
+			kc.c[*rl] = key
+		}
 	}
 }
 
@@ -501,6 +591,7 @@ func newGranterFromAttributes(keyCache *kasKeyCache, attrs ...*policy.Value) (gr
 		grantTable: make(map[string]*keyAccessGrant),
 		mapTable:   make(map[string][]*ResourceLocator),
 		tags:       make([]AttributeValueFQN, len(attrs)),
+		keyCache:   &rlKeyCache{c: make(map[ResourceLocator]*policy.SimpleKasKey)},
 	}
 	for i, v := range attrs {
 		fqn, err := NewAttributeValueFQN(v.GetFqn())
@@ -518,16 +609,16 @@ func newGranterFromAttributes(keyCache *kasKeyCache, attrs ...*policy.Value) (gr
 		}
 
 		if grants.addAllGrants(fqn, v, def) != noKeysFound {
-			storeKeysToCache(v.GetGrants(), v.GetKasKeys(), keyCache)
+			storeKeysToCache(v.GetGrants(), v.GetKasKeys(), keyCache, grants.keyCache)
 			continue
 		}
 		// If no more specific grant was found, then add the attr grants
 		if grants.addAllGrants(fqn, def, def) != noKeysFound {
-			storeKeysToCache(def.GetGrants(), def.GetKasKeys(), keyCache)
+			storeKeysToCache(def.GetGrants(), def.GetKasKeys(), keyCache, grants.keyCache)
 			continue
 		}
 		grants.addAllGrants(fqn, namespace, def)
-		storeKeysToCache(namespace.GetGrants(), namespace.GetKasKeys(), keyCache)
+		storeKeysToCache(namespace.GetGrants(), namespace.GetKasKeys(), keyCache, grants.keyCache)
 	}
 
 	return grants, nil
@@ -608,7 +699,7 @@ func (r granter) plan(defaultKas []string, genSplitID func() string) ([]keySplit
 	return p, nil
 }
 
-func (r granter) resolveTemplate(genSplitID func() string) ([]kaoTpl, error) {
+func (r granter) resolveTemplate(ctx context.Context, genSplitID func() string) ([]kaoTpl, error) {
 	b := r.constructAttributeBoolean()
 	k, err := r.assignKeysTo(*b)
 	if err != nil {
@@ -627,7 +718,30 @@ func (r granter) resolveTemplate(genSplitID func() string) ([]kaoTpl, error) {
 			splitID = genSplitID()
 		}
 		for _, o := range v.values {
-			p = append(p, kaoTpl{keySplitStep{KAS: o.KASURI(), SplitID: splitID}, o.ID()})
+			if o.ID() == "" && r.keyInfoFetcher != nil {
+				// No Key ID, guess what it should be.
+				kpub, err := r.keyInfoFetcher.getPublicKey(ctx, o.KASURI(), "", "")
+				if err != nil {
+					return nil, fmt.Errorf("failed to fetch public key for resource locator [%s]: %w", o, err)
+				}
+				o.identifier = kpub.KID
+				// Convert the string algorithm to the appropriate enum
+				algEnum := convertStringToAlgorithm(kpub.Algorithm)
+				r.keyCache.c[*o] = &policy.SimpleKasKey{
+					KasUri: o.KASURI(),
+					PublicKey: &policy.SimpleKasPublicKey{
+						Algorithm: algEnum,
+						Pem:       kpub.PublicKey,
+						Kid:       kpub.KID,
+					},
+				}
+			}
+			kpub, ok := r.keyCache.c[*o]
+			if !ok || kpub.GetPublicKey() == nil || kpub.GetPublicKey().GetPem() == "" {
+				return nil, fmt.Errorf("no key found for resource locator [%s]", o)
+			}
+			algorithm := algProto2OcryptoKeyType(kpub.GetPublicKey().GetAlgorithm())
+			p = append(p, kaoTpl{o.KASURI(), splitID, o.ID(), kpub.GetPublicKey().GetPem(), algorithm})
 		}
 	}
 	return p, nil
@@ -765,7 +879,7 @@ func (r *granter) assignKeysTo(e attributeBooleanExpression) (booleanKeyExpressi
 	for _, clause := range e.must {
 		kcv := make([]*ResourceLocator, 0, len(clause.values))
 		for _, term := range clause.values {
-			mv, ok := r.mapTable[term.String()]
+			mv, ok := r.mapTable[term.key]
 			if ok {
 				for _, rl := range mv {
 					kcv = append(kcv, rl)
@@ -881,9 +995,7 @@ func (e booleanKeyExpression) reduce() booleanKeyExpression {
 	values := make([]keyClause, len(conjunction))
 	for i, d := range conjunction {
 		pki := make([]*ResourceLocator, len(d))
-		for j, k := range d {
-			pki[j] = k
-		}
+		copy(pki, d)
 		values[i] = keyClause{
 			operator: anyOf,
 			values:   pki,

--- a/sdk/granter_test.go
+++ b/sdk/granter_test.go
@@ -757,6 +757,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			j := 0
 			tpl, err := reasoner.resolveTemplate(
 				t.Context(),
+				"",
 				func() string {
 					j++
 					return strconv.Itoa(j)

--- a/sdk/granter_test.go
+++ b/sdk/granter_test.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"regexp"
 	"slices"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/attributes"
 	"github.com/opentdf/platform/sdk/sdkconnect"
@@ -149,7 +151,7 @@ func mockAttributeFor(fqn AttributeNameFQN) *policy.Attribute {
 	case MP.key:
 		g := make([]*policy.KeyAccessServer, 1)
 		g[0] = mockGrant(specifiedKas, "r1")
-		g[0].PublicKey = createPublicKey("r1", fakePem, policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048)
+		g[0].PublicKey = createPublicKey("r1", mockRSAPublicKey1, policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048)
 		return &policy.Attribute{
 			Id:        "MP",
 			Namespace: &nsOne,
@@ -225,20 +227,89 @@ func mockGrant(kas, kid string) *policy.KeyAccessServer {
 		return mockGrant(kas, "r0")
 	}
 
+	var k policy.SimpleKasPublicKey
+	switch kid {
+	case "r0":
+		k = policy.SimpleKasPublicKey{
+			Algorithm: policy.Algorithm_ALGORITHM_RSA_2048,
+			Kid:       kid,
+			Pem:       fakePem,
+		}
+	case "r1":
+		k = policy.SimpleKasPublicKey{
+			Algorithm: policy.Algorithm_ALGORITHM_RSA_2048,
+			Kid:       kid,
+			Pem:       mockRSAPublicKey1,
+		}
+	case "r2":
+		k = policy.SimpleKasPublicKey{
+			Algorithm: policy.Algorithm_ALGORITHM_RSA_4096,
+			Kid:       kid,
+			Pem:       mockRSAPublicKey2,
+		}
+	case "r3":
+		k = policy.SimpleKasPublicKey{
+			Algorithm: policy.Algorithm_ALGORITHM_RSA_2048,
+			Kid:       kid,
+			Pem:       mockRSAPublicKey3,
+		}
+	case "e1":
+		k = policy.SimpleKasPublicKey{
+			Algorithm: policy.Algorithm_ALGORITHM_EC_P256,
+			Kid:       kid,
+			Pem:       mockECPublicKey1,
+		}
+	case "e2":
+		k = policy.SimpleKasPublicKey{
+			Algorithm: policy.Algorithm_ALGORITHM_EC_P256,
+			Kid:       kid,
+			Pem:       mockECPublicKey2,
+		}
+	default:
+		panic("invalid kas kid: " + kid)
+	}
+
 	return &policy.KeyAccessServer{
 		Uri: kas,
 		Id:  kas,
 		KasKeys: []*policy.SimpleKasKey{
 			{
-				KasUri: kas,
-				PublicKey: &policy.SimpleKasPublicKey{
-					Algorithm: policy.Algorithm_ALGORITHM_RSA_2048,
-					Kid:       kid,
-					Pem:       fakePem,
-				},
+				KasUri:    kas,
+				PublicKey: &k,
 			},
 		},
 	}
+}
+
+type fakeKeyInfoFetcher struct{}
+
+func (f *fakeKeyInfoFetcher) getPublicKey(_ context.Context, kasurl, _, _ string) (*KASInfo, error) {
+	if kasurl == "" {
+		return nil, errors.New("kas URI is empty")
+	}
+
+	k := KASInfo{
+		URL: kasurl,
+	}
+
+	switch kasurl {
+	case kasAu, kasCa, kasUk, kasNz, kasUs:
+		k.PublicKey = mockRSAPublicKey1
+		k.KID = "r1"
+		k.Algorithm = "rsa:2048"
+	case kasUsHCS, kasUsSA:
+		k.PublicKey = mockRSAPublicKey2
+		k.KID = "r2"
+		k.Algorithm = "rsa:4096"
+	case lessSpecificKas:
+		k.PublicKey = mockRSAPublicKey3
+		k.KID = "r3"
+		k.Algorithm = "rsa:2048"
+	default:
+		return nil, errors.New("unexpected kas URL: " + kasurl)
+	}
+
+	return &k, nil
 }
 
 func mockSimpleKasKey(kas, kid string) *policy.SimpleKasKey {
@@ -249,13 +320,23 @@ func mockSimpleKasKey(kas, kid string) *policy.SimpleKasKey {
 		panic("invalid kas kid")
 	}
 	var alg policy.Algorithm
+	var pem string
 	switch kid {
-	case "r0", "r1", "r3":
+	case "r0":
 		alg = policy.Algorithm_ALGORITHM_RSA_2048
+		pem = fakePem
+	case "r1":
+		alg = policy.Algorithm_ALGORITHM_RSA_2048
+		pem = mockRSAPublicKey1
 	case "r2":
 		alg = policy.Algorithm_ALGORITHM_RSA_4096
+		pem = mockRSAPublicKey2
+	case "r3":
+		alg = policy.Algorithm_ALGORITHM_RSA_2048
+		pem = mockRSAPublicKey3
 	case "e1":
 		alg = policy.Algorithm_ALGORITHM_EC_P256
+		pem = mockECPublicKey1
 	default:
 		panic("invalid kas kid: " + kid)
 	}
@@ -264,7 +345,7 @@ func mockSimpleKasKey(kas, kid string) *policy.SimpleKasKey {
 		PublicKey: &policy.SimpleKasPublicKey{
 			Algorithm: alg,
 			Kid:       kid,
-			Pem:       fakePem,
+			Pem:       pem,
 		},
 	}
 }
@@ -304,10 +385,10 @@ func mockValueFor(fqn AttributeValueFQN) *policy.Value {
 			p.Grants[0] = mockGrant(kasUk, "r1")
 		case "HCS":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = mockGrant(kasUsHCS, "r1")
+			p.Grants[0] = mockGrant(kasUsHCS, "r2")
 		case "SI":
 			p.Grants = make([]*policy.KeyAccessServer, 1)
-			p.Grants[0] = mockGrant(kasUsSA, "r1")
+			p.Grants[0] = mockGrant(kasUsSA, "r2")
 		}
 
 	case REL.key:
@@ -525,9 +606,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			"[DEFAULT]&(https://kas.ca/)",
 			"(https://kas.ca/)",
 			[]keySplitStep{{kasCa, ""}},
-			[]kaoTpl{
-				{keySplitStep{kasCa, ""}, ""},
-			},
+			[]kaoTpl{{kasCa, "", "r1", mockRSAPublicKey1, ocrypto.RSA2048Key}},
 		},
 		{
 			"one defaulted attr",
@@ -567,9 +646,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			"[DEFAULT]&(https://kas.uk/)&(https://kas.uk/)",
 			"(https://kas.uk/)",
 			[]keySplitStep{{kasUk, ""}},
-			[]kaoTpl{
-				{keySplitStep{kasUk, ""}, ""},
-			},
+			[]kaoTpl{{kasUk, "", "r1", mockRSAPublicKey1, ocrypto.RSA2048Key}},
 		},
 		{
 			"simple with namespace",
@@ -580,7 +657,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			"(https://namespace.kas.com/)",
 			[]keySplitStep{{lessSpecificKas, ""}},
 			[]kaoTpl{
-				{keySplitStep{lessSpecificKas, ""}, ""},
+				{lessSpecificKas, "", "r3", mockRSAPublicKey3, ocrypto.RSA2048Key},
 			},
 		},
 		{
@@ -592,10 +669,10 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			"(https://kas.uk/⋁https://kas.us/)&(https://hcs.kas.us/)&(https://si.kas.us/)",
 			[]keySplitStep{{kasUk, "1"}, {kasUs, "1"}, {kasUsHCS, "2"}, {kasUsSA, "3"}},
 			[]kaoTpl{
-				{keySplitStep{kasUk, "1"}, ""},
-				{keySplitStep{kasUs, "1"}, ""},
-				{keySplitStep{kasUsHCS, "2"}, ""},
-				{keySplitStep{kasUsSA, "3"}, ""},
+				{kasUk, "1", "r1", mockRSAPublicKey1, ocrypto.RSA2048Key},
+				{kasUs, "1", "r1", mockRSAPublicKey1, ocrypto.RSA2048Key},
+				{kasUsHCS, "2", "r2", mockRSAPublicKey2, ocrypto.KeyType("rsa:4096")},
+				{kasUsSA, "3", "r2", mockRSAPublicKey2, ocrypto.KeyType("rsa:4096")},
 			},
 		},
 		{
@@ -607,10 +684,10 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			"(https://kas.uk/⋁https://kas.us/)&(https://hcs.kas.us/)&(https://si.kas.us/)",
 			[]keySplitStep{{kasUk, "1"}, {kasUs, "1"}, {kasUsHCS, "2"}, {kasUsSA, "3"}},
 			[]kaoTpl{
-				{keySplitStep{kasUk, "1"}, ""},
-				{keySplitStep{kasUs, "1"}, ""},
-				{keySplitStep{kasUsHCS, "2"}, ""},
-				{keySplitStep{kasUsSA, "3"}, ""},
+				{kasUk, "1", "r1", mockRSAPublicKey1, ocrypto.RSA2048Key},
+				{kasUs, "1", "r1", mockRSAPublicKey1, ocrypto.RSA2048Key},
+				{kasUsHCS, "2", "r2", mockRSAPublicKey2, ocrypto.KeyType("rsa:4096")},
+				{kasUsSA, "3", "r2", mockRSAPublicKey2, ocrypto.KeyType("rsa:4096")},
 			},
 		},
 		{
@@ -622,8 +699,8 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			"(https://value.kas.com/)",
 			[]keySplitStep{{evenMoreSpecificKas, ""}},
 			[]kaoTpl{
-				{keySplitStep{evenMoreSpecificKas, "1"}, "e1"},
-				{keySplitStep{evenMoreSpecificKas, "1"}, "r2"},
+				{evenMoreSpecificKas, "1", "e1", mockECPublicKey1, ocrypto.EC256Key},
+				{evenMoreSpecificKas, "1", "r2", mockRSAPublicKey2, ocrypto.KeyType("rsa:4096")},
 			},
 		},
 		{
@@ -635,7 +712,7 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			"(https://attr.kas.com/)",
 			[]keySplitStep{{specifiedKas, ""}},
 			[]kaoTpl{
-				{keySplitStep{specifiedKas, ""}, "r1"},
+				{specifiedKas, "", "r1", mockRSAPublicKey1, ocrypto.RSA2048Key},
 			},
 		},
 		{
@@ -647,15 +724,17 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			"(https://attr.kas.com/⋁https://value.kas.com/)",
 			[]keySplitStep{{specifiedKas, "1"}, {evenMoreSpecificKas, "1"}},
 			[]kaoTpl{
-				{keySplitStep{specifiedKas, "1"}, "r1"},
-				{keySplitStep{evenMoreSpecificKas, "1"}, "e1"},
-				{keySplitStep{evenMoreSpecificKas, "1"}, "r2"},
+				{specifiedKas, "1", "r1", mockRSAPublicKey1, ocrypto.RSA2048Key},
+				{evenMoreSpecificKas, "1", "e1", mockECPublicKey1, ocrypto.EC256Key},
+				{evenMoreSpecificKas, "1", "r2", mockRSAPublicKey2, ocrypto.KeyType("rsa:4096")},
 			},
 		},
 	} {
 		t.Run(tc.n, func(t *testing.T) {
 			reasoner, err := newGranterFromAttributes(newKasKeyCache(), valuesToPolicy(tc.policy...)...)
 			require.NoError(t, err)
+
+			reasoner.keyInfoFetcher = &fakeKeyInfoFetcher{}
 
 			actualAB := reasoner.constructAttributeBoolean()
 			assert.Equal(t, strings.ToLower(tc.ats), strings.ToLower(actualAB.String()))
@@ -676,10 +755,12 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 			assert.Equal(t, tc.plan, plan)
 
 			j := 0
-			tpl, err := reasoner.resolveTemplate(func() string {
-				j++
-				return strconv.Itoa(j)
-			})
+			tpl, err := reasoner.resolveTemplate(
+				t.Context(),
+				func() string {
+					j++
+					return strconv.Itoa(j)
+				})
 			require.NoError(t, err)
 			assert.Equal(t, tc.tpl, tpl)
 		})

--- a/sdk/kas_client.go
+++ b/sdk/kas_client.go
@@ -428,6 +428,10 @@ func (c *kasKeyCache) store(ki KASInfo) {
 	c.c[cacheKey] = timeStampedKASInfo{ki, time.Now()}
 }
 
+type KASKeyFetcher interface {
+	getPublicKey(ctx context.Context, kasurl, algorithm, kidToFind string) (*KASInfo, error)
+}
+
 func (s SDK) getPublicKey(ctx context.Context, kasurl, algorithm, kidToFind string) (*KASInfo, error) {
 	if s.kasKeyCache != nil {
 		if cachedValue := s.kasKeyCache.get(kasurl, algorithm, kidToFind); nil != cachedValue {

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -488,7 +488,7 @@ func (s SDK) prepareManifest(ctx context.Context, t *TDFObject, tdfConfig TDFCon
 	}
 
 	if len(tdfConfig.kaoTemplate) == 0 {
-return fmt.Errorf("no key access template specified or inferred in initKAOTemplate: %w", errInvalidKasInfo)
+		return fmt.Errorf("no key access template specified or inferred in initKAOTemplate: %w", errInvalidKasInfo)
 	}
 
 	manifest.EncryptionInformation.KeyAccessType = kSplitKeyType

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -395,7 +395,7 @@ func (tdfConfig *TDFConfig) initKAOTemplate(ctx context.Context, s SDK) error {
 
 		switch g.typ {
 		case mappedFound:
-			tdfConfig.kaoTemplate, err = g.resolveTemplate(ctx, uuidSplitIDGenerator)
+			tdfConfig.kaoTemplate, err = g.resolveTemplate(ctx, string(tdfConfig.preferredKeyWrapAlg), uuidSplitIDGenerator)
 		case grantsFound:
 			tdfConfig.kaoTemplate = nil
 			tdfConfig.splitPlan, err = g.plan(make([]string, 0), uuidSplitIDGenerator)
@@ -433,7 +433,7 @@ func (tdfConfig *TDFConfig) initKAOTemplate(ctx context.Context, s SDK) error {
 		for i, splitInfo := range tdfConfig.splitPlan {
 			kasInfo, ok := latestKASInfo[splitInfo.KAS]
 			if !ok {
-				k, err := s.getPublicKey(ctx, splitInfo.KAS, "", "")
+				k, err := s.getPublicKey(ctx, splitInfo.KAS, string(tdfConfig.preferredKeyWrapAlg), "")
 				if err != nil {
 					return fmt.Errorf("unable to retrieve public key from KAS at [%s]: %w", splitInfo.KAS, err)
 				}
@@ -1484,10 +1484,10 @@ func populateKasInfoFromBaseKey(key *policy.SimpleKasKey, tdfConfig *TDFConfig) 
 	}
 
 	// ? Maybe we shouldn't overwrite the key type
-	if tdfConfig.keyType != ocrypto.KeyType(algoString) {
+	if tdfConfig.wrappingKeyAlg != ocrypto.KeyType(algoString) {
 		slog.Warn("base key is enabled, setting key type", slog.String("key_type", algoString))
 	}
-	tdfConfig.keyType = ocrypto.KeyType(algoString)
+	tdfConfig.wrappingKeyAlg = ocrypto.KeyType(algoString)
 	tdfConfig.splitPlan = nil
 	if len(tdfConfig.kasInfoList) > 0 {
 		slog.Warn("base key is enabled, overwriting kasInfoList with base key info")

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -488,7 +488,7 @@ func (s SDK) prepareManifest(ctx context.Context, t *TDFObject, tdfConfig TDFCon
 	}
 
 	if len(tdfConfig.kaoTemplate) == 0 {
-		return fmt.Errorf("%w: no key access template specified or inferred", errInvalidKasInfo)
+return fmt.Errorf("no key access template specified or inferred in initKAOTemplate: %w", errInvalidKasInfo)
 	}
 
 	manifest.EncryptionInformation.KeyAccessType = kSplitKeyType

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -562,7 +562,7 @@ func (s SDK) prepareManifest(ctx context.Context, t *TDFObject, tdfConfig TDFCon
 				return fmt.Errorf("splitID:[%s], kas:[%s]: %w", splitID, kasInfo.URL, errKasPubKeyMissing)
 			}
 
-			keyAccess, err := createKeyAccess(tdfConfig, kasInfo, symKey, policyBinding, encryptedMetadata, splitID)
+			keyAccess, err := createKeyAccess(kasInfo, symKey, policyBinding, encryptedMetadata, splitID)
 			if err != nil {
 				return err
 			}
@@ -615,7 +615,7 @@ func encryptMetadata(symKey []byte, metaData string) (string, error) {
 	return string(ocrypto.Base64Encode(metadataJSON)), nil
 }
 
-func createKeyAccess(tdfConfig TDFConfig, kasInfo KASInfo, symKey []byte, policyBinding PolicyBinding, encryptedMetadata, splitID string) (KeyAccess, error) {
+func createKeyAccess(kasInfo KASInfo, symKey []byte, policyBinding PolicyBinding, encryptedMetadata, splitID string) (KeyAccess, error) {
 	keyAccess := KeyAccess{
 		KeyType:           kWrapped,
 		KasURL:            kasInfo.URL,
@@ -627,8 +627,9 @@ func createKeyAccess(tdfConfig TDFConfig, kasInfo KASInfo, symKey []byte, policy
 		SchemaVersion:     keyAccessSchemaVersion,
 	}
 
-	if ocrypto.IsECKeyType(tdfConfig.keyType) {
-		mode, err := ocrypto.ECKeyTypeToMode(tdfConfig.keyType)
+	ktype := ocrypto.KeyType(kasInfo.Algorithm)
+	if ocrypto.IsECKeyType(ktype) {
+		mode, err := ocrypto.ECKeyTypeToMode(ktype)
 		if err != nil {
 			return KeyAccess{}, err
 		}

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -1484,10 +1484,10 @@ func populateKasInfoFromBaseKey(key *policy.SimpleKasKey, tdfConfig *TDFConfig) 
 	}
 
 	// ? Maybe we shouldn't overwrite the key type
-	if tdfConfig.wrappingKeyAlg != ocrypto.KeyType(algoString) {
+	if tdfConfig.preferredKeyWrapAlg != ocrypto.KeyType(algoString) {
 		slog.Warn("base key is enabled, setting key type", slog.String("key_type", algoString))
 	}
-	tdfConfig.wrappingKeyAlg = ocrypto.KeyType(algoString)
+	tdfConfig.preferredKeyWrapAlg = ocrypto.KeyType(algoString)
 	tdfConfig.splitPlan = nil
 	if len(tdfConfig.kasInfoList) > 0 {
 		slog.Warn("base key is enabled, overwriting kasInfoList with base key info")

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -517,7 +517,11 @@ func (s SDK) prepareManifest(ctx context.Context, t *TDFObject, tdfConfig TDFCon
 			Algorithm: string(tpl.algorithm),
 		}
 		if ki.PublicKey == "" {
-			k, err := s.getPublicKey(ctx, tpl.KAS, ki.Algorithm, tpl.kid)
+			a := ki.Algorithm
+			if a == "" {
+				a = string(tdfConfig.preferredKeyWrapAlg)
+			}
+			k, err := s.getPublicKey(ctx, tpl.KAS, a, tpl.kid)
 			if err != nil {
 				return fmt.Errorf("unable to retrieve public key from KAS at [%s]: %w", tpl.KAS, err)
 			}

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -102,22 +102,6 @@ func newTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
 	return c, nil
 }
 
-func generateKeyPair(kt ocrypto.KeyType) (string, string, error) {
-	keyPair, err := ocrypto.NewKeyPair(kt)
-	if err != nil {
-		return "", "", fmt.Errorf("ocrypto.NewRSAKeyPair failed: %w", err)
-	}
-	publicKey, err := keyPair.PublicKeyInPemFormat()
-	if err != nil {
-		return "", "", fmt.Errorf("ocrypto.PublicKeyInPemFormat failed: %w", err)
-	}
-	privateKey, err := keyPair.PrivateKeyInPemFormat()
-	if err != nil {
-		return "", "", fmt.Errorf("ocrypto.PrivateKeyInPemFormat failed: %w", err)
-	}
-	return publicKey, privateKey, nil
-}
-
 // WithDataAttributes appends the given data attributes to the bound policy
 func WithDataAttributes(attributes ...string) TDFOption {
 	return func(c *TDFConfig) error {
@@ -238,7 +222,7 @@ func WithAutoconfigure(enable bool) TDFOption {
 	}
 }
 
-// DEPRECATED: WithWrappingKeyAlg sets the key type for the TDF wrapping key for both storage and transit.
+// Deprecated: WithWrappingKeyAlg sets the key type for the TDF wrapping key for both storage and transit.
 func WithWrappingKeyAlg(keyType ocrypto.KeyType) TDFOption {
 	return func(c *TDFConfig) error {
 		if keyType == "" {

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -65,8 +65,6 @@ type TDFConfig struct {
 	defaultSegmentSize         int64
 	enableEncryption           bool
 	tdfFormat                  TDFFormat
-	tdfPublicKey               string // TODO: Remove it
-	tdfPrivateKey              string
 	metaData                   string
 	mimeType                   string
 	integrityAlgorithm         IntegrityAlgorithm
@@ -78,7 +76,6 @@ type TDFConfig struct {
 	kaoTemplate                []kaoTpl
 	splitPlan                  []keySplitStep
 	preferredKeyWrapAlg        ocrypto.KeyType
-	wrappingKeyAlg             ocrypto.KeyType
 	useHex                     bool
 	excludeVersionFromManifest bool
 	addDefaultAssertion        bool
@@ -92,7 +89,6 @@ func newTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
 		tdfFormat:                 JSONFormat,
 		integrityAlgorithm:        HS256,
 		segmentIntegrityAlgorithm: GMAC,
-		wrappingKeyAlg:            ocrypto.RSA2048Key, // default to RSA
 		addDefaultAssertion:       false,
 	}
 
@@ -102,14 +98,6 @@ func newTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
 			return nil, err
 		}
 	}
-
-	publicKey, privateKey, err := generateKeyPair(c.wrappingKeyAlg)
-	if err != nil {
-		return nil, err
-	}
-
-	c.tdfPrivateKey = privateKey
-	c.tdfPublicKey = publicKey
 
 	return c, nil
 }
@@ -250,19 +238,13 @@ func WithAutoconfigure(enable bool) TDFOption {
 	}
 }
 
-func WithPreferredKeyWrapAlg(keyType ocrypto.KeyType) TDFOption {
-	return func(c *TDFConfig) error {
-		c.preferredKeyWrapAlg = keyType
-		return nil
-	}
-}
-
+// DEPRECATED: WithWrappingKeyAlg sets the key type for the TDF wrapping key for both storage and transit.
 func WithWrappingKeyAlg(keyType ocrypto.KeyType) TDFOption {
 	return func(c *TDFConfig) error {
 		if keyType == "" {
 			return errors.New("key type missing")
 		}
-		c.wrappingKeyAlg = keyType
+		c.preferredKeyWrapAlg = keyType
 		return nil
 	}
 }

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -77,7 +77,8 @@ type TDFConfig struct {
 	kasInfoList                []KASInfo
 	kaoTemplate                []kaoTpl
 	splitPlan                  []keySplitStep
-	keyType                    ocrypto.KeyType
+	preferredKeyWrapAlg        ocrypto.KeyType
+	wrappingKeyAlg             ocrypto.KeyType
 	useHex                     bool
 	excludeVersionFromManifest bool
 	addDefaultAssertion        bool
@@ -91,7 +92,7 @@ func newTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
 		tdfFormat:                 JSONFormat,
 		integrityAlgorithm:        HS256,
 		segmentIntegrityAlgorithm: GMAC,
-		keyType:                   ocrypto.RSA2048Key, // default to RSA
+		wrappingKeyAlg:            ocrypto.RSA2048Key, // default to RSA
 		addDefaultAssertion:       false,
 	}
 
@@ -102,7 +103,7 @@ func newTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
 		}
 	}
 
-	publicKey, privateKey, err := generateKeyPair(c.keyType)
+	publicKey, privateKey, err := generateKeyPair(c.wrappingKeyAlg)
 	if err != nil {
 		return nil, err
 	}
@@ -249,12 +250,19 @@ func WithAutoconfigure(enable bool) TDFOption {
 	}
 }
 
+func WithPreferredKeyWrapAlg(keyType ocrypto.KeyType) TDFOption {
+	return func(c *TDFConfig) error {
+		c.preferredKeyWrapAlg = keyType
+		return nil
+	}
+}
+
 func WithWrappingKeyAlg(keyType ocrypto.KeyType) TDFOption {
 	return func(c *TDFConfig) error {
-		if c.keyType == "" {
+		if keyType == "" {
 			return errors.New("key type missing")
 		}
-		c.keyType = keyType
+		c.wrappingKeyAlg = keyType
 		return nil
 	}
 }

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -1948,8 +1948,8 @@ func (s *TDFSuite) Test_Autoconfigure() {
 
 func (s *TDFSuite) Test_PopulateBaseKey_Success() {
 	tdfConfig := &TDFConfig{
-		keyType:     ocrypto.RSA2048Key,
-		kasInfoList: []KASInfo{},
+		wrappingKeyAlg: ocrypto.RSA2048Key,
+		kasInfoList:    []KASInfo{},
 	}
 
 	baseKey := policy.SimpleKasKey{
@@ -1974,7 +1974,7 @@ func (s *TDFSuite) Test_PopulateBaseKey_Success() {
 	s.Require().Equal(baseKeyKID, tdfConfig.kasInfoList[0].KID, "KAS KID should match")
 	s.Require().Equal(string(ocrypto.RSA2048Key), tdfConfig.kasInfoList[0].Algorithm, "Algorithm should match")
 	s.Require().Equal(mockRSAPublicKey1, tdfConfig.kasInfoList[0].PublicKey, "Public key should match")
-	s.Require().Equal(ocrypto.KeyType("rsa:2048"), tdfConfig.keyType, "Key type should be set")
+	s.Require().Equal(ocrypto.KeyType("rsa:2048"), tdfConfig.wrappingKeyAlg, "Key type should be set")
 }
 
 func rotateKey(k *FakeKas, kid, private, public string) func() {

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -63,7 +63,6 @@ const (
 	multipleKeysKID2   = "multiple-keys-kid2"
 	multipleKeysKasURL = "http://multiple-keys-kas.com/"
 	defaultKID         = "r1"
-	r3KID              = "r3"
 )
 
 const (
@@ -1393,7 +1392,7 @@ func (s *TDFSuite) Test_TDFReader() { //nolint:gocognit // requires for testing 
 				if offset < 0 {
 					offset = len(payload) + offset
 				}
-				s.Equal(payload[offset:], string(buf.Bytes()))
+				s.Equal(payload[offset:], buf.String())
 				s.Equal(int64(len(buf.Bytes())), n)
 			}
 		}
@@ -1820,7 +1819,7 @@ func (s *TDFSuite) Test_KeyRotation() {
 			}()
 
 			tdo := s.testEncrypt(s.sdk, []TDFOption{WithKasInformation(kasInfoList...)}, plainTextFileName, tdfFileName, test)
-			s.Equal("r1", tdo.manifest.EncryptionInformation.KeyAccessObjs[0].KID)
+			s.Equal(defaultKID, tdo.manifest.EncryptionInformation.KeyAccessObjs[0].KID)
 
 			defer rotateKey(&s.kases[0], "r2", mockRSAPrivateKey2, mockRSAPublicKey2)()
 			s.testDecryptWithReader(s.sdk, tdfFileName, decryptedTdfFileName, test)
@@ -2150,7 +2149,7 @@ func (s *TDFSuite) startBackend() {
 		{kasNz, mockRSAPrivateKey3, mockRSAPublicKey3, defaultKID},
 		{kasUs, mockRSAPrivateKey1, mockRSAPublicKey1, defaultKID},
 		{baseKeyURL, mockRSAPrivateKey1, mockRSAPublicKey1, baseKeyKID},
-		{evenMoreSpecificKas, mockRSAPrivateKey1, mockRSAPublicKey1, r3KID},
+		{evenMoreSpecificKas, mockRSAPrivateKey3, mockRSAPublicKey3, "r3"},
 	}
 	fkar := &FakeKASRegistry{kases: kasesToMake, s: s}
 
@@ -2388,7 +2387,7 @@ func (f *FakeKas) getRewrapResponse(rewrapRequest string) *kaspb.RewrapResponse 
 				asymDecrypt, err := ocrypto.NewAsymDecryption(kasPrivateKey)
 				f.s.Require().NoError(err, "ocrypto.NewAsymDecryption failed")
 				symmetricKey, err := asymDecrypt.Decrypt(wrappedKey)
-				f.s.Require().NoError(err, "ocrypto.Decrypt failed")
+				f.s.Require().NoError(err, "ocrypto.Decrypt failed for kao:[%s # %s (%s)] kas:[%s # %s (%s)]", kao.GetKasUrl(), kao.GetKid(), kao.GetSplitId(), f.URL, f.KID, f.Algorithm)
 				asymEncrypt, err := ocrypto.NewAsymEncryption(bodyData.GetClientPublicKey())
 				f.s.Require().NoError(err, "ocrypto.NewAsymEncryption failed")
 				entityWrappedKey, err = asymEncrypt.Encrypt(symmetricKey)

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -1948,8 +1948,8 @@ func (s *TDFSuite) Test_Autoconfigure() {
 
 func (s *TDFSuite) Test_PopulateBaseKey_Success() {
 	tdfConfig := &TDFConfig{
-		wrappingKeyAlg: ocrypto.RSA2048Key,
-		kasInfoList:    []KASInfo{},
+		preferredKeyWrapAlg: ocrypto.RSA2048Key,
+		kasInfoList:         []KASInfo{},
 	}
 
 	baseKey := policy.SimpleKasKey{
@@ -1974,7 +1974,7 @@ func (s *TDFSuite) Test_PopulateBaseKey_Success() {
 	s.Require().Equal(baseKeyKID, tdfConfig.kasInfoList[0].KID, "KAS KID should match")
 	s.Require().Equal(string(ocrypto.RSA2048Key), tdfConfig.kasInfoList[0].Algorithm, "Algorithm should match")
 	s.Require().Equal(mockRSAPublicKey1, tdfConfig.kasInfoList[0].PublicKey, "Public key should match")
-	s.Require().Equal(ocrypto.KeyType("rsa:2048"), tdfConfig.wrappingKeyAlg, "Key type should be set")
+	s.Require().Equal(ocrypto.KeyType("rsa:2048"), tdfConfig.preferredKeyWrapAlg, "Key type should be set")
 }
 
 func rotateKey(k *FakeKas, kid, private, public string) func() {

--- a/service/internal/security/crypto_provider.go
+++ b/service/internal/security/crypto_provider.go
@@ -3,6 +3,12 @@ package security
 const (
 	// Key agreement along P-256
 	AlgorithmECP256R1 = "ec:secp256r1"
+	// Key agreement along P-384
+	AlgorithmECP384R1 = "ec:secp384r1"
+	// Key agreement along P-521
+	AlgorithmECP521R1 = "ec:secp521r1"
+
 	// Used for encryption with RSA of the KAO
 	AlgorithmRSA2048 = "rsa:2048"
+	AlgorithmRSA4096 = "rsa:4096"
 )

--- a/service/internal/security/standard_crypto.go
+++ b/service/internal/security/standard_crypto.go
@@ -149,13 +149,13 @@ func loadKey(k KeyPairInfo) (any, error) {
 		}
 	}
 	switch k.Algorithm {
-	case AlgorithmECP256R1:
+	case AlgorithmECP256R1, AlgorithmECP384R1, AlgorithmECP521R1:
 		return StandardECCrypto{
 			KeyPairInfo:      k,
 			ecPrivateKeyPem:  string(privatePEM),
 			ecCertificatePEM: string(certPEM),
 		}, nil
-	case AlgorithmRSA2048:
+	case AlgorithmRSA2048, AlgorithmRSA4096:
 		asymDecryption, err := ocrypto.NewAsymDecryption(string(privatePEM))
 		if err != nil {
 			return nil, fmt.Errorf("ocrypto.NewAsymDecryption failed: %w", err)

--- a/service/trust/delegating_key_service.go
+++ b/service/trust/delegating_key_service.go
@@ -86,12 +86,12 @@ func (d *DelegatingKeyService) Name() string {
 func (d *DelegatingKeyService) Decrypt(ctx context.Context, keyID KeyIdentifier, ciphertext []byte, ephemeralPublicKey []byte) (ProtectedKey, error) {
 	keyDetails, err := d.index.FindKeyByID(ctx, keyID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to find key by ID '%s': %w", keyID, err)
 	}
 
 	manager, err := d.getKeyManager(keyDetails.System())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get key manager for system '%s': %w", keyDetails.System(), err)
 	}
 
 	return manager.Decrypt(ctx, keyDetails, ciphertext, ephemeralPublicKey)
@@ -100,12 +100,12 @@ func (d *DelegatingKeyService) Decrypt(ctx context.Context, keyID KeyIdentifier,
 func (d *DelegatingKeyService) DeriveKey(ctx context.Context, keyID KeyIdentifier, ephemeralPublicKeyBytes []byte, curve elliptic.Curve) (ProtectedKey, error) {
 	keyDetails, err := d.index.FindKeyByID(ctx, keyID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to find key by ID '%s': %w", keyID, err)
 	}
 
 	manager, err := d.getKeyManager(keyDetails.System())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get key manager for system '%s': %w", keyDetails.System(), err)
 	}
 
 	return manager.DeriveKey(ctx, keyDetails, ephemeralPublicKeyBytes, curve)
@@ -115,7 +115,7 @@ func (d *DelegatingKeyService) GenerateECSessionKey(ctx context.Context, ephemer
 	// Assuming a default manager for session key generation
 	manager, err := d._defKM()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get default key manager: %w", err)
 	}
 
 	return manager.GenerateECSessionKey(ctx, ephemeralPublicKey)

--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -60,7 +60,7 @@ runs:
         set -e
 
         keyring='[{"kid":"ec1","alg":"ec:secp256r1"},{"kid":"r1","alg":"rsa:2048"}]'
-        keys='[{"kid":"ec1","alg":"ec:secp256r1","private":"kas-ec-private.pem","cert":"kas-ec-cert.pem"},{"kid":"r1","alg":"rsa:2048","private":"kas-private.pem","cert":"kas-cert.pem"}]'
+        keys='[{"kid":"e1","alg":"ec:secp256r1","private":"kas-ec-private.pem","cert":"kas-ec-cert.pem"},{"kid":"ec1","alg":"ec:secp256r1","private":"kas-ec-private.pem","cert":"kas-ec-cert.pem"},{"kid":"r1","alg":"rsa:2048","private":"kas-private.pem","cert":"kas-cert.pem"}]'
         while IFS= read -r -d $'\0' key_json <&3; do
           printf 'processing %s\n' "${key_json}"
           private_pem="$(jq -r '.privateKey' <<< "${key_json}")"

--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -12,10 +12,9 @@ inputs:
     description: A JSON array containing extra keys for the KAS to load. Each object should have 'kid', 'alg', 'private', and 'cert' fields.
     default: '[]'
   ec-tdf-enabled:
-    default: false
+    default: "false"
     description: 'Whether to enable ECC wrapping for TDFs'
     required: false
-    type: boolean
 
 outputs:
   platform-working-dir:
@@ -48,6 +47,21 @@ runs:
           otdf-test-platform/service/go.sum
           otdf-test-platform/protocol/go/go.sum
           otdf-test-platform/sdk/go.sum
+    - name: Lookup current platform version
+      shell: bash
+      id: platform-version
+      run: |-
+        if ! go run ./service version; then
+          # NOTE: the version command was added in 0.4.37
+          echo "Error: Unable to get platform version; defaulting to tag 0.3.0"
+          echo "PLATFORM_VERSION=0.3.0" >> "$GITHUB_ENV"
+          exit
+        fi
+        # Older version commands output version to stderr; newer versions output to stdout
+        PLATFORM_VERSION=$(go run ./service version 2>&1)
+        echo "PLATFORM_VERSION=$PLATFORM_VERSION" >> "$GITHUB_ENV"
+        echo "## Platform version output: [$PLATFORM_VERSION]"
+      working-directory: otdf-test-platform
     - name: Provide the platform with keys
       shell: bash
       run: .github/scripts/init-temp-keys.sh
@@ -58,11 +72,20 @@ runs:
         EXTRA_KEYS: ${{ inputs.extra-keys }}
       run: |
         set -e
-
+        allowed_algorithms=(ec:secp256r1 rsa:2048)
+        if echo $PLATFORM_VERSION | awk -F. '{ if ($1 > 0 || ($1 == 0 && $2 > 7) || ($1 == 0 && $2 == 7 && $3 >= 1)) exit 0; else exit 1; }'; then
+          # For versions 0.7.1 and later, we allow rsa:4096 ec:secp384r1 ec:secp521r1 
+          allowed_algorithms+=(rsa:4096 ec:secp384r1 ec:secp521r1)
+        fi
         keyring='[{"kid":"ec1","alg":"ec:secp256r1"},{"kid":"r1","alg":"rsa:2048"}]'
         keys='[{"kid":"e1","alg":"ec:secp256r1","private":"kas-ec-private.pem","cert":"kas-ec-cert.pem"},{"kid":"ec1","alg":"ec:secp256r1","private":"kas-ec-private.pem","cert":"kas-ec-cert.pem"},{"kid":"r1","alg":"rsa:2048","private":"kas-private.pem","cert":"kas-cert.pem"}]'
         while IFS= read -r -d $'\0' key_json <&3; do
           printf 'processing %s\n' "${key_json}"
+          alg="$(jq -r '.alg' <<< "${key_json}")"
+          if [[ ! " ${allowed_algorithms[*]} " =~ " ${alg} " ]]; then
+            printf 'algorithm [%s] is not allowed. Skipping extra key [%s]\n' "${alg}" "${kid}" 1>&2
+            continue
+          fi
           private_pem="$(jq -r '.privateKey' <<< "${key_json}")"
           cert_pem="$(jq -r '.cert' <<< "${key_json}")"
           kid="$(jq -r '.kid' <<< "${key_json}")"


### PR DESCRIPTION
When key mappings (grants now with key ids!) are available,
prefer those values when possible, even if that means having multiple
mechanism types in the same TDF (e.g. RSA keys of different lengths).
This was always the intent, but apparently didn't work before.

I've added a couple of small tests,
and now will add more to the integration tests.

Also, updates `start-up-with-containers` to automatically drop unsupported key types on older kases.
This will simplify xtest loading the newly supported key types.

### Proposed Changes

* the `kao template` type is now the preferred input format for `prepareManifest`
* move migration code (from `splitPlan`) into separate method
* modifies tests to correctly associate keys with key ids


### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

