### PR TITLE
feat(core): Prefer deferred log events to better track failure

### DIFF
--- a/service/kas/access/policy.go
+++ b/service/kas/access/policy.go
@@ -16,8 +16,8 @@ type PolicyBody struct {
 }
 
 // Audit helper methods
-func ConvertToAuditKasPolicy(policy Policy) audit.KasPolicy {
-	return audit.KasPolicy{
+func ConvertToAuditKasPolicy(policy Policy) *audit.KasPolicy {
+	return &audit.KasPolicy{
 		UUID: policy.UUID,
 		Body: audit.KasPolicyBody{
 			DataAttributes: convertToAuditKasBodyDataAttributes(policy.Body.DataAttributes),

--- a/service/logger/audit/contextServerInterceptor.go
+++ b/service/logger/audit/contextServerInterceptor.go
@@ -63,15 +63,16 @@ func ContextServerInterceptor(logger *slog.Logger) connect.UnaryInterceptorFunc 
 			ctx = context.WithValue(ctx, contextKey{}, &tx)
 
 			defer func() {
+				auditCtx := context.WithoutCancel(ctx)
 				if r := recover(); r != nil {
 					if err, ok := r.(error); ok {
-						tx.logClose(ctx, logger, false, err)
+						tx.logClose(auditCtx, logger, false, err)
 					} else {
-						tx.logClose(ctx, logger, false, nil)
+						tx.logClose(auditCtx, logger, false, nil)
 					}
 					panic(r)
 				}
-				tx.logClose(ctx, logger, true, nil)
+				tx.logClose(auditCtx, logger, true, nil)
 			}()
 
 			return next(ctx, req)

--- a/service/logger/audit/deferred.go
+++ b/service/logger/audit/deferred.go
@@ -1,0 +1,527 @@
+/*
+`audit` provides event logging for ABAC control operations.
+
+# Why Deferred Audit Events?
+
+Continuous monitoring of access events is one component of the zero trust paradigm.
+
+Deferred audit events provide a fail-safe mechanism to ensure that all operations are audited,
+even when errors, timeouts, and client connection cancellations occur during processing.
+This library uses go's `defer“ mechanism and explicit success/failure signal calls,
+which allows services to log all operations with the appropriate outcome.
+
+## A Note: Panicking and Errors
+
+> A key goal of OpenTDF is to enable zero trust systems,
+> so failures to properly log events block system functionality.
+
+# Basic Usage Pattern
+
+All deferred audit events follow a consistent three-step pattern:
+
+1. Create the audit event with initial parameters
+2. Register it with defer to ensure it's logged even on panic/error
+3. Mark success or failure when the operation completes
+
+# Example: Rewrap Operation
+
+	func handleRewrap(ctx context.Context, logger *audit.Logger) error {
+		// Step 1: Create the deferred audit event with initial parameters
+		auditEvent := logger.Audit.Rewrap(ctx, audit.RewrapAuditEventParams{
+			Policy:        kasPolicy,
+			TDFFormat:     "tdf3",
+			Algorithm:     "rsa-2048",
+			PolicyBinding: "binding-hash",
+			KeyID:         "key-123",
+		})
+
+		// Step 2: Register with defer - guarantees logging even on panic
+		defer auditEvent.Log(ctx)
+
+		// Step 3: Perform the rewrap operation (may panic)
+		result, err := performRewrap(ctx)
+		if err != nil {
+			// On error, return without calling Success()
+			// The deferred Log() will record this as a failure
+			return err
+		}
+
+		// Step 4: Update event with additional details as they become available
+		auditEvent.UpdatePolicy(enrichedPolicy)
+
+		// Step 5: Mark the operation as successful
+		auditEvent.Success(ctx)
+		return nil
+	}
+
+# Example: Policy CRUD Operation
+
+	func updateAttribute(ctx context.Context, logger *audit.Logger, id string, req *UpdateRequest) error {
+		// Create audit event with known parameters
+		auditEvent := logger.Audit.PolicyCRUD(ctx, audit.PolicyEventParams{
+			ActionType: audit.ActionTypeUpdate,
+			ObjectType: audit.ObjectTypeAttributeDefinition,
+			ObjectID:   id,
+		})
+		defer auditEvent.Log(ctx)
+
+		// Load the original object
+		original, err := loadAttribute(id)
+		if err != nil {
+			return err
+		}
+
+		// Update the event with the original state
+		auditEvent.UpdateOriginal(original)
+
+		// Apply updates
+		updated, err := applyUpdates(original, req)
+		if err != nil {
+			// Log will record this as a failure
+			return err
+		}
+
+		// Persist the changes
+		if err := saveAttribute(updated); err != nil {
+			return err
+		}
+
+		// Mark success with the updated object
+		auditEvent.Success(ctx, updated)
+		return nil
+	}
+
+# Progressive Enrichment
+
+For operations that compute results progressively, events can be enriched as
+information becomes available using UpdateX methods:
+
+	auditEvent := logger.Audit.Decision(ctx, entityChainID, resourceAttrID, fqns)
+	defer auditEvent.Log(ctx)
+
+	// Enrich with entitlements as they're computed
+	entitlements := computeEntitlements()
+	auditEvent.UpdateEntitlements(entitlements)
+
+	// Enrich with entity decisions
+	decisions := evaluateEntities()
+	auditEvent.UpdateEntityDecisions(decisions)
+
+	// Finally, record the outcome
+	auditEvent.Success(ctx, finalDecision)
+
+# No Updates After Completion
+
+Once an event is completed
+(by calling Success(), Failure(), or allowing Log() to execute),
+the event is immutable.
+Attempting to call any UpdateX methods after completion will panic with ErrAlreadyCompleted.
+
+	auditEvent := logger.Audit.DecisionV2(ctx, entityID, actionName)
+	defer auditEvent.Log(ctx)
+
+	auditEvent.Success(ctx, decision) // Event is now completed
+
+	// THIS WILL PANIC:
+	auditEvent.UpdateEntitlements(newEntitlements)
+
+# Fail-Safe Default Behavior
+
+If neither Success() nor Failure() is explicitly called,
+the deferred Log() function will record the operation as failed.
+
+- Rewrap: Logged as failure if Success() not called
+- PolicyCRUD: Logged as failure/cancelled if Success() not called
+- Decision operations: Logged with DENY decision if Success() not called
+*/
+package audit
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	"google.golang.org/protobuf/proto"
+)
+
+var ErrAlreadyCompleted = errors.New("cannot update entitlements after event is completed")
+
+// deferred is the generic deferred audit implementation
+type deferred[T any] struct {
+	params        T
+	onSuccess     func(context.Context, T)
+	onFailure     func(context.Context, T)
+	mu            sync.Mutex
+	completed     bool
+	successCalled bool
+}
+
+// markSuccess marks the event as successful (without logging yet)
+func (d *deferred[T]) markSuccess(ctx context.Context) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		return
+	}
+	d.successCalled = true
+	d.completed = true
+	d.onSuccess(ctx, d.params)
+}
+
+// markFailure marks the event as failed (without logging yet)
+func (d *deferred[T]) markFailure(ctx context.Context) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		return
+	}
+	d.completed = true
+	d.onFailure(ctx, d.params)
+}
+
+// log must be called in a defer statement, invoked before any panic-able handler code
+func (d *deferred[T]) log(ctx context.Context) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		return
+	}
+	d.completed = true
+
+	// If neither Success() nor Failure() was called, treat as failure
+	d.onFailure(ctx, d.params)
+}
+
+// PolicyCRUDEvent represents a policy CRUD audit event that will be logged
+// as cancelled unless explicitly marked as success or failure
+type PolicyCRUDEvent struct {
+	*deferred[PolicyEventParams]
+}
+
+// RewrapEvent represents a rewrap audit event that will be logged
+// as cancelled unless explicitly marked as success or failure
+type RewrapEvent struct {
+	*deferred[RewrapAuditEventParams]
+}
+
+// GetDecisionEvent represents a GetDecision audit event that will be logged
+// as a deny decision unless explicitly marked with a final decision
+type GetDecisionEvent struct {
+	*deferred[GetDecisionEventParams]
+}
+
+// GetDecisionV2Event represents a GetDecisionV2 audit event that will be logged
+// as a deny decision unless explicitly marked with a final decision
+type GetDecisionV2Event struct {
+	*deferred[GetDecisionV2EventParams]
+}
+
+// PolicyCRUD creates a deferred policy CRUD audit event.
+// The event will be logged as cancelled unless Success() or Failure() is called.
+// Usage:
+//
+//	auditEvent := logger.PolicyCRUD(ctx, params)
+//	defer auditEvent.Log(ctx)
+//	// ... perform operation ...
+//	auditEvent.Success(ctx, updatedObject)
+func (a *Logger) PolicyCRUD(ctx context.Context, params PolicyEventParams) *PolicyCRUDEvent {
+	if _, ok := ctx.Value(contextKey{}).(*auditTransaction); !ok {
+		panic("audit transaction missing from context in PolicyCRUD")
+	}
+
+	return &PolicyCRUDEvent{
+		deferred: &deferred[PolicyEventParams]{
+			params: params,
+			onSuccess: func(ctx context.Context, p PolicyEventParams) {
+				a.PolicyCRUDSuccess(ctx, p)
+			},
+			onFailure: func(ctx context.Context, p PolicyEventParams) {
+				a.PolicyCRUDFailure(ctx, p)
+			},
+		},
+	}
+}
+
+// UpdateOriginal updates the original object state as it becomes available.
+// This should be called after the event is created if the original object wasn't available at creation time.
+func (d *PolicyCRUDEvent) UpdateOriginal(original proto.Message) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		panic(ErrAlreadyCompleted)
+	}
+
+	d.params.Original = original
+}
+
+// UpdateObjectID updates the object ID as it becomes available.
+// This should be called after the event is created if the object ID wasn't available at creation time.
+func (d *PolicyCRUDEvent) UpdateObjectID(objectID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		panic(ErrAlreadyCompleted)
+	}
+
+	d.params.ObjectID = objectID
+}
+
+// Success marks the audit event as successful and logs it immediately.
+// The updated parameter should contain the updated object state (can be nil for creates).
+func (d *PolicyCRUDEvent) Success(ctx context.Context, updated proto.Message) {
+	d.mu.Lock()
+	// Update the params with the updated object
+	d.params.Updated = updated
+	d.mu.Unlock()
+
+	d.markSuccess(ctx)
+}
+
+// Failure marks the audit event as failed and logs it immediately.
+func (d *PolicyCRUDEvent) Failure(ctx context.Context) {
+	d.markFailure(ctx)
+}
+
+// Log should be called in a defer statement. If neither Success() nor Failure()
+// was called, it will check the context for cancellation and log appropriately.
+func (d *PolicyCRUDEvent) Log(ctx context.Context) {
+	d.log(ctx)
+}
+
+// Rewrap creates a deferred rewrap audit event.
+// The event will be logged as cancelled unless Success() or Failure() is called.
+// Usage:
+//
+//	auditEvent := logger.Rewrap(ctx, params)
+//	defer auditEvent.Log(ctx)
+//	// ... perform operation ...
+//	auditEvent.Success(ctx)
+func (a *Logger) Rewrap(ctx context.Context, params RewrapAuditEventParams) *RewrapEvent {
+	if _, ok := ctx.Value(contextKey{}).(*auditTransaction); !ok {
+		panic("audit transaction missing from context in Rewrap")
+	}
+
+	return &RewrapEvent{
+		deferred: &deferred[RewrapAuditEventParams]{
+			params: params,
+			onSuccess: func(ctx context.Context, p RewrapAuditEventParams) {
+				a.RewrapSuccess(ctx, p)
+			},
+			onFailure: func(ctx context.Context, p RewrapAuditEventParams) {
+				a.RewrapFailure(ctx, p)
+			},
+		},
+	}
+}
+
+func (d *RewrapEvent) UpdatePolicy(kasPolicy KasPolicy) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		panic(ErrAlreadyCompleted)
+	}
+
+	d.params.Policy = kasPolicy
+}
+
+// Success marks the audit event as successful and logs it immediately.
+func (d *RewrapEvent) Success(ctx context.Context) {
+	d.markSuccess(ctx)
+}
+
+// Failure marks the audit event as failed and logs it immediately.
+func (d *RewrapEvent) Failure(ctx context.Context) {
+	d.markFailure(ctx)
+}
+
+// Log should be called in a defer statement. If neither Success() nor Failure()
+// was called, it will check the context for cancellation and log appropriately.
+func (d *RewrapEvent) Log(ctx context.Context) {
+	d.log(ctx)
+}
+
+// Decision creates a deferred GetDecision audit event.
+// The event will be logged with a deny decision unless Success() is called with the actual decision.
+// Usage:
+//
+//	auditEvent := logger.Audit.Decision(ctx, entityChainID, resourceAttributeID, fqns)
+//	defer auditEvent.Log(ctx)
+//	// ... perform operation, enriching with UpdateEntitlements/UpdateEntityDecisions ...
+//	auditEvent.Success(ctx, decision)
+func (a *Logger) Decision(ctx context.Context, entityChainID string, resourceAttributeID string, fqns []string) *GetDecisionEvent {
+	if _, ok := ctx.Value(contextKey{}).(*auditTransaction); !ok {
+		panic("audit transaction missing from context in Decision")
+	}
+
+	params := GetDecisionEventParams{
+		Decision:                GetDecisionResultDeny, // Default to deny on cancellation
+		EntityChainID:           entityChainID,
+		ResourceAttributeID:     resourceAttributeID,
+		FQNs:                    fqns,
+		EntityChainEntitlements: []EntityChainEntitlement{},
+		EntityDecisions:         []EntityDecision{},
+	}
+
+	return &GetDecisionEvent{
+		deferred: &deferred[GetDecisionEventParams]{
+			params: params,
+			onSuccess: func(ctx context.Context, p GetDecisionEventParams) {
+				a.getDecisionBase(ctx, p)
+			},
+			onFailure: func(ctx context.Context, p GetDecisionEventParams) {
+				// On failure/cancellation, log with deny decision (already set in params)
+				a.getDecisionBase(ctx, p)
+			},
+		},
+	}
+}
+
+// UpdateEntitlements updates the entity chain entitlements as they are computed
+func (d *GetDecisionEvent) UpdateEntitlements(entitlements []EntityChainEntitlement) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		panic(ErrAlreadyCompleted)
+	}
+
+	d.params.EntityChainEntitlements = entitlements
+}
+
+// UpdateEntityDecisions updates the entity decisions as they are computed
+func (d *GetDecisionEvent) UpdateEntityDecisions(decisions []EntityDecision) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		panic(ErrAlreadyCompleted)
+	}
+
+	d.params.EntityDecisions = decisions
+}
+
+// Success marks the audit event with the final decision and logs it immediately.
+func (d *GetDecisionEvent) Success(ctx context.Context, decision DecisionResult) {
+	d.params.Decision = decision
+	d.markSuccess(ctx)
+}
+
+// Failure marks the audit event as failed (logs with deny decision)
+func (d *GetDecisionEvent) Failure(ctx context.Context) {
+	d.markFailure(ctx)
+}
+
+// Log should be called in a defer statement. If neither Success() nor Failure()
+// was called, it will log with a deny decision.
+func (d *GetDecisionEvent) Log(ctx context.Context) {
+	d.log(ctx)
+}
+
+// DecisionV2 creates a deferred GetDecisionV2 audit event.
+// The event will be logged with a deny decision unless Success() is called with the actual decision.
+// Usage:
+//
+//	auditEvent := logger.Audit.DecisionV2(ctx, entityID, actionName)
+//	defer auditEvent.Log(ctx)
+//	// ... perform operation, enriching with UpdateEntitlements/UpdateResourceDecisions/UpdateObligations ...
+//	auditEvent.Success(ctx, decision)
+func (a *Logger) DecisionV2(ctx context.Context, entityID string, actionName string) *GetDecisionV2Event {
+	if _, ok := ctx.Value(contextKey{}).(*auditTransaction); !ok {
+		panic("audit transaction missing from context in DecisionV2")
+	}
+
+	params := GetDecisionV2EventParams{
+		EntityID:                       entityID,
+		ActionName:                     actionName,
+		Decision:                       GetDecisionResultDeny, // Default to deny on cancellation
+		Entitlements:                   make(map[string][]*policy.Action),
+		FulfillableObligationValueFQNs: []string{},
+		ObligationsSatisfied:           false,
+		ResourceDecisions:              nil,
+	}
+
+	return &GetDecisionV2Event{
+		deferred: &deferred[GetDecisionV2EventParams]{
+			params: params,
+			onSuccess: func(ctx context.Context, p GetDecisionV2EventParams) {
+				a.getDecisionV2Base(ctx, p)
+			},
+			onFailure: func(ctx context.Context, p GetDecisionV2EventParams) {
+				// On failure/cancellation, log with deny decision (already set in params)
+				a.getDecisionV2Base(ctx, p)
+			},
+		},
+	}
+}
+
+// UpdateEntitlements updates the entitlements as they are computed
+func (d *GetDecisionV2Event) UpdateEntitlements(entitlements map[string][]*policy.Action) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		panic(ErrAlreadyCompleted)
+	}
+
+	d.params.Entitlements = entitlements
+}
+
+// UpdateResourceDecisions updates the resource decisions as they are computed
+func (d *GetDecisionV2Event) UpdateResourceDecisions(resourceDecisions any) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		panic(ErrAlreadyCompleted)
+	}
+
+	d.params.ResourceDecisions = resourceDecisions
+}
+
+// UpdateObligations updates the obligation information as it is computed
+func (d *GetDecisionV2Event) UpdateObligations(fulfillable []string, satisfied bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		panic(ErrAlreadyCompleted)
+	}
+
+	d.params.FulfillableObligationValueFQNs = fulfillable
+	d.params.ObligationsSatisfied = satisfied
+}
+
+func (d *GetDecisionV2Event) UpdateDecisionResult(_ context.Context, decision DecisionResult) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.completed {
+		panic(ErrAlreadyCompleted)
+	}
+
+	d.params.Decision = decision
+}
+
+// Success marks the audit event as successful with the final decision and logs it immediately.
+func (d *GetDecisionV2Event) Success(ctx context.Context, decision DecisionResult) {
+	d.UpdateDecisionResult(ctx, decision)
+	d.markSuccess(ctx)
+}
+
+// Failure marks the audit event as failed (logs with deny decision)
+func (d *GetDecisionV2Event) Failure(ctx context.Context) {
+	d.markFailure(ctx)
+}
+
+// Log should be called in a defer statement. If neither Success() nor Failure()
+// was called, it will log with a deny decision.
+func (d *GetDecisionV2Event) Log(ctx context.Context) {
+	d.log(ctx)
+}

