### PR TITLE
chore(ci): use yaml anchors in checks job for common reused actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,7 +24,7 @@ permissions: {}
 
 jobs:
   go:
-    runs-on: ubuntu-22.04
+    runs-on: &ubuntu-runner ubuntu-22.04
     permissions:
       checks: write
       contents: read
@@ -41,11 +41,11 @@ jobs:
           - lib/identifier
           - tests-bdd
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: &actions-checkout actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: &actions-setup-go actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: ${{ matrix.directory }}/go.mod
           check-latest: false
@@ -103,14 +103,14 @@ jobs:
     permissions:
       contents: read
     name: integration tests
-    runs-on: ubuntu-22.04
+    runs-on: *ubuntu-runner
     env:
       TLS_ENABLED: "true"
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: *actions-checkout
         with:
           persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: *actions-setup-go
         with:
           go-version-file: "service/go.mod"
           check-latest: false
@@ -182,14 +182,14 @@ jobs:
     name: benchmark tests
     outputs:
       markdown: ${{ steps.save-benchmark.outputs.BENCHMARK_MARKDOWN }}
-    runs-on: ubuntu-22.04
+    runs-on: *ubuntu-runner
     env:
       TLS_ENABLED: "true"
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: *actions-checkout
         with:
           persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: *actions-setup-go
         with:
           go-version-file: "service/go.mod"
           check-latest: false
@@ -348,9 +348,9 @@ jobs:
       pull-requests: write
     name: benchmark tests
     needs: benchmark
-    runs-on: ubuntu-22.04
+    runs-on: *ubuntu-runner
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: *actions-checkout
         with:
           persist-credentials: false
 
@@ -374,9 +374,9 @@ jobs:
     permissions:
       contents: read
     name: image build
-    runs-on: ubuntu-22.04
+    runs-on: *ubuntu-runner
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: *actions-checkout
         with:
           persist-credentials: false
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
@@ -402,7 +402,7 @@ jobs:
 
   tests-bdd:
     name: Cucumber BDD Tests
-    runs-on: ubuntu-22.04
+    runs-on: *ubuntu-runner
     strategy:
       fail-fast: false
     permissions:
@@ -420,10 +420,10 @@ jobs:
           sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
 
       - name: "Checkout"
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: *actions-checkout
         with:
           persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: *actions-setup-go
         with:
           go-version-file: ./tests-bdd/go.mod
           cache: false
@@ -463,7 +463,7 @@ jobs:
     permissions:
       contents: read
     name: otdfctl e2e tests
-    runs-on: ubuntu-latest
+    runs-on: *ubuntu-runner
     steps:
       - name: Install GNU parallel
         run: |
@@ -483,9 +483,9 @@ jobs:
     permissions:
       contents: read
     name: Protocol Buffer Lint and Gencode Up-to-date check
-    runs-on: ubuntu-22.04
+    runs-on: *ubuntu-runner
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: *actions-checkout
         with:
           persist-credentials: false
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
@@ -499,7 +499,7 @@ jobs:
         with:
           input: service
           against: "https://github.com/opentdf/platform.git#branch=${{ github.event.pull_request.base.ref || github.base_ref || 'main' }},subdir=service"
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: *actions-setup-go
         with:
           go-version-file: "service/go.mod"
           check-latest: false
@@ -541,7 +541,7 @@ jobs:
       - platform-xtest
       - tests-bdd
       - otdfctl-test
-    runs-on: ubuntu-22.04
+    runs-on: *ubuntu-runner
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure')
@@ -552,12 +552,12 @@ jobs:
     permissions:
       contents: read
     name: license check
-    runs-on: ubuntu-22.04
+    runs-on: *ubuntu-runner
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: *actions-checkout
         with:
           persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: *actions-setup-go
         with:
           go-version-file: "service/go.mod"
           check-latest: false


### PR DESCRIPTION
### Proposed Changes

* If a GHA is used more than 2 times in the `checks.yaml` workflow, we should use a yaml anchor, now [GA in GHA](https://github.blog/changelog/2025-09-18-actions-yaml-anchors-and-non-public-workflow-templates/)

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

