### PR TITLE
feat(policy): Add obligation support to KAS

### DIFF
--- a/service/kas/access/accessPdp.go
+++ b/service/kas/access/accessPdp.go
@@ -23,12 +23,13 @@ var decryptAction = &policy.Action{
 }
 
 type PDPAccessResult struct {
-	Access bool
-	Error  error
-	Policy *Policy
+	Access              bool
+	Error               error
+	Policy              *Policy
+	RequiredObligations []string
 }
 
-func (p *Provider) canAccess(ctx context.Context, token *entity.Token, policies []*Policy) ([]PDPAccessResult, error) {
+func (p *Provider) canAccess(ctx context.Context, token *entity.Token, policies []*Policy, obligations []string) ([]PDPAccessResult, error) {
 	var res []PDPAccessResult
 	var resources []*authzV2.Resource
 	idPolicyMap := make(map[string]*Policy)
@@ -67,7 +68,7 @@ func (p *Provider) canAccess(ctx context.Context, token *entity.Token, policies 
 	ctx, span := p.Start(ctx, "checkAttributes")
 	defer span.End()
 
-	resourceDecisions, err := p.checkAttributes(ctx, resources, token)
+	resourceDecisions, err := p.checkAttributes(ctx, resources, token, obligations)
 	if err != nil {
 		return nil, err
 	}
@@ -78,14 +79,14 @@ func (p *Provider) canAccess(ctx context.Context, token *entity.Token, policies 
 			p.Logger.WarnContext(ctx, "unexpected ephemeral resource id not mapped to a policy")
 			continue
 		}
-		res = append(res, PDPAccessResult{Policy: policy, Access: decision.GetDecision() == authzV2.Decision_DECISION_PERMIT})
+		res = append(res, PDPAccessResult{Policy: policy, Access: decision.GetDecision() == authzV2.Decision_DECISION_PERMIT, RequiredObligations: decision.GetRequiredObligations()})
 	}
 
 	return res, nil
 }
 
 // checkAttributes makes authorization service GetDecision requests to check access to resources
-func (p *Provider) checkAttributes(ctx context.Context, resources []*authzV2.Resource, ent *entity.Token) ([]*authzV2.ResourceDecision, error) {
+func (p *Provider) checkAttributes(ctx context.Context, resources []*authzV2.Resource, ent *entity.Token, obligations []string) ([]*authzV2.ResourceDecision, error) {
 	ctx = tracing.InjectTraceContext(ctx)
 
 	// If only one resource, prefer singular endpoint
@@ -94,8 +95,9 @@ func (p *Provider) checkAttributes(ctx context.Context, resources []*authzV2.Res
 			EntityIdentifier: &authzV2.EntityIdentifier{
 				Identifier: &authzV2.EntityIdentifier_Token{Token: ent},
 			},
-			Action:   decryptAction,
-			Resource: resources[0],
+			Action:                    decryptAction,
+			Resource:                  resources[0],
+			FulfillableObligationFqns: obligations,
 		}
 		dr, err := p.SDK.AuthorizationV2.GetDecision(ctx, req)
 		if err != nil {
@@ -110,8 +112,9 @@ func (p *Provider) checkAttributes(ctx context.Context, resources []*authzV2.Res
 		EntityIdentifier: &authzV2.EntityIdentifier{
 			Identifier: &authzV2.EntityIdentifier_Token{Token: ent},
 		},
-		Action:    decryptAction,
-		Resources: resources,
+		Action:                    decryptAction,
+		Resources:                 resources,
+		FulfillableObligationFqns: obligations,
 	}
 
 	dr, err := p.SDK.AuthorizationV2.GetDecisionMultiResource(ctx, req)

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -1055,7 +1055,8 @@ func populateRequiredObligationsOnResponse(response *kaspb.RewrapResponse, oblig
 	}
 
 	var fields map[string]*structpb.Value
-	if _, ok := metadata[triggeredObligationsHeader]; !ok {
+	obligationValue, ok := metadata[triggeredObligationsHeader]
+	if !ok || obligationValue.GetStructValue() == nil {
 		fields = make(map[string]*structpb.Value)
 		metadata[triggeredObligationsHeader] = structpb.NewStructValue(&structpb.Struct{
 			Fields: fields,

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -376,7 +376,6 @@ func failedKAORewrap(res map[string]kaoResult, kao *kaspb.UnsignedRewrapRequest_
 
 func addResultsToResponse(response *kaspb.RewrapResponse, result policyKAOResults) {
 	for policyID, policyMap := range result {
-		// TODO: Add obligations per policy to metadata
 		policyResults := &kaspb.PolicyRewrapResult{
 			PolicyId: policyID,
 		}
@@ -1048,19 +1047,21 @@ func populateRequiredObligationsOnResponse(response *kaspb.RewrapResponse, oblig
 		metadata = make(map[string]*structpb.Value)
 	}
 
+	var fields map[string]*structpb.Value
 	if _, ok := metadata[triggeredObligationsHeader]; !ok {
-		fields := make(map[string]*structpb.Value)
+		fields = make(map[string]*structpb.Value)
 		metadata[triggeredObligationsHeader] = structpb.NewStructValue(&structpb.Struct{
 			Fields: fields,
 		})
+	} else {
+		fields = metadata[triggeredObligationsHeader].GetStructValue().GetFields()
 	}
 
 	values := make([]*structpb.Value, len(obligations))
 	for i, obligation := range obligations {
 		values[i] = structpb.NewStringValue(obligation)
 	}
-	existing := metadata[triggeredObligationsHeader].GetStructValue()
-	existing.Fields[policyID] = structpb.NewListValue(&structpb.ListValue{
+	fields[policyID] = structpb.NewListValue(&structpb.ListValue{
 		Values: values,
 	})
 	response.Metadata = metadata

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -879,7 +879,7 @@ func (p *Provider) nanoTDFRewrap(ctx context.Context, requests []*kaspb.Unsigned
 		if !ok { // this should not happen
 			continue
 		}
-		policyRes := results[req.GetPolicy().GetId()]
+		policyRes, ok := results[req.GetPolicy().GetId()]
 		if !ok { // this should not happen
 			//nolint:sloglint // reference to key is intentional
 			p.Logger.WarnContext(ctx, "policy not found in policyReq response", "policy.uuid", policy.UUID)
@@ -1065,7 +1065,7 @@ func populateRequiredObligationsOnResponse(response *kaspb.RewrapResponse, oblig
 			Fields: fields,
 		})
 	} else {
-		fields = metadata[requiredObligationsHeader].GetStructValue().GetFields()
+		fields = obligationValue.GetStructValue().GetFields()
 	}
 
 	values := make([]*structpb.Value, len(obligations))

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -46,7 +46,7 @@ const (
 	kFailedStatus                 = "fail"
 	kPermitStatus                 = "permit"
 	additionalRewrapContextHeader = "X-Rewrap-Additional-Context"
-	triggeredObligationsHeader    = "X-Triggered-Obligations"
+	requiredObligationsHeader     = "X-Required-Obligations"
 )
 
 var (
@@ -1058,14 +1058,14 @@ func populateRequiredObligationsOnResponse(response *kaspb.RewrapResponse, oblig
 	}
 
 	var fields map[string]*structpb.Value
-	obligationValue, ok := metadata[triggeredObligationsHeader]
+	obligationValue, ok := metadata[requiredObligationsHeader]
 	if !ok || obligationValue.GetStructValue() == nil {
 		fields = make(map[string]*structpb.Value)
-		metadata[triggeredObligationsHeader] = structpb.NewStructValue(&structpb.Struct{
+		metadata[requiredObligationsHeader] = structpb.NewStructValue(&structpb.Struct{
 			Fields: fields,
 		})
 	} else {
-		fields = metadata[triggeredObligationsHeader].GetStructValue().GetFields()
+		fields = metadata[requiredObligationsHeader].GetStructValue().GetFields()
 	}
 
 	values := make([]*structpb.Value, len(obligations))

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -628,6 +628,16 @@ func TestGetAdditionalRewrapContext(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "no obligations array",
+			header: http.Header{
+				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{}`))},
+			},
+			expectedResult: &AdditionalRewrapContext{
+				Obligations: []string{},
+			},
+			expectedError: nil,
+		},
+		{
 			name: "obligations with empty values filtered out",
 			header: http.Header{
 				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": ["https://demo.com/obl/test/value/watermark","","https://demo.com/obl/test/value/geofence"]}`))},

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -566,7 +566,9 @@ func TestGetAdditionalRewrapContext(t *testing.T) {
 			name:   "nil header",
 			header: nil,
 			expectedResult: &AdditionalRewrapContext{
-				Obligations: []string{},
+				Obligations: ObligationCtx{
+					FulfillableFQNs: []string{},
+				},
 			},
 			expectedError: nil,
 		},
@@ -574,7 +576,9 @@ func TestGetAdditionalRewrapContext(t *testing.T) {
 			name:   "empty header",
 			header: make(http.Header),
 			expectedResult: &AdditionalRewrapContext{
-				Obligations: []string{},
+				Obligations: ObligationCtx{
+					FulfillableFQNs: []string{},
+				},
 			},
 			expectedError: nil,
 		},
@@ -584,34 +588,40 @@ func TestGetAdditionalRewrapContext(t *testing.T) {
 				"Content-Type": []string{"application/json"},
 			},
 			expectedResult: &AdditionalRewrapContext{
-				Obligations: []string{},
+				Obligations: ObligationCtx{
+					FulfillableFQNs: []string{},
+				},
 			},
 			expectedError: nil,
 		},
 		{
 			name: "valid single watermark obligation",
 			header: http.Header{
-				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": ["https://demo.com/obl/test/value/watermark"]}`))},
+				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": {"fulfillableFQNs": ["https://demo.com/obl/test/value/watermark"]}}`))},
 			},
 			expectedResult: &AdditionalRewrapContext{
-				Obligations: []string{"https://demo.com/obl/test/value/watermark"},
+				Obligations: ObligationCtx{
+					FulfillableFQNs: []string{"https://demo.com/obl/test/value/watermark"},
+				},
 			},
 			expectedError: nil,
 		},
 		{
 			name: "valid multiple obligations",
 			header: http.Header{
-				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": ["https://demo.com/obl/test/value/watermark","https://demo.com/obl/test/value/geofence"]}`))},
+				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": {"fulfillableFQNs": ["https://demo.com/obl/test/value/watermark","https://demo.com/obl/test/value/geofence"]}}`))},
 			},
 			expectedResult: &AdditionalRewrapContext{
-				Obligations: []string{"https://demo.com/obl/test/value/watermark", "https://demo.com/obl/test/value/geofence"},
+				Obligations: ObligationCtx{
+					FulfillableFQNs: []string{"https://demo.com/obl/test/value/watermark", "https://demo.com/obl/test/value/geofence"},
+				},
 			},
 			expectedError: nil,
 		},
 		{
 			name: "mixed valid and invalid fqns",
 			header: http.Header{
-				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": ["https://demo.com/obl/test/value/watermark","https://example.com/attr/Classification/value/restricted","https://virtru.com/obl/test/value/audit"]}`))},
+				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": {"fulfillableFQNs": ["https://demo.com/obl/test/value/watermark","https://example.com/attr/Classification/value/restricted","https://virtru.com/obl/test/value/audit"]}}`))},
 			},
 			expectedResult: nil,
 			expectedError:  identifier.ErrInvalidFQNFormat,
@@ -620,10 +630,12 @@ func TestGetAdditionalRewrapContext(t *testing.T) {
 		{
 			name: "empty obligations array",
 			header: http.Header{
-				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": []}`))},
+				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": {"fulfillableFQNs": []}}`))},
 			},
 			expectedResult: &AdditionalRewrapContext{
-				Obligations: []string{},
+				Obligations: ObligationCtx{
+					FulfillableFQNs: []string{},
+				},
 			},
 			expectedError: nil,
 		},
@@ -633,34 +645,40 @@ func TestGetAdditionalRewrapContext(t *testing.T) {
 				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{}`))},
 			},
 			expectedResult: &AdditionalRewrapContext{
-				Obligations: []string{},
+				Obligations: ObligationCtx{
+					FulfillableFQNs: []string{},
+				},
 			},
 			expectedError: nil,
 		},
 		{
 			name: "obligations with empty values filtered out",
 			header: http.Header{
-				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": ["https://demo.com/obl/test/value/watermark","","https://demo.com/obl/test/value/geofence"]}`))},
+				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": {"fulfillableFQNs": ["https://demo.com/obl/test/value/watermark","","https://demo.com/obl/test/value/geofence"]}}`))},
 			},
 			expectedResult: &AdditionalRewrapContext{
-				Obligations: []string{"https://demo.com/obl/test/value/watermark", "https://demo.com/obl/test/value/geofence"},
+				Obligations: ObligationCtx{
+					FulfillableFQNs: []string{"https://demo.com/obl/test/value/watermark", "https://demo.com/obl/test/value/geofence"},
+				},
 			},
 			expectedError: nil,
 		},
 		{
 			name: "obligations with whitespace trimmed",
 			header: http.Header{
-				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": ["  https://demo.com/obl/test/value/watermark  ","  https://demo.com/obl/test/value/geofence  "]}`))},
+				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": {"fulfillableFQNs": [" https://demo.com/obl/test/value/watermark "," https://demo.com/obl/test/value/geofence "]}}`))},
 			},
 			expectedResult: &AdditionalRewrapContext{
-				Obligations: []string{"https://demo.com/obl/test/value/watermark", "https://demo.com/obl/test/value/geofence"},
+				Obligations: ObligationCtx{
+					FulfillableFQNs: []string{"https://demo.com/obl/test/value/watermark", "https://demo.com/obl/test/value/geofence"},
+				},
 			},
 			expectedError: nil,
 		},
 		{
 			name: "invalid FQN format obligation",
 			header: http.Header{
-				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": ["invalid-obligation-format"]}`))},
+				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": {"fulfillableFQNs": ["invalid-obligation-format"]}}`))},
 			},
 			expectedResult: nil,
 			expectedError:  identifier.ErrInvalidFQNFormat,
@@ -669,7 +687,7 @@ func TestGetAdditionalRewrapContext(t *testing.T) {
 		{
 			name: "mixed invalid FQN format obligation",
 			header: http.Header{
-				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": ["https://demo.com/obl/test/value/watermark","invalid-obligation-format"]}`))},
+				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": {"fulfillableFQNs": ["https://demo.com/obl/test/value/watermark","invalid-obligation-format"]}}`))},
 			},
 			expectedResult: nil,
 			expectedError:  identifier.ErrInvalidFQNFormat,
@@ -678,7 +696,7 @@ func TestGetAdditionalRewrapContext(t *testing.T) {
 		{
 			name: "invalid base64 encoding",
 			header: http.Header{
-				additionalRewrapContextHeader: []string{`{"obligations": ["https://demo.com/obl/test/value/watermark","invalid-obligation-format"]}`},
+				additionalRewrapContextHeader: []string{`{"obligations": {"fulfillableFQNs": ["https://demo.com/obl/test/value/watermark","invalid-obligation-format"]}}`},
 			},
 			expectedResult: nil,
 			expectedError:  ErrDecodingRewrapContext,
@@ -697,7 +715,9 @@ func TestGetAdditionalRewrapContext(t *testing.T) {
 				additionalRewrapContextHeader: []string{""},
 			},
 			expectedResult: &AdditionalRewrapContext{
-				Obligations: []string{},
+				Obligations: ObligationCtx{
+					FulfillableFQNs: []string{},
+				},
 			},
 			expectedError: nil,
 		},

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -767,9 +767,9 @@ func TestPopulateRequiredObligationsOnResponse(t *testing.T) {
 			},
 			validate: func(t *testing.T, response *kaspb.RewrapResponse) {
 				metadata := response.GetMetadata()
-				require.Contains(t, metadata, triggeredObligationsHeader) //nolint:staticcheck // testing deprecated field
+				require.Contains(t, metadata, requiredObligationsHeader) //nolint:staticcheck // testing deprecated field
 
-				structValue := metadata[triggeredObligationsHeader].GetStructValue() //nolint:staticcheck // testing deprecated field
+				structValue := metadata[requiredObligationsHeader].GetStructValue() //nolint:staticcheck // testing deprecated field
 				require.NotNil(t, structValue)
 				require.Contains(t, structValue.GetFields(), "policy1")
 
@@ -796,9 +796,9 @@ func TestPopulateRequiredObligationsOnResponse(t *testing.T) {
 			},
 			validate: func(t *testing.T, response *kaspb.RewrapResponse) {
 				metadata := response.GetMetadata()
-				require.Contains(t, metadata, triggeredObligationsHeader)
+				require.Contains(t, metadata, requiredObligationsHeader)
 
-				structValue := metadata[triggeredObligationsHeader].GetStructValue()
+				structValue := metadata[requiredObligationsHeader].GetStructValue()
 				require.NotNil(t, structValue)
 				require.Contains(t, structValue.GetFields(), "policy1")
 
@@ -831,9 +831,9 @@ func TestPopulateRequiredObligationsOnResponse(t *testing.T) {
 			},
 			validate: func(t *testing.T, response *kaspb.RewrapResponse) {
 				metadata := response.GetMetadata()
-				require.Contains(t, metadata, triggeredObligationsHeader)
+				require.Contains(t, metadata, requiredObligationsHeader)
 
-				structValue := metadata[triggeredObligationsHeader].GetStructValue()
+				structValue := metadata[requiredObligationsHeader].GetStructValue()
 				require.NotNil(t, structValue)
 				fields := structValue.GetFields()
 
@@ -872,9 +872,9 @@ func TestPopulateRequiredObligationsOnResponse(t *testing.T) {
 			},
 			validate: func(t *testing.T, response *kaspb.RewrapResponse) {
 				metadata := response.GetMetadata()
-				require.Contains(t, metadata, triggeredObligationsHeader) //nolint:staticcheck // testing deprecated field
+				require.Contains(t, metadata, requiredObligationsHeader) //nolint:staticcheck // testing deprecated field
 
-				structValue := metadata[triggeredObligationsHeader].GetStructValue() //nolint:staticcheck // testing deprecated field
+				structValue := metadata[requiredObligationsHeader].GetStructValue() //nolint:staticcheck // testing deprecated field
 				require.NotNil(t, structValue)
 				require.Contains(t, structValue.GetFields(), "policy1")
 
@@ -897,10 +897,10 @@ func TestPopulateRequiredObligationsOnResponse(t *testing.T) {
 			},
 			validate: func(t *testing.T, response *kaspb.RewrapResponse) {
 				metadata := response.GetMetadata()
-				require.NotNil(t, metadata)                               //nolint:staticcheck // testing deprecated field
-				require.Contains(t, metadata, triggeredObligationsHeader) //nolint:staticcheck // testing deprecated field
+				require.NotNil(t, metadata)                              //nolint:staticcheck // testing deprecated field
+				require.Contains(t, metadata, requiredObligationsHeader) //nolint:staticcheck // testing deprecated field
 
-				structValue := metadata[triggeredObligationsHeader].GetStructValue() //nolint:staticcheck // testing deprecated field
+				structValue := metadata[requiredObligationsHeader].GetStructValue() //nolint:staticcheck // testing deprecated field
 				require.NotNil(t, structValue)
 				require.Contains(t, structValue.GetFields(), "policy1")
 
@@ -950,8 +950,8 @@ func TestPopulateRequiredObligationsOnResponse(t *testing.T) {
 				require.InDelta(t, float64(1672531200), sessionFields["timestamp"].GetNumberValue(), 0.001)
 
 				// Verify new obligations are added
-				require.Contains(t, metadata, triggeredObligationsHeader)
-				structValue := metadata[triggeredObligationsHeader].GetStructValue()
+				require.Contains(t, metadata, requiredObligationsHeader)
+				structValue := metadata[requiredObligationsHeader].GetStructValue()
 				require.NotNil(t, structValue)
 				require.Contains(t, structValue.GetFields(), "policy1")
 

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -640,6 +640,18 @@ func TestGetAdditionalRewrapContext(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "no fulfillableFQNs array",
+			header: http.Header{
+				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{"obligations": {}}`))},
+			},
+			expectedResult: &AdditionalRewrapContext{
+				Obligations: ObligationCtx{
+					FulfillableFQNs: []string{},
+				},
+			},
+			expectedError: nil,
+		},
+		{
 			name: "no obligations array",
 			header: http.Header{
 				additionalRewrapContextHeader: []string{base64.StdEncoding.EncodeToString([]byte(`{}`))},


### PR DESCRIPTION
### Proposed Changes

1.) Add logic to retrieve obligations from request header during rewrap
2.) Add logic to populate required obligations on kas response object

Smoke tests tried manually (no key split or bulk rewrap):
- Obligations are not fulfilled, rewrap fails
- Obligations are fulfilled, rewrap succeeds

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