--- a/service/logger/audit/deferred_test.go
+++ b/service/logger/audit/deferred_test.go
@@ -1,0 +1,352 @@
+package audit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeferredPolicyCRUD_Success(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		auditParams := PolicyEventParams{
+			ActionType: ActionTypeCreate,
+			ObjectType: ObjectTypeAttributeDefinition,
+			ObjectID:   "test-id",
+		}
+
+		auditEvent := l.PolicyCRUD(ctx, auditParams)
+		defer auditEvent.Log(ctx)
+
+		// Simulate successful operation
+		created := &policy.Attribute{
+			Id:   "test-id2",
+			Name: "test-attribute",
+		}
+		auditEvent.Success(ctx, created)
+	})
+
+	auditJSON := string(logEntry.Audit)
+	assert.Contains(t, auditJSON, `"type":"create"`, "should contain create action")
+	assert.Contains(t, auditJSON, `"result":"success"`, "should contain success result")
+	assert.Contains(t, auditJSON, `"id":"test-id2"`, "should contain object ID")
+	assert.Contains(t, auditJSON, TestActorID, "should contain actor ID")
+}
+
+func TestDeferredPolicyCRUD_Failure(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		auditParams := PolicyEventParams{
+			ActionType: ActionTypeCreate,
+			ObjectType: ObjectTypeAttributeDefinition,
+			ObjectID:   "test-id",
+		}
+
+		auditEvent := l.PolicyCRUD(ctx, auditParams)
+		defer auditEvent.Log(ctx)
+
+		// Simulate operation failure - don't call Success()
+	})
+
+	auditJSON := string(logEntry.Audit)
+	assert.Contains(t, auditJSON, `"type":"create"`, "should contain create action")
+	assert.Contains(t, auditJSON, `"result":"error"`, "should contain error result")
+	assert.Contains(t, auditJSON, `"id":"test-id"`, "should contain object ID")
+	assert.Contains(t, auditJSON, TestActorID, "should contain actor ID")
+}
+
+func TestDeferredPolicyCRUD_PanicRecovery(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		auditParams := PolicyEventParams{
+			ActionType: ActionTypeUpdate,
+			ObjectType: ObjectTypeAttributeDefinition,
+			ObjectID:   "test-id",
+		}
+
+		auditEvent := l.PolicyCRUD(ctx, auditParams)
+		defer auditEvent.Log(ctx)
+
+		// Simulate panic during operation
+		panic("test panic")
+	})
+
+	auditJSON := string(logEntry.Audit)
+	assert.Contains(t, auditJSON, `"type":"update"`, "should contain update action")
+	// The interceptor marks panicked events as cancelled
+	assert.Contains(t, auditJSON, `"result":"cancel"`, "should contain cancel result")
+	assert.Contains(t, auditJSON, `"id":"test-id"`, "should contain object ID")
+	assert.Contains(t, auditJSON, TestActorID, "should contain actor ID")
+}
+
+func TestDeferredPolicyCRUD_ContextCancellation(t *testing.T) {
+	l, buf := createTestLogger()
+	ctx, cancel := context.WithCancel(createTestContext(t))
+	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
+	require.True(t, ok, "audit transaction missing from context")
+
+	auditParams := PolicyEventParams{
+		ActionType: ActionTypeDelete,
+		ObjectType: ObjectTypeAttributeDefinition,
+		ObjectID:   "test-id",
+	}
+
+	func() {
+		auditEvent := l.PolicyCRUD(ctx, auditParams)
+		defer auditEvent.Log(ctx)
+
+		// Cancel the context to simulate network cancellation
+		cancel()
+
+		// Don't call Success() - context is cancelled
+	}()
+
+	// Manually flush the logs
+	tx.logClose(ctx, l.logger, true, nil)
+
+	logEntry, _ := extractLogEntry(t, buf)
+	auditJSON := string(logEntry.Audit)
+	assert.Contains(t, auditJSON, `"type":"delete"`, "should contain delete action")
+	assert.Contains(t, auditJSON, `"result":"error"`, "should contain error result")
+	assert.Contains(t, auditJSON, `"id":"test-id"`, "should contain object ID")
+	assert.Contains(t, auditJSON, TestActorID, "should contain actor ID")
+}
+
+func TestDeferredRewrap_Success(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		policyUUID := uuid.New()
+		auditParams := RewrapAuditEventParams{
+			Policy: KasPolicy{
+				UUID: policyUUID,
+				Body: KasPolicyBody{
+					DataAttributes: []KasAttribute{
+						{URI: "https://example.com/attr/test"},
+					},
+				},
+			},
+			TDFFormat:     "tdf3",
+			Algorithm:     "rsa-2048",
+			PolicyBinding: "test-binding",
+			KeyID:         "test-key-id",
+		}
+
+		auditEvent := l.Rewrap(ctx, auditParams)
+		defer auditEvent.Log(ctx)
+
+		// Simulate successful rewrap
+		auditEvent.Success(ctx)
+	})
+
+	auditJSON := string(logEntry.Audit)
+	assert.Contains(t, auditJSON, `"type":"rewrap"`, "should contain rewrap action")
+	assert.Contains(t, auditJSON, `"result":"success"`, "should contain success result")
+	assert.Contains(t, auditJSON, TestActorID, "should contain actor ID")
+}
+
+func TestDeferredRewrap_Failure(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		policyUUID := uuid.New()
+		auditParams := RewrapAuditEventParams{
+			Policy: KasPolicy{
+				UUID: policyUUID,
+				Body: KasPolicyBody{
+					DataAttributes: []KasAttribute{
+						{URI: "https://example.com/attr/test"},
+					},
+				},
+			},
+			TDFFormat:     "Nano",
+			Algorithm:     "aes-256-gcm",
+			PolicyBinding: "test-binding",
+			KeyID:         "test-key-id",
+		}
+
+		auditEvent := l.Rewrap(ctx, auditParams)
+		defer auditEvent.Log(ctx)
+
+		// Simulate failed rewrap - don't call Success()
+	})
+
+	auditJSON := string(logEntry.Audit)
+	assert.Contains(t, auditJSON, `"type":"rewrap"`, "should contain rewrap action")
+	assert.Contains(t, auditJSON, `"result":"error"`, "should contain error result")
+	assert.Contains(t, auditJSON, TestActorID, "should contain actor ID")
+}
+
+func TestDeferredPolicyCRUD_MultipleCallsIdempotent(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		auditParams := PolicyEventParams{
+			ActionType: ActionTypeCreate,
+			ObjectType: ObjectTypeAttributeDefinition,
+			ObjectID:   "test-id",
+		}
+
+		auditEvent := l.PolicyCRUD(ctx, auditParams)
+		defer auditEvent.Log(ctx)
+
+		created := &policy.Attribute{
+			Id:   "test-id",
+			Name: "test-attribute",
+		}
+		auditParams.Original = created
+
+		// Call Success multiple times
+		auditEvent.Success(ctx, created)
+		auditEvent.Success(ctx, created)
+		auditEvent.Success(ctx, created)
+	})
+
+	auditJSON := string(logEntry.Audit)
+	// Should only have logged once despite multiple Success calls
+	assert.Contains(t, auditJSON, `"result":"success"`, "should contain success result")
+}
+
+func TestDeferredPolicyCRUD_UpdateWithOriginalAndUpdated(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		original := &policy.Attribute{
+			Id:   "test-id",
+			Name: "original-name",
+		}
+		updated := &policy.Attribute{
+			Id:   "test-id",
+			Name: "updated-name",
+		}
+
+		auditParams := PolicyEventParams{
+			ActionType: ActionTypeUpdate,
+			ObjectType: ObjectTypeAttributeDefinition,
+			ObjectID:   "test-id",
+			Original:   original,
+		}
+
+		auditEvent := l.PolicyCRUD(ctx, auditParams)
+		defer auditEvent.Log(ctx)
+
+		// Simulate successful update
+		auditEvent.Success(ctx, updated)
+	})
+
+	auditJSON := string(logEntry.Audit)
+	assert.Contains(t, auditJSON, `"type":"update"`, "should contain update action")
+	assert.Contains(t, auditJSON, `"result":"success"`, "should contain success result")
+	assert.Contains(t, auditJSON, `"original"`, "should contain original object")
+	assert.Contains(t, auditJSON, `"updated"`, "should contain updated object")
+	assert.Contains(t, auditJSON, `"original-name"`, "should contain original name")
+	assert.Contains(t, auditJSON, `"updated-name"`, "should contain updated name")
+}
+
+func TestDeferredGetDecision_Success(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		auditEvent := l.Decision(ctx, "test-entity-chain-id", "test-resource-attr-id", []string{"https://example.com/attr/test/value/value1"})
+		defer auditEvent.Log(ctx)
+
+		// Simulate successful operation
+		entitlements := []EntityChainEntitlement{
+			{
+				EntityID:                 "entity-1",
+				EntityCatagory:           "subject",
+				AttributeValueReferences: []string{"https://example.com/attr/test/value/value1"},
+			},
+		}
+		auditEvent.UpdateEntitlements(entitlements)
+
+		entityDecisions := []EntityDecision{
+			{
+				EntityID:     "entity-1",
+				Decision:     "permit",
+				Entitlements: []string{"https://example.com/attr/test/value/value1"},
+			},
+		}
+		auditEvent.UpdateEntityDecisions(entityDecisions)
+
+		auditEvent.Success(ctx, GetDecisionResultPermit)
+	})
+
+	auditJSON := string(logEntry.Audit)
+	// GetDecision events encode decision in action.result as success/failure
+	assert.Contains(t, auditJSON, `"result":"success"`, "should contain success result")
+	assert.Contains(t, auditJSON, `"test-entity-chain-id"`, "should contain entity chain ID")
+	assert.Contains(t, auditJSON, `entity-1`, "should contain entity ID in metadata")
+}
+
+func TestDeferredGetDecision_Failure(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		auditEvent := l.Decision(ctx, "test-entity-chain-id", "test-resource-attr-id", []string{"https://example.com/attr/test/value/value1"})
+		defer auditEvent.Log(ctx)
+
+		// Simulate operation failure - don't call Success()
+		// This should default to deny decision (result=failure)
+	})
+
+	auditJSON := string(logEntry.Audit)
+	// GetDecision events encode deny as action.result = failure
+	assert.Contains(t, auditJSON, `"result":"failure"`, "should contain failure result (deny decision)")
+	assert.Contains(t, auditJSON, `"test-entity-chain-id"`, "should contain entity chain ID")
+}
+
+func TestDeferredGetDecisionV2_Success(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		auditEvent := l.DecisionV2(ctx, "test-entity-id", "test-action")
+		defer auditEvent.Log(ctx)
+
+		// Simulate successful operation with entitlements
+		entitlements := make(map[string][]*policy.Action)
+		entitlements["https://example.com/attr/test/value/value1"] = []*policy.Action{
+			{Name: "test-action"},
+		}
+		auditEvent.UpdateEntitlements(entitlements)
+
+		// Add obligations
+		auditEvent.UpdateObligations([]string{"https://example.com/obligation/test"}, true)
+
+		// Add resource decisions
+		resourceDecisions := []map[string]interface{}{
+			{
+				"passed":                true,
+				"obligations_satisfied": true,
+				"entitled":              true,
+			},
+		}
+		auditEvent.UpdateResourceDecisions(resourceDecisions)
+
+		auditEvent.Success(ctx, GetDecisionResultPermit)
+	})
+
+	auditJSON := string(logEntry.Audit)
+	// GetDecisionV2 events encode permit decision as action.result = success
+	assert.Contains(t, auditJSON, `"result":"success"`, "should contain success result")
+	assert.Contains(t, auditJSON, `"test-entity-id"`, "should contain entity ID")
+	assert.Contains(t, auditJSON, `decisionRequest-test-action`, "should contain action name in object name")
+}
+
+func TestDeferredGetDecisionV2_Failure(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		auditEvent := l.DecisionV2(ctx, "test-entity-id", "test-action")
+		defer auditEvent.Log(ctx)
+
+		// Simulate operation failure - don't call Success()
+		// This should default to deny decision (result=failure)
+	})
+
+	auditJSON := string(logEntry.Audit)
+	// GetDecisionV2 events encode deny as action.result = failure
+	assert.Contains(t, auditJSON, `"result":"failure"`, "should contain failure result (deny decision)")
+	assert.Contains(t, auditJSON, `"test-entity-id"`, "should contain entity ID")
+	assert.Contains(t, auditJSON, `decisionRequest-test-action`, "should contain action name in object name")
+}
+
+func TestDeferredGetDecisionV2_PanicRecovery(t *testing.T) {
+	logEntry, _ := doWithLogger(t, func(ctx context.Context, l *Logger) {
+		auditEvent := l.DecisionV2(ctx, "test-entity-id", "test-action")
+		defer auditEvent.Log(ctx)
+
+		// Simulate panic during operation
+		panic("test panic")
+	})
+
+	auditJSON := string(logEntry.Audit)
+	// Panics are marked as cancel by the interceptor
+	assert.Contains(t, auditJSON, `"result":"cancel"`, "should contain cancel result on panic")
+	assert.Contains(t, auditJSON, `"test-entity-id"`, "should contain entity ID")
+}

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -120,7 +120,17 @@ func (a *Logger) PolicyCRUDFailure(ctx context.Context, eventParams PolicyEventP
 	a.policyCrudBase(ctx, false, eventParams)
 }
 
