### PR TITLE
feat: Support for external key providers via `AssertionSigner`

### DIFF
--- a/sdk/assertion.go
+++ b/sdk/assertion.go
@@ -126,6 +126,7 @@ func signWithAssertionSigner(ctx context.Context, tok jwt.Token, signer Assertio
 
 // assertionSignerAdapter adapts an AssertionSigner to work with the jws.Sign function.
 type assertionSignerAdapter struct {
+	//nolint:containedctx // Required to pass context through crypto.Signer interface which doesn't support context
 	ctx    context.Context
 	signer AssertionSigner
 }

--- a/sdk/assertion_test.go
+++ b/sdk/assertion_test.go
@@ -195,7 +195,7 @@ type mockAssertionSigner struct {
 	err        error
 }
 
-func (m *mockAssertionSigner) Sign(ctx context.Context, data []byte) ([]byte, error) {
+func (m *mockAssertionSigner) Sign(_ context.Context, data []byte) ([]byte, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -217,7 +217,7 @@ func TestSignWithAssertionSigner(t *testing.T) {
 	}
 
 	key := AssertionKey{Alg: AssertionKeyAlgRS256, Key: signer}
-	err = assertion.SignWithContext(context.Background(), "testhash", "testsig", key)
+	err = assertion.SignWithContext(t.Context(), "testhash", "testsig", key)
 	require.NoError(t, err)
 	assert.NotEmpty(t, assertion.Binding.Signature)
 	assert.Equal(t, JWS.String(), assertion.Binding.Method)


### PR DESCRIPTION
### Proposed Changes

* Added support for external key providers like HSM and KMS using the `AssertionSigner` interface.
* Updated tests to ensure compatibility with the new `AssertionSigner` functionality.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

