### PR TITLE
fix(core): return services in the order they were registered

### DIFF
--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -127,11 +127,10 @@ func startServices(ctx context.Context, params startServicesParams) (func(), err
 	keyManagerFactories := params.keyManagerFactories
 
 	// Iterate through the registered namespaces
-	for _, ns := range reg.GetNamespaces() {
-		namespace, err := reg.GetNamespace(ns)
-		if err != nil {
-			return nil, err
-		}
+	for _, nsInfo := range reg.GetNamespaces() {
+		ns := nsInfo.Name
+		namespace := nsInfo.Namespace
+
 		// Check if this namespace should be enabled based on configured modes
 		modeEnabled := namespace.IsEnabled(cfg.Mode)
 

--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -127,7 +127,11 @@ func startServices(ctx context.Context, params startServicesParams) (func(), err
 	keyManagerFactories := params.keyManagerFactories
 
 	// Iterate through the registered namespaces
-	for ns, namespace := range reg.GetNamespaces() {
+	for _, ns := range reg.GetNamespaces() {
+		namespace, err := reg.GetNamespace(ns)
+		if err != nil {
+			return nil, err
+		}
 		// Check if this namespace should be enabled based on configured modes
 		modeEnabled := namespace.IsEnabled(cfg.Mode)
 

--- a/service/pkg/server/services_test.go
+++ b/service/pkg/server/services_test.go
@@ -493,15 +493,19 @@ func (m *mockOrderTrackingService) Start(_ context.Context, _ serviceregistry.Re
 	*m.startOrderTracker = append(*m.startOrderTracker, m.serviceName)
 	return nil
 }
+
 func (m *mockOrderTrackingService) RegisterConfigUpdateHook(context.Context, func(config.ChangeHook)) error {
 	return nil
 }
+
 func (m *mockOrderTrackingService) RegisterConnectRPCServiceHandler(context.Context, *server.ConnectRPC) error {
 	return nil
 }
+
 func (m *mockOrderTrackingService) RegisterGRPCGatewayHandler(context.Context, *runtime.ServeMux, *grpc.ClientConn) error {
 	return nil
 }
+
 func (m *mockOrderTrackingService) RegisterHTTPHandlers(context.Context, *runtime.ServeMux) error {
 	return nil
 }

--- a/service/pkg/serviceregistry/serviceregistry.go
+++ b/service/pkg/serviceregistry/serviceregistry.go
@@ -281,15 +281,14 @@ func NewServiceRegistry() *Registry {
 }
 
 // GetNamespaces returns all namespaces in the registry
-func (reg *Registry) GetNamespaces() map[string]*Namespace {
+func (reg *Registry) GetNamespaces() []string {
 	reg.mu.RLock()
 	defer reg.mu.RUnlock()
 
-	result := make(map[string]*Namespace, len(reg.namespaces))
-	for k, v := range reg.namespaces {
-		result[k] = v
-	}
-	return result
+	// Return a copy to prevent modification of the internal order slice.
+	orderCopy := make([]string, len(reg.order))
+	copy(orderCopy, reg.order)
+	return orderCopy
 }
 
 // RegisterService registers a service in the service registry.

--- a/service/pkg/serviceregistry/serviceregistry.go
+++ b/service/pkg/serviceregistry/serviceregistry.go
@@ -280,15 +280,21 @@ func NewServiceRegistry() *Registry {
 	}
 }
 
+type NamespaceInfo struct {
+	Name      string
+	Namespace *Namespace
+}
+
 // GetNamespaces returns all namespaces in the registry
-func (reg *Registry) GetNamespaces() []string {
+func (reg *Registry) GetNamespaces() []NamespaceInfo {
 	reg.mu.RLock()
 	defer reg.mu.RUnlock()
 
-	// Return a copy to prevent modification of the internal order slice.
-	orderCopy := make([]string, len(reg.order))
-	copy(orderCopy, reg.order)
-	return orderCopy
+	namespaceInfo := make([]NamespaceInfo, len(reg.order))
+	for i, name := range reg.order {
+		namespaceInfo[i] = NamespaceInfo{Name: name, Namespace: reg.namespaces[name]}
+	}
+	return namespaceInfo
 }
 
 // RegisterService registers a service in the service registry.


### PR DESCRIPTION
### Proposed Changes

So right now I have inter-PEP dependencies, so config/PEP-A for example. PEP-A wants to set its config to the config service, for later viewing/editing in another interface. Currently the only place available for this is PEP-A's Init (RegisterFunc). So, right now, this is the solution I'm using. I think there is an alternative with some "OnServicesStarted" type hook or something as well (which might be more useful maybe).


### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