+// Deprecated
 func (a *Logger) GetDecision(ctx context.Context, eventParams GetDecisionEventParams) {
+	a.getDecisionBase(ctx, eventParams)
+}
+
+// Deprecated
+func (a *Logger) GetDecisionV2(ctx context.Context, eventParams GetDecisionV2EventParams) {
+	a.getDecisionV2Base(ctx, eventParams)
+}
+
+func (a *Logger) getDecisionBase(ctx context.Context, eventParams GetDecisionEventParams) {
 	auditEvent, err := CreateGetDecisionEvent(ctx, eventParams)
 	if err != nil {
 		a.logger.ErrorContext(ctx, "error creating get decision audit event", slog.Any("error", err))
@@ -129,7 +139,7 @@ func (a *Logger) GetDecision(ctx context.Context, eventParams GetDecisionEventPa
 	LogAuditEvent(ctx, VerbDecision, auditEvent)
 }
 
-func (a *Logger) GetDecisionV2(ctx context.Context, eventParams GetDecisionV2EventParams) {
+func (a *Logger) getDecisionV2Base(ctx context.Context, eventParams GetDecisionV2EventParams) {
 	event, err := CreateV2GetDecisionEvent(ctx, eventParams)
 	if err != nil {
 		a.logger.ErrorContext(ctx, "error creating v2 get decision audit event", slog.Any("error", err))

--- a/service/logger/audit/policy.go
+++ b/service/logger/audit/policy.go
@@ -74,6 +74,12 @@ func CreatePolicyEvent(ctx context.Context, isSuccess bool, params PolicyEventPa
 			// merge changes from PolicyEventParams, overwriting properties existing in Updated object
 			maps.Copy(auditEvent.Updated, auditEventUpdated)
 		}
+	} else if params.Updated != nil {
+		auditEventUpdated, err := marshallProtoToAuditObject(params.Updated)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal updated audit object: %w", err)
+		}
+		auditEvent.Updated = auditEventUpdated
 	}
 
 	return auditEvent, nil

--- a/service/policy/namespaces/namespaces.go
+++ b/service/policy/namespaces/namespaces.go
@@ -291,4 +291,3 @@ func (ns NamespacesService) RemovePublicKeyFromNamespace(ctx context.Context, r 
 
 	return connect.NewResponse(rsp), nil
 }
-

--- a/service/policy/namespaces/namespaces.go
+++ b/service/policy/namespaces/namespaces.go
@@ -130,18 +130,19 @@ func (ns NamespacesService) CreateNamespace(ctx context.Context, req *connect.Re
 		ActionType: audit.ActionTypeCreate,
 		ObjectType: audit.ObjectTypeNamespace,
 	}
+	auditEvent := ns.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 	rsp := &namespaces.CreateNamespaceResponse{}
 
 	err := ns.dbClient.RunInTx(ctx, func(txClient *policydb.PolicyDBClient) error {
 		n, err := txClient.CreateNamespace(ctx, req.Msg)
 		if err != nil {
-			ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 			return err
 		}
 
-		auditParams.ObjectID = n.GetId()
-		auditParams.Original = n
-		ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.UpdateObjectID(n.GetId())
+		auditEvent.UpdateOriginal(n)
+		auditEvent.Success(ctx, n)
 
 		ns.logger.DebugContext(ctx, "created new namespace", slog.String("name", req.Msg.GetName()))
 		rsp.Namespace = n
@@ -165,23 +166,22 @@ func (ns NamespacesService) UpdateNamespace(ctx context.Context, req *connect.Re
 		ObjectType: audit.ObjectTypeNamespace,
 		ObjectID:   namespaceID,
 	}
+	auditEvent := ns.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	original, err := ns.dbClient.GetNamespace(ctx, namespaceID)
 	if err != nil {
-		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", namespaceID))
 	}
 
 	updated, err := ns.dbClient.UpdateNamespace(ctx, namespaceID, req.Msg)
 	if err != nil {
-		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextUpdateFailed, slog.String("id", namespaceID))
 	}
 
-	auditParams.Original = original
-	auditParams.Updated = updated
+	auditEvent.UpdateOriginal(original)
 
-	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, updated)
 	ns.logger.DebugContext(ctx, "updated namespace", slog.String("id", namespaceID))
 
 	rsp.Namespace = &policy.Namespace{
@@ -201,22 +201,21 @@ func (ns NamespacesService) DeactivateNamespace(ctx context.Context, req *connec
 		ObjectType: audit.ObjectTypeNamespace,
 		ObjectID:   namespaceID,
 	}
+	auditEvent := ns.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	original, err := ns.dbClient.GetNamespace(ctx, namespaceID)
 	if err != nil {
-		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", namespaceID))
 	}
 
 	updated, err := ns.dbClient.DeactivateNamespace(ctx, namespaceID)
 	if err != nil {
-		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextDeletionFailed, slog.String("id", namespaceID))
 	}
 
-	auditParams.Original = original
-	auditParams.Updated = updated
-	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.UpdateOriginal(original)
+	auditEvent.Success(ctx, updated)
 	ns.logger.DebugContext(ctx, "soft-deleted namespace", slog.String("id", namespaceID))
 
 	return connect.NewResponse(rsp), nil
@@ -235,13 +234,14 @@ func (ns NamespacesService) RemoveKeyAccessServerFromNamespace(ctx context.Conte
 		ObjectType: audit.ObjectTypeKasAttributeNamespaceAssignment,
 		ObjectID:   fmt.Sprintf("%s-%s", grant.GetNamespaceId(), grant.GetKeyAccessServerId()),
 	}
+	auditEvent := ns.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	namespaceKas, err := ns.dbClient.RemoveKeyAccessServerFromNamespace(ctx, grant)
 	if err != nil {
-		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextDeletionFailed, slog.String("namespaceKas", grant.String()))
 	}
-	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, namespaceKas)
 
 	rsp.NamespaceKeyAccessServer = namespaceKas
 
@@ -257,13 +257,14 @@ func (ns NamespacesService) AssignPublicKeyToNamespace(ctx context.Context, r *c
 		ObjectType: audit.ObjectTypeKasAttributeNamespaceKeyAssignment,
 		ObjectID:   fmt.Sprintf("%s:%s", key.GetNamespaceId(), key.GetKeyId()),
 	}
+	auditEvent := ns.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	namespaceKey, err := ns.dbClient.AssignPublicKeyToNamespace(ctx, key)
 	if err != nil {
-		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextCreationFailed, slog.String("namespaceKey", key.String()))
 	}
