### PR TITLE
Virtru SaaS PDP Spike

### DIFF
--- a/opentdf-saas.yaml
+++ b/opentdf-saas.yaml
@@ -1,0 +1,168 @@
+logger:
+  level: debug
+  type: text
+  output: stdout
+# DB and Server configurations are defaulted for local development
+# db:
+#   host: localhost
+#   port: 5432
+#   user: postgres
+#   password: changeme
+#   sslmode: prefer
+#   connect_timeout_seconds: 15
+#   pool:
+#     max_connection_count: 4
+#     min_connection_count: 0
+#     min_idle_connections_count: 0
+#     max_connection_lifetime_seconds: 3600
+#     max_connection_idle_seconds: 1800
+#     health_check_period_seconds: 60
+services:
+  kas:
+    preview:
+      ec_tdf_enabled: false
+      key_management: false
+    root_key: a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1 # For local development testing only
+    keyring:
+      - kid: e1
+        alg: ec:secp256r1
+      - kid: e1
+        alg: ec:secp256r1
+        legacy: true
+      - kid: r1
+        alg: rsa:2048
+      - kid: r1
+        alg: rsa:2048
+        legacy: true
+  entityresolution:
+    log_level: info
+    mode: claims
+    # url: http://localhost:8888/auth
+    # clientid: "tdf-entity-resolution"
+    # clientsecret: "secret"
+    # realm: "opentdf"
+    # legacykeycloak: true
+    # inferid:
+    #   from:
+    #     email: true
+    #     username: true
+  # policy is enabled by default in mode 'all'
+  # policy:
+  #   enabled: true
+  #   list_request_limit_default: 1000
+  #   list_request_limit_max: 2500
+  # authorization:
+  #   entitlement_policy_cache:
+  #     enabled: false
+  #     refresh_interval: 30s
+server:
+  public_hostname: localhost
+  tls:
+    enabled: false
+    cert: ./keys/platform.crt
+    key: ./keys/platform-key.pem
+  auth:
+    enabled: true
+    enforceDPoP: false
+    audience: "https://api-develop01.develop.virtru.com"
+    issuer: https://login.develop.virtru.com/oauth2/default
+    policy:
+      ## Dot notation is used to access nested claims (i.e. realm_access.roles)
+      # Claim that represents the user (i.e. email)
+      username_claim: # preferred_username
+      # That claim to access groups (i.e. realm_access.roles)
+      groups_claim: # realm_access.roles
+      ## Extends the builtin policy
+      extension: |
+        g, opentdf-admin, role:admin
+        g, opentdf-standard, role:standard
+      ## Custom policy that overrides builtin policy (see examples https://github.com/casbin/casbin/tree/master/examples)
+      csv: #|
+      #  p, role:admin, *, *, allow
+      ## Custom model (see https://casbin.org/docs/syntax-for-models/)
+      model: #|
+      #  [request_definition]
+      #  r = sub, res, act, obj
+      #
+      #  [policy_definition]
+      #  p = sub, res, act, obj, eft
+      #
+      #  [role_definition]
+      #  g = _, _
+      #
+      #  [policy_effect]
+      #  e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
+      #
+      #  [matchers]
+      #  m = g(r.sub, p.sub) && globOrRegexMatch(r.res, p.res) && globOrRegexMatch(r.act, p.act) && globOrRegexMatch(r.obj, p.obj)
+  trace:
+    enabled: false
+    provider:
+      name: file # file | otlp
+      file:
+        path: "./traces/traces.log"
+        prettyPrint: true # Optional, default is compact JSON
+        maxSize: 50 # Optional, default 20MB
+        maxBackups: 5 # Optional, default 10
+        maxAge: 14 # Optional, default 30 days
+        compress: true # Optional, default false
+      # otlp:
+      # protocol: grpc # Optional, defaults to grpc
+      # endpoint: "localhost:4317"
+      # insecure: true # Set to false if Jaeger requires TLS
+      # headers: {} # Add if authentication is needed
+      # HTTP
+      #        protocol: "http/protobuf"
+      #        endpoint: "http://localhost:4318" # Default OTLP HTTP port
+      #        insecure: true # If collector is just HTTP, not HTTPS
+      # headers: {} # Add if authentication is needed
+  cors:
+    # "*" to allow any origin or a specific domain like "https://yourdomain.com"
+    allowedorigins:
+      - "*"
+    # List of methods. Examples: "GET,POST,PUT"
+    allowedmethods:
+      - GET
+      - POST
+      - PATCH
+      - PUT
+      - DELETE
+      - OPTIONS
+    # List of headers that are allowed in a request
+    allowedheaders:
+      - ACCEPT
+      - Authorization
+      - Connect-Protocol-Version
+      - Content-Type
+      - X-CSRF-Token
+      - X-Request-ID
+    # List of response headers that browsers are allowed to access
+    exposedheaders:
+      - Link
+    # Sets whether credentials are included in the CORS request
+    allowcredentials: true
+    # Sets the maximum age (in seconds) of a specific CORS preflight request
+    maxage: 3600
+  grpc:
+    reflectionEnabled: true # Default is false
+  # http:
+  #   # HTTP server configuration
+  #   # Negative values indicate no timeout, default will be used if the timeout is set to 0
+  #   readTimeout: 15s
+  #   writeTimeout: 15s
+  #   readHeaderTimeout: 10s
+  #   idleTimeout: 20s
+  #   maxHeaderBytes: 1048576 # 1 MB
+  cryptoProvider:
+    type: standard
+    standard:
+      keys:
+        - kid: r1
+          alg: rsa:2048
+          private: kas-private.pem
+          cert: kas-cert.pem
+        - kid: e1
+          alg: ec:secp256r1
+          private: kas-ec-private.pem
+          cert: kas-ec-cert.pem
+  port: 8080

