### PR TITLE
fix(kas): Allow admin to set registered kas uri

### DIFF
--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -21,7 +21,9 @@ services:
   kas:
     preview:
       ec_tdf_enabled: false
-      key_management: false
+      key_management:
+        enabled: false
+        registered_kas_uri: http://localhost:8080 # Should match what you have registered for *this* KAS in the policy db.
     root_key: a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1 # For local development testing only
     keyring:
       - kid: e1
@@ -55,7 +57,6 @@ services:
   #     enabled: false
   #     refresh_interval: 30s
 server:
-  public_hostname: localhost
   tls:
     enabled: false
     cert: ./keys/platform.crt

--- a/opentdf-kas-mode.yaml
+++ b/opentdf-kas-mode.yaml
@@ -15,7 +15,9 @@ services:
   kas:
     preview:
       ec_tdf_enabled: false
-      key_management: false
+      key_management:
+        enabled: false
+        registered_kas_uri: http://localhost:8080 # Should match what you have registered for *this* KAS in the policy db.
     # root_key: # create key `openssl rand 32 -hex`
     keyring:
       - kid: e1
@@ -29,7 +31,6 @@ services:
         alg: rsa:2048
         legacy: true
 server:
-  public_hostname: localhost
   tls:
     enabled: false
     cert: ./keys/platform.crt

--- a/service/internal/fixtures/policy_fixtures.yaml
+++ b/service/internal/fixtures/policy_fixtures.yaml
@@ -489,7 +489,7 @@ kas_registry:
   data:
     key_access_server_1:
       id: 34f2acdc-3d9c-4e92-80b6-90fe4dc9afcb
-      uri: https://kas.example.com
+      uri: http://localhost:8080
       public_key:
         remote: https://kas.example.com/public_key
       name: kas-remote-example