-	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, namespaceKey)
 
 	rsp.NamespaceKey = namespaceKey
 
@@ -279,13 +280,15 @@ func (ns NamespacesService) RemovePublicKeyFromNamespace(ctx context.Context, r 
 		ObjectType: audit.ObjectTypeKasAttributeNamespaceKeyAssignment,
 		ObjectID:   fmt.Sprintf("%s:%s", key.GetNamespaceId(), key.GetKeyId()),
 	}
+	auditEvent := ns.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	_, err := ns.dbClient.RemovePublicKeyFromNamespace(ctx, key)
 	if err != nil {
-		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextDeletionFailed, slog.String("namespaceKey", key.String()))
 	}
-	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, key)
 
 	return connect.NewResponse(rsp), nil
 }
+

--- a/service/policy/obligations/obligations.go
+++ b/service/policy/obligations/obligations.go
@@ -107,6 +107,8 @@ func (s *Service) CreateObligation(ctx context.Context, req *connect.Request[obl
 		ActionType: audit.ActionTypeCreate,
 		ObjectType: audit.ObjectTypeObligationDefinition,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "creating obligation", slog.String("name", req.Msg.GetName()))
 
@@ -116,15 +118,14 @@ func (s *Service) CreateObligation(ctx context.Context, req *connect.Request[obl
 			return err
 		}
 
-		auditParams.ObjectID = obl.GetId()
-		auditParams.Original = obl
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.UpdateObjectID(obl.GetId())
+		auditEvent.UpdateOriginal(obl)
+		auditEvent.Success(ctx, obl)
 
 		rsp.Obligation = obl
 		return nil
 	})
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("obligation", req.Msg.String()))
 	}
 
