### PR TITLE
fix(core): Let default basic keymanager work again

### DIFF
--- a/service/trust/delegating_key_service.go
+++ b/service/trust/delegating_key_service.go
@@ -134,10 +134,11 @@ func (d *DelegatingKeyService) DeriveKey(ctx context.Context, keyID KeyIdentifie
 	}
 
 	pcfg := keyDetails.ProviderConfig()
-	if pcfg == nil {
-		return nil, fmt.Errorf("derive: key details for key ID '%s' returned nil ProviderConfig", keyID)
-	}
 	manager, err := d.getKeyManager(ctx, pcfg)
+	if err != nil {
+		return nil, fmt.Errorf("derive: unable to get key manager [%s#%s]: %w", pcfg.GetManager(), pcfg.GetName(), err)
+	}
+
 	return manager.DeriveKey(ctx, keyDetails, ephemeralPublicKeyBytes, curve)
 }
 


### PR DESCRIPTION

### Proposed Changes

The recent change to us the ProviderConfig accidentally makes that field required for all keys already loaded from the policy db. Since most (all) existing keys won't have this set, and any keys imported via the command line tool's import don't have it set, we should keep the old behavior

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

