### PR TITLE
fix(kas): Ensure root key is not logged.

### DIFF
--- a/service/kas/access/provider.go
+++ b/service/kas/access/provider.go
@@ -139,7 +139,7 @@ func (kasCfg *KASConfig) UpgradeMapToKeyring(c *security.StandardCrypto) {
 func (kasCfg KASConfig) String() string {
 	rootKeySummary := ""
 	if kasCfg.RootKey != "" {
-		rootKeySummary = fmt.Sprintf("[redacted len=%d]", len(kasCfg.RootKey))
+		rootKeySummary = fmt.Sprintf("[REDACTED len=%d]", len(kasCfg.RootKey))
 	}
 
 	return fmt.Sprintf(
@@ -156,16 +156,16 @@ func (kasCfg KASConfig) String() string {
 }
 
 func (kasCfg KASConfig) LogValue() slog.Value {
-	rootKeyField := slog.String("root_key", "")
+	rootKeyVal := ""
 	if kasCfg.RootKey != "" {
-		rootKeyField = slog.String("root_key", fmt.Sprintf("[redacted len=%d]", len(kasCfg.RootKey)))
+		rootKeyVal = fmt.Sprintf("[REDACTED len=%d]", len(kasCfg.RootKey))
 	}
 
 	return slog.GroupValue(
 		slog.Any("keyring", kasCfg.Keyring),
 		slog.String("eccertid", kasCfg.ECCertID),
 		slog.String("rsacertid", kasCfg.RSACertID),
-		rootKeyField,
+		slog.String("root_key", rootKeyVal),
 		slog.Duration("key_cache_expiration", kasCfg.KeyCacheExpiration),
 		slog.Bool("ec_tdf_enabled", kasCfg.ECTDFEnabled),
 		slog.Any("preview", kasCfg.Preview),


### PR DESCRIPTION
### Proposed Changes

1.) Modify the `KasConfig` object to redact the `root_key`
2.) Modify the `ServiceConfig` object to check for the existence of `root_key`, if present redact it.


Logs redacted:

1.) At startup:
<img width="2437" height="82" alt="Screenshot 2025-11-19 at 8 28 18 AM" src="https://github.com/user-attachments/assets/abe29f91-a84c-43ca-86a1-1832175fa0e2" />

2.) Update hook
<img width="2447" height="104" alt="Screenshot 2025-11-19 at 8 26 13 AM" src="https://github.com/user-attachments/assets/7aff9a9e-38b5-48b6-a562-0ee3ca5c230e" />

3.) Startup - Invalid Config
<img width="2435" height="105" alt="Screenshot 2025-11-19 at 8 24 30 AM" src="https://github.com/user-attachments/assets/634c227c-3d01-4908-b3d3-05759a9cf756" />


### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

