### PR TITLE
chore(ci): SRE-5917 Use new gcp auth method

### DIFF
--- a/.github/workflows/traffic.yaml
+++ b/.github/workflows/traffic.yaml
@@ -2,6 +2,7 @@ on:
   schedule:
     # runs once a week on sunday
     - cron: "55 23 * * 0"
+  workflow_dispatch:
 
 permissions: {}
 
@@ -65,9 +66,6 @@ jobs:
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          token_format: "access_token"
-          create_credentials_file: false
 
       - id: "upload-file"
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0


### PR DESCRIPTION
### Proposed Changes

Removes the service account impersonation as it's no longer used. Also added manual_dispatch workflow so we can test this
as needed instead of relying on the weekly schedule

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation

### Testing Instructions

