### PR TITLE
fix(sdk): Format error messages.

### DIFF
--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -1535,9 +1535,9 @@ func createKaoTemplateFromKasInfo(kasInfoArr []KASInfo) []kaoTpl {
 func getKasErrorToReturn(err error, defaultError error) error {
 	errToReturn := defaultError
 	if strings.Contains(err.Error(), codes.InvalidArgument.String()) {
-		errToReturn = errors.Join(ErrRewrapBadRequest, errToReturn)
+		errToReturn = fmt.Errorf("%w: %w", ErrRewrapBadRequest, errToReturn)
 	} else if strings.Contains(err.Error(), codes.PermissionDenied.String()) {
-		errToReturn = errors.Join(ErrRewrapForbidden, errToReturn)
+		errToReturn = fmt.Errorf("%w: %w", ErrRewrapForbidden, errToReturn)
 	}
 
 	return errToReturn


### PR DESCRIPTION
### Proposed Changes

1.) Use colon delimiter for error reporting instead of errors.Join() on each KAO error.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