--- a/service/authorization/v2/authorization.go
+++ b/service/authorization/v2/authorization.go
@@ -166,11 +166,12 @@ func (as *Service) GetDecision(ctx context.Context, req *connect.Request[authzV2
 	propagator := otel.GetTextMapPropagator()
 	ctx = propagator.Extract(ctx, propagation.HeaderCarrier(req.Header()))
 
-	pdp, err := access.NewJustInTimePDP(ctx, as.logger, as.sdk, as.cache)
-	if err != nil {
-		as.logger.ErrorContext(ctx, "failed to create JIT PDP", slog.Any("error", err))
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
+	// pdp, err := access.NewJustInTimePDP(ctx, as.logger, as.sdk, as.cache)
+	// if err != nil {
+	// 	as.logger.ErrorContext(ctx, "failed to create JIT PDP", slog.Any("error", err))
+	// 	return nil, connect.NewError(connect.CodeInternal, err)
+	// }
+	pdp := access.NewSaasPDP()
 
 	request := req.Msg
 	entityIdentifier := request.GetEntityIdentifier()

--- a/service/internal/access/v2/saas_pdp.go
+++ b/service/internal/access/v2/saas_pdp.go
@@ -1,0 +1,96 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	authzV2 "github.com/opentdf/platform/protocol/go/authorization/v2"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/sdk/httputil"
+)
+
+// ACM Client for interacting with the ACM API
+
+type AcmClient struct {
+	client *http.Client
+}
+
+func NewAcmClient() *AcmClient {
+	return &AcmClient{
+		client: httputil.SafeHTTPClient(),
+	}
+}
+
+func (c *AcmClient) GetContract(policyID string, token string) (*http.Response, error) {
+	reqURL, err := url.Parse("https://api-develop01.develop.virtru.com/acm/api/policies/" + policyID + "/contract")
+	if err != nil {
+		return nil, err
+	}
+
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    reqURL,
+		Header: http.Header{
+			"Authorization": []string{"Bearer " + token},
+		},
+	}
+
+	return c.client.Do(req)
+}
+
+// SaasPDP implements the Policy Decision Point (PDP) for SaaS applications
+
+type SaasPDP struct {
+	acmClient *AcmClient
+}
+
+func NewSaasPDP() *SaasPDP {
+	return &SaasPDP{
+		acmClient: NewAcmClient(),
+	}
+}
+
+func (p *SaasPDP) GetDecision(
+	ctx context.Context,
+	entityIdentifier *authzV2.EntityIdentifier,
+	action *policy.Action,
+	resources []*authzV2.Resource,
+) ([]*Decision, bool, error) {
+
+	switch entityIdentifier.GetIdentifier().(type) {
+	case *authzV2.EntityIdentifier_Token:
+		token := entityIdentifier.GetToken().GetJwt()
+		resource := resources[0]
+
+		// https://{OrgID}.kas.virtru.com/attr/cks-acm-adhoc/value/{Policy-UUID}
+		policyResourceAttrFQN := resource.GetAttributeValues().GetFqns()[0]
+		policyID := policyResourceAttrFQN[strings.LastIndex(policyResourceAttrFQN, "/")+1:]
+
+		// call ACM
+		// GET /acm/api/policies/{PolicyID}/contract
+		// HEADER Authorization: Bearer {token}
+		resp, err := p.acmClient.GetContract(policyID, token)
+		if err != nil {
+			return nil, false, err
+		}
+		defer resp.Body.Close()
+
+		decision := ResourceDecision{
+			Passed:     resp.StatusCode == http.StatusOK,
+			ResourceID: resource.GetEphemeralId(),
+		}
+
+		return []*Decision{
+			{
+				Access:  decision.Passed,
+				Results: []ResourceDecision{decision},
+			},
+		}, decision.Passed, nil
+
+	default:
+		return nil, false, errors.New("unsupported entity type")
+	}
+}

--- a/service/internal/auth/casbin_policy.csv
+++ b/service/internal/auth/casbin_policy.csv
@@ -19,24 +19,24 @@ p,	role:admin,		*,					*,			allow
 
 ## Role: Standard
 ## gRPC routes
-p,	role:standard,		policy.*,																read,			allow
-p,	role:standard,		kasregistry.*,													read,			allow
-p,	role:standard,      kas.AccessService/Rewrap, 			           *,			allow
-p,  role:standard,      authorization.AuthorizationService/GetDecisions,        read, allow
-p,  role:standard,      authorization.AuthorizationService/GetDecisionsByToken, read, allow
-p,  role:standard,      authorization.v2.AuthorizationService/GetDecision, read, allow
-p,  role:standard,      authorization.v2.AuthorizationService/GetDecisionMultiResource, read, allow
-p,  role:standard,      authorization.v2.AuthorizationService/GetDecisionBulk, read, allow
+p,	role:unknown,		policy.*,																read,			allow
+p,	role:unknown,		kasregistry.*,													read,			allow
+p,	role:unknown,      kas.AccessService/Rewrap, 			           *,			allow
+p,  role:unknown,      authorization.AuthorizationService/GetDecisions,        read, allow
+p,  role:unknown,      authorization.AuthorizationService/GetDecisionsByToken, read, allow
+p,  role:unknown,      authorization.v2.AuthorizationService/GetDecision, read, allow
+p,  role:unknown,      authorization.v2.AuthorizationService/GetDecisionMultiResource, read, allow
+p,  role:unknown,      authorization.v2.AuthorizationService/GetDecisionBulk, read, allow
 
 ## HTTP routes
-p,	role:standard,		/attributes*,														read,			allow
-p,	role:standard,		/namespaces*,														read,			allow
-p,	role:standard,		/subject-mappings*,											read,			allow
-p,	role:standard,		/resource-mappings*,										read,			allow
-p,	role:standard,		/key-access-servers*,										read,			allow
-p,	role:standard,		/kas/v2/rewrap,													write,		allow
-p,  role:standard,      /v1/authorization,                                                              write,          allow
-p,  role:standard,      /v1/token/authorization,                                                        write,          allow
+p,	role:unknown,		/attributes*,														read,			allow
+p,	role:unknown,		/namespaces*,														read,			allow
+p,	role:unknown,		/subject-mappings*,											read,			allow
+p,	role:unknown,		/resource-mappings*,										read,			allow
+p,	role:unknown,		/key-access-servers*,										read,			allow
+p,	role:unknown,		/kas/v2/rewrap,													write,		allow
+p,  role:unknown,      /v1/authorization,                                                              write,          allow
+p,  role:unknown,      /v1/token/authorization,                                                        write,          allow
 
 # Public routes
 ## gRPC routes


### PR DESCRIPTION
### Proposed Changes

* updates YAML config to use Virtru SaaS Okta OIDC platform as the DSP auth provider
* adds SaaS PDP POC that communicates with ACM for policy access decisions for DSP GetDecision processing
* updates casbin policy to set all roles to `role:unknown` access for POC (this obviously is bad and would not be used in production)

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