@@ -168,6 +169,8 @@ func (s *Service) UpdateObligation(ctx context.Context, req *connect.Request[obl
 		ObjectType: audit.ObjectTypeObligationDefinition,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "updating obligation", slog.String("id", id))
 
@@ -182,15 +185,13 @@ func (s *Service) UpdateObligation(ctx context.Context, req *connect.Request[obl
 			return err
 		}
 
-		auditParams.Original = original
-		auditParams.Updated = updated
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.UpdateOriginal(original)
+		auditEvent.Success(ctx, updated)
 
 		rsp.Obligation = updated
 		return nil
 	})
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("obligation", req.Msg.String()))
 	}
 	return connect.NewResponse(rsp), nil
@@ -204,16 +205,17 @@ func (s *Service) DeleteObligation(ctx context.Context, req *connect.Request[obl
 		ObjectType: audit.ObjectTypeObligationDefinition,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "deleting obligation", slog.String("id", id))
 
 	deleted, err := s.dbClient.DeleteObligation(ctx, req.Msg)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("obligation", req.Msg.String()))
 	}
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, deleted)
 
 	rsp := &obligations.DeleteObligationResponse{Obligation: deleted}
 	return connect.NewResponse(rsp), nil
@@ -226,6 +228,8 @@ func (s *Service) CreateObligationValue(ctx context.Context, req *connect.Reques
 		ActionType: audit.ActionTypeCreate,
 		ObjectType: audit.ObjectTypeObligationValue,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "creating obligation value", slog.String("value", req.Msg.GetValue()))
 
