### PR TITLE
chore: bump Go toolchain from 1.24.11 to 1.24.12

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/examples
 
 go 1.24.0
 
-toolchain go1.24.11
+toolchain go1.24.12
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.24.11
+go 1.24.12
 
 use (
 	./examples

--- a/lib/fixtures/go.mod
+++ b/lib/fixtures/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/lib/fixtures
 
 go 1.23.0
 
-toolchain go1.24.11
+toolchain go1.24.12
 
 require github.com/Nerzal/gocloak/v13 v13.9.0
 

--- a/lib/ocrypto/go.mod
+++ b/lib/ocrypto/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/lib/ocrypto
 
 go 1.24.0
 
-toolchain go1.24.11
+toolchain go1.24.12
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/protocol/go/go.mod
+++ b/protocol/go/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/protocol/go
 
 go 1.24.0
 
-toolchain go1.24.11
+toolchain go1.24.12
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/sdk
 
 go 1.24.0
 
-toolchain go1.24.11
+toolchain go1.24.12
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/service/go.mod
+++ b/service/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/service
 
 go 1.24.0
 
-toolchain go1.24.11
+toolchain go1.24.12
 
 require (
 	buf.build/go/protovalidate v0.13.1

--- a/tests-bdd/go.mod
+++ b/tests-bdd/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentdf/platform/tests-bdd
 
-go 1.24.11
+go 1.24.12
 
 require (
 	github.com/cucumber/godog v0.15.0


### PR DESCRIPTION
## Summary
- Updates Go toolchain version from 1.24.11 to 1.24.12 across all modules

## Changed files
- `go.work`
- `examples/go.mod`
- `lib/fixtures/go.mod`
- `lib/ocrypto/go.mod`
- `protocol/go/go.mod`
- `sdk/go.mod`
- `service/go.mod`
- `tests-bdd/go.mod`