### PR TITLE
feat(core): Add the ability to configure the http server settings

### DIFF
--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -145,6 +145,8 @@ server:
   grpc:
     reflectionEnabled: true # Default is false
   # http:
+  #   # HTTP server configuration
+  #   # Negative values indicate no timeout, default will be used if the timeout is set to 0
   #   readTimeout: 15s
   #   writeTimeout: 15s
   #   readHeaderTimeout: 10s

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -144,6 +144,12 @@ server:
     maxage: 3600
   grpc:
     reflectionEnabled: true # Default is false
+  # http:
+  #   readTimeout: 15s
+  #   writeTimeout: 15s
+  #   readHeaderTimeout: 10s
+  #   idleTimeout: 20s
+  #   maxHeaderBytes: 1 << 20 # 1 MB
   cryptoProvider:
     type: standard
     standard:

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -149,7 +149,7 @@ server:
   #   writeTimeout: 15s
   #   readHeaderTimeout: 10s
   #   idleTimeout: 20s
-  #   maxHeaderBytes: 1 << 20 # 1 MB
+  #   maxHeaderBytes: 1048576 # 1 MB
   cryptoProvider:
     type: standard
     standard:

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -37,9 +37,9 @@ import (
 )
 
 const (
-	writeTimeout    time.Duration = 5 * time.Second
-	readTimeout     time.Duration = 10 * time.Second
-	shutdownTimeout time.Duration = 5 * time.Second
+	defaultWriteTimeout time.Duration = 5 * time.Second
+	defaultReadTimeout  time.Duration = 10 * time.Second
+	shutdownTimeout     time.Duration = 5 * time.Second
 )
 
 type Error string
