### PR TITLE
feat(core): propagate token clientID on configured claim via interceptor into shared context metadata

### DIFF
--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -352,6 +352,9 @@ server:
 
       ## Dot notation is used to access the groups claim
       group_claim: "realm_access.roles"
+
+      # Dot notation is used to access the claim the represents the idP client ID 
+      client_id_claim: # azp
       
       ## Deprecated: Use standard casbin policy groupings (g, <user/group>, <role>)
       ## Maps the external role to the OpenTDF role

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -72,6 +72,8 @@ server:
       username_claim: # preferred_username
       # That claim to access groups (i.e. realm_access.roles)
       groups_claim: # realm_access.roles
+      # Claim the represents the idP client ID 
+      client_id_claim: # azp
       ## Extends the builtin policy
       extension: |
         g, opentdf-admin, role:admin

--- a/opentdf-ers-mode.yaml
+++ b/opentdf-ers-mode.yaml
@@ -28,6 +28,8 @@ server:
       default: #"role:standard"
       ## Dot notation is used to access nested claims (i.e. realm_access.roles)
       claim: # realm_access.roles
+      # Claim the represents the idP client ID 
+      client_id_claim: # azp
       ## Maps the external role to the opentdf role
       ## Note: left side is used in the policy, right side is the external role
       map:

--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -53,6 +53,8 @@ server:
       username_claim: # preferred_username
       # That claim to access groups (i.e. realm_access.roles)
       groups_claim: # realm_access.roles
+      # Claim the represents the idP client ID 
+      client_id_claim: # azp
       ## Extends the builtin policy
       extension: |
         g, opentdf-admin, role:admin

--- a/opentdf-kas-mode.yaml
+++ b/opentdf-kas-mode.yaml
@@ -45,6 +45,8 @@ server:
       default: #"role:standard"
       ## Dot notation is used to access nested claims (i.e. realm_access.roles)
       claim: # realm_access.roles
