### PR TITLE
refactor: DSPX-1808 enable staticcheck linter

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -80,6 +80,7 @@ jobs:
           version: v2.1
           working-directory: ${{ matrix.directory }}
           skip-cache: true
+          only-new-issues: true
       - if: matrix.directory == 'service'
         run: .github/scripts/init-temp-keys.sh
       - run: go test ./... -short

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -59,7 +59,7 @@ linters:
     - sloglint
     - spancheck
     - sqlclosecheck
-    # - staticcheck
+    - staticcheck
     # - tagalign
     # - tagliatelle # maybe we want this to force consistent config to ensure consistent tag alignment across the codebase
     - testableexamples


### PR DESCRIPTION
### Proposed Changes

Enables `staticcheck` linter. Configures golangci-lint to only flag **_new_** issues moving forward.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

n/a