@@ -235,15 +239,14 @@ func (s *Service) CreateObligationValue(ctx context.Context, req *connect.Reques
 			return err
 		}
 
-		auditParams.ObjectID = val.GetId()
-		auditParams.Original = val
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.UpdateObjectID(val.GetId())
+		auditEvent.UpdateOriginal(val)
+		auditEvent.Success(ctx, val)
 
 		rsp.Value = val
 		return nil
 	})
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("obligation value", req.Msg.String()))
 	}
 
@@ -288,6 +291,8 @@ func (s *Service) UpdateObligationValue(ctx context.Context, req *connect.Reques
 		ObjectType: audit.ObjectTypeObligationValue,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "updating obligation value", slog.String("id", id))
 
@@ -302,15 +307,13 @@ func (s *Service) UpdateObligationValue(ctx context.Context, req *connect.Reques
 			return err
 		}
 
-		auditParams.Original = original
-		auditParams.Updated = updated
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.UpdateOriginal(original)
+		auditEvent.Success(ctx, updated)
 
 		rsp.Value = updated
 		return nil
 	})
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("obligation value", req.Msg.String()))
 	}
 	return connect.NewResponse(rsp), nil
@@ -324,16 +327,17 @@ func (s *Service) DeleteObligationValue(ctx context.Context, req *connect.Reques
 		ObjectType: audit.ObjectTypeObligationValue,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "deleting obligation value", slog.String("id", id))
 
 	deleted, err := s.dbClient.DeleteObligationValue(ctx, req.Msg)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("obligation value", req.Msg.String()))
 	}
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, deleted)
 
 	rsp := &obligations.DeleteObligationValueResponse{Value: deleted}
 	return connect.NewResponse(rsp), nil
@@ -346,6 +350,8 @@ func (s *Service) AddObligationTrigger(ctx context.Context, req *connect.Request
 		ActionType: audit.ActionTypeCreate,
 		ObjectType: audit.ObjectTypeObligationTrigger,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	oblIdentifier := req.Msg.GetObligationValue()
 	oblVal := oblIdentifier.GetId()
@@ -377,15 +383,14 @@ func (s *Service) AddObligationTrigger(ctx context.Context, req *connect.Request
 			return err
 		}
 
-		auditParams.ObjectID = trigger.GetId()
-		auditParams.Original = trigger
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.UpdateObjectID(trigger.GetId())
+		auditEvent.UpdateOriginal(trigger)
+		auditEvent.Success(ctx, trigger)
 
 		rsp.Trigger = trigger
 		return nil
 	})
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("obligation trigger", req.Msg.String()))
 	}
 
@@ -400,16 +405,17 @@ func (s *Service) RemoveObligationTrigger(ctx context.Context, req *connect.Requ
 		ObjectType: audit.ObjectTypeObligationTrigger,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "removing obligation trigger", slog.String("id", id))
 
 	deleted, err := s.dbClient.DeleteObligationTrigger(ctx, req.Msg)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("obligation trigger", req.Msg.String()))
 	}
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, deleted)
 
 	rsp := &obligations.RemoveObligationTriggerResponse{Trigger: deleted}
 	return connect.NewResponse(rsp), nil

--- a/service/policy/registeredresources/registered_resources.go
+++ b/service/policy/registeredresources/registered_resources.go
@@ -91,6 +91,8 @@ func (s *RegisteredResourcesService) CreateRegisteredResource(ctx context.Contex
 		ActionType: audit.ActionTypeCreate,
 		ObjectType: audit.ObjectTypeRegisteredResource,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "creating registered resource", slog.String("name", req.Msg.GetName()))
 
@@ -100,15 +102,14 @@ func (s *RegisteredResourcesService) CreateRegisteredResource(ctx context.Contex
 			return err
 		}
 
-		auditParams.ObjectID = resource.GetId()
-		auditParams.Original = resource
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.UpdateObjectID(resource.GetId())
+		auditEvent.UpdateOriginal(resource)
+		auditEvent.Success(ctx, resource)
 
 		rsp.Resource = resource
 		return nil
 	})
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("registered resource", req.Msg.String()))
 	}
 