+      # Claim the represents the idP client ID 
+      client_id_claim: # azp
       ## Maps the external role to the opentdf role
       ## Note: left side is used in the policy, right side is the external role
       map:

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -697,7 +697,7 @@ func (a *Authentication) getClientIDFromToken(tok jwt.Token) (string, string) {
 	var clientID string
 	clientIDClaim := a.oidcConfiguration.Policy.ClientIDClaim
 	if clientIDClaim != "" {
-		if val, ok := tok.Get(clientIDClaim); ok {
+		if val, exists := tok.Get(clientIDClaim); exists {
 			if strVal, ok := val.(string); ok {
 				clientID = strVal
 			}

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -180,9 +180,7 @@ func (s *AuthSuite) SetupTest() {
 				"/static-doublestar4/x/**",
 			},
 		},
-		&logger.Logger{
-			Logger: slog.New(slog.Default().Handler()),
-		},
+		logger.CreateTestLogger(),
 		func(_ string, _ any) error { return nil },
 	)
 
@@ -286,9 +284,7 @@ func (s *AuthSuite) Test_ConnectUnaryServerInterceptor_ClientIDPropagated() {
 	config := Config{
 		AuthNConfig: authnConfig,
 	}
-	auth, err := NewAuthenticator(context.Background(), config, &logger.Logger{
-		Logger: slog.New(slog.Default().Handler()),
-	}, func(_ string, _ any) error { return nil })
+	auth, err := NewAuthenticator(s.T().Context(), config, logger.CreateTestLogger(), func(_ string, _ any) error { return nil })
 	s.Require().NoError(err)
 
 	// Sign the token

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -219,7 +219,8 @@ func TestNormalizeUrl(t *testing.T) {
 func (s *AuthSuite) Test_IPCUnaryServerInterceptor() {
 	// Mock the checkToken method to return a valid token and context
 	mockToken := jwt.New()
-	mockToken.Set("cid", "mockClientID")
+	err := mockToken.Set("cid", "mockClientID")
+	s.Require().NoError(err)
 
 	type contextKey string
 	mockCtx := context.WithValue(context.Background(), contextKey("mockKey"), "mockValue")
@@ -586,7 +587,7 @@ func (s *AuthSuite) TestDPoPEndToEnd_GRPC() {
 	s.Require().NoError(err)
 
 	// interceptor propagated clientID from the token at the configured claim
-	s.Equal(fakeServer.clientID, "client-123")
+	s.Equal("client-123", fakeServer.clientID)
 
 	s.NotNil(fakeServer.dpopKey)
 	dpopJWKFromRequest, ok := fakeServer.dpopKey.(jwk.RSAPublicKey)
@@ -667,7 +668,7 @@ func (s *AuthSuite) TestDPoPEndToEnd_HTTP() {
 		s.Require().FailNow("timed out waiting for call to complete")
 	}
 
-	s.Equal(clientID, "client2")
+	s.Equal("client2", clientID)
 
 	s.NotNil(dpopKeyFromRequest)
 	dpopJWKFromRequest, ok := dpopKeyFromRequest.(jwk.RSAPublicKey)

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -984,7 +984,7 @@ func Test_GetClientIDFromToken(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			clientID, err := auth.getClientIDFromToken(context.Background(), tok)
+			clientID, err := auth.getClientIDFromToken(t.Context(), tok)
 
 			assert.Equal(t, tt.expectedClientID, clientID)
 

--- a/service/internal/auth/config.go
+++ b/service/internal/auth/config.go
@@ -34,6 +34,8 @@ type PolicyConfig struct {
 	UserNameClaim string `mapstructure:"username_claim" json:"username_claim" default:"preferred_username"`
 	// Claim to use for group/role information
 	GroupsClaim string `mapstructure:"groups_claim" json:"groups_claim" default:"realm_access.roles"`
+	// Claim to use to reference idP clientID
+	ClientIDClaim string `mapstructure:"client_id_claim" json:"client_id_claim" default:"azp"`
 	// Deprecated: Use GroupClain instead
 	RoleClaim string `mapstructure:"claim" json:"claim" default:"realm_access.roles"`
 	// Deprecated: Use Casbin grouping statements g, <user/group>, <role>

--- a/service/pkg/auth/context_auth_test.go
+++ b/service/pkg/auth/context_auth_test.go
@@ -77,7 +77,7 @@ func TestContextWithAuthnMetadata(t *testing.T) {
 	mockClientID := "test-client-id"
 
 	t.Run("should add access token and client id to metadata", func(t *testing.T) {
-		ctx := ContextWithAuthNInfo(context.Background(), nil, nil, "raw-token-string")
+		ctx := ContextWithAuthNInfo(t.Context(), nil, nil, "raw-token-string")
 		enrichedCtx := ContextWithAuthnMetadata(ctx, mockClientID)
 
 		md, ok := metadata.FromIncomingContext(enrichedCtx)
@@ -93,7 +93,7 @@ func TestContextWithAuthnMetadata(t *testing.T) {
 	})
 
 	t.Run("should not set client id if empty", func(t *testing.T) {
-		ctx := ContextWithAuthNInfo(context.Background(), nil, nil, "raw-token-string")
+		ctx := ContextWithAuthNInfo(t.Context(), nil, nil, "raw-token-string")
 		enrichedCtx := ContextWithAuthnMetadata(ctx, "")
 
 		md, ok := metadata.FromIncomingContext(enrichedCtx)
@@ -105,7 +105,7 @@ func TestContextWithAuthnMetadata(t *testing.T) {
 
 	t.Run("should preserve existing metadata", func(t *testing.T) {
 		originalMD := metadata.New(map[string]string{"original-key": "original-value"})
-		ctx := metadata.NewIncomingContext(context.Background(), originalMD)
+		ctx := metadata.NewIncomingContext(t.Context(), originalMD)
 		ctx = ContextWithAuthNInfo(ctx, nil, nil, "raw-token-string")
 
 		enrichedCtx := ContextWithAuthnMetadata(ctx, mockClientID)


### PR DESCRIPTION
- adds config for a client ID claim in OIDC access tokens (dot notation capable)
- utility functions to set and get the client ID from golang context metadata (which is made available across gRPC service boundaries, unlike golang context keys that are _not_ saved to the context metadata)
- reads config into various interceptors
- each interceptor propagates the clientID from the parsed token for downstream consumers
- improvements to logs alongside `azp` claim
- unit and integration tests