### PR TITLE
feat(ocrypto): add AES protected key interface and implementation

### DIFF
--- a/lib/ocrypto/interfaces.go
+++ b/lib/ocrypto/interfaces.go
@@ -1,0 +1,30 @@
+package ocrypto
+
+import (
+	"context"
+)
+
+// Encapsulator interface for key encapsulation operations
+type Encapsulator interface {
+	// Encrypt wraps a secret key with the encapsulation key
+	Encrypt(data []byte) ([]byte, error)
+
+	// PublicKeyInPemFormat Returns public key in pem format, or the empty string if not present
+	PublicKeyInPemFormat() (string, error)
+
+	// For EC schemes, this method returns the public part of the ephemeral key.
+	// Otherwise, it returns nil.
+	EphemeralKey() []byte
+}
+
+// ProtectedKey represents a decrypted key with operations that can be performed on it
+type ProtectedKey interface {
+	// VerifyBinding checks if the policy binding matches the given policy data
+	VerifyBinding(ctx context.Context, policy, binding []byte) error
+
+	// Export returns the raw key data, optionally encrypting it with the provided encryptor
+	Export(encryptor Encapsulator) ([]byte, error)
+
+	// Used to decrypt encrypted policies and metadata
+	DecryptAESGCM(iv []byte, body []byte, tagSize int) ([]byte, error)
+}

--- a/lib/ocrypto/protected_key.go
+++ b/lib/ocrypto/protected_key.go
@@ -1,0 +1,91 @@
+package ocrypto
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrEmptyKeyData is returned when the key data is empty
+	ErrEmptyKeyData = errors.New("key data is empty")
+	// ErrPolicyHMACMismatch is returned when policy binding verification fails
+	ErrPolicyHMACMismatch = errors.New("policy hmac mismatch")
+	// ErrHMACGeneration is returned when HMAC digest generation fails
+	ErrHMACGeneration = errors.New("failed to generate hmac digest")
+)
+
+// AESProtectedKey implements the ProtectedKey interface with an in-memory secret key
+type AESProtectedKey struct {
+	rawKey []byte
+}
+
+var _ ProtectedKey = (*AESProtectedKey)(nil)
+
+// NewAESProtectedKey creates a new instance of AESProtectedKey
+func NewAESProtectedKey(rawKey []byte) *AESProtectedKey {
+	return &AESProtectedKey{
+		rawKey: rawKey,
+	}
+}
+
+// DecryptAESGCM decrypts data using AES-GCM with the protected key
+func (k *AESProtectedKey) DecryptAESGCM(iv []byte, body []byte, tagSize int) ([]byte, error) {
+	aesGcm, err := NewAESGcm(k.rawKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES-GCM cipher: %w", err)
+	}
+
+	decryptedData, err := aesGcm.DecryptWithIVAndTagSize(iv, body, tagSize)
+	if err != nil {
+		return nil, fmt.Errorf("AES-GCM decryption failed: %w", err)
+	}
+
+	return decryptedData, nil
+}
+
+// Export returns the raw key data, optionally encrypting it with the provided Encapsulator
+func (k *AESProtectedKey) Export(encapsulator Encapsulator) ([]byte, error) {
+	if encapsulator == nil {
+		// Return raw key data without encryption - caller should be aware of this
+		return k.rawKey, nil
+	}
+
+	// Encrypt the key data before returning
+	encryptedKey, err := encapsulator.Encrypt(k.rawKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt key data for export: %w", err)
+	}
+
+	return encryptedKey, nil
+}
+
+// VerifyBinding checks if the policy binding matches the given policy data
+func (k *AESProtectedKey) VerifyBinding(ctx context.Context, policy, policyBinding []byte) error {
+	if len(k.rawKey) == 0 {
+		return ErrEmptyKeyData
+	}
+
+	actualHMAC, err := k.generateHMACDigest(ctx, policy)
+	if err != nil {
+		return fmt.Errorf("unable to generate policy hmac: %w", err)
+	}
+
+	if !hmac.Equal(actualHMAC, policyBinding) {
+		return ErrPolicyHMACMismatch
+	}
+
+	return nil
+}
+
+// generateHMACDigest is a helper to generate an HMAC digest from a message using the key
+func (k *AESProtectedKey) generateHMACDigest(ctx context.Context, msg []byte) ([]byte, error) {
+	mac := hmac.New(sha256.New, k.rawKey)
+	_, err := mac.Write(msg)
+	if err != nil {
+		return nil, ErrHMACGeneration
+	}
+	return mac.Sum(nil), nil
+}

