### PR TITLE
fix: ECC key loading (deprecated)

### DIFF
--- a/service/internal/security/standard_crypto.go
+++ b/service/internal/security/standard_crypto.go
@@ -236,7 +236,7 @@ func loadDeprecatedKeys(rsaKeys map[string]StandardKeyInfo, ecKeys map[string]St
 		}
 		k := StandardECCrypto{
 			KeyPairInfo: KeyPairInfo{
-				Algorithm:   AlgorithmRSA2048,
+				Algorithm:   AlgorithmECP256R1,
 				KID:         id,
 				Private:     kasInfo.PrivateKeyPath,
 				Certificate: kasInfo.PublicKeyPath,


### PR DESCRIPTION
### Proposed Changes

This pull request updates the deprecated key loading logic in the `service/internal/security/standard_crypto.go` file to ensure the correct cryptographic algorithm is set for ECC keys. The main change is a fix to the algorithm identifier used when loading ECC keys.

Key management fix:

* In the `loadDeprecatedKeys` function, the `Algorithm` field for ECC keys is now correctly set to `AlgorithmECP256R1` instead of the incorrect `AlgorithmRSA2048`, ensuring proper identification and handling of ECC keys.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

