### PR TITLE
feat(policy): Modify KAS indexer to support legacy keys.

### DIFF
--- a/service/internal/security/in_process_provider.go
+++ b/service/internal/security/in_process_provider.go
@@ -267,7 +267,7 @@ func (a *InProcessProvider) FindKeyByID(_ context.Context, id trust.KeyIdentifie
 }
 
 // ListKeys lists all available keys
-func (a *InProcessProvider) ListKeys(ctx context.Context) ([]trust.KeyDetails, error) {
+func (a *InProcessProvider) ListKeys(ctx context.Context, legacyOnly bool) ([]trust.KeyDetails, error) {
 	// This is a limited implementation as CryptoProvider doesn't expose a list of all keys
 	var keys []trust.KeyDetails
 
@@ -275,6 +275,9 @@ func (a *InProcessProvider) ListKeys(ctx context.Context) ([]trust.KeyDetails, e
 	for _, alg := range []string{AlgorithmRSA2048, AlgorithmECP256R1} {
 		if kids, err := a.cryptoProvider.ListKIDsByAlgorithm(alg); err == nil && len(kids) > 0 {
 			for _, kid := range kids {
+				if legacyOnly && !a.legacyKeys[kid] {
+					continue
+				}
 				keys = append(keys, &KeyDetailsAdapter{
 					id:             trust.KeyIdentifier(kid),
 					algorithm:      alg,

--- a/service/internal/security/in_process_provider.go
+++ b/service/internal/security/in_process_provider.go
@@ -267,7 +267,11 @@ func (a *InProcessProvider) FindKeyByID(_ context.Context, id trust.KeyIdentifie
 }
 
 // ListKeys lists all available keys
-func (a *InProcessProvider) ListKeys(ctx context.Context, legacyOnly bool) ([]trust.KeyDetails, error) {
+func (a *InProcessProvider) ListKeys(ctx context.Context) ([]trust.KeyDetails, error) {
+	return a.ListKeysWith(ctx, trust.ListKeyOptions{LegacyOnly: false})
+}
+
+func (a *InProcessProvider) ListKeysWith(ctx context.Context, opts trust.ListKeyOptions) ([]trust.KeyDetails, error) {
 	// This is a limited implementation as CryptoProvider doesn't expose a list of all keys
 	var keys []trust.KeyDetails
 
@@ -275,8 +279,8 @@ func (a *InProcessProvider) ListKeys(ctx context.Context, legacyOnly bool) ([]tr
 	for _, alg := range []string{AlgorithmRSA2048, AlgorithmECP256R1} {
 		if kids, err := a.cryptoProvider.ListKIDsByAlgorithm(alg); err == nil && len(kids) > 0 {
 			for _, kid := range kids {
-				if legacyOnly && !a.legacyKeys[kid] {
-					continue
+				if opts.LegacyOnly && !a.legacyKeys[kid] {
+					continue // Skip non-legacy keys if LegacyOnly is true
 				}
 				keys = append(keys, &KeyDetailsAdapter{
 					id:             trust.KeyIdentifier(kid),

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -288,16 +288,16 @@ func TestExportRsaPublicKeyAsPemStrSuccess(t *testing.T) {
 		E: 65537,
 	}
 
-	outPut, err := exportRsaPublicKeyAsPemStr(mockKey)
+	output, err := exportRsaPublicKeyAsPemStr(mockKey)
 
 	require.NoError(t, err)
-	assert.NotEmpty(t, outPut)
-	assert.IsType(t, "string", outPut)
+	assert.NotEmpty(t, output)
+	assert.IsType(t, "string", output)
 }
 
 func TestExportRsaPublicKeyAsPemStrFailure(t *testing.T) {
-	outPut, err := exportRsaPublicKeyAsPemStr(&rsa.PublicKey{})
-	assert.Empty(t, outPut)
+	output, err := exportRsaPublicKeyAsPemStr(&rsa.PublicKey{})
+	assert.Empty(t, output)
 	assert.Error(t, err)
 }
 
@@ -306,16 +306,16 @@ func TestExportEcPublicKeyAsPemStrSuccess(t *testing.T) {
 	privateKey, err := ecdsa.GenerateKey(curve, rand.Reader)
 	require.NoError(t, err)
 
-	outPut, err := exportEcPublicKeyAsPemStr(&privateKey.PublicKey)
+	output, err := exportEcPublicKeyAsPemStr(&privateKey.PublicKey)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, outPut)
-	assert.IsType(t, "string", outPut)
+	assert.NotEmpty(t, output)
+	assert.IsType(t, "string", output)
 }
 
 func TestExportEcPublicKeyAsPemStrFailure(t *testing.T) {
-	outPut, err := exportEcPublicKeyAsPemStr(&ecdsa.PublicKey{})
-	assert.Empty(t, outPut)
+	output, err := exportEcPublicKeyAsPemStr(&ecdsa.PublicKey{})
+	assert.Empty(t, output)
 	assert.Error(t, err)
 }
 
@@ -341,8 +341,8 @@ func TestExportCertificateAsPemStrSuccess(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	outPut := Error.Error(ErrCertificateEncode)
-	assert.Equal(t, "certificate encode error", outPut)
+	output := Error.Error(ErrCertificateEncode)
+	assert.Equal(t, "certificate encode error", output)
 }
 
 const hostname = "localhost"

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -118,9 +118,12 @@ func (m *MockSecurityProvider) FindKeyByID(_ context.Context, id trust.KeyIdenti
 	return nil, security.ErrCertNotFound
 }
 
-func (m *MockSecurityProvider) ListKeys(_ context.Context) ([]trust.KeyDetails, error) {
+func (m *MockSecurityProvider) ListKeys(_ context.Context, legacyOnly bool) ([]trust.KeyDetails, error) {
 	var keys []trust.KeyDetails
 	for _, key := range m.keys {
+		if legacyOnly && !key.IsLegacy() {
+			continue
+		}
 		keys = append(keys, key)
 	}
 	return keys, nil

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -119,10 +119,18 @@ func (m *MockSecurityProvider) FindKeyByID(_ context.Context, id trust.KeyIdenti
 	return nil, security.ErrCertNotFound
 }
 
-func (m *MockSecurityProvider) ListKeys(_ context.Context, legacyOnly bool) ([]trust.KeyDetails, error) {
+func (m *MockSecurityProvider) ListKeys(_ context.Context) ([]trust.KeyDetails, error) {
 	var keys []trust.KeyDetails
 	for _, key := range m.keys {
-		if legacyOnly && !key.IsLegacy() {
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+func (m *MockSecurityProvider) ListKeysWith(_ context.Context, opts trust.ListKeyOptions) ([]trust.KeyDetails, error) {
+	var keys []trust.KeyDetails
+	for _, key := range m.keys {
+		if opts.LegacyOnly && !key.IsLegacy() {
 			continue
 		}
 		keys = append(keys, key)
@@ -280,16 +288,16 @@ func TestExportRsaPublicKeyAsPemStrSuccess(t *testing.T) {
 		E: 65537,
 	}
 
-	output, err := exportRsaPublicKeyAsPemStr(mockKey)
+	outPut, err := exportRsaPublicKeyAsPemStr(mockKey)
 
 	require.NoError(t, err)
-	assert.NotEmpty(t, output)
-	assert.IsType(t, "string", output)
+	assert.NotEmpty(t, outPut)
+	assert.IsType(t, "string", outPut)
 }
 
 func TestExportRsaPublicKeyAsPemStrFailure(t *testing.T) {
-	output, err := exportRsaPublicKeyAsPemStr(&rsa.PublicKey{})
-	assert.Empty(t, output)
+	outPut, err := exportRsaPublicKeyAsPemStr(&rsa.PublicKey{})
+	assert.Empty(t, outPut)
 	assert.Error(t, err)
 }
 
@@ -298,16 +306,16 @@ func TestExportEcPublicKeyAsPemStrSuccess(t *testing.T) {
 	privateKey, err := ecdsa.GenerateKey(curve, rand.Reader)
 	require.NoError(t, err)
 
-	output, err := exportEcPublicKeyAsPemStr(&privateKey.PublicKey)
+	outPut, err := exportEcPublicKeyAsPemStr(&privateKey.PublicKey)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, output)
-	assert.IsType(t, "string", output)
+	assert.NotEmpty(t, outPut)
+	assert.IsType(t, "string", outPut)
 }
 
 func TestExportEcPublicKeyAsPemStrFailure(t *testing.T) {
-	output, err := exportEcPublicKeyAsPemStr(&ecdsa.PublicKey{})
-	assert.Empty(t, output)
+	outPut, err := exportEcPublicKeyAsPemStr(&ecdsa.PublicKey{})
+	assert.Empty(t, outPut)
 	assert.Error(t, err)
 }
 
@@ -333,8 +341,8 @@ func TestExportCertificateAsPemStrSuccess(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	output := Error.Error(ErrCertificateEncode)
-	assert.Equal(t, "certificate encode error", output)
+	outPut := Error.Error(ErrCertificateEncode)
+	assert.Equal(t, "certificate encode error", outPut)
 }
 
 const hostname = "localhost"

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -652,7 +652,7 @@ func (p *Provider) listLegacyKeys(ctx context.Context) []trust.KeyIdentifier {
 		return kidsToCheck
 	}
 
-	k, err := p.KeyDelegator.ListKeys(ctx)
+	k, err := p.KeyDelegator.ListKeys(ctx, true)
 	if err != nil {
 		p.Logger.WarnContext(ctx, "checkpoint KeyIndex.ListKeys failed", slog.Any("error", err))
 	} else {

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -652,7 +652,7 @@ func (p *Provider) listLegacyKeys(ctx context.Context) []trust.KeyIdentifier {
 		return kidsToCheck
 	}
 
-	k, err := p.KeyDelegator.ListKeys(ctx, true)
+	k, err := p.KeyDelegator.ListKeysWith(ctx, trust.ListKeyOptions{LegacyOnly: true})
 	if err != nil {
 		p.Logger.WarnContext(ctx, "checkpoint KeyIndex.ListKeys failed", slog.Any("error", err))
 	} else {

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -25,6 +25,7 @@ import (
 	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/entity"
 	kaspb "github.com/opentdf/platform/protocol/go/kas"
+	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/sdk"
 	"github.com/opentdf/platform/service/internal/security"
 	"github.com/opentdf/platform/service/logger"
@@ -657,7 +658,7 @@ func (p *Provider) listLegacyKeys(ctx context.Context) []trust.KeyIdentifier {
 		p.Logger.WarnContext(ctx, "checkpoint KeyIndex.ListKeys failed", slog.Any("error", err))
 	} else {
 		for _, key := range k {
-			if key.Algorithm() == security.AlgorithmRSA2048 && key.IsLegacy() {
+			if (key.Algorithm() == security.AlgorithmRSA2048 || key.Algorithm() == policy.Algorithm_ALGORITHM_RSA_2048.String()) && key.IsLegacy() {
 				kidsToCheck = append(kidsToCheck, key.ID())
 			}
 		}

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -69,8 +69,12 @@ func (f *fakeKeyIndex) FindKeyByID(context.Context, trust.KeyIdentifier) (trust.
 	return nil, errors.New("not implemented")
 }
 
-func (f *fakeKeyIndex) ListKeys(_ context.Context, legacyOnly bool) ([]trust.KeyDetails, error) {
-	if legacyOnly {
+func (f *fakeKeyIndex) ListKeys(context.Context) ([]trust.KeyDetails, error) {
+	return f.keys, f.err
+}
+
+func (f *fakeKeyIndex) ListKeysWith(_ context.Context, opts trust.ListKeyOptions) ([]trust.KeyDetails, error) {
+	if opts.LegacyOnly {
 		var legacyKeys []trust.KeyDetails
 		for _, key := range f.keys {
 			if key.IsLegacy() {

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -108,7 +108,6 @@ func TestListLegacyKeys_KeyIndexPopulated(t *testing.T) {
 		&fakeKeyDetails{id: "id2", algorithm: "rsa:2048", legacy: false},
 		&fakeKeyDetails{id: "id3", algorithm: "ec:secp256r1", legacy: true},
 		&fakeKeyDetails{id: "id4", algorithm: "rsa:2048", legacy: true},
-		&fakeKeyDetails{id: "id5", algorithm: "ALGORITHM_RSA_2048", legacy: true},
 	}
 	delegator := trust.NewDelegatingKeyService(&fakeKeyIndex{
 		keys: fakeKeys,
@@ -118,7 +117,7 @@ func TestListLegacyKeys_KeyIndexPopulated(t *testing.T) {
 		KeyDelegator: delegator,
 	}
 	kids := p.listLegacyKeys(t.Context())
-	assert.ElementsMatch(t, []trust.KeyIdentifier{"id1", "id4", "id5"}, kids)
+	assert.ElementsMatch(t, []trust.KeyIdentifier{"id1", "id4"}, kids)
 }
 
 func TestListLegacyKeys_Empty(t *testing.T) {

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -66,7 +66,18 @@ func (f *fakeKeyIndex) FindKeyByAlgorithm(context.Context, string, bool) (trust.
 func (f *fakeKeyIndex) FindKeyByID(context.Context, trust.KeyIdentifier) (trust.KeyDetails, error) {
 	return nil, errors.New("not implemented")
 }
-func (f *fakeKeyIndex) ListKeys(context.Context) ([]trust.KeyDetails, error) { return f.keys, f.err }
+func (f *fakeKeyIndex) ListKeys(_ context.Context, legacyOnly bool) ([]trust.KeyDetails, error) {
+	if legacyOnly {
+		var legacyKeys []trust.KeyDetails
+		for _, key := range f.keys {
+			if key.IsLegacy() {
+				legacyKeys = append(legacyKeys, key)
+			}
+		}
+		return legacyKeys, f.err
+	}
+	return f.keys, f.err
+}
 
 func TestListLegacyKeys_KeyringPopulated(t *testing.T) {
 	testLogger := logger.CreateTestLogger()

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -68,6 +68,7 @@ func (f *fakeKeyIndex) FindKeyByAlgorithm(context.Context, string, bool) (trust.
 func (f *fakeKeyIndex) FindKeyByID(context.Context, trust.KeyIdentifier) (trust.KeyDetails, error) {
 	return nil, errors.New("not implemented")
 }
+
 func (f *fakeKeyIndex) ListKeys(_ context.Context, legacyOnly bool) ([]trust.KeyDetails, error) {
 	if legacyOnly {
 		var legacyKeys []trust.KeyDetails

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -105,6 +105,7 @@ func TestListLegacyKeys_KeyIndexPopulated(t *testing.T) {
 		&fakeKeyDetails{id: "id2", algorithm: "rsa:2048", legacy: false},
 		&fakeKeyDetails{id: "id3", algorithm: "ec:secp256r1", legacy: true},
 		&fakeKeyDetails{id: "id4", algorithm: "rsa:2048", legacy: true},
+		&fakeKeyDetails{id: "id5", algorithm: "ALGORITHM_RSA_2048", legacy: true},
 	}
 	delegator := trust.NewDelegatingKeyService(&fakeKeyIndex{
 		keys: fakeKeys,
@@ -114,7 +115,7 @@ func TestListLegacyKeys_KeyIndexPopulated(t *testing.T) {
 		KeyDelegator: delegator,
 	}
 	kids := p.listLegacyKeys(t.Context())
-	assert.ElementsMatch(t, []trust.KeyIdentifier{"id1", "id4"}, kids)
+	assert.ElementsMatch(t, []trust.KeyIdentifier{"id1", "id4", "id5"}, kids)
 }
 
 func TestListLegacyKeys_Empty(t *testing.T) {

--- a/service/kas/key_indexer.go
+++ b/service/kas/key_indexer.go
@@ -145,17 +145,21 @@ func (p *KeyIndexer) FindKeyByID(ctx context.Context, id trust.KeyIdentifier) (t
 	}, nil
 }
 
-func (p *KeyIndexer) ListKeys(ctx context.Context, legacyOnly bool) ([]trust.KeyDetails, error) {
-	var legacy *bool
-	if legacyOnly {
-		legacy = &legacyOnly
+func (p *KeyIndexer) ListKeys(ctx context.Context) ([]trust.KeyDetails, error) {
+	return p.ListKeysWith(ctx, trust.ListKeyOptions{LegacyOnly: false})
+}
+
+func (p *KeyIndexer) ListKeysWith(ctx context.Context, opts trust.ListKeyOptions) ([]trust.KeyDetails, error) {
+	var legacyOnly *bool
+	if opts.LegacyOnly {
+		legacyOnly = &opts.LegacyOnly
 	}
 
 	req := &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasUri{
 			KasUri: p.kasURI,
 		},
-		Legacy: legacy,
+		Legacy: legacyOnly,
 	}
 	resp, err := p.sdk.KeyAccessServerRegistry.ListKeys(ctx, req)
 	if err != nil {

--- a/service/kas/key_indexer.go
+++ b/service/kas/key_indexer.go
@@ -88,7 +88,7 @@ func (p *KeyIndexer) FindKeyByAlgorithm(ctx context.Context, algorithm string, i
 	}
 
 	var legacy *bool
-	if includeLegacy {
+	if !includeLegacy {
 		legacy = &includeLegacy
 	}
 

--- a/service/kas/key_indexer.go
+++ b/service/kas/key_indexer.go
@@ -87,9 +87,9 @@ func (p *KeyIndexer) FindKeyByAlgorithm(ctx context.Context, algorithm string, i
 		return nil, err
 	}
 
-	var legacy bool
-	if !includeLegacy {
-		legacy = false
+	var legacy *bool
+	if includeLegacy {
+		legacy = &includeLegacy
 	}
 
 	req := &kasregistry.ListKeysRequest{
@@ -97,7 +97,7 @@ func (p *KeyIndexer) FindKeyByAlgorithm(ctx context.Context, algorithm string, i
 		KasFilter: &kasregistry.ListKeysRequest_KasUri{
 			KasUri: p.kasURI,
 		},
-		Legacy: &legacy,
+		Legacy: legacy,
 	}
 	resp, err := p.sdk.KeyAccessServerRegistry.ListKeys(ctx, req)
 	if err != nil {
@@ -146,16 +146,16 @@ func (p *KeyIndexer) FindKeyByID(ctx context.Context, id trust.KeyIdentifier) (t
 }
 
 func (p *KeyIndexer) ListKeys(ctx context.Context, legacyOnly bool) ([]trust.KeyDetails, error) {
-	var legacy bool
+	var legacy *bool
 	if legacyOnly {
-		legacy = true
+		legacy = &legacyOnly
 	}
 
 	req := &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasUri{
 			KasUri: p.kasURI,
 		},
-		Legacy: &legacy,
+		Legacy: legacy,
 	}
 	resp, err := p.sdk.KeyAccessServerRegistry.ListKeys(ctx, req)
 	if err != nil {

--- a/service/kas/key_indexer_test.go
+++ b/service/kas/key_indexer_test.go
@@ -19,47 +19,69 @@ type MockKeyAccessServerRegistryClient struct {
 	mock.Mock
 }
 
-func (m *MockKeyAccessServerRegistryClient) CreateKeyAccessServer(ctx context.Context, req *kasregistry.CreateKeyAccessServerRequest) (*kasregistry.CreateKeyAccessServerResponse, error) {
+func (m *MockKeyAccessServerRegistryClient) CreateKeyAccessServer(context.Context, *kasregistry.CreateKeyAccessServerRequest) (*kasregistry.CreateKeyAccessServerResponse, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *MockKeyAccessServerRegistryClient) GetKeyAccessServer(ctx context.Context, req *kasregistry.GetKeyAccessServerRequest) (*kasregistry.GetKeyAccessServerResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) GetKeyAccessServer(context.Context, *kasregistry.GetKeyAccessServerRequest) (*kasregistry.GetKeyAccessServerResponse, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *MockKeyAccessServerRegistryClient) ListKeyAccessServers(ctx context.Context, req *kasregistry.ListKeyAccessServersRequest) (*kasregistry.ListKeyAccessServersResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) ListKeyAccessServers(context.Context, *kasregistry.ListKeyAccessServersRequest) (*kasregistry.ListKeyAccessServersResponse, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *MockKeyAccessServerRegistryClient) UpdateKeyAccessServer(ctx context.Context, req *kasregistry.UpdateKeyAccessServerRequest) (*kasregistry.UpdateKeyAccessServerResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) UpdateKeyAccessServer(context.Context, *kasregistry.UpdateKeyAccessServerRequest) (*kasregistry.UpdateKeyAccessServerResponse, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *MockKeyAccessServerRegistryClient) DeleteKeyAccessServer(ctx context.Context, req *kasregistry.DeleteKeyAccessServerRequest) (*kasregistry.DeleteKeyAccessServerResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) DeleteKeyAccessServer(context.Context, *kasregistry.DeleteKeyAccessServerRequest) (*kasregistry.DeleteKeyAccessServerResponse, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *MockKeyAccessServerRegistryClient) ListKeyAccessServerGrants(ctx context.Context, req *kasregistry.ListKeyAccessServerGrantsRequest) (*kasregistry.ListKeyAccessServerGrantsResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) ListKeyAccessServerGrants(context.Context, *kasregistry.ListKeyAccessServerGrantsRequest) (*kasregistry.ListKeyAccessServerGrantsResponse, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *MockKeyAccessServerRegistryClient) CreateKey(ctx context.Context, req *kasregistry.CreateKeyRequest) (*kasregistry.CreateKeyResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) CreateKey(context.Context, *kasregistry.CreateKeyRequest) (*kasregistry.CreateKeyResponse, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *MockKeyAccessServerRegistryClient) GetKey(ctx context.Context, req *kasregistry.GetKeyRequest) (*kasregistry.GetKeyResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) GetKey(context.Context, *kasregistry.GetKeyRequest) (*kasregistry.GetKeyResponse, error) {
 	return nil, errors.New("not implemented")
 }
+
 func (m *MockKeyAccessServerRegistryClient) ListKeys(ctx context.Context, req *kasregistry.ListKeysRequest) (*kasregistry.ListKeysResponse, error) {
 	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.ListKeysResponse), args.Error(1) //nolint:errcheck // Mocking
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	var resp *kasregistry.ListKeysResponse
+	var ok bool
+	if resp, ok = args.Get(0).(*kasregistry.ListKeysResponse); !ok {
+		return nil, args.Error(1)
+	}
+	return resp, args.Error(1)
 }
-func (m *MockKeyAccessServerRegistryClient) UpdateKey(ctx context.Context, req *kasregistry.UpdateKeyRequest) (*kasregistry.UpdateKeyResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) UpdateKey(context.Context, *kasregistry.UpdateKeyRequest) (*kasregistry.UpdateKeyResponse, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *MockKeyAccessServerRegistryClient) RotateKey(ctx context.Context, req *kasregistry.RotateKeyRequest) (*kasregistry.RotateKeyResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) RotateKey(context.Context, *kasregistry.RotateKeyRequest) (*kasregistry.RotateKeyResponse, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *MockKeyAccessServerRegistryClient) SetBaseKey(ctx context.Context, req *kasregistry.SetBaseKeyRequest) (*kasregistry.SetBaseKeyResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) SetBaseKey(context.Context, *kasregistry.SetBaseKeyRequest) (*kasregistry.SetBaseKeyResponse, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *MockKeyAccessServerRegistryClient) GetBaseKey(ctx context.Context, req *kasregistry.GetBaseKeyRequest) (*kasregistry.GetBaseKeyResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) GetBaseKey(context.Context, *kasregistry.GetBaseKeyRequest) (*kasregistry.GetBaseKeyResponse, error) {
 	return nil, errors.New("not implemented")
 }
-func (m *MockKeyAccessServerRegistryClient) ListKeyMappings(ctx context.Context, req *kasregistry.ListKeyMappingsRequest) (*kasregistry.ListKeyMappingsResponse, error) {
+
+func (m *MockKeyAccessServerRegistryClient) ListKeyMappings(context.Context, *kasregistry.ListKeyMappingsRequest) (*kasregistry.ListKeyMappingsResponse, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -234,7 +256,7 @@ func (s *KeyIndexTestSuite) TestFindKeyByAlgorithm() {
 
 	mockClient.On("ListKeys", mock.Anything, mock.MatchedBy(func(req *kasregistry.ListKeysRequest) bool {
 		//nolint:staticcheck // Legacy optional flag should not be set
-		return req.KeyAlgorithm == policy.Algorithm_ALGORITHM_RSA_2048 && (req.Legacy != nil && req.GetLegacy() == false)
+		return req.GetKeyAlgorithm() == policy.Algorithm_ALGORITHM_RSA_2048 && (req.Legacy != nil && req.GetLegacy() == false)
 	})).Return(&kasregistry.ListKeysResponse{
 		KasKeys: []*policy.KasKey{
 			{

--- a/service/kas/key_indexer_test.go
+++ b/service/kas/key_indexer_test.go
@@ -2,6 +2,7 @@ package kas
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -19,73 +20,47 @@ type MockKeyAccessServerRegistryClient struct {
 }
 
 func (m *MockKeyAccessServerRegistryClient) CreateKeyAccessServer(ctx context.Context, req *kasregistry.CreateKeyAccessServerRequest) (*kasregistry.CreateKeyAccessServerResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.CreateKeyAccessServerResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) GetKeyAccessServer(ctx context.Context, req *kasregistry.GetKeyAccessServerRequest) (*kasregistry.GetKeyAccessServerResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.GetKeyAccessServerResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) ListKeyAccessServers(ctx context.Context, req *kasregistry.ListKeyAccessServersRequest) (*kasregistry.ListKeyAccessServersResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.ListKeyAccessServersResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) UpdateKeyAccessServer(ctx context.Context, req *kasregistry.UpdateKeyAccessServerRequest) (*kasregistry.UpdateKeyAccessServerResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.UpdateKeyAccessServerResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) DeleteKeyAccessServer(ctx context.Context, req *kasregistry.DeleteKeyAccessServerRequest) (*kasregistry.DeleteKeyAccessServerResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.DeleteKeyAccessServerResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) ListKeyAccessServerGrants(ctx context.Context, req *kasregistry.ListKeyAccessServerGrantsRequest) (*kasregistry.ListKeyAccessServerGrantsResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.ListKeyAccessServerGrantsResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) CreateKey(ctx context.Context, req *kasregistry.CreateKeyRequest) (*kasregistry.CreateKeyResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.CreateKeyResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) GetKey(ctx context.Context, req *kasregistry.GetKeyRequest) (*kasregistry.GetKeyResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.GetKeyResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) ListKeys(ctx context.Context, req *kasregistry.ListKeysRequest) (*kasregistry.ListKeysResponse, error) {
 	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.ListKeysResponse), args.Error(1)
+	return args.Get(0).(*kasregistry.ListKeysResponse), args.Error(1) //nolint:errcheck // Mocking
 }
-
 func (m *MockKeyAccessServerRegistryClient) UpdateKey(ctx context.Context, req *kasregistry.UpdateKeyRequest) (*kasregistry.UpdateKeyResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.UpdateKeyResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) RotateKey(ctx context.Context, req *kasregistry.RotateKeyRequest) (*kasregistry.RotateKeyResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.RotateKeyResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) SetBaseKey(ctx context.Context, req *kasregistry.SetBaseKeyRequest) (*kasregistry.SetBaseKeyResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.SetBaseKeyResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) GetBaseKey(ctx context.Context, req *kasregistry.GetBaseKeyRequest) (*kasregistry.GetBaseKeyResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.GetBaseKeyResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
-
 func (m *MockKeyAccessServerRegistryClient) ListKeyMappings(ctx context.Context, req *kasregistry.ListKeyMappingsRequest) (*kasregistry.ListKeyMappingsResponse, error) {
-	args := m.Called(ctx, req)
-	return args.Get(0).(*kasregistry.ListKeyMappingsResponse), args.Error(1)
+	return nil, errors.New("not implemented")
 }
 
 type KeyIndexTestSuite struct {
@@ -211,13 +186,13 @@ func (s *KeyIndexTestSuite) TestListKeysWith() {
 
 	// Test with legacy flag set to true
 	keys, err := keyIndexer.ListKeysWith(context.Background(), trust.ListKeyOptions{LegacyOnly: true})
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(keys, 1)
 	s.Equal("legacy-key-id", string(keys[0].ID()))
 
 	// Test with legacy flag set to false
 	keys, err = keyIndexer.ListKeysWith(context.Background(), trust.ListKeyOptions{LegacyOnly: false})
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(keys, 2)
 	s.Equal("non-legacy-key-id", string(keys[0].ID()))
 	s.Equal("legacy-key-id", string(keys[1].ID()))
@@ -244,7 +219,7 @@ func (s *KeyIndexTestSuite) TestListKeys() {
 	}, nil)
 
 	keys, err := keyIndexer.ListKeys(context.Background())
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(keys, 1)
 	s.Equal("test-key-id", string(keys[0].ID()))
 }
@@ -274,7 +249,7 @@ func (s *KeyIndexTestSuite) TestFindKeyByAlgorithm() {
 
 	mockClient.On("ListKeys", mock.Anything, mock.MatchedBy(func(req *kasregistry.ListKeysRequest) bool {
 		//nolint:staticcheck // Legacy optional flag should not be set
-		return req.KeyAlgorithm == policy.Algorithm_ALGORITHM_RSA_2048 && req.Legacy == nil
+		return req.GetKeyAlgorithm() == policy.Algorithm_ALGORITHM_RSA_2048 && req.Legacy == nil
 	})).Return(&kasregistry.ListKeysResponse{
 		KasKeys: []*policy.KasKey{
 			{
@@ -295,12 +270,12 @@ func (s *KeyIndexTestSuite) TestFindKeyByAlgorithm() {
 	}, nil)
 
 	key, err := keyIndexer.FindKeyByAlgorithm(context.Background(), string(ocrypto.RSA2048Key), false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(key)
 	s.Equal("test-key-id", string(key.ID()))
 
 	key, err = keyIndexer.FindKeyByAlgorithm(context.Background(), string(ocrypto.RSA2048Key), true)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(key)
 	s.Equal("test-legacy-key-id", string(key.ID()))
 }

--- a/service/kas/key_indexer_test.go
+++ b/service/kas/key_indexer_test.go
@@ -73,6 +73,26 @@ func (s *KeyIndexTestSuite) TestKeyExportPublicKey_PKCSFormat() {
 	s.Equal(pubCtx.GetPem(), string(base64Pem))
 }
 
+func (s *KeyIndexTestSuite) TestKeyDetails_Legacy() {
+	legacyKey := &KeyAdapter{
+		key: &policy.KasKey{
+			KasId: "test-kas-id",
+			Key: &policy.AsymmetricKey{
+				Id:           "test-id-legacy",
+				KeyId:        "test-key-id-legacy",
+				KeyAlgorithm: policy.Algorithm_ALGORITHM_RSA_2048,
+				KeyStatus:    policy.KeyStatus_KEY_STATUS_ACTIVE,
+				KeyMode:      policy.KeyMode_KEY_MODE_CONFIG_ROOT_KEY,
+				Legacy:       true, // Mark as legacy
+				PublicKeyCtx: &policy.PublicKeyCtx{
+					Pem: "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF3SEw0TkVrOFpDa0JzNjZXQVpWagpIS3NseDRseWdmaXN3aW42RUx5OU9OczZLVDRYa1crRGxsdExtck14bHZkbzVRaDg1UmFZS01mWUdDTWtPM0dGCkFsK0JOeWFOM1kwa0N1QjNPU2ErTzdyMURhNVZteVVuaEJNbFBrYnVPY1Y0cjlLMUhOSGd3eDl2UFp3RjRpQW8KQStEY1VBcWFEeHlvYjV6enNGZ0hUNjJHLzdLdEtiZ2hYT1dCanRUYUl1ZHpsK2FaSjFPemY0U1RkOXhST2QrMQordVo2VG1ocmFEUm9zdDUrTTZUN0toL2lGWk40TTFUY2hwWXU1TDhKR2tVaG9YaEdZcHUrMGczSzlqYlh6RVh5CnpJU3VXN2d6SGRWYUxvcnBkQlNkRHpOWkNvTFVoL0U1T3d5TFZFQkNKaDZJVUtvdWJ5WHVucnIxQnJmK2tLbEsKeHdJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==",
+				},
+			},
+		},
+	}
+	s.True(legacyKey.IsLegacy())
+}
+
 func TestNewPlatformKeyIndexTestSuite(t *testing.T) {
 	suite.Run(t, new(KeyIndexTestSuite))
 }

--- a/service/trust/delegating_key_service.go
+++ b/service/trust/delegating_key_service.go
@@ -74,8 +74,8 @@ func (d *DelegatingKeyService) FindKeyByID(ctx context.Context, id KeyIdentifier
 	return d.index.FindKeyByID(ctx, id)
 }
 
-func (d *DelegatingKeyService) ListKeys(ctx context.Context) ([]KeyDetails, error) {
-	return d.index.ListKeys(ctx)
+func (d *DelegatingKeyService) ListKeys(ctx context.Context, legacyOnly bool) ([]KeyDetails, error) {
+	return d.index.ListKeys(ctx, legacyOnly)
 }
 
 // Implementing KeyManager methods

--- a/service/trust/delegating_key_service.go
+++ b/service/trust/delegating_key_service.go
@@ -74,8 +74,12 @@ func (d *DelegatingKeyService) FindKeyByID(ctx context.Context, id KeyIdentifier
 	return d.index.FindKeyByID(ctx, id)
 }
 
-func (d *DelegatingKeyService) ListKeys(ctx context.Context, legacyOnly bool) ([]KeyDetails, error) {
-	return d.index.ListKeys(ctx, legacyOnly)
+func (d *DelegatingKeyService) ListKeys(ctx context.Context) ([]KeyDetails, error) {
+	return d.index.ListKeys(ctx)
+}
+
+func (d *DelegatingKeyService) ListKeysWith(ctx context.Context, opts ListKeyOptions) ([]KeyDetails, error) {
+	return d.index.ListKeysWith(ctx, opts)
 }
 
 // Implementing KeyManager methods

--- a/service/trust/key_index.go
+++ b/service/trust/key_index.go
@@ -10,6 +10,12 @@ import (
 // KeyType represents the format in which a key can be exported
 type KeyType int
 
+// Key Options to pass into ListKeysWith
+// when filtering keys
+type ListKeyOptions struct {
+	LegacyOnly bool
+}
+
 const (
 	// KeyTypeJWK represents a key in JWK format
 	KeyTypeJWK KeyType = iota
@@ -65,7 +71,8 @@ type KeyIndex interface {
 	FindKeyByID(ctx context.Context, id KeyIdentifier) (KeyDetails, error)
 
 	// ListKeys returns all available keys
-	// If legacyOnly is true, only legacy keys will be returned.
-	// If false, all keys will be returned.
-	ListKeys(ctx context.Context, legacyOnly bool) ([]KeyDetails, error)
+	ListKeys(ctx context.Context) ([]KeyDetails, error)
+
+	// List keys with options
+	ListKeysWith(ctx context.Context, opts ListKeyOptions) ([]KeyDetails, error)
 }

--- a/service/trust/key_index.go
+++ b/service/trust/key_index.go
@@ -64,5 +64,7 @@ type KeyIndex interface {
 	FindKeyByID(ctx context.Context, id KeyIdentifier) (KeyDetails, error)
 
 	// ListKeys returns all available keys
-	ListKeys(ctx context.Context) ([]KeyDetails, error)
+	// If legacyOnly is true, only legacy keys will be returned.
+	// If false, all keys will be returned.
+	ListKeys(ctx context.Context, legacyOnly bool) ([]KeyDetails, error)
 }


### PR DESCRIPTION
### Proposed Changes

1.) Create a new function for **key_index** called ListKeysWith allowing developers to pass in common ListKeyOptions
2.) Modify ListKeys/FindKeyByAlgorithm within **key_indexer** to support listing legacy keys.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

