### PR TITLE
feat(sdk): Expose policy binding hash from Nano.

### DIFF
--- a/sdk/nanotdf.go
+++ b/sdk/nanotdf.go
@@ -88,7 +88,7 @@ type gmacPolicyBinding struct {
 
 type PolicyBind interface {
 	Verify() (bool, error)
-	Hash() []byte
+	fmt.Stringer
 }
 
 func NewNanoTDFHeaderFromReader(reader io.Reader) (NanoTDFHeader, uint32, error) {
@@ -268,8 +268,8 @@ func (b *ecdsaPolicyBinding) Verify() (bool, error) {
 		ephemeralECDSAPublicKey), nil
 }
 
-func (b *ecdsaPolicyBinding) Hash() []byte {
-	return ocrypto.SHA256AsHex(append(b.r, b.s...))
+func (b *ecdsaPolicyBinding) String() string {
+	return string(ocrypto.SHA256AsHex(append(b.r, b.s...)))
 }
 
 func (b *gmacPolicyBinding) Verify() (bool, error) {
@@ -277,10 +277,8 @@ func (b *gmacPolicyBinding) Verify() (bool, error) {
 	return bytes.Equal(bindingToCheck, b.binding), nil
 }
 
-func (b *gmacPolicyBinding) Hash() []byte {
-	dst := make([]byte, hex.EncodedLen(len(b.binding)))
-	hex.Encode(dst, b.binding)
-	return dst
+func (b *gmacPolicyBinding) String() string {
+	return hex.EncodeToString(b.binding)
 }
 
 func (header *NanoTDFHeader) PolicyBinding() (PolicyBind, error) {

--- a/sdk/nanotdf_test.go
+++ b/sdk/nanotdf_test.go
@@ -954,9 +954,8 @@ func (s *NanoSuite) Test_PolicyBinding_GMAC() {
 		digest:  digest,
 	}
 
-	// Test Hash function
-	hash := binding.Hash()
-	s.Require().Equal([]byte(hex.EncodeToString(gmacBytes)), hash, "GMAC hash should return binding data directly")
+	// Test String function
+	s.Require().Equal(hex.EncodeToString(gmacBytes), binding.String(), "GMAC hash should return binding data directly")
 
 	// Test Verify function - should pass with correct binding
 	valid, err := binding.Verify()
@@ -998,11 +997,10 @@ func (s *NanoSuite) Test_PolicyBinding_ECDSA() {
 		curve:           keyPair.PrivateKey.Curve,
 	}
 
-	// Test Hash function
-	hash := binding.Hash()
-	expectedHash := ocrypto.SHA256AsHex(append(r, sBytes...))
-	s.Require().Equal(expectedHash, hash, "ECDSA hash should be SHA256 of r||s")
-	s.Require().NotEmpty(hash, "Hash should not be empty")
+	// Test String function
+	expectedHash := string(ocrypto.SHA256AsHex(append(r, sBytes...)))
+	s.Require().NotEmpty(binding.String(), "Hash should not be empty")
+	s.Require().Equal(expectedHash, binding.String(), "ECDSA hash should be SHA256 of r||s")
 
 	// Test Verify function - should pass with correct signature
 	valid, err := binding.Verify()


### PR DESCRIPTION
### Proposed Changes

1.) Expose `PolicyBinding` method that returns a implementation of the new `PolicyBind` interface.
2.) Create new `PolicyBind` interface with methods `String()` and `Verify()`.


DSPX-1875

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