--- a/service/kas/access/provider.go
+++ b/service/kas/access/provider.go
@@ -21,7 +21,6 @@ const (
 
 type Provider struct {
 	kaspb.AccessServiceServer
-	URI          url.URL `json:"uri"`
 	SDK          *otdf.SDK
 	AttributeSvc *url.URL
 	KeyDelegator *trust.DelegatingKeyService
@@ -54,8 +53,13 @@ type KASConfig struct {
 }
 
 type Preview struct {
-	ECTDFEnabled  bool `mapstructure:"ec_tdf_enabled" json:"ec_tdf_enabled"`
-	KeyManagement bool `mapstructure:"key_management" json:"key_management"`
+	ECTDFEnabled  bool          `mapstructure:"ec_tdf_enabled" json:"ec_tdf_enabled"`
+	KeyManagement KeyManagement `mapstructure:"key_management" json:"key_management"`
+}
+
+type KeyManagement struct {
+	Enabled          bool   `mapstructure:"enabled" json:"enabled"`
+	RegisteredKasURI string `mapstructure:"registered_kas_uri" json:"registered_kas_uri"`
 }
 
 // Specifies the preferred/default key for a given algorithm type.

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"math/big"
-	"net/url"
 	"os"
 	"testing"
 
@@ -181,13 +180,10 @@ func TestPublicKeyWithSecurityProvider(t *testing.T) {
 		certData:  "-----BEGIN CERTIFICATE-----\nMIIBcTCCARegAwIBAgIUTxgZ1CzWBXgysrV4bKVGw+1iBTwwCgYIKoZIzj0EAwIw\nDjEMMAoGA1UEAwwDa2FzMB4XDTIzMDYxMzAwMDAwMFoXDTI4MDYxMzAwMDAwMFow\nDjEMMAoGA1UEAwwDa2FzMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEn6WYEj3s\nxP/IR0W1O5TYHKPyhceFki4Y/9YYeK/D3QkYQrv+DkKXPKkR/MQS6uzmHZY9NS8X\nbcwJ4cGpR6l4FaNmMGQwHQYDVR0OBBYEFFQ8TIybvYhMKH0E+lOVDS0F7r9PMB8G\nA1UdIwQYMBaAFFQ8TIybvYhMKH0E+lOVDS0F7r9PMA8GA1UdEwEB/wQFMAMBAf8w\nEQYDVR0gBAowCDAGBgRVHSAAMAoGCCqGSM49BAMCA0gAMEUCIQD5adIeKGCpbI1E\nJr3jVwQNJL6+bLGXRORhIeKjpvd3egIgRZ7qwTpjZwrkXpDS2i1ODQjj2Ap9ZeMN\nzuDaXdOl90E=\n-----END CERTIFICATE-----",
 	})
 
-	kasURI := urlHost(t)
-
 	// Create Provider with the mock security provider
 	delegator := trust.NewDelegatingKeyService(mockProvider, logger.CreateTestLogger(), nil)
 	delegator.RegisterKeyManager(mockProvider.Name(), func(_ *trust.KeyManagerFactoryOptions) (trust.KeyManager, error) { return mockProvider, nil })
 	kas := Provider{
-		URI:          *kasURI,
 		KeyDelegator: delegator,
 		KASConfig: KASConfig{
 			Keyring: []CurrentKeyFor{
@@ -345,15 +341,12 @@ func TestError(t *testing.T) {
 	assert.Equal(t, "certificate encode error", output)
 }
 
-const hostname = "localhost"
-
 func TestStandardCertificateHandlerEmpty(t *testing.T) {
 	configStandard := security.Config{
 		Type: "standard",
 	}
 	c := mustNewCryptoProvider(t, configStandard)
 	defer c.Close()
-	kasURI := urlHost(t)
 
 	inProcess := security.NewSecurityProviderAdapter(c, nil, nil)
 
@@ -363,7 +356,6 @@ func TestStandardCertificateHandlerEmpty(t *testing.T) {
 	})
 
 	kas := Provider{
-		URI:          *kasURI,
 		KeyDelegator: delegator,
 		Logger:       logger.CreateTestLogger(),
 		Tracer:       noop.NewTracerProvider().Tracer(""),
@@ -380,12 +372,3 @@ func mustNewCryptoProvider(t *testing.T, configStandard security.Config) *securi
 	require.NotNil(t, c)
 	return c
 }
-
-func urlHost(t *testing.T) *url.URL {
-	url, err := url.Parse("https://" + hostname + ":5000")
-	require.NoError(t, err)
-	return url
-}
-
-// Original tests kept for backward compatibility
-// They test the direct CryptoProvider usage path

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/url"
-	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
 	kaspb "github.com/opentdf/platform/protocol/go/kas"
@@ -45,53 +43,14 @@ func NewRegistration() *serviceregistry.Service[kasconnect.AccessServiceHandler]
 			GRPCGatewayFunc: kaspb.RegisterAccessServiceHandler,
 			OnConfigUpdate:  onConfigUpdate,
 			RegisterFunc: func(srp serviceregistry.RegistrationParams) (kasconnect.AccessServiceHandler, serviceregistry.HandlerServer) {
-				// Determine KAS URI based on public hostname and server's listening port/scheme
-				kasHost := srp.OTDF.PublicHostname
-				serverAddr := srp.OTDF.HTTPServer.Addr
-
-				// Extract port from serverAddr
-				// serverAddr is typically in "host:port" or ":port" format
-				_, port, err := net.SplitHostPort(serverAddr)
-				if err != nil {
-					// If SplitHostPort fails, it might be because serverAddr is just ":port"
-					if strings.HasPrefix(serverAddr, ":") {
-						port = strings.TrimPrefix(serverAddr, ":")
-					} else {
-						// Or if serverAddr is invalid or unexpected format
-						panic(fmt.Errorf("could not extract port from KAS server address '%s': %w", serverAddr, err))
-					}
-				}
-
-				if kasHost == "" {
-					// Fallback if PublicHostname is not configured
-					hostFromServerAddr, _, _ := net.SplitHostPort(serverAddr) // Error already handled for port
-					if hostFromServerAddr != "" && hostFromServerAddr != "0.0.0.0" {
-						kasHost = hostFromServerAddr
-					} else {
-						// Default to localhost if listening on all interfaces or host is not specified in Addr
-						kasHost = "localhost"
-					}
-				}
-
-				scheme := "http"
-				if srp.OTDF.HTTPServer.TLSConfig != nil {
-					scheme = "https"
-				}
-
-				kasURLString := fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(kasHost, port))
-
-				kasURI, err := url.Parse(kasURLString)
-				if err != nil {
-					panic(fmt.Errorf("invalid kas address [%s] %w", kasURLString, err))
-				}
-
 				var kasCfg access.KASConfig
 				if err := mapstructure.Decode(srp.Config, &kasCfg); err != nil {
 					panic(fmt.Errorf("invalid kas cfg [%v] %w", srp.Config, err))
-				} // kasURLString will be used for p.URI
+				}
 
 				var cacheClient *cache.Cache
 				if kasCfg.KeyCacheExpiration != 0 {
+					var err error
 					cacheClient, err = srp.NewCacheClient(cache.Options{
 						Expiration: kasCfg.KeyCacheExpiration,
 					})
@@ -100,11 +59,18 @@ func NewRegistration() *serviceregistry.Service[kasconnect.AccessServiceHandler]
 					}
 				}
 
-				if kasCfg.Preview.KeyManagement {
+				if kasCfg.Preview.KeyManagement.Enabled {
 					srp.Logger.Info("preview feature: key management is enabled")
 
+					kasURL, err := url.Parse(kasCfg.Preview.KeyManagement.RegisteredKasURI)
+					if err != nil {
+						panic(fmt.Errorf("failed to parse registered KAS URI [%v]: %w", kasCfg.Preview.KeyManagement.RegisteredKasURI, err))
+					}
+
+					srp.Logger.Info("using registered KAS URI", slog.String("uri", kasURL.String()))
+
 					// Configure new delegation service
-					p.KeyDelegator = trust.NewDelegatingKeyService(NewPlatformKeyIndexer(srp.SDK, kasURLString, srp.Logger), srp.Logger, cacheClient)
+					p.KeyDelegator = trust.NewDelegatingKeyService(NewPlatformKeyIndexer(srp.SDK, kasURL.String(), srp.Logger), srp.Logger, cacheClient)
 					for _, manager := range srp.KeyManagerFactories {
 						p.KeyDelegator.RegisterKeyManager(manager.Name, manager.Factory)
 					}
@@ -136,7 +102,6 @@ func NewRegistration() *serviceregistry.Service[kasconnect.AccessServiceHandler]
 					p.KeyDelegator.SetDefaultMode(inProcessService.Name())
 				}
 
-				p.URI = *kasURI
 				p.SDK = srp.SDK
 				p.Logger = srp.Logger
 				p.KASConfig = kasCfg


### PR DESCRIPTION
### Proposed Changes

1.) Allow admin to set the registered KAS URI, instead of inferring it.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

