### PR TITLE
fix(sdk): conditionally set client_id based on auth method

### DIFF
--- a/sdk/auth/oauth/oauth.go
+++ b/sdk/auth/oauth/oauth.go
@@ -290,7 +290,7 @@ func getTokenExchangeRequest(ctx context.Context, tokenEndpoint, dpopNonce strin
 	}
 
 	if len(scopes) > 0 {
-		data.Set("scopes", strings.Join(scopes, " "))
+		data.Set("scope", strings.Join(scopes, " "))
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, nil)


### PR DESCRIPTION
Move client_id setting from generic request setup to auth-method-specific handlers. This ensures client_id is only included when using client assertion authentication, not for all request types.

### Proposed Changes

* fix #3076 

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

