### PR TITLE
fix(service): Fix mode negation and core mode

### DIFF
--- a/service/pkg/server/services_test.go
+++ b/service/pkg/server/services_test.go
@@ -361,8 +361,20 @@ func (suite *ServiceTestSuite) TestRegisterCoreServices_WithNegation() {
 				return
 			}
 
+			modeStrings := make([]string, len(tc.modes))
+			for i, m := range tc.modes {
+				modeStrings[i] = m.String()
+			}
+
 			suite.Require().NoError(err)
 			suite.ElementsMatch(tc.expectedServices, registeredServices)
+			// check that registered namesapces are enabled
+			for _, namespace := range registry.GetNamespaces() {
+				suite.Contains(tc.expectedServices, namespace.Name)
+				suite.Contains(modeStrings, namespace.Namespace.Mode)
+
+				namespace.Namespace.IsEnabled(modeStrings)
+			}
 		})
 	}
 }
@@ -409,6 +421,18 @@ func (suite *ServiceTestSuite) TestRegisterCoreServices_BackwardCompatibility() 
 
 			suite.Require().NoError(err)
 			suite.ElementsMatch(tc.expectedServices, registeredServices)
+
+			modeStrings := make([]string, len(tc.mode))
+			for i, m := range tc.mode {
+				modeStrings[i] = m.String()
+			}
+			// check that registered namesapces are enabled
+			for _, namespace := range registry.GetNamespaces() {
+				suite.Contains(tc.expectedServices, namespace.Name)
+				suite.Contains(modeStrings, namespace.Namespace.Mode)
+
+				namespace.Namespace.IsEnabled(modeStrings)
+			}
 		})
 	}
 }

--- a/service/pkg/serviceregistry/serviceregistry.go
+++ b/service/pkg/serviceregistry/serviceregistry.go
@@ -409,15 +409,15 @@ func (reg *Registry) RegisterServicesFromConfiguration(modes []string, configura
 			continue
 		}
 
-		shouldRegister := false
+		var nsMode ModeName
 		for _, requestedMode := range includedModes {
 			if slices.Contains(config.Modes, requestedMode) {
-				shouldRegister = true
+				nsMode = requestedMode
 				break
 			}
 		}
 
-		if !shouldRegister {
+		if nsMode == "" {
 			continue
 		}
 
@@ -425,11 +425,8 @@ func (reg *Registry) RegisterServicesFromConfiguration(modes []string, configura
 
 		// Register all services using their own defined namespace
 		for _, service := range config.Services {
-			// Get the namespace from the service itself
-			namespace := service.GetNamespace()
-
-			// Always register the service in its own namespace
-			if err := reg.RegisterService(service, ModeName(namespace)); err != nil {
+			// Register the service with the determined mode
+			if err := reg.RegisterService(service, nsMode); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
### Proposed Changes

* There was an issue where services started in core mode were registered but not starting. It looks like they were registered with the namespace as the mode instead of the specified mode from the config. This PR corrects this and adds test checks to ensure services registered are also enabled.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

