### PR TITLE
chore(ci): fix yq command by removing unsupported if-else syntax

### DIFF
--- a/test/start-additional-kas/action.yaml
+++ b/test/start-additional-kas/action.yaml
@@ -107,7 +107,7 @@ runs:
             | (.services.kas.preview.ec_tdf_enabled = env(EC_TDF_ENABLED))
             | (.services.kas.preview.key_management = env(KEY_MANAGEMENT))
             | (.services.kas.registered_kas_uri = "http://localhost:" + env(KAS_PORT))
-            | (if env(KEY_MANAGEMENT) == "true" then (.services.kas.root_key = env(ROOT_KEY)) else del(.services.kas.root_key) end)
+            | del(.services.kas.root_key)
             | (.logger.level = env(LOG_LEVEL))
             | (.logger.type = env(LOG_TYPE))
             | (.sdk_config = {"client_id":"opentdf","client_secret":"secret","core":{"endpoint":"http://localhost:8080","plaintext":true}})


### PR DESCRIPTION
## Summary
- Fixed the `start-additional-kas` workflow that was failing due to unsupported yq if-else syntax
- Replaced conditional if-else with `del()` call and existing bash conditional logic

## Details
The workflow was using `if env(KEY_MANAGEMENT) == "true" then ... else del(...) end` syntax which is not supported in current yq versions (unlike jq). The fix removes the yq conditional and relies on the existing bash conditional (lines 115-117) to set `root_key` when `KEY_MANAGEMENT` is true, achieving the same result with yq-supported syntax.

## Test plan
- Verify the `start-additional-kas` workflow runs successfully
- Confirm that when `KEY_MANAGEMENT` is false, `root_key` is deleted
- Confirm that when `KEY_MANAGEMENT` is true, `root_key` is set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)