### PR TITLE
fix: EC fallback to PEM

### DIFF
--- a/lib/ocrypto/ec_key_pair.go
+++ b/lib/ocrypto/ec_key_pair.go
@@ -351,7 +351,12 @@ func ECPrivateKeyFromPem(privateECKeyInPem []byte) (*ecdh.PrivateKey, error) {
 
 	priv, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("ec x509.ParsePKCS8PrivateKey failed: %w", err)
+	    // If PKCS8 fails, try EC private key format
+	    ecKey, ecErr := x509.ParseECPrivateKey(block.Bytes)
+	    if ecErr != nil {
+	        return nil, fmt.Errorf("failed to parse private key as PKCS8 or EC format: PKCS8 error: %w, EC error: %v", err, ecErr)
+	    }
+	    return ConvertToECDHPrivateKey(ecKey)
 	}
 
 	switch privateKey := priv.(type) {


### PR DESCRIPTION
### Proposed Changes

This pull request improves the robustness of the `ECPrivateKeyFromPem` function in `ec_key_pair.go` by adding support for parsing EC private keys in both PKCS8 and traditional EC formats. If parsing as PKCS8 fails, the function now attempts to parse the key as an EC private key before returning an error.

Key improvement to private key parsing:

* Enhanced `ECPrivateKeyFromPem` to try parsing the input as a traditional EC private key if PKCS8 parsing fails, improving compatibility with different PEM-encoded EC key formats.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

