### PR TITLE
Assertion Provider

### DIFF
--- a/sdk/assertion.go
+++ b/sdk/assertion.go
@@ -182,6 +182,9 @@ type Binding struct {
 	Method string `json:"method,omitempty"`
 	// Signature of the assertion.
 	Signature string `json:"signature,omitempty"`
+	// Version of the canonicalization and binding format (default: "1.0")
+	// This allows future changes to canonicalization while maintaining compatibility
+	Version string `json:"version,omitempty"`
 }
 
 // AssertionType represents the type of the assertion.

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -43,6 +43,8 @@ type config struct {
 	entityResolutionConn               *ConnectRPCConnection
 	collectionStore                    *collectionStore
 	shouldValidatePlatformConnectivity bool
+	assertionSigner                    AssertionSigner
+	assertionVerifier                  AssertionVerifier
 }
 
 // Options specific to TDF protocol features
@@ -228,5 +230,23 @@ func WithExtraClientOptions(opts ...connect.ClientOption) Option {
 func WithNoKIDInNano() Option {
 	return func(c *config) {
 		c.nanoFeatures.noKID = true
+	}
+}
+
+// WithAssertionSigner returns an Option that sets a custom assertion signer.
+// The provided signer will be used for signing assertions during TDF creation.
+// If not set, a default signer will be used.
+func WithAssertionSigner(s AssertionSigner) Option {
+	return func(c *config) {
+		c.assertionSigner = s
+	}
+}
+
+// WithAssertionVerifier returns an Option that sets a custom assertion verifier.
+// The provided verifier will be used for verifying assertions during TDF reading.
+// If not set, a default verifier will be used.
+func WithAssertionVerifier(v AssertionVerifier) Option {
+	return func(c *config) {
+		c.assertionVerifier = v
 	}
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -69,6 +69,8 @@ type SDK struct {
 	Unsafe                  sdkconnect.UnsafeServiceClient
 	KeyManagement           sdkconnect.KeyManagementServiceClient
 	wellknownConfiguration  sdkconnect.WellKnownServiceClient
+	assertionSigner         AssertionSigner
+	assertionVerifier       AssertionVerifier
 }
 
 func New(platformEndpoint string, opts ...Option) (*SDK, error) {
@@ -179,6 +181,17 @@ func New(platformEndpoint string, opts ...Option) (*SDK, error) {
 		ersConn = platformConn
 	}
 
+	// Initialize assertion providers with defaults if not provided
+	assertionSigner := cfg.assertionSigner
+	if assertionSigner == nil {
+		assertionSigner = defaultAssertionSigner{}
+	}
+
+	assertionVerifier := cfg.assertionVerifier
+	if assertionVerifier == nil {
+		assertionVerifier = defaultAssertionVerifier{}
+	}
+
 	return &SDK{
 		config:                  *cfg,
 		collectionStore:         cfg.collectionStore,
@@ -199,6 +212,8 @@ func New(platformEndpoint string, opts ...Option) (*SDK, error) {
 		EntityResolutionV2:      sdkconnect.NewEntityResolutionServiceClientV2ConnectWrapper(ersConn.Client, ersConn.Endpoint, ersConn.Options...),
 		KeyManagement:           sdkconnect.NewKeyManagementServiceClientConnectWrapper(platformConn.Client, platformConn.Endpoint, platformConn.Options...),
 		wellknownConfiguration:  sdkconnect.NewWellKnownServiceClientConnectWrapper(platformConn.Client, platformConn.Endpoint, platformConn.Options...),
+		assertionSigner:         assertionSigner,
+		assertionVerifier:       assertionVerifier,
 	}, nil
 }
 

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -266,6 +266,7 @@ type TDFReaderOption func(*TDFReaderConfig) error
 type TDFReaderConfig struct {
 	verifiers                    AssertionVerificationKeys
 	disableAssertionVerification bool
+	assertionVerifier            AssertionVerifier // Optional custom verifier override
 
 	schemaValidationIntensity SchemaValidationIntensity
 	kasSessionKey             ocrypto.KeyPair
@@ -367,6 +368,15 @@ func newTDFReaderConfig(opt ...TDFReaderOption) (*TDFReaderConfig, error) {
 func WithAssertionVerificationKeys(keys AssertionVerificationKeys) TDFReaderOption {
 	return func(c *TDFReaderConfig) error {
 		c.verifiers = keys
+		return nil
+	}
+}
+
+// WithReaderAssertionVerifier sets a custom assertion verifier for this specific reader.
+// This overrides the SDK-level verifier if one was set.
+func WithReaderAssertionVerifier(verifier AssertionVerifier) TDFReaderOption {
+	return func(c *TDFReaderConfig) error {
+		c.assertionVerifier = verifier
 		return nil
 	}
 }


### PR DESCRIPTION
# Assertion Provider Implementation Summary

## Overview
This implementation adds **extensible assertion signing and verification** to the Go SDK via provider interfaces, following the architect-level specification. It enables integrators to plug in **custom signing** (e.g., HSM/KMS) and **custom verification** (e.g., external trust bundles), while preserving existing behavior when no providers are supplied.

**Key properties**
- Backward compatible: defaults preserve existing signing/verification.
- Context-aware: `context.Context` is threaded through sign/verify.
- Deterministic & secure: canonicalization (JCS/RFC 8785), algorithm allow-list, aggregate ordering, constant-time verification.
- Observable: warnings when verification is disabled; interfaces documented as concurrency-safe.

---

## Key Changes

### 1) New Files
- `sdk/assertion_provider.go` — Public provider interfaces (`AssertionSigner`, `AssertionVerifier`) and core types.
- `sdk/assertion_default.go` — Default provider implementations that wrap internal logic.
- `sdk/assertion_errors.go` — Typed error taxonomy supporting `errors.Is/As`.
- `sdk/canonicalization.go` — Canonicalization helpers (JCS-style) and digest utilities.
- `docs/Custom-Assertion-Providers.md` — Developer documentation: how to implement and wire providers.

### 2) Updated Files (selected)
- `sdk/options.go` — New functional options: `WithAssertionSigner(...)`, `WithAssertionVerifier(...)`.
- `sdk/sdk.go` — Stores provider defaults on initialization; wires context, concurrency notes.
- `sdk/tdf_config.go` — Adds `assertionVerifier` override and `disableAssertionVerification` flag.
- `sdk/tdf.go` — Hooks verification path to provider; warns once when verification is disabled or no verifier configured.

### 3) Internal Behavior
- **Canonicalization**: JSON Canonicalization Scheme (JCS / RFC 8785) for `Assertion` (excluding `Binding`), then SHA-256 digest.
- **Binding Versioning**: `binding.version` added to support forward compatibility.
- **Aggregate Integrity**: Multi-assertion hash uses **lexicographic order by `Assertion.ID`**; reordering is detected.
- **Algorithm Policy**: Allow-list (initially HS256/RS256). Unknown/weak algorithms fail with `ErrUnsupportedAlg`.
- **Constant-Time Verify**: Signature comparison uses constant-time checks.
- **Concurrency**: Providers must be safe for concurrent use; SDK may parallelize verification.

---

## Public API (Pseudo)

```go
// Provider interfaces
type AssertionSigner interface {
    Sign(ctx context.Context, a Assertion, key AssertionKey) (Binding, error)
}

type AssertionVerifier interface {
    Verify(ctx context.Context, a Assertion, key AssertionKey) error
}

// SDK options
func WithAssertionSigner(s AssertionSigner) Option
func WithAssertionVerifier(v AssertionVerifier) Option

// Reader-level override
type TDFReaderConfig struct {
    disableAssertionVerification bool
    assertionVerifier            AssertionVerifier // optional override
}
```

**Defaults**  
If options are not provided, the SDK uses `defaultAssertionSigner` and `defaultAssertionVerifier` which delegate to internal signing/verify logic. Behavior remains unchanged for existing consumers.

---

## Core Domain Types (Pseudo)

```go
type Assertion struct {
    ID        string
    Type      string
    Scope     string
    Statement map[string]any
    Binding   *Binding // added/verified by providers
}

type Binding struct {
    Algorithm string // e.g., "HS256", "RS256"
    Signature string // base64url-encoded
    KeyID     string
    Version   int // binding.version
}

type AssertionKey struct {
    Alg string
    Kid string
    Key any // SDK-owned wrapper; adapters avoid raw private key exposure
}
```

---

## Canonicalization & Integrity (Pseudo)

```go
// canonicalize excludes Binding and is language-agnostic
data   := JCS.Marshal(assertion.WithoutBinding())
digest := sha256(data)

// Aggregate multi-assertion digest: sort by Assertion.ID (lexicographic)
// Reordering is treated as tampering.
```

---

## Error Taxonomy (Typed Errors)

```go
var (
    ErrMissingBinding   = &AssertionError{Kind: "missing_binding"}
    ErrUnsupportedAlg   = &AssertionError{Kind: "unsupported_alg"}
    ErrBadSignature     = &AssertionError{Kind: "bad_signature"}
    ErrKeyMismatch      = &AssertionError{Kind: "key_mismatch"}
    ErrUnknownVersion   = &AssertionError{Kind: "unknown_binding_version"}
)
```

Fields commonly attached for diagnostics: `Alg`, `Kid`, `AssertionID`, `BindingVersion`.  
All errors support `errors.Is/As`.

---

## Usage Examples (Pseudo)

### SDK-level configuration
```go
sdk := New(
    endpoint,
    WithAssertionSigner(MySigner{hsm: myHSM}),
    WithAssertionVerifier(MyVerifier{trust: myTrustBundle}),
)
```

### Reader-level override
```go
reader := newReader(sdk, TDFReaderConfig{
    assertionVerifier: myVerifier,          // optional override per-read
    disableAssertionVerification: false,    // set true only with care
})
```

### Provider implementations
```go
type MySigner struct { hsm HSMClient }
func (s MySigner) Sign(ctx context.Context, a Assertion, key AssertionKey) (Binding, error) {
    bytes  := canonicalize(a)          // exclude Binding
    digest := sha256(bytes)
    sig    := s.hsm.Sign(ctx, key.Kid, digest)
    return Binding{
        Algorithm: "RS256",
        Signature: b64url(sig),
        KeyID:     key.Kid,
        Version:   1,
    }, nil
}

type MyVerifier struct { trust TrustBundle }
func (v MyVerifier) Verify(ctx context.Context, a Assertion, key AssertionKey) error {
    if a.Binding == nil {
        return ErrMissingBinding
    }
    if !allowList.Contains(a.Binding.Algorithm) {
        return ErrUnsupportedAlg
    }
    bytes  := canonicalize(a)          // exclude Binding
    digest := sha256(bytes)
    sig    := b64urlDecode(a.Binding.Signature)
    return v.trust.Verify(ctx, key, digest, sig) // constant-time inside
}
```

---

## Reader Warnings
- If `disableAssertionVerification == true` and assertions exist, the reader logs a **single warning** and skips verification.
- If `assertionVerifier == nil`, the reader logs a **single warning** and skips verification.

---

## Tests Added

### Security / Invariants
- **Canonicalization invariants**: key order / whitespace independence.
- **Order tamper detection**: swapping assertions fails verification.
- **Algorithm policy**: only HS256/RS256 accepted.
- **Binding version**: unknown versions produce `ErrUnknownVersion`.
- **Legacy compatibility**: TDF hex path remains valid.

### Behavior
- **Default providers parity**: no-options path equals old behavior.
- **Custom provider invocation**: hooks are called as expected.
- **Concurrency**: parallel sign/verify safe (`-race` clean).

### Reader Controls
- **Overrides**: per-reader verifier replaces SDK default.
- **Disabled verification**: warns once; skips verification.

---

## How to Run (Suggested CI)

```bash
go build ./...
golangci-lint run

# Security/invariant tests
go test ./sdk -run TestCanonicalizationInvariants -v
go test ./sdk -run TestAssertionOrderTampering -v
go test ./sdk -run TestAlgorithmPolicy -v
go test ./sdk -run TestBindingVersion -v
go test ./sdk -run TestLegacyTDFHexEncoding -v

# Provider behavior
go test ./sdk -run TestDefaultProviders -v
go test ./sdk -run TestAssertionProviderInvocation -v
go test ./sdk -run TestConcurrentSigning -v
go test ./sdk -run TestConcurrentVerification -v

# Reader controls
go test ./sdk -run TestReaderOverrides -v
go test ./sdk -run TestDisabledVerificationWarning -v

# Race & coverage
go test ./sdk -race -v
go test ./... -coverprofile=coverage.out
go tool cover -func=coverage.out | tee coverage.txt
```

---

## Known Limitations / Follow-ups
- Configurable algorithm allow-list as an SDK option (future).
- Metrics counters/spans (sign/verify ok/fail/skip) to be added in telemetry PR.
- Public `SignKey`/`VerifyKey` interfaces can be exposed in a follow-on change if needed by integrators.
- Additional algorithms (e.g., ES256/EdDSA) require allow-list updates and new vectors.

---

## Changelog (Developer-Facing)
- Added `AssertionSigner` and `AssertionVerifier` interfaces.
- Added SDK options: `WithAssertionSigner`, `WithAssertionVerifier`.
- Added reader override and disable flag behavior with warning.
- Introduced canonicalization (JCS) + binding versioning.
- Implemented algorithm allow-list and typed errors.
- Added comprehensive tests and documentation.

---

## Appendix: Minimal Pseudo-Code Snippets

```go
// SDK init defaults
sdk.signer   = cfg.signer   ?? defaultAssertionSigner{}
sdk.verifier = cfg.verifier ?? defaultAssertionVerifier{}

// Create path (sign)
for _, a := range manifest.Assertions {
    b, err := sdk.signer.Sign(ctx, a, signKey)
    if err != nil { return wrap(SigningFailed, err, a.ID) }
    a.Binding = &b
}

// Read path (verify)
if !reader.config.disableAssertionVerification {
    if reader.assertionVerifier == nil {
        warnOnce("No assertion verifier configured; skipping validation")
    } else {
        for _, a := range r.manifest.Assertions {
            if err := reader.assertionVerifier.Verify(ctx, a, verifyKey); err != nil {
                return wrap(AssertionVerificationFailed, err, a.ID)
            }
        }
    }
}
```