--- a/lib/ocrypto/protected_key_test.go
+++ b/lib/ocrypto/protected_key_test.go
@@ -1,0 +1,208 @@
+package ocrypto
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAESProtectedKey(t *testing.T) {
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+
+	protectedKey := NewAESProtectedKey(key)
+	assert.NotNil(t, protectedKey)
+	assert.Equal(t, key, protectedKey.rawKey)
+}
+
+func TestAESProtectedKey_DecryptAESGCM(t *testing.T) {
+	// Generate a random 256-bit key
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+
+	protectedKey := NewAESProtectedKey(key)
+
+	// Test data
+	plaintext := []byte("Hello, World!")
+
+	// Encrypt the data first using the same key
+	aesGcm, err := NewAESGcm(key)
+	require.NoError(t, err)
+
+	encrypted, err := aesGcm.Encrypt(plaintext)
+	require.NoError(t, err)
+
+	// Extract IV and ciphertext (first 12 bytes are IV for GCM standard nonce size)
+	iv := encrypted[:GcmStandardNonceSize]
+	ciphertext := encrypted[GcmStandardNonceSize:]
+
+	// Test decryption
+	decrypted, err := protectedKey.DecryptAESGCM(iv, ciphertext, 16) // 16 is standard GCM tag size
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestAESProtectedKey_DecryptAESGCM_InvalidKey(t *testing.T) {
+	// Empty key should fail
+	protectedKey := NewAESProtectedKey([]byte{})
+
+	iv := make([]byte, 12)
+	ciphertext := make([]byte, 16)
+
+	_, err := protectedKey.DecryptAESGCM(iv, ciphertext, 16)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create AES-GCM cipher")
+}
+
+func TestAESProtectedKey_Export_NoEncapsulator(t *testing.T) {
+	key := []byte("test-key-1234567890123456") // 24 bytes
+	protectedKey := NewAESProtectedKey(key)
+
+	exported, err := protectedKey.Export(nil)
+	require.NoError(t, err)
+	assert.Equal(t, key, exported)
+}
+
+func TestAESProtectedKey_Export_WithEncapsulator(t *testing.T) {
+	key := []byte("test-key-1234567890123456") // 24 bytes
+	protectedKey := NewAESProtectedKey(key)
+
+	// Mock encapsulator
+	mockEncapsulator := &mockEncapsulator{
+		encryptFunc: func(data []byte) ([]byte, error) {
+			// Simple XOR encryption for testing
+			result := make([]byte, len(data))
+			for i, b := range data {
+				result[i] = b ^ 0xFF
+			}
+			return result, nil
+		},
+	}
+
+	exported, err := protectedKey.Export(mockEncapsulator)
+	require.NoError(t, err)
+
+	// Verify it was encrypted (should be different from original)
+	assert.NotEqual(t, key, exported)
+	assert.Equal(t, len(key), len(exported))
+
+	// Verify we can decrypt it back
+	for i, b := range exported {
+		assert.Equal(t, key[i], b^0xFF)
+	}
+}
+
+func TestAESProtectedKey_Export_EncapsulatorError(t *testing.T) {
+	key := []byte("test-key-1234567890123456")
+	protectedKey := NewAESProtectedKey(key)
+
+	mockEncapsulator := &mockEncapsulator{
+		encryptFunc: func(data []byte) ([]byte, error) {
+			return nil, assert.AnError
+		},
+	}
+
+	_, err := protectedKey.Export(mockEncapsulator)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to encrypt key data for export")
+}
+
+func TestAESProtectedKey_VerifyBinding(t *testing.T) {
+	key := []byte("test-key-1234567890123456")
+	protectedKey := NewAESProtectedKey(key)
+
+	policy := []byte("test-policy-data")
+	ctx := context.Background()
+
+	// Generate the expected HMAC
+	expectedHMAC, err := protectedKey.generateHMACDigest(ctx, policy)
+	require.NoError(t, err)
+
+	// Verify binding should succeed with correct HMAC
+	err = protectedKey.VerifyBinding(ctx, policy, expectedHMAC)
+	assert.NoError(t, err)
+}
+
+func TestAESProtectedKey_VerifyBinding_Mismatch(t *testing.T) {
+	key := []byte("test-key-1234567890123456")
+	protectedKey := NewAESProtectedKey(key)
+
+	policy := []byte("test-policy-data")
+	wrongBinding := []byte("wrong-binding-data")
+	ctx := context.Background()
+
+	err := protectedKey.VerifyBinding(ctx, policy, wrongBinding)
+	assert.Error(t, err)
+	assert.Equal(t, ErrPolicyHMACMismatch, err)
+}
+
+func TestAESProtectedKey_VerifyBinding_EmptyKey(t *testing.T) {
+	protectedKey := NewAESProtectedKey([]byte{})
+
+	policy := []byte("test-policy-data")
+	binding := []byte("some-binding")
+	ctx := context.Background()
+
+	err := protectedKey.VerifyBinding(ctx, policy, binding)
+	assert.Error(t, err)
+	assert.Equal(t, ErrEmptyKeyData, err)
+}
+
+func TestAESProtectedKey_VerifyBinding_DifferentPolicyData(t *testing.T) {
+	key := []byte("test-key-1234567890123456")
+	protectedKey := NewAESProtectedKey(key)
+
+	ctx := context.Background()
+
+	// Generate HMAC for first policy
+	policy1 := []byte("policy-data-1")
+	hmac1, err := protectedKey.generateHMACDigest(ctx, policy1)
+	require.NoError(t, err)
+
+	// Try to verify with different policy data
+	policy2 := []byte("policy-data-2")
+	err = protectedKey.VerifyBinding(ctx, policy2, hmac1)
+	assert.Error(t, err)
+	assert.Equal(t, ErrPolicyHMACMismatch, err)
+}
+
+func TestAESProtectedKey_InterfaceCompliance(t *testing.T) {
+	key := make([]byte, 32)
+	protectedKey := NewAESProtectedKey(key)
+
+	// Ensure it implements the ProtectedKey interface
+	var _ ProtectedKey = protectedKey
+}
+
+// Mock encapsulator for testing
+type mockEncapsulator struct {
+	encryptFunc        func([]byte) ([]byte, error)
+	publicKeyPEMFunc   func() (string, error)
+	ephemeralKeyFunc   func() []byte
+}
+
+func (m *mockEncapsulator) Encrypt(data []byte) ([]byte, error) {
+	if m.encryptFunc != nil {
+		return m.encryptFunc(data)
+	}
+	return data, nil
+}
+
+func (m *mockEncapsulator) PublicKeyInPemFormat() (string, error) {
+	if m.publicKeyPEMFunc != nil {
+		return m.publicKeyPEMFunc()
+	}
+	return "", nil
+}
+
+func (m *mockEncapsulator) EphemeralKey() []byte {
+	if m.ephemeralKeyFunc != nil {
+		return m.ephemeralKeyFunc()
+	}
+	return nil
+}


### PR DESCRIPTION
Add ProtectedKey and Encapsulator interfaces to lib/ocrypto package, along with AESProtectedKey implementation. This exposes previously internal cryptographic functionality for external consumption.

- Add interfaces.go with ProtectedKey and Encapsulator interfaces
- Add protected_key.go with AESProtectedKey implementation
- Add comprehensive test suite in protected_key_test.go
- Use standard error types without logging dependencies

### Proposed Changes

*

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

