### PR TITLE
feat(core): Encapsulate>Encrypt

### DIFF
--- a/lib/ocrypto/ec_key_pair.go
+++ b/lib/ocrypto/ec_key_pair.go
@@ -446,7 +446,7 @@ func ECPrivateKeyInPemFormat(privateKey ecdsa.PrivateKey) (string, error) {
 
 // ECPublicKeyInPemFormat Returns public key in pem format.
 func ECPublicKeyInPemFormat(publicKey ecdsa.PublicKey) (string, error) {
-	publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	pkb, err := x509.MarshalPKIXPublicKey(publicKey)
 	if err != nil {
 		return "", fmt.Errorf("x509.MarshalPKIXPublicKey failed: %w", err)
 	}
@@ -454,7 +454,7 @@ func ECPublicKeyInPemFormat(publicKey ecdsa.PublicKey) (string, error) {
 	publicKeyPem := pem.EncodeToMemory(
 		&pem.Block{
 			Type:  "PUBLIC KEY",
-			Bytes: publicKeyBytes,
+			Bytes: pkb,
 		},
 	)
 

--- a/lib/ocrypto/interfaces.go
+++ b/lib/ocrypto/interfaces.go
@@ -27,6 +27,7 @@ type ProtectedKey interface {
 	VerifyBinding(ctx context.Context, policy, policyBinding []byte) error
 
 	// Export returns the raw key data, optionally encrypting it with the provided encapsulator
+	// Deprecated: Use the Encapsulator's Encapsulate method instead
 	Export(encapsulator Encapsulator) ([]byte, error)
 
 	// DecryptAESGCM decrypts encrypted policies and metadata

--- a/lib/ocrypto/protected_key.go
+++ b/lib/ocrypto/protected_key.go
@@ -55,6 +55,7 @@ func (k *AESProtectedKey) DecryptAESGCM(iv []byte, body []byte, tagSize int) ([]
 }
 
 // Export returns the raw key data, optionally encrypting it with the provided Encapsulator
+// Deprecated: Use the Encapsulator's Encapsulate method instead
 func (k *AESProtectedKey) Export(encapsulator Encapsulator) ([]byte, error) {
 	if encapsulator == nil {
 		// Return error if encapsulator is nil
@@ -62,7 +63,7 @@ func (k *AESProtectedKey) Export(encapsulator Encapsulator) ([]byte, error) {
 	}
 
 	// Encrypt the key data before returning
-	encryptedKey, err := encapsulator.Encrypt(k.rawKey)
+	encryptedKey, err := encapsulator.Encapsulate(k)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt key data for export: %w", err)
 	}

--- a/lib/ocrypto/protected_key_test.go
+++ b/lib/ocrypto/protected_key_test.go
@@ -75,14 +75,22 @@ func TestAESProtectedKey_Export_WithEncapsulator(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mock encapsulator
+	mockEncryptFunc := func(data []byte) ([]byte, error) {
+		// Simple XOR encryption for testing
+		result := make([]byte, len(data))
+		for i, b := range data {
+			result[i] = b ^ 0xFF
+		}
+		return result, nil
+	}
 	mockEncapsulator := &mockEncapsulator{
-		encryptFunc: func(data []byte) ([]byte, error) {
-			// Simple XOR encryption for testing
-			result := make([]byte, len(data))
-			for i, b := range data {
-				result[i] = b ^ 0xFF
+		encryptFunc: mockEncryptFunc,
+		encapsulateFunc: func(k ProtectedKey) ([]byte, error) {
+			aeskey, ok := k.(*AESProtectedKey)
+			if !ok {
+				return nil, assert.AnError
 			}
-			return result, nil
+			return mockEncryptFunc(aeskey.rawKey)
 		},
 	}
 
@@ -105,7 +113,7 @@ func TestAESProtectedKey_Export_EncapsulatorError(t *testing.T) {
 	require.NoError(t, err)
 
 	mockEncapsulator := &mockEncapsulator{
-		encryptFunc: func(_ []byte) ([]byte, error) {
+		encapsulateFunc: func(_ ProtectedKey) ([]byte, error) {
 			return nil, assert.AnError
 		},
 	}
@@ -175,6 +183,7 @@ func TestAESProtectedKey_InterfaceCompliance(t *testing.T) {
 // Mock encapsulator for testing
 type mockEncapsulator struct {
 	encryptFunc      func([]byte) ([]byte, error)
+	encapsulateFunc  func(ProtectedKey) ([]byte, error)
 	publicKeyPEMFunc func() (string, error)
 	ephemeralKeyFunc func() []byte
 }

--- a/lib/ocrypto/protected_key_test.go
+++ b/lib/ocrypto/protected_key_test.go
@@ -188,8 +188,8 @@ type mockEncapsulator struct {
 	ephemeralKeyFunc func() []byte
 }
 
-func (m *mockEncapsulator) Encapsulate(_ ProtectedKey) ([]byte, error) {
-	return nil, nil
+func (m *mockEncapsulator) Encapsulate(pk ProtectedKey) ([]byte, error) {
+	return m.encapsulateFunc(pk)
 }
 
 func (m *mockEncapsulator) Encrypt(data []byte) ([]byte, error) {

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -712,6 +712,7 @@ func (p *Provider) tdf3Rewrap(ctx context.Context, requests []*kaspb.UnsignedRew
 		failAllKaos(requests, results, err400("invalid request"))
 		return "", results
 	}
+	encap := security.OCEncapsulator{PublicKeyEncryptor: asymEncrypt}
 
 	var sessionKey string
 	if e, ok := asymEncrypt.(ocrypto.ECEncryptor); ok {
@@ -771,7 +772,7 @@ func (p *Provider) tdf3Rewrap(ctx context.Context, requests []*kaspb.UnsignedRew
 			}
 
 			// Use the Export method with the asymEncrypt encryptor
-			encryptedKey, err := kaoRes.DEK.Export(asymEncrypt)
+			encryptedKey, err := encap.Encapsulate(kaoRes.DEK)
 			if err != nil {
 				//nolint:sloglint // reference to camelcase key is intentional
 				p.Logger.WarnContext(ctx, "rewrap: Export with encryptor failed", slog.String("clientPublicKey", clientPublicKey), slog.Any("error", err))

--- a/service/trust/delegating_key_service_test.go
+++ b/service/trust/delegating_key_service_test.go
@@ -172,6 +172,14 @@ type MockEncapsulator struct {
 	mock.Mock
 }
 
+func (m *MockEncapsulator) Encapsulate(dek ProtectedKey) ([]byte, error) {
+	args := m.Called(dek)
+	if a0, ok := args.Get(0).([]byte); ok {
+		return a0, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (m *MockEncapsulator) Encrypt(data []byte) ([]byte, error) {
 	args := m.Called(data)
 	if a0, ok := args.Get(0).([]byte); ok {

--- a/service/trust/key_manager.go
+++ b/service/trust/key_manager.go
@@ -6,6 +6,9 @@ import (
 )
 
 type Encapsulator interface {
+	// Encapsulate wraps a secret key with the encapsulation key
+	Encapsulate(dek ProtectedKey) ([]byte, error)
+
 	// Encrypt wraps a secret key with the encapsulation key
 	Encrypt(data []byte) ([]byte, error)
 
@@ -23,6 +26,7 @@ type ProtectedKey interface {
 	VerifyBinding(ctx context.Context, policy, binding []byte) error
 
 	// Export returns the raw key data, optionally encrypting it with the provided encryptor
+	// Deprecated: Use the Encapsulator's Encapsulate method instead
 	Export(encryptor Encapsulator) ([]byte, error)
 
 	// Used to decrypt encrypted policies and metadata


### PR DESCRIPTION
### Proposed Changes

- Prefer using the Encapsulate interface method, when possible
- Deprecate the Key's Export method, since we generally don't want to export the keys and Encapsulate is more accurate for what we want.
- The goal here is to present an interface that supports a fully delegated rewrap, e.g. using a [Luna Functionality Module](https://thalesdocs.com/gphsm/luna/7/docs/network/Content/FM_SDK/preface.htm) or other KAS. In this case, the call to Encapsulate would trigger the external rewrap.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

