### PR TITLE
feat: Update Go toolchain version to 1.24.11 across all modules

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/examples
 
 go 1.24.0
 
-toolchain go1.24.9
+toolchain go1.24.11
 
 require (
 	connectrpc.com/connect v1.18.1

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.24.9
+go 1.24.11
 
 use (
 	./examples

--- a/lib/fixtures/go.mod
+++ b/lib/fixtures/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/lib/fixtures
 
 go 1.23.0
 
-toolchain go1.24.9
+toolchain go1.24.11
 
 require github.com/Nerzal/gocloak/v13 v13.9.0
 

--- a/lib/ocrypto/go.mod
+++ b/lib/ocrypto/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/lib/ocrypto
 
 go 1.24.0
 
-toolchain go1.24.9
+toolchain go1.24.11
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/protocol/go/go.mod
+++ b/protocol/go/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/protocol/go
 
 go 1.24.0
 
-toolchain go1.24.9
+toolchain go1.24.11
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/sdk
 
 go 1.24.0
 
-toolchain go1.24.9
+toolchain go1.24.11
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/service/go.mod
+++ b/service/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/service
 
 go 1.24.0
 
-toolchain go1.24.9
+toolchain go1.24.11
 
 require (
 	buf.build/go/protovalidate v0.13.1

--- a/tests-bdd/go.mod
+++ b/tests-bdd/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentdf/platform/tests-bdd
 
-go 1.24.9
+go 1.24.11
 
 require (
 	github.com/cucumber/godog v0.15.0


### PR DESCRIPTION
### Proposed Changes

* 
This pull request updates the Go toolchain and Go version across multiple modules in the repository to use Go 1.24.11 instead of Go 1.24.9. This ensures consistency and access to the latest patches and improvements in the Go 1.24.x series.

Go version and toolchain updates:

* Updated the `go` version and/or `toolchain` directive to `go1.24.11` in the following files and modules:
  - `examples/go.mod` (`github.com/opentdf/platform/examples`)
  - `lib/fixtures/go.mod` (`github.com/opentdf/platform/lib/fixtures`)
  - `lib/ocrypto/go.mod` (`github.com/opentdf/platform/lib/ocrypto`)
  - `protocol/go/go.mod` (`github.com/opentdf/platform/protocol/go`)
  - `sdk/go.mod` (`github.com/opentdf/platform/sdk`)
  - `service/go.mod` (`github.com/opentdf/platform/service`)
  - `tests-bdd/go.mod`
  - `go.work`

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

