### PR TITLE
fix: remove lingering kas info endpoint definition

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -39,7 +39,6 @@ var (
 		// KAS Public Key Endpoints
 		"/kas.AccessService/PublicKey",
 		"/kas.AccessService/LegacyPublicKey",
-		"/kas.AccessService/Info",
 		"/kas/kas_public_key",
 		"/kas/v2/kas_public_key",
 		// HealthZ

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -857,7 +857,7 @@ func (s *AuthSuite) Test_LookupGatewayPaths() {
 			header: http.Header{
 				"Grpcgateway-Origin": []string{"https://origin.com"},
 			},
-			expected: []string{"https://origin.com/wellknownconfiguration.WellKnownService/GetWellKnownConfiguration", "https://origin.com/.well-known/opentdf-configuration", "https://origin.com/kas.AccessService/PublicKey", "https://origin.com/kas.AccessService/LegacyPublicKey", "https://origin.com/kas.AccessService/Info", "https://origin.com/kas/kas_public_key", "https://origin.com/kas/v2/kas_public_key", "https://origin.com/healthz", "https://origin.com/grpc.health.v1.Health/Check"},
+			expected: []string{"https://origin.com/wellknownconfiguration.WellKnownService/GetWellKnownConfiguration", "https://origin.com/.well-known/opentdf-configuration", "https://origin.com/kas.AccessService/PublicKey", "https://origin.com/kas.AccessService/LegacyPublicKey", "https://origin.com/kas/kas_public_key", "https://origin.com/kas/v2/kas_public_key", "https://origin.com/healthz", "https://origin.com/grpc.health.v1.Health/Check"},
 		},
 		{
 			name: "Bad Path",


### PR DESCRIPTION
### Proposed Changes

* Remove `/kas.AccessService/Info` from the public allowlist so it requires authentication.

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

- `make test` (fails: rootless Docker not found)
- `cd service && go test ./internal/auth -race`
- `cd service && golangci-lint run -c ../.golangci.yaml ./internal/auth/...`
