### PR TITLE
fix: Go 1.25

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -72,12 +72,12 @@ jobs:
       - name: govluncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: "1.24.12"
+          go-version-input: "1.25.7"
           work-dir: ${{ matrix.directory }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1
+          version: v2.8.0
           working-directory: ${{ matrix.directory }}
           skip-cache: true
           only-new-issues: true
@@ -533,7 +533,7 @@ jobs:
       - run: cd service && go get github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
       - run: cd service && go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
       - run: cd service && go install github.com/sudorandom/protoc-gen-connect-openapi@v0.18.0
-      - run: cd service && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1
+      - run: cd service && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
       - run: make proto-generate
       - name: generate connect wrappers
         run: make connect-wrapper-generate

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,7 +26,7 @@ jobs:
       - name: "Setup Go"
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.23"
+          go-version: "1.25.7"
           check-latest: false
           cache-dependency-path: |
             service/go.sum

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -25,5 +25,5 @@ jobs:
       - name: govluncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: "1.24.12"
+          go-version-input: "1.25.7"
           work-dir: ${{ matrix.directory }}

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ toolcheck:
 		echo "Please upgrade buf. See https://docs.buf.build/installation for instructions."; \
 		exit 1; \
 	fi
-	@which golangci-lint > /dev/null || (echo "golangci-lint not found, run  'go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.1.6'" && exit 1)
+	@which golangci-lint > /dev/null || (echo "golangci-lint not found, run  'go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0'" && exit 1)
 	@which protoc-gen-doc > /dev/null || (echo "protoc-gen-doc not found, run 'go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1'" && exit 1)
 	@which protoc-gen-connect-openapi > /dev/null || (echo "protoc-gen-connect-openapi not found, run 'go install github.com/sudorandom/protoc-gen-connect-openapi@v0.18.0'" && exit 1)
-	@required_golangci_lint_version="2.1.0"; \
+	@required_golangci_lint_version="2.8.0"; \
 	current_version=$$(golangci-lint --version | grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^v//' | head -n 1); \
 	[ "$$(printf '%s\n' "$$required_golangci_lint_version" "$$current_version" | sort -V | head -n1)" = "$$required_golangci_lint_version" ] || \
 		(echo "golangci-lint version must be v$$required_golangci_lint_version or later [found: $$current_version]" && exit 1)

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,8 +1,8 @@
 module github.com/opentdf/platform/examples
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.12
+toolchain go1.25.7
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.24.12
+go 1.25.0
 
 use (
 	./examples

--- a/lib/fixtures/go.mod
+++ b/lib/fixtures/go.mod
@@ -1,8 +1,8 @@
 module github.com/opentdf/platform/lib/fixtures
 
-go 1.23.0
+go 1.25.0
 
-toolchain go1.24.12
+toolchain go1.25.7
 
 require github.com/Nerzal/gocloak/v13 v13.9.0
 

--- a/lib/flattening/go.mod
+++ b/lib/flattening/go.mod
@@ -1,6 +1,8 @@
 module github.com/opentdf/platform/lib/flattening
 
-go 1.23
+go 1.25.0
+
+toolchain go1.25.7
 
 require github.com/stretchr/testify v1.10.0
 

--- a/lib/identifier/go.mod
+++ b/lib/identifier/go.mod
@@ -1,6 +1,8 @@
 module github.com/opentdf/platform/lib/identifier
 
-go 1.23
+go 1.25.0
+
+toolchain go1.25.7
 
 require github.com/stretchr/testify v1.10.0
 

--- a/lib/ocrypto/go.mod
+++ b/lib/ocrypto/go.mod
@@ -1,8 +1,8 @@
 module github.com/opentdf/platform/lib/ocrypto
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.12
+toolchain go1.25.7
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/protocol/go/go.mod
+++ b/protocol/go/go.mod
@@ -1,8 +1,8 @@
 module github.com/opentdf/platform/protocol/go
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.12
+toolchain go1.25.7
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,8 +1,8 @@
 module github.com/opentdf/platform/sdk
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.12
+toolchain go1.25.7
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/service/go.mod
+++ b/service/go.mod
@@ -1,8 +1,8 @@
 module github.com/opentdf/platform/service
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.12
+toolchain go1.25.7
 
 require (
 	buf.build/go/protovalidate v0.13.1

--- a/tests-bdd/go.mod
+++ b/tests-bdd/go.mod
@@ -1,6 +1,8 @@
 module github.com/opentdf/platform/tests-bdd
 
-go 1.24.12
+go 1.25.0
+
+toolchain go1.25.7
 
 require (
 	github.com/cucumber/godog v0.15.0


### PR DESCRIPTION
## Summary
- Upgrades `go` directive to `1.25.0` and `toolchain` to `go1.25.7` in all workspace modules and `go.work`
- Addresses GO-2026-4337 (`crypto/tls` vulnerability, fixed in go1.25.7)
- Updates `golangci-lint` from `v2.1` to `v2.8.0` in CI workflow and Makefile (required for Go 1.25 compatibility)
- Updates `govulncheck` `go-version-input` to `1.25.7` in `checks.yaml` and `vulnerability-check.yaml`
- Updates `sonarcloud.yml` Go version from `1.23` to `1.25.7`

## Test plan
- [x] `go mod tidy` succeeds in all modules
- [x] `go build ./...` succeeds in all modules
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)