### PR TITLE
fix(deps): bump toolchain to go1.24.9 for CVEs found by govulncheck

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/examples
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.9
 
 require (
 	github.com/opentdf/platform/lib/ocrypto v0.7.0

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.9
 
 use (
 	./examples

--- a/lib/fixtures/go.mod
+++ b/lib/fixtures/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/lib/fixtures
 
 go 1.23.0
 
-toolchain go1.24.6
+toolchain go1.24.9
 
 require github.com/Nerzal/gocloak/v13 v13.9.0
 

--- a/lib/ocrypto/go.mod
+++ b/lib/ocrypto/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/lib/ocrypto
 
 go 1.23.0
 
-toolchain go1.24.6
+toolchain go1.24.9
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/protocol/go/go.mod
+++ b/protocol/go/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/protocol/go
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.9
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/sdk
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.9
 
 require (
 	connectrpc.com/connect v1.18.1

--- a/service/go.mod
+++ b/service/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/service
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.9
 
 require (
 	buf.build/go/protovalidate v0.13.1


### PR DESCRIPTION
DSPX-1861
```

go env
Run go install golang.org/x/vuln/cmd/govulncheck@latest
Run govulncheck -C lib/ocrypto -format text ./...
=== Symbol Results ===

Vulnerability #1: GO-2025-4011
    Parsing DER payload can cause memory exhaustion in encoding/asn1
  More info: https://pkg.go.dev/vuln/GO-2025-4011
  Standard library
    Found in: encoding/asn1@go1.24.6
    Fixed in: encoding/asn1@go1.24.8
    Example traces found:
Error:       #1: ec_key_pair.go:471:37: ocrypto.GetECKeySize calls x509.ParsePKIXPublicKey, which calls asn1.Unmarshal

Vulnerability #2: GO-2025-4010
    Insufficient validation of bracketed IPv6 hostnames in net/url
  More info: https://pkg.go.dev/vuln/GO-2025-4010
  Standard library
    Found in: net/url@go1.24.6
    Fixed in: net/url@go1.24.8
    Example traces found:
Error:       #1: ec_key_pair.go:318:37: ocrypto.ECPubKeyFromPem calls x509.ParseCertificate, which eventually calls url.Parse

Vulnerability #3: GO-2025-4009
    Quadratic complexity when parsing some invalid inputs in encoding/pem
  More info: https://pkg.go.dev/vuln/GO-2025-4009
  Standard library
    Found in: encoding/pem@go1.24.6
    Fixed in: encoding/pem@go1.24.8
    Example traces found:
Error:       #1: ec_key_pair.go:466:24: ocrypto.GetECKeySize calls pem.Decode

Vulnerability #4: GO-2025-4007
    Quadratic complexity when checking name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4007
  Standard library
    Found in: crypto/x509@go1.24.6
    Fixed in: crypto/x509@go1.24.9
    Example traces found:
Error:       #1: ec_key_pair.go:433:53: ocrypto.ECPrivateKeyInPemFormat calls x509.MarshalPKCS8PrivateKey
Error:       #2: ec_key_pair.go:449:39: ocrypto.ECPublicKeyInPemFormat calls x509.MarshalPKIXPublicKey
Error:       #3: ec_key_pair.go:318:37: ocrypto.ECPubKeyFromPem calls x509.ParseCertificate
Error:       #4: asym_decryption.go:57:37: ocrypto.FromPrivatePEMWithSalt calls x509.ParseECPrivateKey
Error:       #5: asym_decryption.go:52:40: ocrypto.FromPrivatePEMWithSalt calls x509.ParsePKCS1PrivateKey
Error:       #6: ec_key_pair.go:352:40: ocrypto.ECPrivateKeyFromPem calls x509.ParsePKCS8PrivateKey
Error:       #7: ec_key_pair.go:471:37: ocrypto.GetECKeySize calls x509.ParsePKIXPublicKey

Your code is affected by 4 vulnerabilities from the Go standard library.
This scan also found 1 vulnerability in packages you import and 5
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```
