### PR TITLE
feat(core): Redirect REST calls without `/kas/` prefix

### DIFF
--- a/service/internal/server/handler_test.go
+++ b/service/internal/server/handler_test.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRedirectMissingKASPrefixHandler tests the behavior of the redirectMissingKASPrefixHandler
+func TestRedirectMissingKASPrefixHandler(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		queryString        string
+		expectedStatusCode int
+		expectedLocation   string
+		shouldRedirect     bool
+	}{
+		{
+			name:               "v2 kas_public_key without trailing slash",
+			path:               "/v2/kas_public_key",
+			queryString:        "",
+			expectedStatusCode: http.StatusMovedPermanently,
+			expectedLocation:   "/kas/v2/kas_public_key",
+			shouldRedirect:     true,
+		},
+		{
+			name:               "v2 kas_public_key with trailing slash",
+			path:               "/v2/kas_public_key/",
+			queryString:        "",
+			expectedStatusCode: http.StatusMovedPermanently,
+			expectedLocation:   "/kas/v2/kas_public_key/",
+			shouldRedirect:     true,
+		},
+		{
+			name:               "kas_public_key without trailing slash",
+			path:               "/kas_public_key",
+			queryString:        "",
+			expectedStatusCode: http.StatusMovedPermanently,
+			expectedLocation:   "/kas/kas_public_key",
+			shouldRedirect:     true,
+		},
+		{
+			name:               "kas_public_key with trailing slash",
+			path:               "/kas_public_key/",
+			queryString:        "",
+			expectedStatusCode: http.StatusMovedPermanently,
+			expectedLocation:   "/kas/kas_public_key/",
+			shouldRedirect:     true,
+		},
+		{
+			name:               "v2 rewrap without trailing slash",
+			path:               "/v2/rewrap",
+			queryString:        "",
+			expectedStatusCode: http.StatusMovedPermanently,
+			expectedLocation:   "/kas/v2/rewrap",
+			shouldRedirect:     true,
+		},
+		{
+			name:               "v2 rewrap with trailing slash",
+			path:               "/v2/rewrap/",
+			queryString:        "",
+			expectedStatusCode: http.StatusMovedPermanently,
+			expectedLocation:   "/kas/v2/rewrap/",
+			shouldRedirect:     true,
+		},
+		{
+			name:               "with query parameters",
+			path:               "/v2/rewrap",
+			queryString:        "param1=value1&param2=value2",
+			expectedStatusCode: http.StatusMovedPermanently,
+			expectedLocation:   "/kas/v2/rewrap?param1=value1&param2=value2",
+			shouldRedirect:     true,
+		},
+		{
+			name:           "unrelated path should not redirect",
+			path:           "/some/other/path",
+			shouldRedirect: false,
+		},
+		{
+			name:           "path already prefixed with /kas should not redirect",
+			path:           "/kas/v2/kas_public_key",
+			shouldRedirect: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a handler that always returns 200 OK
+			mockHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// Wrap it with our redirect handler
+			handler := redirectMissingKASPrefixHandler(mockHandler)
+
+			// Create a test request with the test path
+			url := tc.path
+			if tc.queryString != "" {
+				url += "?" + tc.queryString
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			rec := httptest.NewRecorder()
+
+			// Send the request through our handler
+			handler.ServeHTTP(rec, req)
+
+			if tc.shouldRedirect { //nolint:nestif // Nested to keep the test cases together
+				// Check that we got a redirect response
+				if rec.Code != tc.expectedStatusCode {
+					t.Errorf("Expected status code %d, got %d", tc.expectedStatusCode, rec.Code)
+				}
+
+				// Check the redirect location
+				location := rec.Header().Get("Location")
+				if location != tc.expectedLocation {
+					t.Errorf("Expected redirect to %q, got %q", tc.expectedLocation, location)
+				}
+			} else {
+				// Check that we didn't get a redirect
+				if rec.Code != http.StatusOK {
+					t.Errorf("Expected status code %d, got %d", http.StatusOK, rec.Code)
+				}
+				if rec.Header().Get("Location") != "" {
+					t.Errorf("Did not expect a Location header, but got %q", rec.Header().Get("Location"))
+				}
+			}
+		})
+	}
+}

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -346,15 +346,16 @@ func newHTTPServer(c Config, connectRPC http.Handler, originalGrpcGateway http.H
 		}
 	}
 
+	redirectingHandler := redirectMissingKASPrefixHandler(grpcGateway)
 	var handler http.Handler
 	if !c.TLS.Enabled {
-		handler = h2c.NewHandler(routeConnectRPCRequests(connectRPC, grpcGateway), &http2.Server{})
+		handler = h2c.NewHandler(routeConnectRPCRequests(connectRPC, redirectingHandler), &http2.Server{})
 	} else {
 		tc, err = loadTLSConfig(c.TLS)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load tls config: %w", err)
 		}
-		handler = routeConnectRPCRequests(connectRPC, grpcGateway)
+		handler = routeConnectRPCRequests(connectRPC, redirectingHandler)
 	}
 
 	if c.HTTPServerConfig.ReadTimeout == 0 {
@@ -408,6 +409,31 @@ func pprofHandler(h http.Handler) http.Handler {
 		} else {
 			h.ServeHTTP(w, r)
 		}
+	})
+}
+
+func redirectMissingKASPrefixHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Use regex to match KAS paths that should be redirected
+		pathsToRedirect := []string{
+			"/v2/kas_public_key",
+			"/kas_public_key",
+			"/v2/rewrap",
+		}
+
+		for _, path := range pathsToRedirect {
+			// Match the path with or without trailing slash
+			if r.URL.Path == path || r.URL.Path == path+"/" {
+				newPath := "/kas" + r.URL.Path
+				if r.URL.RawQuery != "" {
+					newPath += "?" + r.URL.RawQuery
+				}
+				http.Redirect(w, r, newPath, http.StatusMovedPermanently)
+				return
+			}
+		}
+		// If the path does not start with /kas, serve the request normally
+		h.ServeHTTP(w, r)
 	})
 }
 


### PR DESCRIPTION
### Proposed Changes

* Some clients are configured without the `/kas` prefix for their REST requests. This simplifies maintaining them

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

