### PR TITLE
fix(sdk): newGranter nil check

### DIFF
--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -374,9 +374,7 @@ func (tdfConfig *TDFConfig) initKAOTemplate(ctx context.Context, s SDK) error {
 
 	// * Get base key before autoconfigure to condition off of.
 	if tdfConfig.autoconfigure {
-		var g granter
-		var err error
-		g, err = s.newGranter(ctx, tdfConfig)
+		g, err := s.newGranter(ctx, tdfConfig)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This pull request makes a targeted fix to the error handling logic in the `newGranter` function within `sdk/tdf.go`. The change ensures that if an error occurs while creating the granter, the function immediately returns the error, preventing further operations on a potentially invalid object.

Error handling improvement:

* Added an early return in the `newGranter` function to immediately return if `err` is not nil, improving reliability and preventing assignment to `g.keyInfoFetcher` when an error occurs. (`sdk/tdf.go`, [sdk/tdf.goR458-R460](diffhunk://#diff-04aae07cffd4333871c74efd45d47c4e6739b11bf4ebd9a9b5e90376cbf46d08R458-R460)