@@ -150,6 +151,8 @@ func (s *RegisteredResourcesService) UpdateRegisteredResource(ctx context.Contex
 		ObjectType: audit.ObjectTypeRegisteredResource,
 		ObjectID:   resourceID,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "updating registered resource", slog.String("id", resourceID))
 
@@ -168,15 +171,13 @@ func (s *RegisteredResourcesService) UpdateRegisteredResource(ctx context.Contex
 			return err
 		}
 
-		auditParams.Original = original
-		auditParams.Updated = updated
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.UpdateOriginal(original)
+		auditEvent.Success(ctx, updated)
 
 		rsp.Resource = updated
 		return nil
 	})
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("registered resource", req.Msg.String()))
 	}
 
@@ -193,16 +194,17 @@ func (s *RegisteredResourcesService) DeleteRegisteredResource(ctx context.Contex
 		ObjectType: audit.ObjectTypeRegisteredResource,
 		ObjectID:   resourceID,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "deleting registered resource", slog.String("id", resourceID))
 
 	deleted, err := s.dbClient.DeleteRegisteredResource(ctx, resourceID)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("registered resource", req.Msg.String()))
 	}
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, deleted)
 
 	rsp.Resource = deleted
 
@@ -218,6 +220,8 @@ func (s *RegisteredResourcesService) CreateRegisteredResourceValue(ctx context.C
 		ActionType: audit.ActionTypeCreate,
 		ObjectType: audit.ObjectTypeRegisteredResourceValue,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "creating registered resource value", slog.String("value", req.Msg.GetValue()))
 
@@ -227,15 +231,14 @@ func (s *RegisteredResourcesService) CreateRegisteredResourceValue(ctx context.C
 			return err
 		}
 
-		auditParams.ObjectID = value.GetId()
-		auditParams.Original = value
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.UpdateObjectID(value.GetId())
+		auditEvent.UpdateOriginal(value)
+		auditEvent.Success(ctx, value)
 
 		rsp.Value = value
 		return nil
 	})
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("registered resource value", req.Msg.String()))
 	}
 
@@ -293,6 +296,8 @@ func (s *RegisteredResourcesService) UpdateRegisteredResourceValue(ctx context.C
 		ObjectType: audit.ObjectTypeRegisteredResourceValue,
 		ObjectID:   valueID,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "updating registered resource value", slog.String("id", valueID))
 
@@ -311,16 +316,14 @@ func (s *RegisteredResourcesService) UpdateRegisteredResourceValue(ctx context.C
 			return err
 		}
 
-		auditParams.Original = original
-		auditParams.Updated = updated
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.UpdateOriginal(original)
+		auditEvent.Success(ctx, updated)
 
 		rsp.Value = updated
 
 		return nil
 	})
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("registered resource value", req.Msg.String()))
 	}
 
@@ -337,16 +340,17 @@ func (s *RegisteredResourcesService) DeleteRegisteredResourceValue(ctx context.C
 		ObjectType: audit.ObjectTypeRegisteredResourceValue,
 		ObjectID:   valueID,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	s.logger.DebugContext(ctx, "deleting registered resource value", slog.String("id", valueID))
 
 	deleted, err := s.dbClient.DeleteRegisteredResourceValue(ctx, valueID)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("registered resource value", req.Msg.String()))
 	}
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, deleted)
 
 	rsp.Value = deleted
 

--- a/service/policy/resourcemapping/resource_mapping.go
+++ b/service/policy/resourcemapping/resource_mapping.go
@@ -107,16 +107,17 @@ func (s ResourceMappingService) CreateResourceMappingGroup(ctx context.Context, 
 		ActionType: audit.ActionTypeCreate,
 		ObjectType: audit.ObjectTypeResourceMappingGroup,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	rmGroup, err := s.dbClient.CreateResourceMappingGroup(ctx, req.Msg)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("resourceMappingGroup", req.Msg.String()))
 	}
 
-	auditParams.ObjectID = rmGroup.GetId()
-	auditParams.Original = rmGroup
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.UpdateObjectID(rmGroup.GetId())
+	auditEvent.UpdateOriginal(rmGroup)
+	auditEvent.Success(ctx, rmGroup)
 
 	rsp.ResourceMappingGroup = rmGroup
 
@@ -133,23 +134,22 @@ func (s ResourceMappingService) UpdateResourceMappingGroup(ctx context.Context, 
 		ObjectType: audit.ObjectTypeResourceMappingGroup,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	originalRmGroup, err := s.dbClient.GetResourceMappingGroup(ctx, id)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	updatedRmGroup, err := s.dbClient.UpdateResourceMappingGroup(ctx, id, req.Msg)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", id))
 	}
 
-	auditParams.Original = originalRmGroup
-	auditParams.Updated = updatedRmGroup
+	auditEvent.UpdateOriginal(originalRmGroup)
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, updatedRmGroup)
 
 	rsp.ResourceMappingGroup = &policy.ResourceMappingGroup{
 		Id: id,
@@ -168,14 +168,17 @@ func (s ResourceMappingService) DeleteResourceMappingGroup(ctx context.Context, 
 		ObjectType: audit.ObjectTypeResourceMappingGroup,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	_, err := s.dbClient.DeleteResourceMappingGroup(ctx, id)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", id))
 	}
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, &policy.ResourceMappingGroup{
+		Id: id,
+	})
 
 	rsp.ResourceMappingGroup = &policy.ResourceMappingGroup{
 		Id: id,
@@ -240,16 +243,17 @@ func (s ResourceMappingService) CreateResourceMapping(ctx context.Context,
 		ActionType: audit.ActionTypeCreate,
 		ObjectType: audit.ObjectTypeResourceMapping,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	rm, err := s.dbClient.CreateResourceMapping(ctx, req.Msg)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("resourceMapping", req.Msg.String()))
 	}
 
-	auditParams.ObjectID = rm.GetId()
-	auditParams.Original = rm
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.UpdateObjectID(rm.GetId())
+	auditEvent.UpdateOriginal(rm)
+	auditEvent.Success(ctx, rm)
 
 	rsp.ResourceMapping = rm
 
@@ -268,25 +272,24 @@ func (s ResourceMappingService) UpdateResourceMapping(ctx context.Context,
 		ObjectType: audit.ObjectTypeResourceMapping,
 		ObjectID:   resourceMappingID,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	originalRM, err := s.dbClient.GetResourceMapping(ctx, resourceMappingID)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed)
 	}
 
 	updatedRM, err := s.dbClient.UpdateResourceMapping(ctx, resourceMappingID, req.Msg)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed,
 			slog.String("id", req.Msg.GetId()),
 			slog.String("resourceMapping", req.Msg.String()),
 		)
 	}
 