@@ -64,7 +64,8 @@ type Config struct {
 	Port           int    `mapstructure:"port" json:"port" default:"8080"`
 	Host           string `mapstructure:"host,omitempty" json:"host"`
 	PublicHostname string `mapstructure:"public_hostname,omitempty" json:"publicHostname"`
-
+	// Http server config
+	HttpServerConfig HttpServerConfig `mapstructure:"http" json:"http"`
 	// Enable pprof
 	EnablePprof bool `mapstructure:"enable_pprof" json:"enable_pprof" default:"false"`
 	// Trace is for configuring open telemetry based tracing.
@@ -107,6 +108,14 @@ type TLSConfig struct {
 	Cert string `mapstructure:"cert" json:"cert"`
 	// Path to the key file
 	Key string `mapstructure:"key" json:"key"`
+}
+
+type HttpServerConfig struct {
+	ReadTimeout       time.Duration `mapstructure:"readTimeout" json:"readTimeout"`
+	ReadHeaderTimeout time.Duration `mapstructure:"readHeaderTimeout" json:"readHeaderTimeout"`
+	WriteTimeout      time.Duration `mapstructure:"writeTimeout" json:"writeTimeout"`
+	IdleTimeout       time.Duration `mapstructure:"idleTimeout" json:"idleTimeout"`
+	MaxHeaderBytes    int           `mapstructure:"maxHeaderBytes" json:"maxHeaderBytes"`
 }
 
 // CORS Configuration for the server
@@ -283,9 +292,8 @@ func (rw *grpcGatewayResponseWriter) Write(data []byte) (int, error) {
 // newHTTPServer creates a new http server with the given handler and grpc server
 func newHTTPServer(c Config, connectRPC http.Handler, originalGrpcGateway http.Handler, a *auth.Authentication, l *logger.Logger) (*http.Server, error) {
 	var (
-		err                  error
-		tc                   *tls.Config
-		writeTimeoutOverride = writeTimeout
+		err error
+		tc  *tls.Config
 	)
 
 	// Adds deprecation header to any grpcGateway responses.
@@ -333,7 +341,9 @@ func newHTTPServer(c Config, connectRPC http.Handler, originalGrpcGateway http.H
 	if c.EnablePprof {
 		grpcGateway = pprofHandler(grpcGateway)
 		// Need to extend write timeout to collect pprof data.
-		writeTimeoutOverride = 30 * time.Second //nolint:mnd // easier to read that we are overriding the default
+		if c.HttpServerConfig.WriteTimeout < 30*time.Second {
+			c.HttpServerConfig.WriteTimeout = 30 * time.Second //nolint:mnd // easier to read that we are overriding the default
+		}
 	}
 
 	var handler http.Handler
@@ -347,12 +357,22 @@ func newHTTPServer(c Config, connectRPC http.Handler, originalGrpcGateway http.H
 		handler = routeConnectRPCRequests(connectRPC, grpcGateway)
 	}
 
+	if c.HttpServerConfig.ReadTimeout == 0 {
+		c.HttpServerConfig.ReadTimeout = defaultReadTimeout
+	}
+	if c.HttpServerConfig.WriteTimeout == 0 {
+		c.HttpServerConfig.WriteTimeout = defaultWriteTimeout
+	}
+
 	return &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", c.Host, c.Port),
-		WriteTimeout: writeTimeoutOverride,
-		ReadTimeout:  readTimeout,
-		Handler:      handler,
-		TLSConfig:    tc,
+		Addr:              fmt.Sprintf("%s:%d", c.Host, c.Port),
+		WriteTimeout:      c.HttpServerConfig.WriteTimeout,
+		ReadTimeout:       c.HttpServerConfig.ReadTimeout,
+		ReadHeaderTimeout: c.HttpServerConfig.ReadHeaderTimeout,
+		IdleTimeout:       c.HttpServerConfig.IdleTimeout,
+		MaxHeaderBytes:    c.HttpServerConfig.MaxHeaderBytes,
+		Handler:           handler,
+		TLSConfig:         tc,
 	}, nil
 }
 

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -65,7 +65,7 @@ type Config struct {
 	Host           string `mapstructure:"host,omitempty" json:"host"`
 	PublicHostname string `mapstructure:"public_hostname,omitempty" json:"publicHostname"`
 	// Http server config
-	HttpServerConfig HttpServerConfig `mapstructure:"http" json:"http"`
+	HTTPServerConfig HTTPServerConfig `mapstructure:"http" json:"http"`
 	// Enable pprof
 	EnablePprof bool `mapstructure:"enable_pprof" json:"enable_pprof" default:"false"`
 	// Trace is for configuring open telemetry based tracing.
@@ -110,7 +110,7 @@ type TLSConfig struct {
 	Key string `mapstructure:"key" json:"key"`
 }
 
-type HttpServerConfig struct {
+type HTTPServerConfig struct {
 	ReadTimeout       time.Duration `mapstructure:"readTimeout" json:"readTimeout"`
 	ReadHeaderTimeout time.Duration `mapstructure:"readHeaderTimeout" json:"readHeaderTimeout"`
 	WriteTimeout      time.Duration `mapstructure:"writeTimeout" json:"writeTimeout"`
@@ -341,8 +341,8 @@ func newHTTPServer(c Config, connectRPC http.Handler, originalGrpcGateway http.H
 	if c.EnablePprof {
 		grpcGateway = pprofHandler(grpcGateway)
 		// Need to extend write timeout to collect pprof data.
-		if c.HttpServerConfig.WriteTimeout < 30*time.Second {
-			c.HttpServerConfig.WriteTimeout = 30 * time.Second //nolint:mnd // easier to read that we are overriding the default
+		if c.HTTPServerConfig.WriteTimeout < 30*time.Second {
+			c.HTTPServerConfig.WriteTimeout = 30 * time.Second //nolint:mnd // easier to read that we are overriding the default
 		}
 	}
 
@@ -357,20 +357,20 @@ func newHTTPServer(c Config, connectRPC http.Handler, originalGrpcGateway http.H
 		handler = routeConnectRPCRequests(connectRPC, grpcGateway)
 	}
 
-	if c.HttpServerConfig.ReadTimeout == 0 {
-		c.HttpServerConfig.ReadTimeout = defaultReadTimeout
+	if c.HTTPServerConfig.ReadTimeout == 0 {
+		c.HTTPServerConfig.ReadTimeout = defaultReadTimeout
 	}
-	if c.HttpServerConfig.WriteTimeout == 0 {
-		c.HttpServerConfig.WriteTimeout = defaultWriteTimeout
+	if c.HTTPServerConfig.WriteTimeout == 0 {
+		c.HTTPServerConfig.WriteTimeout = defaultWriteTimeout
 	}
 
 	return &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", c.Host, c.Port),
-		WriteTimeout:      c.HttpServerConfig.WriteTimeout,
-		ReadTimeout:       c.HttpServerConfig.ReadTimeout,
-		ReadHeaderTimeout: c.HttpServerConfig.ReadHeaderTimeout,
-		IdleTimeout:       c.HttpServerConfig.IdleTimeout,
-		MaxHeaderBytes:    c.HttpServerConfig.MaxHeaderBytes,
+		WriteTimeout:      c.HTTPServerConfig.WriteTimeout,
+		ReadTimeout:       c.HTTPServerConfig.ReadTimeout,
+		ReadHeaderTimeout: c.HTTPServerConfig.ReadHeaderTimeout,
+		IdleTimeout:       c.HTTPServerConfig.IdleTimeout,
+		MaxHeaderBytes:    c.HTTPServerConfig.MaxHeaderBytes,
 		Handler:           handler,
 		TLSConfig:         tc,
 	}, nil


### PR DESCRIPTION
### Proposed Changes

* ability to specify read, write, readheader, and idle timeouts and maxheaderbytes via the opentdf.yaml

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

