### PR TITLE
fix: Connect RPC v1.19.1 

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -21,7 +21,7 @@ plugins:
   - remote: buf.build/grpc/go:v1.3.0
     out: protocol/go
     opt: paths=source_relative
-  - remote: buf.build/connectrpc/go:v1.17.0
+  - remote: buf.build/connectrpc/go:v1.19.1
     out: protocol/go
     opt:
       - paths=source_relative

--- a/protocol/go/authorization/authorizationconnect/authorization.connect.go
+++ b/protocol/go/authorization/authorizationconnect/authorization.connect.go
@@ -44,14 +44,6 @@ const (
 	AuthorizationServiceGetEntitlementsProcedure = "/authorization.AuthorizationService/GetEntitlements"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	authorizationServiceServiceDescriptor                   = authorization.File_authorization_authorization_proto.Services().ByName("AuthorizationService")
-	authorizationServiceGetDecisionsMethodDescriptor        = authorizationServiceServiceDescriptor.Methods().ByName("GetDecisions")
-	authorizationServiceGetDecisionsByTokenMethodDescriptor = authorizationServiceServiceDescriptor.Methods().ByName("GetDecisionsByToken")
-	authorizationServiceGetEntitlementsMethodDescriptor     = authorizationServiceServiceDescriptor.Methods().ByName("GetEntitlements")
-)
-
 // AuthorizationServiceClient is a client for the authorization.AuthorizationService service.
 type AuthorizationServiceClient interface {
 	GetDecisions(context.Context, *connect.Request[authorization.GetDecisionsRequest]) (*connect.Response[authorization.GetDecisionsResponse], error)
@@ -68,23 +60,24 @@ type AuthorizationServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewAuthorizationServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) AuthorizationServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	authorizationServiceMethods := authorization.File_authorization_authorization_proto.Services().ByName("AuthorizationService").Methods()
 	return &authorizationServiceClient{
 		getDecisions: connect.NewClient[authorization.GetDecisionsRequest, authorization.GetDecisionsResponse](
 			httpClient,
 			baseURL+AuthorizationServiceGetDecisionsProcedure,
-			connect.WithSchema(authorizationServiceGetDecisionsMethodDescriptor),
+			connect.WithSchema(authorizationServiceMethods.ByName("GetDecisions")),
 			connect.WithClientOptions(opts...),
 		),
 		getDecisionsByToken: connect.NewClient[authorization.GetDecisionsByTokenRequest, authorization.GetDecisionsByTokenResponse](
 			httpClient,
 			baseURL+AuthorizationServiceGetDecisionsByTokenProcedure,
-			connect.WithSchema(authorizationServiceGetDecisionsByTokenMethodDescriptor),
+			connect.WithSchema(authorizationServiceMethods.ByName("GetDecisionsByToken")),
 			connect.WithClientOptions(opts...),
 		),
 		getEntitlements: connect.NewClient[authorization.GetEntitlementsRequest, authorization.GetEntitlementsResponse](
 			httpClient,
 			baseURL+AuthorizationServiceGetEntitlementsProcedure,
-			connect.WithSchema(authorizationServiceGetEntitlementsMethodDescriptor),
+			connect.WithSchema(authorizationServiceMethods.ByName("GetEntitlements")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -126,22 +119,23 @@ type AuthorizationServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewAuthorizationServiceHandler(svc AuthorizationServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	authorizationServiceMethods := authorization.File_authorization_authorization_proto.Services().ByName("AuthorizationService").Methods()
 	authorizationServiceGetDecisionsHandler := connect.NewUnaryHandler(
 		AuthorizationServiceGetDecisionsProcedure,
 		svc.GetDecisions,
-		connect.WithSchema(authorizationServiceGetDecisionsMethodDescriptor),
+		connect.WithSchema(authorizationServiceMethods.ByName("GetDecisions")),
 		connect.WithHandlerOptions(opts...),
 	)
 	authorizationServiceGetDecisionsByTokenHandler := connect.NewUnaryHandler(
 		AuthorizationServiceGetDecisionsByTokenProcedure,
 		svc.GetDecisionsByToken,
-		connect.WithSchema(authorizationServiceGetDecisionsByTokenMethodDescriptor),
+		connect.WithSchema(authorizationServiceMethods.ByName("GetDecisionsByToken")),
 		connect.WithHandlerOptions(opts...),
 	)
 	authorizationServiceGetEntitlementsHandler := connect.NewUnaryHandler(
 		AuthorizationServiceGetEntitlementsProcedure,
 		svc.GetEntitlements,
-		connect.WithSchema(authorizationServiceGetEntitlementsMethodDescriptor),
+		connect.WithSchema(authorizationServiceMethods.ByName("GetEntitlements")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/authorization.AuthorizationService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/authorization/v2/authorizationv2connect/authorization.connect.go
+++ b/protocol/go/authorization/v2/authorizationv2connect/authorization.connect.go
@@ -47,15 +47,6 @@ const (
 	AuthorizationServiceGetEntitlementsProcedure = "/authorization.v2.AuthorizationService/GetEntitlements"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	authorizationServiceServiceDescriptor                        = v2.File_authorization_v2_authorization_proto.Services().ByName("AuthorizationService")
-	authorizationServiceGetDecisionMethodDescriptor              = authorizationServiceServiceDescriptor.Methods().ByName("GetDecision")
-	authorizationServiceGetDecisionMultiResourceMethodDescriptor = authorizationServiceServiceDescriptor.Methods().ByName("GetDecisionMultiResource")
-	authorizationServiceGetDecisionBulkMethodDescriptor          = authorizationServiceServiceDescriptor.Methods().ByName("GetDecisionBulk")
-	authorizationServiceGetEntitlementsMethodDescriptor          = authorizationServiceServiceDescriptor.Methods().ByName("GetEntitlements")
-)
-
 // AuthorizationServiceClient is a client for the authorization.v2.AuthorizationService service.
 type AuthorizationServiceClient interface {
 	GetDecision(context.Context, *connect.Request[v2.GetDecisionRequest]) (*connect.Response[v2.GetDecisionResponse], error)
@@ -73,29 +64,30 @@ type AuthorizationServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewAuthorizationServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) AuthorizationServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	authorizationServiceMethods := v2.File_authorization_v2_authorization_proto.Services().ByName("AuthorizationService").Methods()
 	return &authorizationServiceClient{
 		getDecision: connect.NewClient[v2.GetDecisionRequest, v2.GetDecisionResponse](
 			httpClient,
 			baseURL+AuthorizationServiceGetDecisionProcedure,
-			connect.WithSchema(authorizationServiceGetDecisionMethodDescriptor),
+			connect.WithSchema(authorizationServiceMethods.ByName("GetDecision")),
 			connect.WithClientOptions(opts...),
 		),
 		getDecisionMultiResource: connect.NewClient[v2.GetDecisionMultiResourceRequest, v2.GetDecisionMultiResourceResponse](
 			httpClient,
 			baseURL+AuthorizationServiceGetDecisionMultiResourceProcedure,
-			connect.WithSchema(authorizationServiceGetDecisionMultiResourceMethodDescriptor),
+			connect.WithSchema(authorizationServiceMethods.ByName("GetDecisionMultiResource")),
 			connect.WithClientOptions(opts...),
 		),
 		getDecisionBulk: connect.NewClient[v2.GetDecisionBulkRequest, v2.GetDecisionBulkResponse](
 			httpClient,
 			baseURL+AuthorizationServiceGetDecisionBulkProcedure,
-			connect.WithSchema(authorizationServiceGetDecisionBulkMethodDescriptor),
+			connect.WithSchema(authorizationServiceMethods.ByName("GetDecisionBulk")),
 			connect.WithClientOptions(opts...),
 		),
 		getEntitlements: connect.NewClient[v2.GetEntitlementsRequest, v2.GetEntitlementsResponse](
 			httpClient,
 			baseURL+AuthorizationServiceGetEntitlementsProcedure,
-			connect.WithSchema(authorizationServiceGetEntitlementsMethodDescriptor),
+			connect.WithSchema(authorizationServiceMethods.ByName("GetEntitlements")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -144,28 +136,29 @@ type AuthorizationServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewAuthorizationServiceHandler(svc AuthorizationServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	authorizationServiceMethods := v2.File_authorization_v2_authorization_proto.Services().ByName("AuthorizationService").Methods()
 	authorizationServiceGetDecisionHandler := connect.NewUnaryHandler(
 		AuthorizationServiceGetDecisionProcedure,
 		svc.GetDecision,
-		connect.WithSchema(authorizationServiceGetDecisionMethodDescriptor),
+		connect.WithSchema(authorizationServiceMethods.ByName("GetDecision")),
 		connect.WithHandlerOptions(opts...),
 	)
 	authorizationServiceGetDecisionMultiResourceHandler := connect.NewUnaryHandler(
 		AuthorizationServiceGetDecisionMultiResourceProcedure,
 		svc.GetDecisionMultiResource,
-		connect.WithSchema(authorizationServiceGetDecisionMultiResourceMethodDescriptor),
+		connect.WithSchema(authorizationServiceMethods.ByName("GetDecisionMultiResource")),
 		connect.WithHandlerOptions(opts...),
 	)
 	authorizationServiceGetDecisionBulkHandler := connect.NewUnaryHandler(
 		AuthorizationServiceGetDecisionBulkProcedure,
 		svc.GetDecisionBulk,
-		connect.WithSchema(authorizationServiceGetDecisionBulkMethodDescriptor),
+		connect.WithSchema(authorizationServiceMethods.ByName("GetDecisionBulk")),
 		connect.WithHandlerOptions(opts...),
 	)
 	authorizationServiceGetEntitlementsHandler := connect.NewUnaryHandler(
 		AuthorizationServiceGetEntitlementsProcedure,
 		svc.GetEntitlements,
-		connect.WithSchema(authorizationServiceGetEntitlementsMethodDescriptor),
+		connect.WithSchema(authorizationServiceMethods.ByName("GetEntitlements")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/authorization.v2.AuthorizationService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/entityresolution/entityresolutionconnect/entity_resolution.connect.go
+++ b/protocol/go/entityresolution/entityresolutionconnect/entity_resolution.connect.go
@@ -41,13 +41,6 @@ const (
 	EntityResolutionServiceCreateEntityChainFromJwtProcedure = "/entityresolution.EntityResolutionService/CreateEntityChainFromJwt"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	entityResolutionServiceServiceDescriptor                        = entityresolution.File_entityresolution_entity_resolution_proto.Services().ByName("EntityResolutionService")
-	entityResolutionServiceResolveEntitiesMethodDescriptor          = entityResolutionServiceServiceDescriptor.Methods().ByName("ResolveEntities")
-	entityResolutionServiceCreateEntityChainFromJwtMethodDescriptor = entityResolutionServiceServiceDescriptor.Methods().ByName("CreateEntityChainFromJwt")
-)
-
 // EntityResolutionServiceClient is a client for the entityresolution.EntityResolutionService
 // service.
 type EntityResolutionServiceClient interface {
@@ -66,17 +59,18 @@ type EntityResolutionServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewEntityResolutionServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) EntityResolutionServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	entityResolutionServiceMethods := entityresolution.File_entityresolution_entity_resolution_proto.Services().ByName("EntityResolutionService").Methods()
 	return &entityResolutionServiceClient{
 		resolveEntities: connect.NewClient[entityresolution.ResolveEntitiesRequest, entityresolution.ResolveEntitiesResponse](
 			httpClient,
 			baseURL+EntityResolutionServiceResolveEntitiesProcedure,
-			connect.WithSchema(entityResolutionServiceResolveEntitiesMethodDescriptor),
+			connect.WithSchema(entityResolutionServiceMethods.ByName("ResolveEntities")),
 			connect.WithClientOptions(opts...),
 		),
 		createEntityChainFromJwt: connect.NewClient[entityresolution.CreateEntityChainFromJwtRequest, entityresolution.CreateEntityChainFromJwtResponse](
 			httpClient,
 			baseURL+EntityResolutionServiceCreateEntityChainFromJwtProcedure,
-			connect.WithSchema(entityResolutionServiceCreateEntityChainFromJwtMethodDescriptor),
+			connect.WithSchema(entityResolutionServiceMethods.ByName("CreateEntityChainFromJwt")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -113,16 +107,17 @@ type EntityResolutionServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewEntityResolutionServiceHandler(svc EntityResolutionServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	entityResolutionServiceMethods := entityresolution.File_entityresolution_entity_resolution_proto.Services().ByName("EntityResolutionService").Methods()
 	entityResolutionServiceResolveEntitiesHandler := connect.NewUnaryHandler(
 		EntityResolutionServiceResolveEntitiesProcedure,
 		svc.ResolveEntities,
-		connect.WithSchema(entityResolutionServiceResolveEntitiesMethodDescriptor),
+		connect.WithSchema(entityResolutionServiceMethods.ByName("ResolveEntities")),
 		connect.WithHandlerOptions(opts...),
 	)
 	entityResolutionServiceCreateEntityChainFromJwtHandler := connect.NewUnaryHandler(
 		EntityResolutionServiceCreateEntityChainFromJwtProcedure,
 		svc.CreateEntityChainFromJwt,
-		connect.WithSchema(entityResolutionServiceCreateEntityChainFromJwtMethodDescriptor),
+		connect.WithSchema(entityResolutionServiceMethods.ByName("CreateEntityChainFromJwt")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/entityresolution.EntityResolutionService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/entityresolution/v2/entityresolutionv2connect/entity_resolution.connect.go
+++ b/protocol/go/entityresolution/v2/entityresolutionv2connect/entity_resolution.connect.go
@@ -41,13 +41,6 @@ const (
 	EntityResolutionServiceCreateEntityChainsFromTokensProcedure = "/entityresolution.v2.EntityResolutionService/CreateEntityChainsFromTokens"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	entityResolutionServiceServiceDescriptor                            = v2.File_entityresolution_v2_entity_resolution_proto.Services().ByName("EntityResolutionService")
-	entityResolutionServiceResolveEntitiesMethodDescriptor              = entityResolutionServiceServiceDescriptor.Methods().ByName("ResolveEntities")
-	entityResolutionServiceCreateEntityChainsFromTokensMethodDescriptor = entityResolutionServiceServiceDescriptor.Methods().ByName("CreateEntityChainsFromTokens")
-)
-
 // EntityResolutionServiceClient is a client for the entityresolution.v2.EntityResolutionService
 // service.
 type EntityResolutionServiceClient interface {
@@ -65,17 +58,18 @@ type EntityResolutionServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewEntityResolutionServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) EntityResolutionServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	entityResolutionServiceMethods := v2.File_entityresolution_v2_entity_resolution_proto.Services().ByName("EntityResolutionService").Methods()
 	return &entityResolutionServiceClient{
 		resolveEntities: connect.NewClient[v2.ResolveEntitiesRequest, v2.ResolveEntitiesResponse](
 			httpClient,
 			baseURL+EntityResolutionServiceResolveEntitiesProcedure,
-			connect.WithSchema(entityResolutionServiceResolveEntitiesMethodDescriptor),
+			connect.WithSchema(entityResolutionServiceMethods.ByName("ResolveEntities")),
 			connect.WithClientOptions(opts...),
 		),
 		createEntityChainsFromTokens: connect.NewClient[v2.CreateEntityChainsFromTokensRequest, v2.CreateEntityChainsFromTokensResponse](
 			httpClient,
 			baseURL+EntityResolutionServiceCreateEntityChainsFromTokensProcedure,
-			connect.WithSchema(entityResolutionServiceCreateEntityChainsFromTokensMethodDescriptor),
+			connect.WithSchema(entityResolutionServiceMethods.ByName("CreateEntityChainsFromTokens")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -111,16 +105,17 @@ type EntityResolutionServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewEntityResolutionServiceHandler(svc EntityResolutionServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	entityResolutionServiceMethods := v2.File_entityresolution_v2_entity_resolution_proto.Services().ByName("EntityResolutionService").Methods()
 	entityResolutionServiceResolveEntitiesHandler := connect.NewUnaryHandler(
 		EntityResolutionServiceResolveEntitiesProcedure,
 		svc.ResolveEntities,
-		connect.WithSchema(entityResolutionServiceResolveEntitiesMethodDescriptor),
+		connect.WithSchema(entityResolutionServiceMethods.ByName("ResolveEntities")),
 		connect.WithHandlerOptions(opts...),
 	)
 	entityResolutionServiceCreateEntityChainsFromTokensHandler := connect.NewUnaryHandler(
 		EntityResolutionServiceCreateEntityChainsFromTokensProcedure,
 		svc.CreateEntityChainsFromTokens,
-		connect.WithSchema(entityResolutionServiceCreateEntityChainsFromTokensMethodDescriptor),
+		connect.WithSchema(entityResolutionServiceMethods.ByName("CreateEntityChainsFromTokens")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/entityresolution.v2.EntityResolutionService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/go.mod
+++ b/protocol/go/go.mod
@@ -6,11 +6,11 @@ toolchain go1.24.11
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1
-	connectrpc.com/connect v1.17.0
+	connectrpc.com/connect v1.19.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9
 	google.golang.org/grpc v1.67.1
-	google.golang.org/protobuf v1.36.6
+	google.golang.org/protobuf v1.36.9
 )
 
 require (

--- a/protocol/go/go.sum
+++ b/protocol/go/go.sum
@@ -1,7 +1,7 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1 h1:LEXWFH/xZ5oOWrC3oOtHbUyBdzRWMCPpAQmKC9v05mA=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1/go.mod h1:XF+P8+RmfdufmIYpGUC+6bF7S+IlmHDEnCrO3OXaUAQ=
-connectrpc.com/connect v1.17.0 h1:W0ZqMhtVzn9Zhn2yATuUokDLO5N+gIuBWMOnsQrfmZk=
-connectrpc.com/connect v1.17.0/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
+connectrpc.com/connect v1.19.1 h1:R5M57z05+90EfEvCY1b7hBxDVOUl45PrtXtAV2fOC14=
+connectrpc.com/connect v1.19.1/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -23,5 +23,5 @@ google.golang.org/grpc v1.67.1 h1:zWnc1Vrcno+lHZCOofnIMvycFcc0QRGIzm9dhnDX68E=
 google.golang.org/grpc v1.67.1/go.mod h1:1gLDyUQU7CTLJI90u3nXZ9ekeghjeM7pTDZlqFNg2AA=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
-google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
+google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=

--- a/protocol/go/policy/actions/actionsconnect/actions.connect.go
+++ b/protocol/go/policy/actions/actionsconnect/actions.connect.go
@@ -49,16 +49,6 @@ const (
 	ActionServiceDeleteActionProcedure = "/policy.actions.ActionService/DeleteAction"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	actionServiceServiceDescriptor            = actions.File_policy_actions_actions_proto.Services().ByName("ActionService")
-	actionServiceGetActionMethodDescriptor    = actionServiceServiceDescriptor.Methods().ByName("GetAction")
-	actionServiceListActionsMethodDescriptor  = actionServiceServiceDescriptor.Methods().ByName("ListActions")
-	actionServiceCreateActionMethodDescriptor = actionServiceServiceDescriptor.Methods().ByName("CreateAction")
-	actionServiceUpdateActionMethodDescriptor = actionServiceServiceDescriptor.Methods().ByName("UpdateAction")
-	actionServiceDeleteActionMethodDescriptor = actionServiceServiceDescriptor.Methods().ByName("DeleteAction")
-)
-
 // ActionServiceClient is a client for the policy.actions.ActionService service.
 type ActionServiceClient interface {
 	GetAction(context.Context, *connect.Request[actions.GetActionRequest]) (*connect.Response[actions.GetActionResponse], error)
@@ -77,35 +67,36 @@ type ActionServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewActionServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) ActionServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	actionServiceMethods := actions.File_policy_actions_actions_proto.Services().ByName("ActionService").Methods()
 	return &actionServiceClient{
 		getAction: connect.NewClient[actions.GetActionRequest, actions.GetActionResponse](
 			httpClient,
 			baseURL+ActionServiceGetActionProcedure,
-			connect.WithSchema(actionServiceGetActionMethodDescriptor),
+			connect.WithSchema(actionServiceMethods.ByName("GetAction")),
 			connect.WithClientOptions(opts...),
 		),
 		listActions: connect.NewClient[actions.ListActionsRequest, actions.ListActionsResponse](
 			httpClient,
 			baseURL+ActionServiceListActionsProcedure,
-			connect.WithSchema(actionServiceListActionsMethodDescriptor),
+			connect.WithSchema(actionServiceMethods.ByName("ListActions")),
 			connect.WithClientOptions(opts...),
 		),
 		createAction: connect.NewClient[actions.CreateActionRequest, actions.CreateActionResponse](
 			httpClient,
 			baseURL+ActionServiceCreateActionProcedure,
-			connect.WithSchema(actionServiceCreateActionMethodDescriptor),
+			connect.WithSchema(actionServiceMethods.ByName("CreateAction")),
 			connect.WithClientOptions(opts...),
 		),
 		updateAction: connect.NewClient[actions.UpdateActionRequest, actions.UpdateActionResponse](
 			httpClient,
 			baseURL+ActionServiceUpdateActionProcedure,
-			connect.WithSchema(actionServiceUpdateActionMethodDescriptor),
+			connect.WithSchema(actionServiceMethods.ByName("UpdateAction")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteAction: connect.NewClient[actions.DeleteActionRequest, actions.DeleteActionResponse](
 			httpClient,
 			baseURL+ActionServiceDeleteActionProcedure,
-			connect.WithSchema(actionServiceDeleteActionMethodDescriptor),
+			connect.WithSchema(actionServiceMethods.ByName("DeleteAction")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -160,34 +151,35 @@ type ActionServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewActionServiceHandler(svc ActionServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	actionServiceMethods := actions.File_policy_actions_actions_proto.Services().ByName("ActionService").Methods()
 	actionServiceGetActionHandler := connect.NewUnaryHandler(
 		ActionServiceGetActionProcedure,
 		svc.GetAction,
-		connect.WithSchema(actionServiceGetActionMethodDescriptor),
+		connect.WithSchema(actionServiceMethods.ByName("GetAction")),
 		connect.WithHandlerOptions(opts...),
 	)
 	actionServiceListActionsHandler := connect.NewUnaryHandler(
 		ActionServiceListActionsProcedure,
 		svc.ListActions,
-		connect.WithSchema(actionServiceListActionsMethodDescriptor),
+		connect.WithSchema(actionServiceMethods.ByName("ListActions")),
 		connect.WithHandlerOptions(opts...),
 	)
 	actionServiceCreateActionHandler := connect.NewUnaryHandler(
 		ActionServiceCreateActionProcedure,
 		svc.CreateAction,
-		connect.WithSchema(actionServiceCreateActionMethodDescriptor),
+		connect.WithSchema(actionServiceMethods.ByName("CreateAction")),
 		connect.WithHandlerOptions(opts...),
 	)
 	actionServiceUpdateActionHandler := connect.NewUnaryHandler(
 		ActionServiceUpdateActionProcedure,
 		svc.UpdateAction,
-		connect.WithSchema(actionServiceUpdateActionMethodDescriptor),
+		connect.WithSchema(actionServiceMethods.ByName("UpdateAction")),
 		connect.WithHandlerOptions(opts...),
 	)
 	actionServiceDeleteActionHandler := connect.NewUnaryHandler(
 		ActionServiceDeleteActionProcedure,
 		svc.DeleteAction,
-		connect.WithSchema(actionServiceDeleteActionMethodDescriptor),
+		connect.WithSchema(actionServiceMethods.ByName("DeleteAction")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/policy.actions.ActionService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/policy/attributes/attributesconnect/attributes.connect.go
+++ b/protocol/go/policy/attributes/attributesconnect/attributes.connect.go
@@ -92,30 +92,6 @@ const (
 	AttributesServiceRemovePublicKeyFromValueProcedure = "/policy.attributes.AttributesService/RemovePublicKeyFromValue"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	attributesServiceServiceDescriptor                                  = attributes.File_policy_attributes_attributes_proto.Services().ByName("AttributesService")
-	attributesServiceListAttributesMethodDescriptor                     = attributesServiceServiceDescriptor.Methods().ByName("ListAttributes")
-	attributesServiceListAttributeValuesMethodDescriptor                = attributesServiceServiceDescriptor.Methods().ByName("ListAttributeValues")
-	attributesServiceGetAttributeMethodDescriptor                       = attributesServiceServiceDescriptor.Methods().ByName("GetAttribute")
-	attributesServiceGetAttributeValuesByFqnsMethodDescriptor           = attributesServiceServiceDescriptor.Methods().ByName("GetAttributeValuesByFqns")
-	attributesServiceCreateAttributeMethodDescriptor                    = attributesServiceServiceDescriptor.Methods().ByName("CreateAttribute")
-	attributesServiceUpdateAttributeMethodDescriptor                    = attributesServiceServiceDescriptor.Methods().ByName("UpdateAttribute")
-	attributesServiceDeactivateAttributeMethodDescriptor                = attributesServiceServiceDescriptor.Methods().ByName("DeactivateAttribute")
-	attributesServiceGetAttributeValueMethodDescriptor                  = attributesServiceServiceDescriptor.Methods().ByName("GetAttributeValue")
-	attributesServiceCreateAttributeValueMethodDescriptor               = attributesServiceServiceDescriptor.Methods().ByName("CreateAttributeValue")
-	attributesServiceUpdateAttributeValueMethodDescriptor               = attributesServiceServiceDescriptor.Methods().ByName("UpdateAttributeValue")
-	attributesServiceDeactivateAttributeValueMethodDescriptor           = attributesServiceServiceDescriptor.Methods().ByName("DeactivateAttributeValue")
-	attributesServiceAssignKeyAccessServerToAttributeMethodDescriptor   = attributesServiceServiceDescriptor.Methods().ByName("AssignKeyAccessServerToAttribute")
-	attributesServiceRemoveKeyAccessServerFromAttributeMethodDescriptor = attributesServiceServiceDescriptor.Methods().ByName("RemoveKeyAccessServerFromAttribute")
-	attributesServiceAssignKeyAccessServerToValueMethodDescriptor       = attributesServiceServiceDescriptor.Methods().ByName("AssignKeyAccessServerToValue")
-	attributesServiceRemoveKeyAccessServerFromValueMethodDescriptor     = attributesServiceServiceDescriptor.Methods().ByName("RemoveKeyAccessServerFromValue")
-	attributesServiceAssignPublicKeyToAttributeMethodDescriptor         = attributesServiceServiceDescriptor.Methods().ByName("AssignPublicKeyToAttribute")
-	attributesServiceRemovePublicKeyFromAttributeMethodDescriptor       = attributesServiceServiceDescriptor.Methods().ByName("RemovePublicKeyFromAttribute")
-	attributesServiceAssignPublicKeyToValueMethodDescriptor             = attributesServiceServiceDescriptor.Methods().ByName("AssignPublicKeyToValue")
-	attributesServiceRemovePublicKeyFromValueMethodDescriptor           = attributesServiceServiceDescriptor.Methods().ByName("RemovePublicKeyFromValue")
-)
-
 // AttributesServiceClient is a client for the policy.attributes.AttributesService service.
 type AttributesServiceClient interface {
 	// --------------------------------------*
@@ -166,124 +142,125 @@ type AttributesServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewAttributesServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) AttributesServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	attributesServiceMethods := attributes.File_policy_attributes_attributes_proto.Services().ByName("AttributesService").Methods()
 	return &attributesServiceClient{
 		listAttributes: connect.NewClient[attributes.ListAttributesRequest, attributes.ListAttributesResponse](
 			httpClient,
 			baseURL+AttributesServiceListAttributesProcedure,
-			connect.WithSchema(attributesServiceListAttributesMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("ListAttributes")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		listAttributeValues: connect.NewClient[attributes.ListAttributeValuesRequest, attributes.ListAttributeValuesResponse](
 			httpClient,
 			baseURL+AttributesServiceListAttributeValuesProcedure,
-			connect.WithSchema(attributesServiceListAttributeValuesMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("ListAttributeValues")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		getAttribute: connect.NewClient[attributes.GetAttributeRequest, attributes.GetAttributeResponse](
 			httpClient,
 			baseURL+AttributesServiceGetAttributeProcedure,
-			connect.WithSchema(attributesServiceGetAttributeMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("GetAttribute")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		getAttributeValuesByFqns: connect.NewClient[attributes.GetAttributeValuesByFqnsRequest, attributes.GetAttributeValuesByFqnsResponse](
 			httpClient,
 			baseURL+AttributesServiceGetAttributeValuesByFqnsProcedure,
-			connect.WithSchema(attributesServiceGetAttributeValuesByFqnsMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("GetAttributeValuesByFqns")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		createAttribute: connect.NewClient[attributes.CreateAttributeRequest, attributes.CreateAttributeResponse](
 			httpClient,
 			baseURL+AttributesServiceCreateAttributeProcedure,
-			connect.WithSchema(attributesServiceCreateAttributeMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("CreateAttribute")),
 			connect.WithClientOptions(opts...),
 		),
 		updateAttribute: connect.NewClient[attributes.UpdateAttributeRequest, attributes.UpdateAttributeResponse](
 			httpClient,
 			baseURL+AttributesServiceUpdateAttributeProcedure,
-			connect.WithSchema(attributesServiceUpdateAttributeMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("UpdateAttribute")),
 			connect.WithClientOptions(opts...),
 		),
 		deactivateAttribute: connect.NewClient[attributes.DeactivateAttributeRequest, attributes.DeactivateAttributeResponse](
 			httpClient,
 			baseURL+AttributesServiceDeactivateAttributeProcedure,
-			connect.WithSchema(attributesServiceDeactivateAttributeMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("DeactivateAttribute")),
 			connect.WithClientOptions(opts...),
 		),
 		getAttributeValue: connect.NewClient[attributes.GetAttributeValueRequest, attributes.GetAttributeValueResponse](
 			httpClient,
 			baseURL+AttributesServiceGetAttributeValueProcedure,
-			connect.WithSchema(attributesServiceGetAttributeValueMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("GetAttributeValue")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		createAttributeValue: connect.NewClient[attributes.CreateAttributeValueRequest, attributes.CreateAttributeValueResponse](
 			httpClient,
 			baseURL+AttributesServiceCreateAttributeValueProcedure,
-			connect.WithSchema(attributesServiceCreateAttributeValueMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("CreateAttributeValue")),
 			connect.WithClientOptions(opts...),
 		),
 		updateAttributeValue: connect.NewClient[attributes.UpdateAttributeValueRequest, attributes.UpdateAttributeValueResponse](
 			httpClient,
 			baseURL+AttributesServiceUpdateAttributeValueProcedure,
-			connect.WithSchema(attributesServiceUpdateAttributeValueMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("UpdateAttributeValue")),
 			connect.WithClientOptions(opts...),
 		),
 		deactivateAttributeValue: connect.NewClient[attributes.DeactivateAttributeValueRequest, attributes.DeactivateAttributeValueResponse](
 			httpClient,
 			baseURL+AttributesServiceDeactivateAttributeValueProcedure,
-			connect.WithSchema(attributesServiceDeactivateAttributeValueMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("DeactivateAttributeValue")),
 			connect.WithClientOptions(opts...),
 		),
 		assignKeyAccessServerToAttribute: connect.NewClient[attributes.AssignKeyAccessServerToAttributeRequest, attributes.AssignKeyAccessServerToAttributeResponse](
 			httpClient,
 			baseURL+AttributesServiceAssignKeyAccessServerToAttributeProcedure,
-			connect.WithSchema(attributesServiceAssignKeyAccessServerToAttributeMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("AssignKeyAccessServerToAttribute")),
 			connect.WithClientOptions(opts...),
 		),
 		removeKeyAccessServerFromAttribute: connect.NewClient[attributes.RemoveKeyAccessServerFromAttributeRequest, attributes.RemoveKeyAccessServerFromAttributeResponse](
 			httpClient,
 			baseURL+AttributesServiceRemoveKeyAccessServerFromAttributeProcedure,
-			connect.WithSchema(attributesServiceRemoveKeyAccessServerFromAttributeMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("RemoveKeyAccessServerFromAttribute")),
 			connect.WithClientOptions(opts...),
 		),
 		assignKeyAccessServerToValue: connect.NewClient[attributes.AssignKeyAccessServerToValueRequest, attributes.AssignKeyAccessServerToValueResponse](
 			httpClient,
 			baseURL+AttributesServiceAssignKeyAccessServerToValueProcedure,
-			connect.WithSchema(attributesServiceAssignKeyAccessServerToValueMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("AssignKeyAccessServerToValue")),
 			connect.WithClientOptions(opts...),
 		),
 		removeKeyAccessServerFromValue: connect.NewClient[attributes.RemoveKeyAccessServerFromValueRequest, attributes.RemoveKeyAccessServerFromValueResponse](
 			httpClient,
 			baseURL+AttributesServiceRemoveKeyAccessServerFromValueProcedure,
-			connect.WithSchema(attributesServiceRemoveKeyAccessServerFromValueMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("RemoveKeyAccessServerFromValue")),
 			connect.WithClientOptions(opts...),
 		),
 		assignPublicKeyToAttribute: connect.NewClient[attributes.AssignPublicKeyToAttributeRequest, attributes.AssignPublicKeyToAttributeResponse](
 			httpClient,
 			baseURL+AttributesServiceAssignPublicKeyToAttributeProcedure,
-			connect.WithSchema(attributesServiceAssignPublicKeyToAttributeMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("AssignPublicKeyToAttribute")),
 			connect.WithClientOptions(opts...),
 		),
 		removePublicKeyFromAttribute: connect.NewClient[attributes.RemovePublicKeyFromAttributeRequest, attributes.RemovePublicKeyFromAttributeResponse](
 			httpClient,
 			baseURL+AttributesServiceRemovePublicKeyFromAttributeProcedure,
-			connect.WithSchema(attributesServiceRemovePublicKeyFromAttributeMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("RemovePublicKeyFromAttribute")),
 			connect.WithClientOptions(opts...),
 		),
 		assignPublicKeyToValue: connect.NewClient[attributes.AssignPublicKeyToValueRequest, attributes.AssignPublicKeyToValueResponse](
 			httpClient,
 			baseURL+AttributesServiceAssignPublicKeyToValueProcedure,
-			connect.WithSchema(attributesServiceAssignPublicKeyToValueMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("AssignPublicKeyToValue")),
 			connect.WithClientOptions(opts...),
 		),
 		removePublicKeyFromValue: connect.NewClient[attributes.RemovePublicKeyFromValueRequest, attributes.RemovePublicKeyFromValueResponse](
 			httpClient,
 			baseURL+AttributesServiceRemovePublicKeyFromValueProcedure,
-			connect.WithSchema(attributesServiceRemovePublicKeyFromValueMethodDescriptor),
+			connect.WithSchema(attributesServiceMethods.ByName("RemovePublicKeyFromValue")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -467,123 +444,124 @@ type AttributesServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewAttributesServiceHandler(svc AttributesServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	attributesServiceMethods := attributes.File_policy_attributes_attributes_proto.Services().ByName("AttributesService").Methods()
 	attributesServiceListAttributesHandler := connect.NewUnaryHandler(
 		AttributesServiceListAttributesProcedure,
 		svc.ListAttributes,
-		connect.WithSchema(attributesServiceListAttributesMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("ListAttributes")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceListAttributeValuesHandler := connect.NewUnaryHandler(
 		AttributesServiceListAttributeValuesProcedure,
 		svc.ListAttributeValues,
-		connect.WithSchema(attributesServiceListAttributeValuesMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("ListAttributeValues")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceGetAttributeHandler := connect.NewUnaryHandler(
 		AttributesServiceGetAttributeProcedure,
 		svc.GetAttribute,
-		connect.WithSchema(attributesServiceGetAttributeMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("GetAttribute")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceGetAttributeValuesByFqnsHandler := connect.NewUnaryHandler(
 		AttributesServiceGetAttributeValuesByFqnsProcedure,
 		svc.GetAttributeValuesByFqns,
-		connect.WithSchema(attributesServiceGetAttributeValuesByFqnsMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("GetAttributeValuesByFqns")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceCreateAttributeHandler := connect.NewUnaryHandler(
 		AttributesServiceCreateAttributeProcedure,
 		svc.CreateAttribute,
-		connect.WithSchema(attributesServiceCreateAttributeMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("CreateAttribute")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceUpdateAttributeHandler := connect.NewUnaryHandler(
 		AttributesServiceUpdateAttributeProcedure,
 		svc.UpdateAttribute,
-		connect.WithSchema(attributesServiceUpdateAttributeMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("UpdateAttribute")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceDeactivateAttributeHandler := connect.NewUnaryHandler(
 		AttributesServiceDeactivateAttributeProcedure,
 		svc.DeactivateAttribute,
-		connect.WithSchema(attributesServiceDeactivateAttributeMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("DeactivateAttribute")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceGetAttributeValueHandler := connect.NewUnaryHandler(
 		AttributesServiceGetAttributeValueProcedure,
 		svc.GetAttributeValue,
-		connect.WithSchema(attributesServiceGetAttributeValueMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("GetAttributeValue")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceCreateAttributeValueHandler := connect.NewUnaryHandler(
 		AttributesServiceCreateAttributeValueProcedure,
 		svc.CreateAttributeValue,
-		connect.WithSchema(attributesServiceCreateAttributeValueMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("CreateAttributeValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceUpdateAttributeValueHandler := connect.NewUnaryHandler(
 		AttributesServiceUpdateAttributeValueProcedure,
 		svc.UpdateAttributeValue,
-		connect.WithSchema(attributesServiceUpdateAttributeValueMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("UpdateAttributeValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceDeactivateAttributeValueHandler := connect.NewUnaryHandler(
 		AttributesServiceDeactivateAttributeValueProcedure,
 		svc.DeactivateAttributeValue,
-		connect.WithSchema(attributesServiceDeactivateAttributeValueMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("DeactivateAttributeValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceAssignKeyAccessServerToAttributeHandler := connect.NewUnaryHandler(
 		AttributesServiceAssignKeyAccessServerToAttributeProcedure,
 		svc.AssignKeyAccessServerToAttribute,
-		connect.WithSchema(attributesServiceAssignKeyAccessServerToAttributeMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("AssignKeyAccessServerToAttribute")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceRemoveKeyAccessServerFromAttributeHandler := connect.NewUnaryHandler(
 		AttributesServiceRemoveKeyAccessServerFromAttributeProcedure,
 		svc.RemoveKeyAccessServerFromAttribute,
-		connect.WithSchema(attributesServiceRemoveKeyAccessServerFromAttributeMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("RemoveKeyAccessServerFromAttribute")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceAssignKeyAccessServerToValueHandler := connect.NewUnaryHandler(
 		AttributesServiceAssignKeyAccessServerToValueProcedure,
 		svc.AssignKeyAccessServerToValue,
-		connect.WithSchema(attributesServiceAssignKeyAccessServerToValueMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("AssignKeyAccessServerToValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceRemoveKeyAccessServerFromValueHandler := connect.NewUnaryHandler(
 		AttributesServiceRemoveKeyAccessServerFromValueProcedure,
 		svc.RemoveKeyAccessServerFromValue,
-		connect.WithSchema(attributesServiceRemoveKeyAccessServerFromValueMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("RemoveKeyAccessServerFromValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceAssignPublicKeyToAttributeHandler := connect.NewUnaryHandler(
 		AttributesServiceAssignPublicKeyToAttributeProcedure,
 		svc.AssignPublicKeyToAttribute,
-		connect.WithSchema(attributesServiceAssignPublicKeyToAttributeMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("AssignPublicKeyToAttribute")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceRemovePublicKeyFromAttributeHandler := connect.NewUnaryHandler(
 		AttributesServiceRemovePublicKeyFromAttributeProcedure,
 		svc.RemovePublicKeyFromAttribute,
-		connect.WithSchema(attributesServiceRemovePublicKeyFromAttributeMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("RemovePublicKeyFromAttribute")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceAssignPublicKeyToValueHandler := connect.NewUnaryHandler(
 		AttributesServiceAssignPublicKeyToValueProcedure,
 		svc.AssignPublicKeyToValue,
-		connect.WithSchema(attributesServiceAssignPublicKeyToValueMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("AssignPublicKeyToValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	attributesServiceRemovePublicKeyFromValueHandler := connect.NewUnaryHandler(
 		AttributesServiceRemovePublicKeyFromValueProcedure,
 		svc.RemovePublicKeyFromValue,
-		connect.WithSchema(attributesServiceRemovePublicKeyFromValueMethodDescriptor),
+		connect.WithSchema(attributesServiceMethods.ByName("RemovePublicKeyFromValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/policy.attributes.AttributesService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/policy/kasregistry/kasregistryconnect/key_access_server_registry.connect.go
+++ b/protocol/go/policy/kasregistry/kasregistryconnect/key_access_server_registry.connect.go
@@ -78,25 +78,6 @@ const (
 	KeyAccessServerRegistryServiceListKeyMappingsProcedure = "/policy.kasregistry.KeyAccessServerRegistryService/ListKeyMappings"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	keyAccessServerRegistryServiceServiceDescriptor                         = kasregistry.File_policy_kasregistry_key_access_server_registry_proto.Services().ByName("KeyAccessServerRegistryService")
-	keyAccessServerRegistryServiceListKeyAccessServersMethodDescriptor      = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("ListKeyAccessServers")
-	keyAccessServerRegistryServiceGetKeyAccessServerMethodDescriptor        = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("GetKeyAccessServer")
-	keyAccessServerRegistryServiceCreateKeyAccessServerMethodDescriptor     = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("CreateKeyAccessServer")
-	keyAccessServerRegistryServiceUpdateKeyAccessServerMethodDescriptor     = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("UpdateKeyAccessServer")
-	keyAccessServerRegistryServiceDeleteKeyAccessServerMethodDescriptor     = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("DeleteKeyAccessServer")
-	keyAccessServerRegistryServiceListKeyAccessServerGrantsMethodDescriptor = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("ListKeyAccessServerGrants")
-	keyAccessServerRegistryServiceCreateKeyMethodDescriptor                 = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("CreateKey")
-	keyAccessServerRegistryServiceGetKeyMethodDescriptor                    = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("GetKey")
-	keyAccessServerRegistryServiceListKeysMethodDescriptor                  = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("ListKeys")
-	keyAccessServerRegistryServiceUpdateKeyMethodDescriptor                 = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("UpdateKey")
-	keyAccessServerRegistryServiceRotateKeyMethodDescriptor                 = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("RotateKey")
-	keyAccessServerRegistryServiceSetBaseKeyMethodDescriptor                = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("SetBaseKey")
-	keyAccessServerRegistryServiceGetBaseKeyMethodDescriptor                = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("GetBaseKey")
-	keyAccessServerRegistryServiceListKeyMappingsMethodDescriptor           = keyAccessServerRegistryServiceServiceDescriptor.Methods().ByName("ListKeyMappings")
-)
-
 // KeyAccessServerRegistryServiceClient is a client for the
 // policy.kasregistry.KeyAccessServerRegistryService service.
 type KeyAccessServerRegistryServiceClient interface {
@@ -138,92 +119,93 @@ type KeyAccessServerRegistryServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewKeyAccessServerRegistryServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) KeyAccessServerRegistryServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	keyAccessServerRegistryServiceMethods := kasregistry.File_policy_kasregistry_key_access_server_registry_proto.Services().ByName("KeyAccessServerRegistryService").Methods()
 	return &keyAccessServerRegistryServiceClient{
 		listKeyAccessServers: connect.NewClient[kasregistry.ListKeyAccessServersRequest, kasregistry.ListKeyAccessServersResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceListKeyAccessServersProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceListKeyAccessServersMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("ListKeyAccessServers")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		getKeyAccessServer: connect.NewClient[kasregistry.GetKeyAccessServerRequest, kasregistry.GetKeyAccessServerResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceGetKeyAccessServerProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceGetKeyAccessServerMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("GetKeyAccessServer")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		createKeyAccessServer: connect.NewClient[kasregistry.CreateKeyAccessServerRequest, kasregistry.CreateKeyAccessServerResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceCreateKeyAccessServerProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceCreateKeyAccessServerMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("CreateKeyAccessServer")),
 			connect.WithClientOptions(opts...),
 		),
 		updateKeyAccessServer: connect.NewClient[kasregistry.UpdateKeyAccessServerRequest, kasregistry.UpdateKeyAccessServerResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceUpdateKeyAccessServerProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceUpdateKeyAccessServerMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("UpdateKeyAccessServer")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteKeyAccessServer: connect.NewClient[kasregistry.DeleteKeyAccessServerRequest, kasregistry.DeleteKeyAccessServerResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceDeleteKeyAccessServerProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceDeleteKeyAccessServerMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("DeleteKeyAccessServer")),
 			connect.WithClientOptions(opts...),
 		),
 		listKeyAccessServerGrants: connect.NewClient[kasregistry.ListKeyAccessServerGrantsRequest, kasregistry.ListKeyAccessServerGrantsResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceListKeyAccessServerGrantsProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceListKeyAccessServerGrantsMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("ListKeyAccessServerGrants")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		createKey: connect.NewClient[kasregistry.CreateKeyRequest, kasregistry.CreateKeyResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceCreateKeyProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceCreateKeyMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("CreateKey")),
 			connect.WithClientOptions(opts...),
 		),
 		getKey: connect.NewClient[kasregistry.GetKeyRequest, kasregistry.GetKeyResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceGetKeyProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceGetKeyMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("GetKey")),
 			connect.WithClientOptions(opts...),
 		),
 		listKeys: connect.NewClient[kasregistry.ListKeysRequest, kasregistry.ListKeysResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceListKeysProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceListKeysMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("ListKeys")),
 			connect.WithClientOptions(opts...),
 		),
 		updateKey: connect.NewClient[kasregistry.UpdateKeyRequest, kasregistry.UpdateKeyResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceUpdateKeyProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceUpdateKeyMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("UpdateKey")),
 			connect.WithClientOptions(opts...),
 		),
 		rotateKey: connect.NewClient[kasregistry.RotateKeyRequest, kasregistry.RotateKeyResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceRotateKeyProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceRotateKeyMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("RotateKey")),
 			connect.WithClientOptions(opts...),
 		),
 		setBaseKey: connect.NewClient[kasregistry.SetBaseKeyRequest, kasregistry.SetBaseKeyResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceSetBaseKeyProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceSetBaseKeyMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("SetBaseKey")),
 			connect.WithClientOptions(opts...),
 		),
 		getBaseKey: connect.NewClient[kasregistry.GetBaseKeyRequest, kasregistry.GetBaseKeyResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceGetBaseKeyProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceGetBaseKeyMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("GetBaseKey")),
 			connect.WithClientOptions(opts...),
 		),
 		listKeyMappings: connect.NewClient[kasregistry.ListKeyMappingsRequest, kasregistry.ListKeyMappingsResponse](
 			httpClient,
 			baseURL+KeyAccessServerRegistryServiceListKeyMappingsProcedure,
-			connect.WithSchema(keyAccessServerRegistryServiceListKeyMappingsMethodDescriptor),
+			connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("ListKeyMappings")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -361,91 +343,92 @@ type KeyAccessServerRegistryServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewKeyAccessServerRegistryServiceHandler(svc KeyAccessServerRegistryServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	keyAccessServerRegistryServiceMethods := kasregistry.File_policy_kasregistry_key_access_server_registry_proto.Services().ByName("KeyAccessServerRegistryService").Methods()
 	keyAccessServerRegistryServiceListKeyAccessServersHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceListKeyAccessServersProcedure,
 		svc.ListKeyAccessServers,
-		connect.WithSchema(keyAccessServerRegistryServiceListKeyAccessServersMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("ListKeyAccessServers")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceGetKeyAccessServerHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceGetKeyAccessServerProcedure,
 		svc.GetKeyAccessServer,
-		connect.WithSchema(keyAccessServerRegistryServiceGetKeyAccessServerMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("GetKeyAccessServer")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceCreateKeyAccessServerHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceCreateKeyAccessServerProcedure,
 		svc.CreateKeyAccessServer,
-		connect.WithSchema(keyAccessServerRegistryServiceCreateKeyAccessServerMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("CreateKeyAccessServer")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceUpdateKeyAccessServerHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceUpdateKeyAccessServerProcedure,
 		svc.UpdateKeyAccessServer,
-		connect.WithSchema(keyAccessServerRegistryServiceUpdateKeyAccessServerMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("UpdateKeyAccessServer")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceDeleteKeyAccessServerHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceDeleteKeyAccessServerProcedure,
 		svc.DeleteKeyAccessServer,
-		connect.WithSchema(keyAccessServerRegistryServiceDeleteKeyAccessServerMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("DeleteKeyAccessServer")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceListKeyAccessServerGrantsHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceListKeyAccessServerGrantsProcedure,
 		svc.ListKeyAccessServerGrants,
-		connect.WithSchema(keyAccessServerRegistryServiceListKeyAccessServerGrantsMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("ListKeyAccessServerGrants")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceCreateKeyHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceCreateKeyProcedure,
 		svc.CreateKey,
-		connect.WithSchema(keyAccessServerRegistryServiceCreateKeyMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("CreateKey")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceGetKeyHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceGetKeyProcedure,
 		svc.GetKey,
-		connect.WithSchema(keyAccessServerRegistryServiceGetKeyMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("GetKey")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceListKeysHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceListKeysProcedure,
 		svc.ListKeys,
-		connect.WithSchema(keyAccessServerRegistryServiceListKeysMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("ListKeys")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceUpdateKeyHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceUpdateKeyProcedure,
 		svc.UpdateKey,
-		connect.WithSchema(keyAccessServerRegistryServiceUpdateKeyMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("UpdateKey")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceRotateKeyHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceRotateKeyProcedure,
 		svc.RotateKey,
-		connect.WithSchema(keyAccessServerRegistryServiceRotateKeyMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("RotateKey")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceSetBaseKeyHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceSetBaseKeyProcedure,
 		svc.SetBaseKey,
-		connect.WithSchema(keyAccessServerRegistryServiceSetBaseKeyMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("SetBaseKey")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceGetBaseKeyHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceGetBaseKeyProcedure,
 		svc.GetBaseKey,
-		connect.WithSchema(keyAccessServerRegistryServiceGetBaseKeyMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("GetBaseKey")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyAccessServerRegistryServiceListKeyMappingsHandler := connect.NewUnaryHandler(
 		KeyAccessServerRegistryServiceListKeyMappingsProcedure,
 		svc.ListKeyMappings,
-		connect.WithSchema(keyAccessServerRegistryServiceListKeyMappingsMethodDescriptor),
+		connect.WithSchema(keyAccessServerRegistryServiceMethods.ByName("ListKeyMappings")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/policy.kasregistry.KeyAccessServerRegistryService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/policy/keymanagement/keymanagementconnect/key_management.connect.go
+++ b/protocol/go/policy/keymanagement/keymanagementconnect/key_management.connect.go
@@ -50,16 +50,6 @@ const (
 	KeyManagementServiceDeleteProviderConfigProcedure = "/policy.keymanagement.KeyManagementService/DeleteProviderConfig"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	keyManagementServiceServiceDescriptor                    = keymanagement.File_policy_keymanagement_key_management_proto.Services().ByName("KeyManagementService")
-	keyManagementServiceCreateProviderConfigMethodDescriptor = keyManagementServiceServiceDescriptor.Methods().ByName("CreateProviderConfig")
-	keyManagementServiceGetProviderConfigMethodDescriptor    = keyManagementServiceServiceDescriptor.Methods().ByName("GetProviderConfig")
-	keyManagementServiceListProviderConfigsMethodDescriptor  = keyManagementServiceServiceDescriptor.Methods().ByName("ListProviderConfigs")
-	keyManagementServiceUpdateProviderConfigMethodDescriptor = keyManagementServiceServiceDescriptor.Methods().ByName("UpdateProviderConfig")
-	keyManagementServiceDeleteProviderConfigMethodDescriptor = keyManagementServiceServiceDescriptor.Methods().ByName("DeleteProviderConfig")
-)
-
 // KeyManagementServiceClient is a client for the policy.keymanagement.KeyManagementService service.
 type KeyManagementServiceClient interface {
 	// Key Management
@@ -80,35 +70,36 @@ type KeyManagementServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewKeyManagementServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) KeyManagementServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	keyManagementServiceMethods := keymanagement.File_policy_keymanagement_key_management_proto.Services().ByName("KeyManagementService").Methods()
 	return &keyManagementServiceClient{
 		createProviderConfig: connect.NewClient[keymanagement.CreateProviderConfigRequest, keymanagement.CreateProviderConfigResponse](
 			httpClient,
 			baseURL+KeyManagementServiceCreateProviderConfigProcedure,
-			connect.WithSchema(keyManagementServiceCreateProviderConfigMethodDescriptor),
+			connect.WithSchema(keyManagementServiceMethods.ByName("CreateProviderConfig")),
 			connect.WithClientOptions(opts...),
 		),
 		getProviderConfig: connect.NewClient[keymanagement.GetProviderConfigRequest, keymanagement.GetProviderConfigResponse](
 			httpClient,
 			baseURL+KeyManagementServiceGetProviderConfigProcedure,
-			connect.WithSchema(keyManagementServiceGetProviderConfigMethodDescriptor),
+			connect.WithSchema(keyManagementServiceMethods.ByName("GetProviderConfig")),
 			connect.WithClientOptions(opts...),
 		),
 		listProviderConfigs: connect.NewClient[keymanagement.ListProviderConfigsRequest, keymanagement.ListProviderConfigsResponse](
 			httpClient,
 			baseURL+KeyManagementServiceListProviderConfigsProcedure,
-			connect.WithSchema(keyManagementServiceListProviderConfigsMethodDescriptor),
+			connect.WithSchema(keyManagementServiceMethods.ByName("ListProviderConfigs")),
 			connect.WithClientOptions(opts...),
 		),
 		updateProviderConfig: connect.NewClient[keymanagement.UpdateProviderConfigRequest, keymanagement.UpdateProviderConfigResponse](
 			httpClient,
 			baseURL+KeyManagementServiceUpdateProviderConfigProcedure,
-			connect.WithSchema(keyManagementServiceUpdateProviderConfigMethodDescriptor),
+			connect.WithSchema(keyManagementServiceMethods.ByName("UpdateProviderConfig")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteProviderConfig: connect.NewClient[keymanagement.DeleteProviderConfigRequest, keymanagement.DeleteProviderConfigResponse](
 			httpClient,
 			baseURL+KeyManagementServiceDeleteProviderConfigProcedure,
-			connect.WithSchema(keyManagementServiceDeleteProviderConfigMethodDescriptor),
+			connect.WithSchema(keyManagementServiceMethods.ByName("DeleteProviderConfig")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -166,34 +157,35 @@ type KeyManagementServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewKeyManagementServiceHandler(svc KeyManagementServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	keyManagementServiceMethods := keymanagement.File_policy_keymanagement_key_management_proto.Services().ByName("KeyManagementService").Methods()
 	keyManagementServiceCreateProviderConfigHandler := connect.NewUnaryHandler(
 		KeyManagementServiceCreateProviderConfigProcedure,
 		svc.CreateProviderConfig,
-		connect.WithSchema(keyManagementServiceCreateProviderConfigMethodDescriptor),
+		connect.WithSchema(keyManagementServiceMethods.ByName("CreateProviderConfig")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyManagementServiceGetProviderConfigHandler := connect.NewUnaryHandler(
 		KeyManagementServiceGetProviderConfigProcedure,
 		svc.GetProviderConfig,
-		connect.WithSchema(keyManagementServiceGetProviderConfigMethodDescriptor),
+		connect.WithSchema(keyManagementServiceMethods.ByName("GetProviderConfig")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyManagementServiceListProviderConfigsHandler := connect.NewUnaryHandler(
 		KeyManagementServiceListProviderConfigsProcedure,
 		svc.ListProviderConfigs,
-		connect.WithSchema(keyManagementServiceListProviderConfigsMethodDescriptor),
+		connect.WithSchema(keyManagementServiceMethods.ByName("ListProviderConfigs")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyManagementServiceUpdateProviderConfigHandler := connect.NewUnaryHandler(
 		KeyManagementServiceUpdateProviderConfigProcedure,
 		svc.UpdateProviderConfig,
-		connect.WithSchema(keyManagementServiceUpdateProviderConfigMethodDescriptor),
+		connect.WithSchema(keyManagementServiceMethods.ByName("UpdateProviderConfig")),
 		connect.WithHandlerOptions(opts...),
 	)
 	keyManagementServiceDeleteProviderConfigHandler := connect.NewUnaryHandler(
 		KeyManagementServiceDeleteProviderConfigProcedure,
 		svc.DeleteProviderConfig,
-		connect.WithSchema(keyManagementServiceDeleteProviderConfigMethodDescriptor),
+		connect.WithSchema(keyManagementServiceMethods.ByName("DeleteProviderConfig")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/policy.keymanagement.KeyManagementService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/policy/namespaces/namespacesconnect/namespaces.connect.go
+++ b/protocol/go/policy/namespaces/namespacesconnect/namespaces.connect.go
@@ -68,22 +68,6 @@ const (
 	NamespaceServiceRemoveCertificateFromNamespaceProcedure = "/policy.namespaces.NamespaceService/RemoveCertificateFromNamespace"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	namespaceServiceServiceDescriptor                                  = namespaces.File_policy_namespaces_namespaces_proto.Services().ByName("NamespaceService")
-	namespaceServiceGetNamespaceMethodDescriptor                       = namespaceServiceServiceDescriptor.Methods().ByName("GetNamespace")
-	namespaceServiceListNamespacesMethodDescriptor                     = namespaceServiceServiceDescriptor.Methods().ByName("ListNamespaces")
-	namespaceServiceCreateNamespaceMethodDescriptor                    = namespaceServiceServiceDescriptor.Methods().ByName("CreateNamespace")
-	namespaceServiceUpdateNamespaceMethodDescriptor                    = namespaceServiceServiceDescriptor.Methods().ByName("UpdateNamespace")
-	namespaceServiceDeactivateNamespaceMethodDescriptor                = namespaceServiceServiceDescriptor.Methods().ByName("DeactivateNamespace")
-	namespaceServiceAssignKeyAccessServerToNamespaceMethodDescriptor   = namespaceServiceServiceDescriptor.Methods().ByName("AssignKeyAccessServerToNamespace")
-	namespaceServiceRemoveKeyAccessServerFromNamespaceMethodDescriptor = namespaceServiceServiceDescriptor.Methods().ByName("RemoveKeyAccessServerFromNamespace")
-	namespaceServiceAssignPublicKeyToNamespaceMethodDescriptor         = namespaceServiceServiceDescriptor.Methods().ByName("AssignPublicKeyToNamespace")
-	namespaceServiceRemovePublicKeyFromNamespaceMethodDescriptor       = namespaceServiceServiceDescriptor.Methods().ByName("RemovePublicKeyFromNamespace")
-	namespaceServiceAssignCertificateToNamespaceMethodDescriptor       = namespaceServiceServiceDescriptor.Methods().ByName("AssignCertificateToNamespace")
-	namespaceServiceRemoveCertificateFromNamespaceMethodDescriptor     = namespaceServiceServiceDescriptor.Methods().ByName("RemoveCertificateFromNamespace")
-)
-
 // NamespaceServiceClient is a client for the policy.namespaces.NamespaceService service.
 type NamespaceServiceClient interface {
 	GetNamespace(context.Context, *connect.Request[namespaces.GetNamespaceRequest]) (*connect.Response[namespaces.GetNamespaceResponse], error)
@@ -118,73 +102,74 @@ type NamespaceServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewNamespaceServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) NamespaceServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	namespaceServiceMethods := namespaces.File_policy_namespaces_namespaces_proto.Services().ByName("NamespaceService").Methods()
 	return &namespaceServiceClient{
 		getNamespace: connect.NewClient[namespaces.GetNamespaceRequest, namespaces.GetNamespaceResponse](
 			httpClient,
 			baseURL+NamespaceServiceGetNamespaceProcedure,
-			connect.WithSchema(namespaceServiceGetNamespaceMethodDescriptor),
+			connect.WithSchema(namespaceServiceMethods.ByName("GetNamespace")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		listNamespaces: connect.NewClient[namespaces.ListNamespacesRequest, namespaces.ListNamespacesResponse](
 			httpClient,
 			baseURL+NamespaceServiceListNamespacesProcedure,
-			connect.WithSchema(namespaceServiceListNamespacesMethodDescriptor),
+			connect.WithSchema(namespaceServiceMethods.ByName("ListNamespaces")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		createNamespace: connect.NewClient[namespaces.CreateNamespaceRequest, namespaces.CreateNamespaceResponse](
 			httpClient,
 			baseURL+NamespaceServiceCreateNamespaceProcedure,
-			connect.WithSchema(namespaceServiceCreateNamespaceMethodDescriptor),
+			connect.WithSchema(namespaceServiceMethods.ByName("CreateNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 		updateNamespace: connect.NewClient[namespaces.UpdateNamespaceRequest, namespaces.UpdateNamespaceResponse](
 			httpClient,
 			baseURL+NamespaceServiceUpdateNamespaceProcedure,
-			connect.WithSchema(namespaceServiceUpdateNamespaceMethodDescriptor),
+			connect.WithSchema(namespaceServiceMethods.ByName("UpdateNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 		deactivateNamespace: connect.NewClient[namespaces.DeactivateNamespaceRequest, namespaces.DeactivateNamespaceResponse](
 			httpClient,
 			baseURL+NamespaceServiceDeactivateNamespaceProcedure,
-			connect.WithSchema(namespaceServiceDeactivateNamespaceMethodDescriptor),
+			connect.WithSchema(namespaceServiceMethods.ByName("DeactivateNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 		assignKeyAccessServerToNamespace: connect.NewClient[namespaces.AssignKeyAccessServerToNamespaceRequest, namespaces.AssignKeyAccessServerToNamespaceResponse](
 			httpClient,
 			baseURL+NamespaceServiceAssignKeyAccessServerToNamespaceProcedure,
-			connect.WithSchema(namespaceServiceAssignKeyAccessServerToNamespaceMethodDescriptor),
+			connect.WithSchema(namespaceServiceMethods.ByName("AssignKeyAccessServerToNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 		removeKeyAccessServerFromNamespace: connect.NewClient[namespaces.RemoveKeyAccessServerFromNamespaceRequest, namespaces.RemoveKeyAccessServerFromNamespaceResponse](
 			httpClient,
 			baseURL+NamespaceServiceRemoveKeyAccessServerFromNamespaceProcedure,
-			connect.WithSchema(namespaceServiceRemoveKeyAccessServerFromNamespaceMethodDescriptor),
+			connect.WithSchema(namespaceServiceMethods.ByName("RemoveKeyAccessServerFromNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 		assignPublicKeyToNamespace: connect.NewClient[namespaces.AssignPublicKeyToNamespaceRequest, namespaces.AssignPublicKeyToNamespaceResponse](
 			httpClient,
 			baseURL+NamespaceServiceAssignPublicKeyToNamespaceProcedure,
-			connect.WithSchema(namespaceServiceAssignPublicKeyToNamespaceMethodDescriptor),
+			connect.WithSchema(namespaceServiceMethods.ByName("AssignPublicKeyToNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 		removePublicKeyFromNamespace: connect.NewClient[namespaces.RemovePublicKeyFromNamespaceRequest, namespaces.RemovePublicKeyFromNamespaceResponse](
 			httpClient,
 			baseURL+NamespaceServiceRemovePublicKeyFromNamespaceProcedure,
-			connect.WithSchema(namespaceServiceRemovePublicKeyFromNamespaceMethodDescriptor),
+			connect.WithSchema(namespaceServiceMethods.ByName("RemovePublicKeyFromNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 		assignCertificateToNamespace: connect.NewClient[namespaces.AssignCertificateToNamespaceRequest, namespaces.AssignCertificateToNamespaceResponse](
 			httpClient,
 			baseURL+NamespaceServiceAssignCertificateToNamespaceProcedure,
-			connect.WithSchema(namespaceServiceAssignCertificateToNamespaceMethodDescriptor),
+			connect.WithSchema(namespaceServiceMethods.ByName("AssignCertificateToNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 		removeCertificateFromNamespace: connect.NewClient[namespaces.RemoveCertificateFromNamespaceRequest, namespaces.RemoveCertificateFromNamespaceResponse](
 			httpClient,
 			baseURL+NamespaceServiceRemoveCertificateFromNamespaceProcedure,
-			connect.WithSchema(namespaceServiceRemoveCertificateFromNamespaceMethodDescriptor),
+			connect.WithSchema(namespaceServiceMethods.ByName("RemoveCertificateFromNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -300,72 +285,73 @@ type NamespaceServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewNamespaceServiceHandler(svc NamespaceServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	namespaceServiceMethods := namespaces.File_policy_namespaces_namespaces_proto.Services().ByName("NamespaceService").Methods()
 	namespaceServiceGetNamespaceHandler := connect.NewUnaryHandler(
 		NamespaceServiceGetNamespaceProcedure,
 		svc.GetNamespace,
-		connect.WithSchema(namespaceServiceGetNamespaceMethodDescriptor),
+		connect.WithSchema(namespaceServiceMethods.ByName("GetNamespace")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	namespaceServiceListNamespacesHandler := connect.NewUnaryHandler(
 		NamespaceServiceListNamespacesProcedure,
 		svc.ListNamespaces,
-		connect.WithSchema(namespaceServiceListNamespacesMethodDescriptor),
+		connect.WithSchema(namespaceServiceMethods.ByName("ListNamespaces")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	namespaceServiceCreateNamespaceHandler := connect.NewUnaryHandler(
 		NamespaceServiceCreateNamespaceProcedure,
 		svc.CreateNamespace,
-		connect.WithSchema(namespaceServiceCreateNamespaceMethodDescriptor),
+		connect.WithSchema(namespaceServiceMethods.ByName("CreateNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	namespaceServiceUpdateNamespaceHandler := connect.NewUnaryHandler(
 		NamespaceServiceUpdateNamespaceProcedure,
 		svc.UpdateNamespace,
-		connect.WithSchema(namespaceServiceUpdateNamespaceMethodDescriptor),
+		connect.WithSchema(namespaceServiceMethods.ByName("UpdateNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	namespaceServiceDeactivateNamespaceHandler := connect.NewUnaryHandler(
 		NamespaceServiceDeactivateNamespaceProcedure,
 		svc.DeactivateNamespace,
-		connect.WithSchema(namespaceServiceDeactivateNamespaceMethodDescriptor),
+		connect.WithSchema(namespaceServiceMethods.ByName("DeactivateNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	namespaceServiceAssignKeyAccessServerToNamespaceHandler := connect.NewUnaryHandler(
 		NamespaceServiceAssignKeyAccessServerToNamespaceProcedure,
 		svc.AssignKeyAccessServerToNamespace,
-		connect.WithSchema(namespaceServiceAssignKeyAccessServerToNamespaceMethodDescriptor),
+		connect.WithSchema(namespaceServiceMethods.ByName("AssignKeyAccessServerToNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	namespaceServiceRemoveKeyAccessServerFromNamespaceHandler := connect.NewUnaryHandler(
 		NamespaceServiceRemoveKeyAccessServerFromNamespaceProcedure,
 		svc.RemoveKeyAccessServerFromNamespace,
-		connect.WithSchema(namespaceServiceRemoveKeyAccessServerFromNamespaceMethodDescriptor),
+		connect.WithSchema(namespaceServiceMethods.ByName("RemoveKeyAccessServerFromNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	namespaceServiceAssignPublicKeyToNamespaceHandler := connect.NewUnaryHandler(
 		NamespaceServiceAssignPublicKeyToNamespaceProcedure,
 		svc.AssignPublicKeyToNamespace,
-		connect.WithSchema(namespaceServiceAssignPublicKeyToNamespaceMethodDescriptor),
+		connect.WithSchema(namespaceServiceMethods.ByName("AssignPublicKeyToNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	namespaceServiceRemovePublicKeyFromNamespaceHandler := connect.NewUnaryHandler(
 		NamespaceServiceRemovePublicKeyFromNamespaceProcedure,
 		svc.RemovePublicKeyFromNamespace,
-		connect.WithSchema(namespaceServiceRemovePublicKeyFromNamespaceMethodDescriptor),
+		connect.WithSchema(namespaceServiceMethods.ByName("RemovePublicKeyFromNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	namespaceServiceAssignCertificateToNamespaceHandler := connect.NewUnaryHandler(
 		NamespaceServiceAssignCertificateToNamespaceProcedure,
 		svc.AssignCertificateToNamespace,
-		connect.WithSchema(namespaceServiceAssignCertificateToNamespaceMethodDescriptor),
+		connect.WithSchema(namespaceServiceMethods.ByName("AssignCertificateToNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	namespaceServiceRemoveCertificateFromNamespaceHandler := connect.NewUnaryHandler(
 		NamespaceServiceRemoveCertificateFromNamespaceProcedure,
 		svc.RemoveCertificateFromNamespace,
-		connect.WithSchema(namespaceServiceRemoveCertificateFromNamespaceMethodDescriptor),
+		connect.WithSchema(namespaceServiceMethods.ByName("RemoveCertificateFromNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/policy.namespaces.NamespaceService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/policy/obligations/obligationsconnect/obligations.connect.go
+++ b/protocol/go/policy/obligations/obligationsconnect/obligations.connect.go
@@ -75,25 +75,6 @@ const (
 	ServiceListObligationTriggersProcedure = "/policy.obligations.Service/ListObligationTriggers"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	serviceServiceDescriptor                         = obligations.File_policy_obligations_obligations_proto.Services().ByName("Service")
-	serviceListObligationsMethodDescriptor           = serviceServiceDescriptor.Methods().ByName("ListObligations")
-	serviceGetObligationMethodDescriptor             = serviceServiceDescriptor.Methods().ByName("GetObligation")
-	serviceGetObligationsByFQNsMethodDescriptor      = serviceServiceDescriptor.Methods().ByName("GetObligationsByFQNs")
-	serviceCreateObligationMethodDescriptor          = serviceServiceDescriptor.Methods().ByName("CreateObligation")
-	serviceUpdateObligationMethodDescriptor          = serviceServiceDescriptor.Methods().ByName("UpdateObligation")
-	serviceDeleteObligationMethodDescriptor          = serviceServiceDescriptor.Methods().ByName("DeleteObligation")
-	serviceGetObligationValueMethodDescriptor        = serviceServiceDescriptor.Methods().ByName("GetObligationValue")
-	serviceGetObligationValuesByFQNsMethodDescriptor = serviceServiceDescriptor.Methods().ByName("GetObligationValuesByFQNs")
-	serviceCreateObligationValueMethodDescriptor     = serviceServiceDescriptor.Methods().ByName("CreateObligationValue")
-	serviceUpdateObligationValueMethodDescriptor     = serviceServiceDescriptor.Methods().ByName("UpdateObligationValue")
-	serviceDeleteObligationValueMethodDescriptor     = serviceServiceDescriptor.Methods().ByName("DeleteObligationValue")
-	serviceAddObligationTriggerMethodDescriptor      = serviceServiceDescriptor.Methods().ByName("AddObligationTrigger")
-	serviceRemoveObligationTriggerMethodDescriptor   = serviceServiceDescriptor.Methods().ByName("RemoveObligationTrigger")
-	serviceListObligationTriggersMethodDescriptor    = serviceServiceDescriptor.Methods().ByName("ListObligationTriggers")
-)
-
 // ServiceClient is a client for the policy.obligations.Service service.
 type ServiceClient interface {
 	ListObligations(context.Context, *connect.Request[obligations.ListObligationsRequest]) (*connect.Response[obligations.ListObligationsResponse], error)
@@ -121,94 +102,95 @@ type ServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) ServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	serviceMethods := obligations.File_policy_obligations_obligations_proto.Services().ByName("Service").Methods()
 	return &serviceClient{
 		listObligations: connect.NewClient[obligations.ListObligationsRequest, obligations.ListObligationsResponse](
 			httpClient,
 			baseURL+ServiceListObligationsProcedure,
-			connect.WithSchema(serviceListObligationsMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("ListObligations")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		getObligation: connect.NewClient[obligations.GetObligationRequest, obligations.GetObligationResponse](
 			httpClient,
 			baseURL+ServiceGetObligationProcedure,
-			connect.WithSchema(serviceGetObligationMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("GetObligation")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		getObligationsByFQNs: connect.NewClient[obligations.GetObligationsByFQNsRequest, obligations.GetObligationsByFQNsResponse](
 			httpClient,
 			baseURL+ServiceGetObligationsByFQNsProcedure,
-			connect.WithSchema(serviceGetObligationsByFQNsMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("GetObligationsByFQNs")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		createObligation: connect.NewClient[obligations.CreateObligationRequest, obligations.CreateObligationResponse](
 			httpClient,
 			baseURL+ServiceCreateObligationProcedure,
-			connect.WithSchema(serviceCreateObligationMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("CreateObligation")),
 			connect.WithClientOptions(opts...),
 		),
 		updateObligation: connect.NewClient[obligations.UpdateObligationRequest, obligations.UpdateObligationResponse](
 			httpClient,
 			baseURL+ServiceUpdateObligationProcedure,
-			connect.WithSchema(serviceUpdateObligationMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("UpdateObligation")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteObligation: connect.NewClient[obligations.DeleteObligationRequest, obligations.DeleteObligationResponse](
 			httpClient,
 			baseURL+ServiceDeleteObligationProcedure,
-			connect.WithSchema(serviceDeleteObligationMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("DeleteObligation")),
 			connect.WithClientOptions(opts...),
 		),
 		getObligationValue: connect.NewClient[obligations.GetObligationValueRequest, obligations.GetObligationValueResponse](
 			httpClient,
 			baseURL+ServiceGetObligationValueProcedure,
-			connect.WithSchema(serviceGetObligationValueMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("GetObligationValue")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		getObligationValuesByFQNs: connect.NewClient[obligations.GetObligationValuesByFQNsRequest, obligations.GetObligationValuesByFQNsResponse](
 			httpClient,
 			baseURL+ServiceGetObligationValuesByFQNsProcedure,
-			connect.WithSchema(serviceGetObligationValuesByFQNsMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("GetObligationValuesByFQNs")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		createObligationValue: connect.NewClient[obligations.CreateObligationValueRequest, obligations.CreateObligationValueResponse](
 			httpClient,
 			baseURL+ServiceCreateObligationValueProcedure,
-			connect.WithSchema(serviceCreateObligationValueMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("CreateObligationValue")),
 			connect.WithClientOptions(opts...),
 		),
 		updateObligationValue: connect.NewClient[obligations.UpdateObligationValueRequest, obligations.UpdateObligationValueResponse](
 			httpClient,
 			baseURL+ServiceUpdateObligationValueProcedure,
-			connect.WithSchema(serviceUpdateObligationValueMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("UpdateObligationValue")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteObligationValue: connect.NewClient[obligations.DeleteObligationValueRequest, obligations.DeleteObligationValueResponse](
 			httpClient,
 			baseURL+ServiceDeleteObligationValueProcedure,
-			connect.WithSchema(serviceDeleteObligationValueMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("DeleteObligationValue")),
 			connect.WithClientOptions(opts...),
 		),
 		addObligationTrigger: connect.NewClient[obligations.AddObligationTriggerRequest, obligations.AddObligationTriggerResponse](
 			httpClient,
 			baseURL+ServiceAddObligationTriggerProcedure,
-			connect.WithSchema(serviceAddObligationTriggerMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("AddObligationTrigger")),
 			connect.WithClientOptions(opts...),
 		),
 		removeObligationTrigger: connect.NewClient[obligations.RemoveObligationTriggerRequest, obligations.RemoveObligationTriggerResponse](
 			httpClient,
 			baseURL+ServiceRemoveObligationTriggerProcedure,
-			connect.WithSchema(serviceRemoveObligationTriggerMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("RemoveObligationTrigger")),
 			connect.WithClientOptions(opts...),
 		),
 		listObligationTriggers: connect.NewClient[obligations.ListObligationTriggersRequest, obligations.ListObligationTriggersResponse](
 			httpClient,
 			baseURL+ServiceListObligationTriggersProcedure,
-			connect.WithSchema(serviceListObligationTriggersMethodDescriptor),
+			connect.WithSchema(serviceMethods.ByName("ListObligationTriggers")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
@@ -327,93 +309,94 @@ type ServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewServiceHandler(svc ServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	serviceMethods := obligations.File_policy_obligations_obligations_proto.Services().ByName("Service").Methods()
 	serviceListObligationsHandler := connect.NewUnaryHandler(
 		ServiceListObligationsProcedure,
 		svc.ListObligations,
-		connect.WithSchema(serviceListObligationsMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("ListObligations")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceGetObligationHandler := connect.NewUnaryHandler(
 		ServiceGetObligationProcedure,
 		svc.GetObligation,
-		connect.WithSchema(serviceGetObligationMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("GetObligation")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceGetObligationsByFQNsHandler := connect.NewUnaryHandler(
 		ServiceGetObligationsByFQNsProcedure,
 		svc.GetObligationsByFQNs,
-		connect.WithSchema(serviceGetObligationsByFQNsMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("GetObligationsByFQNs")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceCreateObligationHandler := connect.NewUnaryHandler(
 		ServiceCreateObligationProcedure,
 		svc.CreateObligation,
-		connect.WithSchema(serviceCreateObligationMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("CreateObligation")),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceUpdateObligationHandler := connect.NewUnaryHandler(
 		ServiceUpdateObligationProcedure,
 		svc.UpdateObligation,
-		connect.WithSchema(serviceUpdateObligationMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("UpdateObligation")),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceDeleteObligationHandler := connect.NewUnaryHandler(
 		ServiceDeleteObligationProcedure,
 		svc.DeleteObligation,
-		connect.WithSchema(serviceDeleteObligationMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("DeleteObligation")),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceGetObligationValueHandler := connect.NewUnaryHandler(
 		ServiceGetObligationValueProcedure,
 		svc.GetObligationValue,
-		connect.WithSchema(serviceGetObligationValueMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("GetObligationValue")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceGetObligationValuesByFQNsHandler := connect.NewUnaryHandler(
 		ServiceGetObligationValuesByFQNsProcedure,
 		svc.GetObligationValuesByFQNs,
-		connect.WithSchema(serviceGetObligationValuesByFQNsMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("GetObligationValuesByFQNs")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceCreateObligationValueHandler := connect.NewUnaryHandler(
 		ServiceCreateObligationValueProcedure,
 		svc.CreateObligationValue,
-		connect.WithSchema(serviceCreateObligationValueMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("CreateObligationValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceUpdateObligationValueHandler := connect.NewUnaryHandler(
 		ServiceUpdateObligationValueProcedure,
 		svc.UpdateObligationValue,
-		connect.WithSchema(serviceUpdateObligationValueMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("UpdateObligationValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceDeleteObligationValueHandler := connect.NewUnaryHandler(
 		ServiceDeleteObligationValueProcedure,
 		svc.DeleteObligationValue,
-		connect.WithSchema(serviceDeleteObligationValueMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("DeleteObligationValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceAddObligationTriggerHandler := connect.NewUnaryHandler(
 		ServiceAddObligationTriggerProcedure,
 		svc.AddObligationTrigger,
-		connect.WithSchema(serviceAddObligationTriggerMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("AddObligationTrigger")),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceRemoveObligationTriggerHandler := connect.NewUnaryHandler(
 		ServiceRemoveObligationTriggerProcedure,
 		svc.RemoveObligationTrigger,
-		connect.WithSchema(serviceRemoveObligationTriggerMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("RemoveObligationTrigger")),
 		connect.WithHandlerOptions(opts...),
 	)
 	serviceListObligationTriggersHandler := connect.NewUnaryHandler(
 		ServiceListObligationTriggersProcedure,
 		svc.ListObligationTriggers,
-		connect.WithSchema(serviceListObligationTriggersMethodDescriptor),
+		connect.WithSchema(serviceMethods.ByName("ListObligationTriggers")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)

--- a/protocol/go/policy/registeredresources/registeredresourcesconnect/registered_resources.connect.go
+++ b/protocol/go/policy/registeredresources/registeredresourcesconnect/registered_resources.connect.go
@@ -69,22 +69,6 @@ const (
 	RegisteredResourcesServiceDeleteRegisteredResourceValueProcedure = "/policy.registeredresources.RegisteredResourcesService/DeleteRegisteredResourceValue"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	registeredResourcesServiceServiceDescriptor                                 = registeredresources.File_policy_registeredresources_registered_resources_proto.Services().ByName("RegisteredResourcesService")
-	registeredResourcesServiceCreateRegisteredResourceMethodDescriptor          = registeredResourcesServiceServiceDescriptor.Methods().ByName("CreateRegisteredResource")
-	registeredResourcesServiceGetRegisteredResourceMethodDescriptor             = registeredResourcesServiceServiceDescriptor.Methods().ByName("GetRegisteredResource")
-	registeredResourcesServiceListRegisteredResourcesMethodDescriptor           = registeredResourcesServiceServiceDescriptor.Methods().ByName("ListRegisteredResources")
-	registeredResourcesServiceUpdateRegisteredResourceMethodDescriptor          = registeredResourcesServiceServiceDescriptor.Methods().ByName("UpdateRegisteredResource")
-	registeredResourcesServiceDeleteRegisteredResourceMethodDescriptor          = registeredResourcesServiceServiceDescriptor.Methods().ByName("DeleteRegisteredResource")
-	registeredResourcesServiceCreateRegisteredResourceValueMethodDescriptor     = registeredResourcesServiceServiceDescriptor.Methods().ByName("CreateRegisteredResourceValue")
-	registeredResourcesServiceGetRegisteredResourceValueMethodDescriptor        = registeredResourcesServiceServiceDescriptor.Methods().ByName("GetRegisteredResourceValue")
-	registeredResourcesServiceGetRegisteredResourceValuesByFQNsMethodDescriptor = registeredResourcesServiceServiceDescriptor.Methods().ByName("GetRegisteredResourceValuesByFQNs")
-	registeredResourcesServiceListRegisteredResourceValuesMethodDescriptor      = registeredResourcesServiceServiceDescriptor.Methods().ByName("ListRegisteredResourceValues")
-	registeredResourcesServiceUpdateRegisteredResourceValueMethodDescriptor     = registeredResourcesServiceServiceDescriptor.Methods().ByName("UpdateRegisteredResourceValue")
-	registeredResourcesServiceDeleteRegisteredResourceValueMethodDescriptor     = registeredResourcesServiceServiceDescriptor.Methods().ByName("DeleteRegisteredResourceValue")
-)
-
 // RegisteredResourcesServiceClient is a client for the
 // policy.registeredresources.RegisteredResourcesService service.
 type RegisteredResourcesServiceClient interface {
@@ -111,71 +95,72 @@ type RegisteredResourcesServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewRegisteredResourcesServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) RegisteredResourcesServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	registeredResourcesServiceMethods := registeredresources.File_policy_registeredresources_registered_resources_proto.Services().ByName("RegisteredResourcesService").Methods()
 	return &registeredResourcesServiceClient{
 		createRegisteredResource: connect.NewClient[registeredresources.CreateRegisteredResourceRequest, registeredresources.CreateRegisteredResourceResponse](
 			httpClient,
 			baseURL+RegisteredResourcesServiceCreateRegisteredResourceProcedure,
-			connect.WithSchema(registeredResourcesServiceCreateRegisteredResourceMethodDescriptor),
+			connect.WithSchema(registeredResourcesServiceMethods.ByName("CreateRegisteredResource")),
 			connect.WithClientOptions(opts...),
 		),
 		getRegisteredResource: connect.NewClient[registeredresources.GetRegisteredResourceRequest, registeredresources.GetRegisteredResourceResponse](
 			httpClient,
 			baseURL+RegisteredResourcesServiceGetRegisteredResourceProcedure,
-			connect.WithSchema(registeredResourcesServiceGetRegisteredResourceMethodDescriptor),
+			connect.WithSchema(registeredResourcesServiceMethods.ByName("GetRegisteredResource")),
 			connect.WithClientOptions(opts...),
 		),
 		listRegisteredResources: connect.NewClient[registeredresources.ListRegisteredResourcesRequest, registeredresources.ListRegisteredResourcesResponse](
 			httpClient,
 			baseURL+RegisteredResourcesServiceListRegisteredResourcesProcedure,
-			connect.WithSchema(registeredResourcesServiceListRegisteredResourcesMethodDescriptor),
+			connect.WithSchema(registeredResourcesServiceMethods.ByName("ListRegisteredResources")),
 			connect.WithClientOptions(opts...),
 		),
 		updateRegisteredResource: connect.NewClient[registeredresources.UpdateRegisteredResourceRequest, registeredresources.UpdateRegisteredResourceResponse](
 			httpClient,
 			baseURL+RegisteredResourcesServiceUpdateRegisteredResourceProcedure,
-			connect.WithSchema(registeredResourcesServiceUpdateRegisteredResourceMethodDescriptor),
+			connect.WithSchema(registeredResourcesServiceMethods.ByName("UpdateRegisteredResource")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteRegisteredResource: connect.NewClient[registeredresources.DeleteRegisteredResourceRequest, registeredresources.DeleteRegisteredResourceResponse](
 			httpClient,
 			baseURL+RegisteredResourcesServiceDeleteRegisteredResourceProcedure,
-			connect.WithSchema(registeredResourcesServiceDeleteRegisteredResourceMethodDescriptor),
+			connect.WithSchema(registeredResourcesServiceMethods.ByName("DeleteRegisteredResource")),
 			connect.WithClientOptions(opts...),
 		),
 		createRegisteredResourceValue: connect.NewClient[registeredresources.CreateRegisteredResourceValueRequest, registeredresources.CreateRegisteredResourceValueResponse](
 			httpClient,
 			baseURL+RegisteredResourcesServiceCreateRegisteredResourceValueProcedure,
-			connect.WithSchema(registeredResourcesServiceCreateRegisteredResourceValueMethodDescriptor),
+			connect.WithSchema(registeredResourcesServiceMethods.ByName("CreateRegisteredResourceValue")),
 			connect.WithClientOptions(opts...),
 		),
 		getRegisteredResourceValue: connect.NewClient[registeredresources.GetRegisteredResourceValueRequest, registeredresources.GetRegisteredResourceValueResponse](
 			httpClient,
 			baseURL+RegisteredResourcesServiceGetRegisteredResourceValueProcedure,
-			connect.WithSchema(registeredResourcesServiceGetRegisteredResourceValueMethodDescriptor),
+			connect.WithSchema(registeredResourcesServiceMethods.ByName("GetRegisteredResourceValue")),
 			connect.WithClientOptions(opts...),
 		),
 		getRegisteredResourceValuesByFQNs: connect.NewClient[registeredresources.GetRegisteredResourceValuesByFQNsRequest, registeredresources.GetRegisteredResourceValuesByFQNsResponse](
 			httpClient,
 			baseURL+RegisteredResourcesServiceGetRegisteredResourceValuesByFQNsProcedure,
-			connect.WithSchema(registeredResourcesServiceGetRegisteredResourceValuesByFQNsMethodDescriptor),
+			connect.WithSchema(registeredResourcesServiceMethods.ByName("GetRegisteredResourceValuesByFQNs")),
 			connect.WithClientOptions(opts...),
 		),
 		listRegisteredResourceValues: connect.NewClient[registeredresources.ListRegisteredResourceValuesRequest, registeredresources.ListRegisteredResourceValuesResponse](
 			httpClient,
 			baseURL+RegisteredResourcesServiceListRegisteredResourceValuesProcedure,
-			connect.WithSchema(registeredResourcesServiceListRegisteredResourceValuesMethodDescriptor),
+			connect.WithSchema(registeredResourcesServiceMethods.ByName("ListRegisteredResourceValues")),
 			connect.WithClientOptions(opts...),
 		),
 		updateRegisteredResourceValue: connect.NewClient[registeredresources.UpdateRegisteredResourceValueRequest, registeredresources.UpdateRegisteredResourceValueResponse](
 			httpClient,
 			baseURL+RegisteredResourcesServiceUpdateRegisteredResourceValueProcedure,
-			connect.WithSchema(registeredResourcesServiceUpdateRegisteredResourceValueMethodDescriptor),
+			connect.WithSchema(registeredResourcesServiceMethods.ByName("UpdateRegisteredResourceValue")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteRegisteredResourceValue: connect.NewClient[registeredresources.DeleteRegisteredResourceValueRequest, registeredresources.DeleteRegisteredResourceValueResponse](
 			httpClient,
 			baseURL+RegisteredResourcesServiceDeleteRegisteredResourceValueProcedure,
-			connect.WithSchema(registeredResourcesServiceDeleteRegisteredResourceValueMethodDescriptor),
+			connect.WithSchema(registeredResourcesServiceMethods.ByName("DeleteRegisteredResourceValue")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -284,70 +269,71 @@ type RegisteredResourcesServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewRegisteredResourcesServiceHandler(svc RegisteredResourcesServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	registeredResourcesServiceMethods := registeredresources.File_policy_registeredresources_registered_resources_proto.Services().ByName("RegisteredResourcesService").Methods()
 	registeredResourcesServiceCreateRegisteredResourceHandler := connect.NewUnaryHandler(
 		RegisteredResourcesServiceCreateRegisteredResourceProcedure,
 		svc.CreateRegisteredResource,
-		connect.WithSchema(registeredResourcesServiceCreateRegisteredResourceMethodDescriptor),
+		connect.WithSchema(registeredResourcesServiceMethods.ByName("CreateRegisteredResource")),
 		connect.WithHandlerOptions(opts...),
 	)
 	registeredResourcesServiceGetRegisteredResourceHandler := connect.NewUnaryHandler(
 		RegisteredResourcesServiceGetRegisteredResourceProcedure,
 		svc.GetRegisteredResource,
-		connect.WithSchema(registeredResourcesServiceGetRegisteredResourceMethodDescriptor),
+		connect.WithSchema(registeredResourcesServiceMethods.ByName("GetRegisteredResource")),
 		connect.WithHandlerOptions(opts...),
 	)
 	registeredResourcesServiceListRegisteredResourcesHandler := connect.NewUnaryHandler(
 		RegisteredResourcesServiceListRegisteredResourcesProcedure,
 		svc.ListRegisteredResources,
-		connect.WithSchema(registeredResourcesServiceListRegisteredResourcesMethodDescriptor),
+		connect.WithSchema(registeredResourcesServiceMethods.ByName("ListRegisteredResources")),
 		connect.WithHandlerOptions(opts...),
 	)
 	registeredResourcesServiceUpdateRegisteredResourceHandler := connect.NewUnaryHandler(
 		RegisteredResourcesServiceUpdateRegisteredResourceProcedure,
 		svc.UpdateRegisteredResource,
-		connect.WithSchema(registeredResourcesServiceUpdateRegisteredResourceMethodDescriptor),
+		connect.WithSchema(registeredResourcesServiceMethods.ByName("UpdateRegisteredResource")),
 		connect.WithHandlerOptions(opts...),
 	)
 	registeredResourcesServiceDeleteRegisteredResourceHandler := connect.NewUnaryHandler(
 		RegisteredResourcesServiceDeleteRegisteredResourceProcedure,
 		svc.DeleteRegisteredResource,
-		connect.WithSchema(registeredResourcesServiceDeleteRegisteredResourceMethodDescriptor),
+		connect.WithSchema(registeredResourcesServiceMethods.ByName("DeleteRegisteredResource")),
 		connect.WithHandlerOptions(opts...),
 	)
 	registeredResourcesServiceCreateRegisteredResourceValueHandler := connect.NewUnaryHandler(
 		RegisteredResourcesServiceCreateRegisteredResourceValueProcedure,
 		svc.CreateRegisteredResourceValue,
-		connect.WithSchema(registeredResourcesServiceCreateRegisteredResourceValueMethodDescriptor),
+		connect.WithSchema(registeredResourcesServiceMethods.ByName("CreateRegisteredResourceValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	registeredResourcesServiceGetRegisteredResourceValueHandler := connect.NewUnaryHandler(
 		RegisteredResourcesServiceGetRegisteredResourceValueProcedure,
 		svc.GetRegisteredResourceValue,
-		connect.WithSchema(registeredResourcesServiceGetRegisteredResourceValueMethodDescriptor),
+		connect.WithSchema(registeredResourcesServiceMethods.ByName("GetRegisteredResourceValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	registeredResourcesServiceGetRegisteredResourceValuesByFQNsHandler := connect.NewUnaryHandler(
 		RegisteredResourcesServiceGetRegisteredResourceValuesByFQNsProcedure,
 		svc.GetRegisteredResourceValuesByFQNs,
-		connect.WithSchema(registeredResourcesServiceGetRegisteredResourceValuesByFQNsMethodDescriptor),
+		connect.WithSchema(registeredResourcesServiceMethods.ByName("GetRegisteredResourceValuesByFQNs")),
 		connect.WithHandlerOptions(opts...),
 	)
 	registeredResourcesServiceListRegisteredResourceValuesHandler := connect.NewUnaryHandler(
 		RegisteredResourcesServiceListRegisteredResourceValuesProcedure,
 		svc.ListRegisteredResourceValues,
-		connect.WithSchema(registeredResourcesServiceListRegisteredResourceValuesMethodDescriptor),
+		connect.WithSchema(registeredResourcesServiceMethods.ByName("ListRegisteredResourceValues")),
 		connect.WithHandlerOptions(opts...),
 	)
 	registeredResourcesServiceUpdateRegisteredResourceValueHandler := connect.NewUnaryHandler(
 		RegisteredResourcesServiceUpdateRegisteredResourceValueProcedure,
 		svc.UpdateRegisteredResourceValue,
-		connect.WithSchema(registeredResourcesServiceUpdateRegisteredResourceValueMethodDescriptor),
+		connect.WithSchema(registeredResourcesServiceMethods.ByName("UpdateRegisteredResourceValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	registeredResourcesServiceDeleteRegisteredResourceValueHandler := connect.NewUnaryHandler(
 		RegisteredResourcesServiceDeleteRegisteredResourceValueProcedure,
 		svc.DeleteRegisteredResourceValue,
-		connect.WithSchema(registeredResourcesServiceDeleteRegisteredResourceValueMethodDescriptor),
+		connect.WithSchema(registeredResourcesServiceMethods.ByName("DeleteRegisteredResourceValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/policy.registeredresources.RegisteredResourcesService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/policy/resourcemapping/resourcemappingconnect/resource_mapping.connect.go
+++ b/protocol/go/policy/resourcemapping/resourcemappingconnect/resource_mapping.connect.go
@@ -68,22 +68,6 @@ const (
 	ResourceMappingServiceDeleteResourceMappingProcedure = "/policy.resourcemapping.ResourceMappingService/DeleteResourceMapping"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	resourceMappingServiceServiceDescriptor                               = resourcemapping.File_policy_resourcemapping_resource_mapping_proto.Services().ByName("ResourceMappingService")
-	resourceMappingServiceListResourceMappingGroupsMethodDescriptor       = resourceMappingServiceServiceDescriptor.Methods().ByName("ListResourceMappingGroups")
-	resourceMappingServiceGetResourceMappingGroupMethodDescriptor         = resourceMappingServiceServiceDescriptor.Methods().ByName("GetResourceMappingGroup")
-	resourceMappingServiceCreateResourceMappingGroupMethodDescriptor      = resourceMappingServiceServiceDescriptor.Methods().ByName("CreateResourceMappingGroup")
-	resourceMappingServiceUpdateResourceMappingGroupMethodDescriptor      = resourceMappingServiceServiceDescriptor.Methods().ByName("UpdateResourceMappingGroup")
-	resourceMappingServiceDeleteResourceMappingGroupMethodDescriptor      = resourceMappingServiceServiceDescriptor.Methods().ByName("DeleteResourceMappingGroup")
-	resourceMappingServiceListResourceMappingsMethodDescriptor            = resourceMappingServiceServiceDescriptor.Methods().ByName("ListResourceMappings")
-	resourceMappingServiceListResourceMappingsByGroupFqnsMethodDescriptor = resourceMappingServiceServiceDescriptor.Methods().ByName("ListResourceMappingsByGroupFqns")
-	resourceMappingServiceGetResourceMappingMethodDescriptor              = resourceMappingServiceServiceDescriptor.Methods().ByName("GetResourceMapping")
-	resourceMappingServiceCreateResourceMappingMethodDescriptor           = resourceMappingServiceServiceDescriptor.Methods().ByName("CreateResourceMapping")
-	resourceMappingServiceUpdateResourceMappingMethodDescriptor           = resourceMappingServiceServiceDescriptor.Methods().ByName("UpdateResourceMapping")
-	resourceMappingServiceDeleteResourceMappingMethodDescriptor           = resourceMappingServiceServiceDescriptor.Methods().ByName("DeleteResourceMapping")
-)
-
 // ResourceMappingServiceClient is a client for the policy.resourcemapping.ResourceMappingService
 // service.
 type ResourceMappingServiceClient interface {
@@ -110,76 +94,77 @@ type ResourceMappingServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewResourceMappingServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) ResourceMappingServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	resourceMappingServiceMethods := resourcemapping.File_policy_resourcemapping_resource_mapping_proto.Services().ByName("ResourceMappingService").Methods()
 	return &resourceMappingServiceClient{
 		listResourceMappingGroups: connect.NewClient[resourcemapping.ListResourceMappingGroupsRequest, resourcemapping.ListResourceMappingGroupsResponse](
 			httpClient,
 			baseURL+ResourceMappingServiceListResourceMappingGroupsProcedure,
-			connect.WithSchema(resourceMappingServiceListResourceMappingGroupsMethodDescriptor),
+			connect.WithSchema(resourceMappingServiceMethods.ByName("ListResourceMappingGroups")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		getResourceMappingGroup: connect.NewClient[resourcemapping.GetResourceMappingGroupRequest, resourcemapping.GetResourceMappingGroupResponse](
 			httpClient,
 			baseURL+ResourceMappingServiceGetResourceMappingGroupProcedure,
-			connect.WithSchema(resourceMappingServiceGetResourceMappingGroupMethodDescriptor),
+			connect.WithSchema(resourceMappingServiceMethods.ByName("GetResourceMappingGroup")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		createResourceMappingGroup: connect.NewClient[resourcemapping.CreateResourceMappingGroupRequest, resourcemapping.CreateResourceMappingGroupResponse](
 			httpClient,
 			baseURL+ResourceMappingServiceCreateResourceMappingGroupProcedure,
-			connect.WithSchema(resourceMappingServiceCreateResourceMappingGroupMethodDescriptor),
+			connect.WithSchema(resourceMappingServiceMethods.ByName("CreateResourceMappingGroup")),
 			connect.WithClientOptions(opts...),
 		),
 		updateResourceMappingGroup: connect.NewClient[resourcemapping.UpdateResourceMappingGroupRequest, resourcemapping.UpdateResourceMappingGroupResponse](
 			httpClient,
 			baseURL+ResourceMappingServiceUpdateResourceMappingGroupProcedure,
-			connect.WithSchema(resourceMappingServiceUpdateResourceMappingGroupMethodDescriptor),
+			connect.WithSchema(resourceMappingServiceMethods.ByName("UpdateResourceMappingGroup")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteResourceMappingGroup: connect.NewClient[resourcemapping.DeleteResourceMappingGroupRequest, resourcemapping.DeleteResourceMappingGroupResponse](
 			httpClient,
 			baseURL+ResourceMappingServiceDeleteResourceMappingGroupProcedure,
-			connect.WithSchema(resourceMappingServiceDeleteResourceMappingGroupMethodDescriptor),
+			connect.WithSchema(resourceMappingServiceMethods.ByName("DeleteResourceMappingGroup")),
 			connect.WithClientOptions(opts...),
 		),
 		listResourceMappings: connect.NewClient[resourcemapping.ListResourceMappingsRequest, resourcemapping.ListResourceMappingsResponse](
 			httpClient,
 			baseURL+ResourceMappingServiceListResourceMappingsProcedure,
-			connect.WithSchema(resourceMappingServiceListResourceMappingsMethodDescriptor),
+			connect.WithSchema(resourceMappingServiceMethods.ByName("ListResourceMappings")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		listResourceMappingsByGroupFqns: connect.NewClient[resourcemapping.ListResourceMappingsByGroupFqnsRequest, resourcemapping.ListResourceMappingsByGroupFqnsResponse](
 			httpClient,
 			baseURL+ResourceMappingServiceListResourceMappingsByGroupFqnsProcedure,
-			connect.WithSchema(resourceMappingServiceListResourceMappingsByGroupFqnsMethodDescriptor),
+			connect.WithSchema(resourceMappingServiceMethods.ByName("ListResourceMappingsByGroupFqns")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		getResourceMapping: connect.NewClient[resourcemapping.GetResourceMappingRequest, resourcemapping.GetResourceMappingResponse](
 			httpClient,
 			baseURL+ResourceMappingServiceGetResourceMappingProcedure,
-			connect.WithSchema(resourceMappingServiceGetResourceMappingMethodDescriptor),
+			connect.WithSchema(resourceMappingServiceMethods.ByName("GetResourceMapping")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		createResourceMapping: connect.NewClient[resourcemapping.CreateResourceMappingRequest, resourcemapping.CreateResourceMappingResponse](
 			httpClient,
 			baseURL+ResourceMappingServiceCreateResourceMappingProcedure,
-			connect.WithSchema(resourceMappingServiceCreateResourceMappingMethodDescriptor),
+			connect.WithSchema(resourceMappingServiceMethods.ByName("CreateResourceMapping")),
 			connect.WithClientOptions(opts...),
 		),
 		updateResourceMapping: connect.NewClient[resourcemapping.UpdateResourceMappingRequest, resourcemapping.UpdateResourceMappingResponse](
 			httpClient,
 			baseURL+ResourceMappingServiceUpdateResourceMappingProcedure,
-			connect.WithSchema(resourceMappingServiceUpdateResourceMappingMethodDescriptor),
+			connect.WithSchema(resourceMappingServiceMethods.ByName("UpdateResourceMapping")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteResourceMapping: connect.NewClient[resourcemapping.DeleteResourceMappingRequest, resourcemapping.DeleteResourceMappingResponse](
 			httpClient,
 			baseURL+ResourceMappingServiceDeleteResourceMappingProcedure,
-			connect.WithSchema(resourceMappingServiceDeleteResourceMappingMethodDescriptor),
+			connect.WithSchema(resourceMappingServiceMethods.ByName("DeleteResourceMapping")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -283,75 +268,76 @@ type ResourceMappingServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewResourceMappingServiceHandler(svc ResourceMappingServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	resourceMappingServiceMethods := resourcemapping.File_policy_resourcemapping_resource_mapping_proto.Services().ByName("ResourceMappingService").Methods()
 	resourceMappingServiceListResourceMappingGroupsHandler := connect.NewUnaryHandler(
 		ResourceMappingServiceListResourceMappingGroupsProcedure,
 		svc.ListResourceMappingGroups,
-		connect.WithSchema(resourceMappingServiceListResourceMappingGroupsMethodDescriptor),
+		connect.WithSchema(resourceMappingServiceMethods.ByName("ListResourceMappingGroups")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	resourceMappingServiceGetResourceMappingGroupHandler := connect.NewUnaryHandler(
 		ResourceMappingServiceGetResourceMappingGroupProcedure,
 		svc.GetResourceMappingGroup,
-		connect.WithSchema(resourceMappingServiceGetResourceMappingGroupMethodDescriptor),
+		connect.WithSchema(resourceMappingServiceMethods.ByName("GetResourceMappingGroup")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	resourceMappingServiceCreateResourceMappingGroupHandler := connect.NewUnaryHandler(
 		ResourceMappingServiceCreateResourceMappingGroupProcedure,
 		svc.CreateResourceMappingGroup,
-		connect.WithSchema(resourceMappingServiceCreateResourceMappingGroupMethodDescriptor),
+		connect.WithSchema(resourceMappingServiceMethods.ByName("CreateResourceMappingGroup")),
 		connect.WithHandlerOptions(opts...),
 	)
 	resourceMappingServiceUpdateResourceMappingGroupHandler := connect.NewUnaryHandler(
 		ResourceMappingServiceUpdateResourceMappingGroupProcedure,
 		svc.UpdateResourceMappingGroup,
-		connect.WithSchema(resourceMappingServiceUpdateResourceMappingGroupMethodDescriptor),
+		connect.WithSchema(resourceMappingServiceMethods.ByName("UpdateResourceMappingGroup")),
 		connect.WithHandlerOptions(opts...),
 	)
 	resourceMappingServiceDeleteResourceMappingGroupHandler := connect.NewUnaryHandler(
 		ResourceMappingServiceDeleteResourceMappingGroupProcedure,
 		svc.DeleteResourceMappingGroup,
-		connect.WithSchema(resourceMappingServiceDeleteResourceMappingGroupMethodDescriptor),
+		connect.WithSchema(resourceMappingServiceMethods.ByName("DeleteResourceMappingGroup")),
 		connect.WithHandlerOptions(opts...),
 	)
 	resourceMappingServiceListResourceMappingsHandler := connect.NewUnaryHandler(
 		ResourceMappingServiceListResourceMappingsProcedure,
 		svc.ListResourceMappings,
-		connect.WithSchema(resourceMappingServiceListResourceMappingsMethodDescriptor),
+		connect.WithSchema(resourceMappingServiceMethods.ByName("ListResourceMappings")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	resourceMappingServiceListResourceMappingsByGroupFqnsHandler := connect.NewUnaryHandler(
 		ResourceMappingServiceListResourceMappingsByGroupFqnsProcedure,
 		svc.ListResourceMappingsByGroupFqns,
-		connect.WithSchema(resourceMappingServiceListResourceMappingsByGroupFqnsMethodDescriptor),
+		connect.WithSchema(resourceMappingServiceMethods.ByName("ListResourceMappingsByGroupFqns")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	resourceMappingServiceGetResourceMappingHandler := connect.NewUnaryHandler(
 		ResourceMappingServiceGetResourceMappingProcedure,
 		svc.GetResourceMapping,
-		connect.WithSchema(resourceMappingServiceGetResourceMappingMethodDescriptor),
+		connect.WithSchema(resourceMappingServiceMethods.ByName("GetResourceMapping")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	resourceMappingServiceCreateResourceMappingHandler := connect.NewUnaryHandler(
 		ResourceMappingServiceCreateResourceMappingProcedure,
 		svc.CreateResourceMapping,
-		connect.WithSchema(resourceMappingServiceCreateResourceMappingMethodDescriptor),
+		connect.WithSchema(resourceMappingServiceMethods.ByName("CreateResourceMapping")),
 		connect.WithHandlerOptions(opts...),
 	)
 	resourceMappingServiceUpdateResourceMappingHandler := connect.NewUnaryHandler(
 		ResourceMappingServiceUpdateResourceMappingProcedure,
 		svc.UpdateResourceMapping,
-		connect.WithSchema(resourceMappingServiceUpdateResourceMappingMethodDescriptor),
+		connect.WithSchema(resourceMappingServiceMethods.ByName("UpdateResourceMapping")),
 		connect.WithHandlerOptions(opts...),
 	)
 	resourceMappingServiceDeleteResourceMappingHandler := connect.NewUnaryHandler(
 		ResourceMappingServiceDeleteResourceMappingProcedure,
 		svc.DeleteResourceMapping,
-		connect.WithSchema(resourceMappingServiceDeleteResourceMappingMethodDescriptor),
+		connect.WithSchema(resourceMappingServiceMethods.ByName("DeleteResourceMapping")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/policy.resourcemapping.ResourceMappingService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/policy/subjectmapping/subjectmappingconnect/subject_mapping.connect.go
+++ b/protocol/go/policy/subjectmapping/subjectmappingconnect/subject_mapping.connect.go
@@ -71,23 +71,6 @@ const (
 	SubjectMappingServiceDeleteAllUnmappedSubjectConditionSetsProcedure = "/policy.subjectmapping.SubjectMappingService/DeleteAllUnmappedSubjectConditionSets"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	subjectMappingServiceServiceDescriptor                                     = subjectmapping.File_policy_subjectmapping_subject_mapping_proto.Services().ByName("SubjectMappingService")
-	subjectMappingServiceMatchSubjectMappingsMethodDescriptor                  = subjectMappingServiceServiceDescriptor.Methods().ByName("MatchSubjectMappings")
-	subjectMappingServiceListSubjectMappingsMethodDescriptor                   = subjectMappingServiceServiceDescriptor.Methods().ByName("ListSubjectMappings")
-	subjectMappingServiceGetSubjectMappingMethodDescriptor                     = subjectMappingServiceServiceDescriptor.Methods().ByName("GetSubjectMapping")
-	subjectMappingServiceCreateSubjectMappingMethodDescriptor                  = subjectMappingServiceServiceDescriptor.Methods().ByName("CreateSubjectMapping")
-	subjectMappingServiceUpdateSubjectMappingMethodDescriptor                  = subjectMappingServiceServiceDescriptor.Methods().ByName("UpdateSubjectMapping")
-	subjectMappingServiceDeleteSubjectMappingMethodDescriptor                  = subjectMappingServiceServiceDescriptor.Methods().ByName("DeleteSubjectMapping")
-	subjectMappingServiceListSubjectConditionSetsMethodDescriptor              = subjectMappingServiceServiceDescriptor.Methods().ByName("ListSubjectConditionSets")
-	subjectMappingServiceGetSubjectConditionSetMethodDescriptor                = subjectMappingServiceServiceDescriptor.Methods().ByName("GetSubjectConditionSet")
-	subjectMappingServiceCreateSubjectConditionSetMethodDescriptor             = subjectMappingServiceServiceDescriptor.Methods().ByName("CreateSubjectConditionSet")
-	subjectMappingServiceUpdateSubjectConditionSetMethodDescriptor             = subjectMappingServiceServiceDescriptor.Methods().ByName("UpdateSubjectConditionSet")
-	subjectMappingServiceDeleteSubjectConditionSetMethodDescriptor             = subjectMappingServiceServiceDescriptor.Methods().ByName("DeleteSubjectConditionSet")
-	subjectMappingServiceDeleteAllUnmappedSubjectConditionSetsMethodDescriptor = subjectMappingServiceServiceDescriptor.Methods().ByName("DeleteAllUnmappedSubjectConditionSets")
-)
-
 // SubjectMappingServiceClient is a client for the policy.subjectmapping.SubjectMappingService
 // service.
 type SubjectMappingServiceClient interface {
@@ -116,81 +99,82 @@ type SubjectMappingServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewSubjectMappingServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) SubjectMappingServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	subjectMappingServiceMethods := subjectmapping.File_policy_subjectmapping_subject_mapping_proto.Services().ByName("SubjectMappingService").Methods()
 	return &subjectMappingServiceClient{
 		matchSubjectMappings: connect.NewClient[subjectmapping.MatchSubjectMappingsRequest, subjectmapping.MatchSubjectMappingsResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceMatchSubjectMappingsProcedure,
-			connect.WithSchema(subjectMappingServiceMatchSubjectMappingsMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("MatchSubjectMappings")),
 			connect.WithClientOptions(opts...),
 		),
 		listSubjectMappings: connect.NewClient[subjectmapping.ListSubjectMappingsRequest, subjectmapping.ListSubjectMappingsResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceListSubjectMappingsProcedure,
-			connect.WithSchema(subjectMappingServiceListSubjectMappingsMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("ListSubjectMappings")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		getSubjectMapping: connect.NewClient[subjectmapping.GetSubjectMappingRequest, subjectmapping.GetSubjectMappingResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceGetSubjectMappingProcedure,
-			connect.WithSchema(subjectMappingServiceGetSubjectMappingMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("GetSubjectMapping")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		createSubjectMapping: connect.NewClient[subjectmapping.CreateSubjectMappingRequest, subjectmapping.CreateSubjectMappingResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceCreateSubjectMappingProcedure,
-			connect.WithSchema(subjectMappingServiceCreateSubjectMappingMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("CreateSubjectMapping")),
 			connect.WithClientOptions(opts...),
 		),
 		updateSubjectMapping: connect.NewClient[subjectmapping.UpdateSubjectMappingRequest, subjectmapping.UpdateSubjectMappingResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceUpdateSubjectMappingProcedure,
-			connect.WithSchema(subjectMappingServiceUpdateSubjectMappingMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("UpdateSubjectMapping")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteSubjectMapping: connect.NewClient[subjectmapping.DeleteSubjectMappingRequest, subjectmapping.DeleteSubjectMappingResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceDeleteSubjectMappingProcedure,
-			connect.WithSchema(subjectMappingServiceDeleteSubjectMappingMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("DeleteSubjectMapping")),
 			connect.WithClientOptions(opts...),
 		),
 		listSubjectConditionSets: connect.NewClient[subjectmapping.ListSubjectConditionSetsRequest, subjectmapping.ListSubjectConditionSetsResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceListSubjectConditionSetsProcedure,
-			connect.WithSchema(subjectMappingServiceListSubjectConditionSetsMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("ListSubjectConditionSets")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		getSubjectConditionSet: connect.NewClient[subjectmapping.GetSubjectConditionSetRequest, subjectmapping.GetSubjectConditionSetResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceGetSubjectConditionSetProcedure,
-			connect.WithSchema(subjectMappingServiceGetSubjectConditionSetMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("GetSubjectConditionSet")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		createSubjectConditionSet: connect.NewClient[subjectmapping.CreateSubjectConditionSetRequest, subjectmapping.CreateSubjectConditionSetResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceCreateSubjectConditionSetProcedure,
-			connect.WithSchema(subjectMappingServiceCreateSubjectConditionSetMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("CreateSubjectConditionSet")),
 			connect.WithClientOptions(opts...),
 		),
 		updateSubjectConditionSet: connect.NewClient[subjectmapping.UpdateSubjectConditionSetRequest, subjectmapping.UpdateSubjectConditionSetResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceUpdateSubjectConditionSetProcedure,
-			connect.WithSchema(subjectMappingServiceUpdateSubjectConditionSetMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("UpdateSubjectConditionSet")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteSubjectConditionSet: connect.NewClient[subjectmapping.DeleteSubjectConditionSetRequest, subjectmapping.DeleteSubjectConditionSetResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceDeleteSubjectConditionSetProcedure,
-			connect.WithSchema(subjectMappingServiceDeleteSubjectConditionSetMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("DeleteSubjectConditionSet")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteAllUnmappedSubjectConditionSets: connect.NewClient[subjectmapping.DeleteAllUnmappedSubjectConditionSetsRequest, subjectmapping.DeleteAllUnmappedSubjectConditionSetsResponse](
 			httpClient,
 			baseURL+SubjectMappingServiceDeleteAllUnmappedSubjectConditionSetsProcedure,
-			connect.WithSchema(subjectMappingServiceDeleteAllUnmappedSubjectConditionSetsMethodDescriptor),
+			connect.WithSchema(subjectMappingServiceMethods.ByName("DeleteAllUnmappedSubjectConditionSets")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -301,80 +285,81 @@ type SubjectMappingServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewSubjectMappingServiceHandler(svc SubjectMappingServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	subjectMappingServiceMethods := subjectmapping.File_policy_subjectmapping_subject_mapping_proto.Services().ByName("SubjectMappingService").Methods()
 	subjectMappingServiceMatchSubjectMappingsHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceMatchSubjectMappingsProcedure,
 		svc.MatchSubjectMappings,
-		connect.WithSchema(subjectMappingServiceMatchSubjectMappingsMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("MatchSubjectMappings")),
 		connect.WithHandlerOptions(opts...),
 	)
 	subjectMappingServiceListSubjectMappingsHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceListSubjectMappingsProcedure,
 		svc.ListSubjectMappings,
-		connect.WithSchema(subjectMappingServiceListSubjectMappingsMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("ListSubjectMappings")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	subjectMappingServiceGetSubjectMappingHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceGetSubjectMappingProcedure,
 		svc.GetSubjectMapping,
-		connect.WithSchema(subjectMappingServiceGetSubjectMappingMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("GetSubjectMapping")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	subjectMappingServiceCreateSubjectMappingHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceCreateSubjectMappingProcedure,
 		svc.CreateSubjectMapping,
-		connect.WithSchema(subjectMappingServiceCreateSubjectMappingMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("CreateSubjectMapping")),
 		connect.WithHandlerOptions(opts...),
 	)
 	subjectMappingServiceUpdateSubjectMappingHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceUpdateSubjectMappingProcedure,
 		svc.UpdateSubjectMapping,
-		connect.WithSchema(subjectMappingServiceUpdateSubjectMappingMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("UpdateSubjectMapping")),
 		connect.WithHandlerOptions(opts...),
 	)
 	subjectMappingServiceDeleteSubjectMappingHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceDeleteSubjectMappingProcedure,
 		svc.DeleteSubjectMapping,
-		connect.WithSchema(subjectMappingServiceDeleteSubjectMappingMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("DeleteSubjectMapping")),
 		connect.WithHandlerOptions(opts...),
 	)
 	subjectMappingServiceListSubjectConditionSetsHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceListSubjectConditionSetsProcedure,
 		svc.ListSubjectConditionSets,
-		connect.WithSchema(subjectMappingServiceListSubjectConditionSetsMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("ListSubjectConditionSets")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	subjectMappingServiceGetSubjectConditionSetHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceGetSubjectConditionSetProcedure,
 		svc.GetSubjectConditionSet,
-		connect.WithSchema(subjectMappingServiceGetSubjectConditionSetMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("GetSubjectConditionSet")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	subjectMappingServiceCreateSubjectConditionSetHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceCreateSubjectConditionSetProcedure,
 		svc.CreateSubjectConditionSet,
-		connect.WithSchema(subjectMappingServiceCreateSubjectConditionSetMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("CreateSubjectConditionSet")),
 		connect.WithHandlerOptions(opts...),
 	)
 	subjectMappingServiceUpdateSubjectConditionSetHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceUpdateSubjectConditionSetProcedure,
 		svc.UpdateSubjectConditionSet,
-		connect.WithSchema(subjectMappingServiceUpdateSubjectConditionSetMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("UpdateSubjectConditionSet")),
 		connect.WithHandlerOptions(opts...),
 	)
 	subjectMappingServiceDeleteSubjectConditionSetHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceDeleteSubjectConditionSetProcedure,
 		svc.DeleteSubjectConditionSet,
-		connect.WithSchema(subjectMappingServiceDeleteSubjectConditionSetMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("DeleteSubjectConditionSet")),
 		connect.WithHandlerOptions(opts...),
 	)
 	subjectMappingServiceDeleteAllUnmappedSubjectConditionSetsHandler := connect.NewUnaryHandler(
 		SubjectMappingServiceDeleteAllUnmappedSubjectConditionSetsProcedure,
 		svc.DeleteAllUnmappedSubjectConditionSets,
-		connect.WithSchema(subjectMappingServiceDeleteAllUnmappedSubjectConditionSetsMethodDescriptor),
+		connect.WithSchema(subjectMappingServiceMethods.ByName("DeleteAllUnmappedSubjectConditionSets")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/policy.subjectmapping.SubjectMappingService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/policy/unsafe/unsafeconnect/unsafe.connect.go
+++ b/protocol/go/policy/unsafe/unsafeconnect/unsafe.connect.go
@@ -65,21 +65,6 @@ const (
 	UnsafeServiceUnsafeDeleteKasKeyProcedure = "/policy.unsafe.UnsafeService/UnsafeDeleteKasKey"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	unsafeServiceServiceDescriptor                              = unsafe.File_policy_unsafe_unsafe_proto.Services().ByName("UnsafeService")
-	unsafeServiceUnsafeUpdateNamespaceMethodDescriptor          = unsafeServiceServiceDescriptor.Methods().ByName("UnsafeUpdateNamespace")
-	unsafeServiceUnsafeReactivateNamespaceMethodDescriptor      = unsafeServiceServiceDescriptor.Methods().ByName("UnsafeReactivateNamespace")
-	unsafeServiceUnsafeDeleteNamespaceMethodDescriptor          = unsafeServiceServiceDescriptor.Methods().ByName("UnsafeDeleteNamespace")
-	unsafeServiceUnsafeUpdateAttributeMethodDescriptor          = unsafeServiceServiceDescriptor.Methods().ByName("UnsafeUpdateAttribute")
-	unsafeServiceUnsafeReactivateAttributeMethodDescriptor      = unsafeServiceServiceDescriptor.Methods().ByName("UnsafeReactivateAttribute")
-	unsafeServiceUnsafeDeleteAttributeMethodDescriptor          = unsafeServiceServiceDescriptor.Methods().ByName("UnsafeDeleteAttribute")
-	unsafeServiceUnsafeUpdateAttributeValueMethodDescriptor     = unsafeServiceServiceDescriptor.Methods().ByName("UnsafeUpdateAttributeValue")
-	unsafeServiceUnsafeReactivateAttributeValueMethodDescriptor = unsafeServiceServiceDescriptor.Methods().ByName("UnsafeReactivateAttributeValue")
-	unsafeServiceUnsafeDeleteAttributeValueMethodDescriptor     = unsafeServiceServiceDescriptor.Methods().ByName("UnsafeDeleteAttributeValue")
-	unsafeServiceUnsafeDeleteKasKeyMethodDescriptor             = unsafeServiceServiceDescriptor.Methods().ByName("UnsafeDeleteKasKey")
-)
-
 // UnsafeServiceClient is a client for the policy.unsafe.UnsafeService service.
 type UnsafeServiceClient interface {
 	// --------------------------------------*
@@ -115,65 +100,66 @@ type UnsafeServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewUnsafeServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) UnsafeServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	unsafeServiceMethods := unsafe.File_policy_unsafe_unsafe_proto.Services().ByName("UnsafeService").Methods()
 	return &unsafeServiceClient{
 		unsafeUpdateNamespace: connect.NewClient[unsafe.UnsafeUpdateNamespaceRequest, unsafe.UnsafeUpdateNamespaceResponse](
 			httpClient,
 			baseURL+UnsafeServiceUnsafeUpdateNamespaceProcedure,
-			connect.WithSchema(unsafeServiceUnsafeUpdateNamespaceMethodDescriptor),
+			connect.WithSchema(unsafeServiceMethods.ByName("UnsafeUpdateNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 		unsafeReactivateNamespace: connect.NewClient[unsafe.UnsafeReactivateNamespaceRequest, unsafe.UnsafeReactivateNamespaceResponse](
 			httpClient,
 			baseURL+UnsafeServiceUnsafeReactivateNamespaceProcedure,
-			connect.WithSchema(unsafeServiceUnsafeReactivateNamespaceMethodDescriptor),
+			connect.WithSchema(unsafeServiceMethods.ByName("UnsafeReactivateNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 		unsafeDeleteNamespace: connect.NewClient[unsafe.UnsafeDeleteNamespaceRequest, unsafe.UnsafeDeleteNamespaceResponse](
 			httpClient,
 			baseURL+UnsafeServiceUnsafeDeleteNamespaceProcedure,
-			connect.WithSchema(unsafeServiceUnsafeDeleteNamespaceMethodDescriptor),
+			connect.WithSchema(unsafeServiceMethods.ByName("UnsafeDeleteNamespace")),
 			connect.WithClientOptions(opts...),
 		),
 		unsafeUpdateAttribute: connect.NewClient[unsafe.UnsafeUpdateAttributeRequest, unsafe.UnsafeUpdateAttributeResponse](
 			httpClient,
 			baseURL+UnsafeServiceUnsafeUpdateAttributeProcedure,
-			connect.WithSchema(unsafeServiceUnsafeUpdateAttributeMethodDescriptor),
+			connect.WithSchema(unsafeServiceMethods.ByName("UnsafeUpdateAttribute")),
 			connect.WithClientOptions(opts...),
 		),
 		unsafeReactivateAttribute: connect.NewClient[unsafe.UnsafeReactivateAttributeRequest, unsafe.UnsafeReactivateAttributeResponse](
 			httpClient,
 			baseURL+UnsafeServiceUnsafeReactivateAttributeProcedure,
-			connect.WithSchema(unsafeServiceUnsafeReactivateAttributeMethodDescriptor),
+			connect.WithSchema(unsafeServiceMethods.ByName("UnsafeReactivateAttribute")),
 			connect.WithClientOptions(opts...),
 		),
 		unsafeDeleteAttribute: connect.NewClient[unsafe.UnsafeDeleteAttributeRequest, unsafe.UnsafeDeleteAttributeResponse](
 			httpClient,
 			baseURL+UnsafeServiceUnsafeDeleteAttributeProcedure,
-			connect.WithSchema(unsafeServiceUnsafeDeleteAttributeMethodDescriptor),
+			connect.WithSchema(unsafeServiceMethods.ByName("UnsafeDeleteAttribute")),
 			connect.WithClientOptions(opts...),
 		),
 		unsafeUpdateAttributeValue: connect.NewClient[unsafe.UnsafeUpdateAttributeValueRequest, unsafe.UnsafeUpdateAttributeValueResponse](
 			httpClient,
 			baseURL+UnsafeServiceUnsafeUpdateAttributeValueProcedure,
-			connect.WithSchema(unsafeServiceUnsafeUpdateAttributeValueMethodDescriptor),
+			connect.WithSchema(unsafeServiceMethods.ByName("UnsafeUpdateAttributeValue")),
 			connect.WithClientOptions(opts...),
 		),
 		unsafeReactivateAttributeValue: connect.NewClient[unsafe.UnsafeReactivateAttributeValueRequest, unsafe.UnsafeReactivateAttributeValueResponse](
 			httpClient,
 			baseURL+UnsafeServiceUnsafeReactivateAttributeValueProcedure,
-			connect.WithSchema(unsafeServiceUnsafeReactivateAttributeValueMethodDescriptor),
+			connect.WithSchema(unsafeServiceMethods.ByName("UnsafeReactivateAttributeValue")),
 			connect.WithClientOptions(opts...),
 		),
 		unsafeDeleteAttributeValue: connect.NewClient[unsafe.UnsafeDeleteAttributeValueRequest, unsafe.UnsafeDeleteAttributeValueResponse](
 			httpClient,
 			baseURL+UnsafeServiceUnsafeDeleteAttributeValueProcedure,
-			connect.WithSchema(unsafeServiceUnsafeDeleteAttributeValueMethodDescriptor),
+			connect.WithSchema(unsafeServiceMethods.ByName("UnsafeDeleteAttributeValue")),
 			connect.WithClientOptions(opts...),
 		),
 		unsafeDeleteKasKey: connect.NewClient[unsafe.UnsafeDeleteKasKeyRequest, unsafe.UnsafeDeleteKasKeyResponse](
 			httpClient,
 			baseURL+UnsafeServiceUnsafeDeleteKasKeyProcedure,
-			connect.WithSchema(unsafeServiceUnsafeDeleteKasKeyMethodDescriptor),
+			connect.WithSchema(unsafeServiceMethods.ByName("UnsafeDeleteKasKey")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -275,64 +261,65 @@ type UnsafeServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewUnsafeServiceHandler(svc UnsafeServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	unsafeServiceMethods := unsafe.File_policy_unsafe_unsafe_proto.Services().ByName("UnsafeService").Methods()
 	unsafeServiceUnsafeUpdateNamespaceHandler := connect.NewUnaryHandler(
 		UnsafeServiceUnsafeUpdateNamespaceProcedure,
 		svc.UnsafeUpdateNamespace,
-		connect.WithSchema(unsafeServiceUnsafeUpdateNamespaceMethodDescriptor),
+		connect.WithSchema(unsafeServiceMethods.ByName("UnsafeUpdateNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	unsafeServiceUnsafeReactivateNamespaceHandler := connect.NewUnaryHandler(
 		UnsafeServiceUnsafeReactivateNamespaceProcedure,
 		svc.UnsafeReactivateNamespace,
-		connect.WithSchema(unsafeServiceUnsafeReactivateNamespaceMethodDescriptor),
+		connect.WithSchema(unsafeServiceMethods.ByName("UnsafeReactivateNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	unsafeServiceUnsafeDeleteNamespaceHandler := connect.NewUnaryHandler(
 		UnsafeServiceUnsafeDeleteNamespaceProcedure,
 		svc.UnsafeDeleteNamespace,
-		connect.WithSchema(unsafeServiceUnsafeDeleteNamespaceMethodDescriptor),
+		connect.WithSchema(unsafeServiceMethods.ByName("UnsafeDeleteNamespace")),
 		connect.WithHandlerOptions(opts...),
 	)
 	unsafeServiceUnsafeUpdateAttributeHandler := connect.NewUnaryHandler(
 		UnsafeServiceUnsafeUpdateAttributeProcedure,
 		svc.UnsafeUpdateAttribute,
-		connect.WithSchema(unsafeServiceUnsafeUpdateAttributeMethodDescriptor),
+		connect.WithSchema(unsafeServiceMethods.ByName("UnsafeUpdateAttribute")),
 		connect.WithHandlerOptions(opts...),
 	)
 	unsafeServiceUnsafeReactivateAttributeHandler := connect.NewUnaryHandler(
 		UnsafeServiceUnsafeReactivateAttributeProcedure,
 		svc.UnsafeReactivateAttribute,
-		connect.WithSchema(unsafeServiceUnsafeReactivateAttributeMethodDescriptor),
+		connect.WithSchema(unsafeServiceMethods.ByName("UnsafeReactivateAttribute")),
 		connect.WithHandlerOptions(opts...),
 	)
 	unsafeServiceUnsafeDeleteAttributeHandler := connect.NewUnaryHandler(
 		UnsafeServiceUnsafeDeleteAttributeProcedure,
 		svc.UnsafeDeleteAttribute,
-		connect.WithSchema(unsafeServiceUnsafeDeleteAttributeMethodDescriptor),
+		connect.WithSchema(unsafeServiceMethods.ByName("UnsafeDeleteAttribute")),
 		connect.WithHandlerOptions(opts...),
 	)
 	unsafeServiceUnsafeUpdateAttributeValueHandler := connect.NewUnaryHandler(
 		UnsafeServiceUnsafeUpdateAttributeValueProcedure,
 		svc.UnsafeUpdateAttributeValue,
-		connect.WithSchema(unsafeServiceUnsafeUpdateAttributeValueMethodDescriptor),
+		connect.WithSchema(unsafeServiceMethods.ByName("UnsafeUpdateAttributeValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	unsafeServiceUnsafeReactivateAttributeValueHandler := connect.NewUnaryHandler(
 		UnsafeServiceUnsafeReactivateAttributeValueProcedure,
 		svc.UnsafeReactivateAttributeValue,
-		connect.WithSchema(unsafeServiceUnsafeReactivateAttributeValueMethodDescriptor),
+		connect.WithSchema(unsafeServiceMethods.ByName("UnsafeReactivateAttributeValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	unsafeServiceUnsafeDeleteAttributeValueHandler := connect.NewUnaryHandler(
 		UnsafeServiceUnsafeDeleteAttributeValueProcedure,
 		svc.UnsafeDeleteAttributeValue,
-		connect.WithSchema(unsafeServiceUnsafeDeleteAttributeValueMethodDescriptor),
+		connect.WithSchema(unsafeServiceMethods.ByName("UnsafeDeleteAttributeValue")),
 		connect.WithHandlerOptions(opts...),
 	)
 	unsafeServiceUnsafeDeleteKasKeyHandler := connect.NewUnaryHandler(
 		UnsafeServiceUnsafeDeleteKasKeyProcedure,
 		svc.UnsafeDeleteKasKey,
-		connect.WithSchema(unsafeServiceUnsafeDeleteKasKeyMethodDescriptor),
+		connect.WithSchema(unsafeServiceMethods.ByName("UnsafeDeleteKasKey")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/policy.unsafe.UnsafeService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/protocol/go/wellknownconfiguration/wellknownconfigurationconnect/wellknown_configuration.connect.go
+++ b/protocol/go/wellknownconfiguration/wellknownconfigurationconnect/wellknown_configuration.connect.go
@@ -38,12 +38,6 @@ const (
 	WellKnownServiceGetWellKnownConfigurationProcedure = "/wellknownconfiguration.WellKnownService/GetWellKnownConfiguration"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	wellKnownServiceServiceDescriptor                         = wellknownconfiguration.File_wellknownconfiguration_wellknown_configuration_proto.Services().ByName("WellKnownService")
-	wellKnownServiceGetWellKnownConfigurationMethodDescriptor = wellKnownServiceServiceDescriptor.Methods().ByName("GetWellKnownConfiguration")
-)
-
 // WellKnownServiceClient is a client for the wellknownconfiguration.WellKnownService service.
 type WellKnownServiceClient interface {
 	GetWellKnownConfiguration(context.Context, *connect.Request[wellknownconfiguration.GetWellKnownConfigurationRequest]) (*connect.Response[wellknownconfiguration.GetWellKnownConfigurationResponse], error)
@@ -58,11 +52,12 @@ type WellKnownServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewWellKnownServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) WellKnownServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	wellKnownServiceMethods := wellknownconfiguration.File_wellknownconfiguration_wellknown_configuration_proto.Services().ByName("WellKnownService").Methods()
 	return &wellKnownServiceClient{
 		getWellKnownConfiguration: connect.NewClient[wellknownconfiguration.GetWellKnownConfigurationRequest, wellknownconfiguration.GetWellKnownConfigurationResponse](
 			httpClient,
 			baseURL+WellKnownServiceGetWellKnownConfigurationProcedure,
-			connect.WithSchema(wellKnownServiceGetWellKnownConfigurationMethodDescriptor),
+			connect.WithSchema(wellKnownServiceMethods.ByName("GetWellKnownConfiguration")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
@@ -92,10 +87,11 @@ type WellKnownServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewWellKnownServiceHandler(svc WellKnownServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	wellKnownServiceMethods := wellknownconfiguration.File_wellknownconfiguration_wellknown_configuration_proto.Services().ByName("WellKnownService").Methods()
 	wellKnownServiceGetWellKnownConfigurationHandler := connect.NewUnaryHandler(
 		WellKnownServiceGetWellKnownConfigurationProcedure,
 		svc.GetWellKnownConfiguration,
-		connect.WithSchema(wellKnownServiceGetWellKnownConfigurationMethodDescriptor),
+		connect.WithSchema(wellKnownServiceMethods.ByName("GetWellKnownConfiguration")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)

--- a/service/go.mod
+++ b/service/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.11
 
 require (
 	buf.build/go/protovalidate v0.13.1
-	connectrpc.com/connect v1.18.1
+	connectrpc.com/connect v1.19.1
 	connectrpc.com/grpchealth v1.4.0
 	connectrpc.com/grpcreflect v1.3.0
 	connectrpc.com/validate v0.3.0

--- a/service/go.sum
+++ b/service/go.sum
@@ -4,8 +4,8 @@ buf.build/go/protovalidate v0.13.1 h1:6loHDTWdY/1qmqmt1MijBIKeN4T9Eajrqb9isT1W1s
 buf.build/go/protovalidate v0.13.1/go.mod h1:C/QcOn/CjXRn5udUwYBiLs8y1TGy7RS+GOSKqjS77aU=
 cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
 cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
-connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
-connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
+connectrpc.com/connect v1.19.1 h1:R5M57z05+90EfEvCY1b7hBxDVOUl45PrtXtAV2fOC14=
+connectrpc.com/connect v1.19.1/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
 connectrpc.com/grpchealth v1.4.0 h1:MJC96JLelARPgZTiRF9KRfY/2N9OcoQvF2EWX07v2IE=
 connectrpc.com/grpchealth v1.4.0/go.mod h1:WhW6m1EzTmq3Ky1FE8EfkIpSDc6TfUx2M2KqZO3ts/Q=
 connectrpc.com/grpcreflect v1.3.0 h1:Y4V+ACf8/vOb1XOc251Qun7jMB75gCUNw6llvB9csXc=


### PR DESCRIPTION
This pull request updates the Go client and handler code generated from protobuf definitions for several services, focusing on simplifying method descriptor usage and updating dependencies. The changes remove manually defined protoreflect descriptor variables and instead retrieve method descriptors dynamically, leading to cleaner and more maintainable generated code. Additionally, the Connect and Protobuf dependencies are updated to newer versions.

Dependency updates:

* Upgraded `connectrpc.com/connect` from v1.17.0 to v1.19.1 and `google.golang.org/protobuf` from v1.36.6 to v1.36.9 in `protocol/go/go.mod` and the relevant plugin configuration in `buf.gen.yaml`. 

