### PR TITLE
feat(keycloak): add public client for browser-based SDK authentication

### DIFF
--- a/service/cmd/keycloak_data.yaml
+++ b/service/cmd/keycloak_data.yaml
@@ -77,8 +77,21 @@ realms:
           name: cli-client
           serviceAccountsEnabled: false
           publicClient: true
+          directAccessGrantsEnabled: true
           redirectUris:
             - 'http://localhost:*'
+          protocolMappers:
+            - *customAudMapper
+      - client:
+          clientID: opentdf-public
+          enabled: true
+          name: opentdf-public
+          serviceAccountsEnabled: false
+          publicClient: true
+          directAccessGrantsEnabled: true
+          redirectUris:
+            - 'http://localhost:*'
+            - 'http://127.0.0.1:*'
           protocolMappers:
             - *customAudMapper
     users:


### PR DESCRIPTION
Add opentdf-public client and enable direct access grants to support browser-based JavaScript SDK quickstart authentication flow.

### Proposed Changes
- Add opentdf-public client (public, directAccessGrantsEnabled: true)
- Enable directAccessGrantsEnabled on cli-client
- Both clients restricted to localhost redirect URIs (`localhost:*` and `127.0.0.1:*`)

This enables the JavaScript SDK quickstart to obtain refresh tokens via password grant for local development/testing, as the browser-based SDK cannot use client credentials (client secrets) for security reasons.

Is it a security change? Yes - it enables a less secure OAuth flow (password grant).

However, the following factors mitigate the risk:
- Quickstart/testing context only
- Public client (no secret exposure risk)
- Localhost-only redirect URIs
- Documentation warns against production use
- Matches how Go/Java SDKs use client credentials for testing

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

