### PR TITLE
feat(sdk): expose base key API

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -59,6 +59,14 @@ func main() {
 }
 ```
 
+## Base key
+
+The platform may publish a base KAS public key in its well-known configuration. Retrieve it via:
+
+```go
+baseKey, err := s.GetBaseKey(ctx)
+```
+
 ## Development
 
 To test, run 

--- a/sdk/basekey.go
+++ b/sdk/basekey.go
@@ -58,6 +58,12 @@ func formatAlg(alg policy.Algorithm) (string, error) {
 	}
 }
 
+// GetBaseKey retrieves the platform base KAS key from the well-known configuration.
+// The returned key material is expected to be public (algorithm, KID, PEM).
+func (s SDK) GetBaseKey(ctx context.Context) (*policy.SimpleKasKey, error) {
+	return getBaseKey(ctx, s)
+}
+
 func getBaseKey(ctx context.Context, s SDK) (*policy.SimpleKasKey, error) {
 	req := &wellknownconfiguration.GetWellKnownConfigurationRequest{}
 	response, err := s.wellknownConfiguration.GetWellKnownConfiguration(ctx, req)

--- a/sdk/basekey_test.go
+++ b/sdk/basekey_test.go
@@ -202,8 +202,8 @@ func (s *BaseKeyTestSuite) TestGetBaseKeySuccess() {
 	mockService := newMockWellKnownService(wellknownConfig, nil)
 	s.sdk.wellknownConfiguration = mockService
 
-	// Call getBaseKey
-	baseKey, err := getBaseKey(s.T().Context(), s.sdk)
+	// Call exported API
+	baseKey, err := s.sdk.GetBaseKey(s.T().Context())
 
 	// Validate result
 	s.Require().NoError(err)
@@ -221,8 +221,8 @@ func (s *BaseKeyTestSuite) TestGetBaseKeyServiceError() {
 	mockService := newMockWellKnownService(nil, errors.New("service unavailable"))
 	s.sdk.wellknownConfiguration = mockService
 
-	// Call getBaseKey
-	baseKey, err := getBaseKey(s.T().Context(), s.sdk)
+	// Call exported API
+	baseKey, err := s.sdk.GetBaseKey(s.T().Context())
 
 	// Validate result
 	s.Require().True(mockService.called)
@@ -241,8 +241,8 @@ func (s *BaseKeyTestSuite) TestGetBaseKeyMissingBaseKey() {
 	mockService := newMockWellKnownService(wellknownConfig, nil)
 	s.sdk.wellknownConfiguration = mockService
 
-	// Call getBaseKey
-	baseKey, err := getBaseKey(s.T().Context(), s.sdk)
+	// Call exported API
+	baseKey, err := s.sdk.GetBaseKey(s.T().Context())
 
 	// Validate result
 	s.Require().True(mockService.called)
@@ -259,8 +259,8 @@ func (s *BaseKeyTestSuite) TestGetBaseKeyInvalidBaseKeyFormat() {
 	mockService := newMockWellKnownService(wellknownConfig, nil)
 	s.sdk.wellknownConfiguration = mockService
 
-	// Call getBaseKey
-	baseKey, err := getBaseKey(s.T().Context(), s.sdk)
+	// Call exported API
+	baseKey, err := s.sdk.GetBaseKey(s.T().Context())
 
 	// Validate result
 	s.Require().True(mockService.called)
@@ -278,8 +278,8 @@ func (s *BaseKeyTestSuite) TestGetBaseKeyEmptyBaseKey() {
 	mockService := newMockWellKnownService(wellknownConfig, nil)
 	s.sdk.wellknownConfiguration = mockService
 
-	// Call getBaseKey
-	baseKey, err := getBaseKey(s.T().Context(), s.sdk)
+	// Call exported API
+	baseKey, err := s.sdk.GetBaseKey(s.T().Context())
 
 	// Validate result
 	s.Require().True(mockService.called)
@@ -300,8 +300,8 @@ func (s *BaseKeyTestSuite) TestGetBaseKeyMissingPublicKey() {
 	mockService := newMockWellKnownService(wellknownConfig, nil)
 	s.sdk.wellknownConfiguration = mockService
 
-	// Call getBaseKey
-	baseKey, err := getBaseKey(s.T().Context(), s.sdk)
+	// Call exported API
+	baseKey, err := s.sdk.GetBaseKey(s.T().Context())
 
 	// Validate result
 	s.Require().True(mockService.called)
@@ -322,8 +322,8 @@ func (s *BaseKeyTestSuite) TestGetBaseKeyInvalidPublicKey() {
 	mockService := newMockWellKnownService(wellknownConfig, nil)
 	s.sdk.wellknownConfiguration = mockService
 
-	// Call getBaseKey
-	baseKey, err := getBaseKey(s.T().Context(), s.sdk)
+	// Call exported API
+	baseKey, err := s.sdk.GetBaseKey(s.T().Context())
 
 	// Validate result
 	s.Require().True(mockService.called)

--- a/sdk/nanotdf.go
+++ b/sdk/nanotdf.go
@@ -1190,7 +1190,7 @@ func updateConfigWithBaseKey(ki *KASInfo, config *NanoTDFConfig) error {
 }
 
 func getNanoKasInfoFromBaseKey(s *SDK) (*KASInfo, error) {
-	baseKey, err := getBaseKey(context.Background(), *s)
+	baseKey, err := s.GetBaseKey(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -393,7 +393,7 @@ func (tdfConfig *TDFConfig) initKAOTemplate(ctx context.Context, s SDK) error {
 			tdfConfig.splitPlan, err = g.plan(make([]string, 0), uuidSplitIDGenerator)
 		case noKeysFound:
 			var baseKey *policy.SimpleKasKey
-			baseKey, err = getBaseKeyFromWellKnown(ctx, s)
+			baseKey, err = s.GetBaseKey(ctx)
 			if err == nil {
 				err = populateKasInfoFromBaseKey(baseKey, tdfConfig)
 			} else {
@@ -1471,15 +1471,6 @@ func isLessThanSemver(version, target string) (bool, error) {
 	}
 	// Check if the provided version is less than the target version based on semantic versioning rules.
 	return v1.LessThan(v2), nil
-}
-
-func getBaseKeyFromWellKnown(ctx context.Context, s SDK) (*policy.SimpleKasKey, error) {
-	key, err := getBaseKey(ctx, s)
-	if err != nil {
-		return nil, err
-	}
-
-	return key, nil
 }
 
 func populateKasInfoFromBaseKey(key *policy.SimpleKasKey, tdfConfig *TDFConfig) error {


### PR DESCRIPTION
### Proposed Changes

* Add SDK.GetBaseKey(ctx) to retrieve the platform base KAS public key from well-known configuration.
* Refactor internal TDF/NanoTDF base-key consumers to use the exported API; update tests/docs.

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation

### Testing Instructions

- `cd sdk && go list ./... | rg -v '^github.com/opentdf/platform/sdk/auth/oauth$' | xargs go test -race`
- `cd sdk && golangci-lint run -c ../.golangci.yaml --new-from-rev=main`

Note: `cd sdk && go test ./... -race` fails locally because `sdk/auth/oauth` requires Docker/testcontainers.