-	auditParams.Original = originalRM
-	auditParams.Updated = updatedRM
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.UpdateOriginal(originalRM)
+	auditEvent.Success(ctx, updatedRM)
 
 	rsp.ResourceMapping = &policy.ResourceMapping{
 		Id: resourceMappingID,
@@ -307,14 +310,17 @@ func (s ResourceMappingService) DeleteResourceMapping(ctx context.Context,
 		ObjectType: audit.ObjectTypeResourceMapping,
 		ObjectID:   resourceMappingID,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	_, err := s.dbClient.DeleteResourceMapping(ctx, resourceMappingID)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", resourceMappingID))
 	}
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, &policy.ResourceMapping{
+		Id: resourceMappingID,
+	})
 
 	rsp.ResourceMapping = &policy.ResourceMapping{
 		Id: resourceMappingID,

--- a/service/policy/unsafe/unsafe.go
+++ b/service/policy/unsafe/unsafe.go
@@ -88,24 +88,23 @@ func (s *UnsafeService) UnsafeUpdateNamespace(ctx context.Context, req *connect.
 		ObjectType: audit.ObjectTypeNamespace,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	err := s.dbClient.RunInTx(ctx, func(txClient *policydb.PolicyDBClient) error {
 		original, err := txClient.GetNamespace(ctx, id)
 		if err != nil {
-			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 			return err
 		}
 
 		updated, err := txClient.UnsafeUpdateNamespace(ctx, id, name)
 		if err != nil {
-			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 			return err
 		}
 
-		auditParams.Original = original
-		auditParams.Updated = updated
+		auditEvent.UpdateOriginal(original)
 
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.Success(ctx, updated)
 
 		rsp.Namespace = &policy.Namespace{
 			Id: id,
@@ -130,23 +129,22 @@ func (s *UnsafeService) UnsafeReactivateNamespace(ctx context.Context, req *conn
 		ObjectType: audit.ObjectTypeNamespace,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	original, err := s.dbClient.GetNamespace(ctx, id)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	updated, err := s.dbClient.UnsafeReactivateNamespace(ctx, id)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", id))
 	}
 
-	auditParams.Original = original
-	auditParams.Updated = updated
+	auditEvent.UpdateOriginal(original)
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, updated)
 
 	rsp.Namespace = &policy.Namespace{
 		Id: id,
@@ -165,20 +163,20 @@ func (s *UnsafeService) UnsafeDeleteNamespace(ctx context.Context, req *connect.
 		ObjectType: audit.ObjectTypeNamespace,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	existing, err := s.dbClient.GetNamespace(ctx, id)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	_, err = s.dbClient.UnsafeDeleteNamespace(ctx, existing, req.Msg.GetFqn())
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", id))
 	}
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, existing)
 
 	rsp.Namespace = &policy.Namespace{
 		Id: id,
@@ -201,24 +199,23 @@ func (s *UnsafeService) UnsafeUpdateAttribute(ctx context.Context, req *connect.
 		ObjectType: audit.ObjectTypeAttributeDefinition,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	err := s.dbClient.RunInTx(ctx, func(txClient *policydb.PolicyDBClient) error {
 		original, err := txClient.GetAttribute(ctx, id)
 		if err != nil {
-			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 			return err
 		}
 
 		updated, err := txClient.UnsafeUpdateAttribute(ctx, req.Msg)
 		if err != nil {
-			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 			return err
 		}
 
-		auditParams.Original = original
-		auditParams.Updated = updated
+		auditEvent.UpdateOriginal(original)
 
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.Success(ctx, updated)
 
 		rsp.Attribute = &policy.Attribute{
 			Id: id,
@@ -243,23 +240,22 @@ func (s *UnsafeService) UnsafeReactivateAttribute(ctx context.Context, req *conn
 		ObjectType: audit.ObjectTypeAttributeDefinition,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	original, err := s.dbClient.GetAttribute(ctx, id)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	updated, err := s.dbClient.UnsafeReactivateAttribute(ctx, id)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", id))
 	}
 
-	auditParams.Original = original
-	auditParams.Updated = updated
+	auditEvent.UpdateOriginal(original)
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, updated)
 
 	rsp.Attribute = &policy.Attribute{
 		Id: id,
@@ -278,20 +274,20 @@ func (s *UnsafeService) UnsafeDeleteAttribute(ctx context.Context, req *connect.
 		ObjectType: audit.ObjectTypeAttributeDefinition,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	existing, err := s.dbClient.GetAttribute(ctx, id)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	_, err = s.dbClient.UnsafeDeleteAttribute(ctx, existing, req.Msg.GetFqn())
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", id))
 	}
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, existing)
 
 	rsp.Attribute = &policy.Attribute{
 		Id: id,
@@ -314,24 +310,23 @@ func (s *UnsafeService) UnsafeUpdateAttributeValue(ctx context.Context, req *con
 		ObjectType: audit.ObjectTypeAttributeValue,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	err := s.dbClient.RunInTx(ctx, func(txClient *policydb.PolicyDBClient) error {
 		original, err := txClient.GetAttributeValue(ctx, id)
 		if err != nil {
-			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 			return err
 		}
 
 		updated, err := txClient.UnsafeUpdateAttributeValue(ctx, req.Msg)
 		if err != nil {
-			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 			return err
 		}
 
-		auditParams.Original = original
-		auditParams.Updated = updated
+		auditEvent.UpdateOriginal(original)
 
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.Success(ctx, updated)
 
 		rsp.Value = &policy.Value{
 			Id: id,
@@ -356,23 +351,22 @@ func (s *UnsafeService) UnsafeReactivateAttributeValue(ctx context.Context, req 
 		ObjectType: audit.ObjectTypeAttributeValue,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	original, err := s.dbClient.GetAttributeValue(ctx, id)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	updated, err := s.dbClient.UnsafeReactivateAttributeValue(ctx, id)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", id))
 	}
 
-	auditParams.Original = original
-	auditParams.Updated = updated
+	auditEvent.UpdateOriginal(original)
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, updated)
 
 	rsp.Value = &policy.Value{
 		Id: id,
@@ -390,20 +384,20 @@ func (s *UnsafeService) UnsafeDeleteAttributeValue(ctx context.Context, req *con
 		ObjectType: audit.ObjectTypeAttributeValue,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	existing, err := s.dbClient.GetAttributeValue(ctx, id)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 	}
 
 	_, err = s.dbClient.UnsafeDeleteAttributeValue(ctx, existing, req.Msg)
 	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", id))
 	}
 
-	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+	auditEvent.Success(ctx, existing)
 
 	rsp.Value = &policy.Value{
 		Id: id,
@@ -421,29 +415,35 @@ func (s *UnsafeService) UnsafeDeleteKasKey(ctx context.Context, req *connect.Req
 		ObjectType: audit.ObjectTypeKasRegistryKeys,
 		ObjectID:   id,
 	}
+	auditEvent := s.logger.Audit.PolicyCRUD(ctx, auditParams)
+	defer auditEvent.Log(ctx)
 
 	err := s.dbClient.RunInTx(ctx, func(txClient *policydb.PolicyDBClient) error {
 		existing, err := txClient.GetKey(ctx, &kasregistry.GetKeyRequest_Id{Id: id})
 		if err != nil {
-			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 			return db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("id", id))
 		}
 
-		auditParams.Original = &policy.KasKey{
+		auditEvent.UpdateOriginal(&policy.KasKey{
 			KasUri: existing.GetKasUri(),
 			Key: &policy.AsymmetricKey{
 				Id:    existing.GetKey().GetId(),
 				KeyId: existing.GetKey().GetKeyId(),
 			},
-		}
+		})
 
 		_, err = txClient.UnsafeDeleteKey(ctx, existing, req.Msg)
 		if err != nil {
-			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 			return db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("id", id))
 		}
 
-		s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
+		auditEvent.Success(ctx, &policy.KasKey{
+			KasUri: existing.GetKasUri(),
+			Key: &policy.AsymmetricKey{
+				Id:    existing.GetKey().GetId(),
+				KeyId: existing.GetKey().GetKeyId(),
+			},
+		})
 		rsp.Key = &policy.KasKey{
 			KasUri: existing.GetKasUri(),
 			Key: &policy.AsymmetricKey{


### PR DESCRIPTION
### Proposed Changes

* Audit events should be added to the context stack as soon as possible in the handler, notably before the network request can be cancelled, or timeouts due to slow backend calls.
* This PR introduces new audit methods that return updateable `audit.Event` objects, which in turn have their own log method.
* To get the benefit of this feature, all existing calls to audit events must be re-written to use the new deferred log pattern:


```go
auditEvent := as.logger.Audit.[EventType](ctx, ...)
defer auditEvent.Log(ctx)

... do background work ...
auditEvent.UpdateWith(newValues...)
```

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

