### PR TITLE
fix(sdk): exp SDK tests and fix

### DIFF
--- a/examples/cmd/benchmark_experimental.go
+++ b/examples/cmd/benchmark_experimental.go
@@ -2,9 +2,14 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -13,7 +18,6 @@ import (
 	kasp "github.com/opentdf/platform/protocol/go/kas"
 	"github.com/opentdf/platform/protocol/go/kas/kasconnect"
 	"github.com/opentdf/platform/protocol/go/policy"
-
 	"github.com/opentdf/platform/sdk/experimental/tdf"
 	"github.com/opentdf/platform/sdk/httputil"
 	"github.com/spf13/cobra"
@@ -35,7 +39,7 @@ func init() {
 	//nolint: mnd // no magic number, this is just default value for payload size
 	benchmarkCmd.Flags().IntVar(&payloadSize, "payload-size", 1024*1024, "Payload size in bytes") // Default 1MB
 	//nolint: mnd  // same as above
-	benchmarkCmd.Flags().IntVar(&segmentChunk, "segment-chunks", 16*1024, "segment chunks ize") // Default 16 segments
+	benchmarkCmd.Flags().IntVar(&segmentChunk, "segment-chunks", 16*1024, "segment chunk size") // Default 16KB
 	ExamplesCmd.AddCommand(benchmarkCmd)
 }
 
@@ -46,16 +50,21 @@ func runExperimentalWriterBenchmark(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to generate random payload: %w", err)
 	}
 
-	http := httputil.SafeHTTPClient()
+	var httpClient *http.Client
+	if insecureSkipVerify {
+		httpClient = httputil.SafeHTTPClientWithTLSConfig(&tls.Config{InsecureSkipVerify: true}) //nolint:gosec // user-requested flag
+	} else {
+		httpClient = httputil.SafeHTTPClient()
+	}
 	fmt.Println("endpoint:", platformEndpoint)
-	serviceClient := kasconnect.NewAccessServiceClient(http, platformEndpoint)
+	serviceClient := kasconnect.NewAccessServiceClient(httpClient, platformEndpoint)
 	resp, err := serviceClient.PublicKey(context.Background(), connect.NewRequest(&kasp.PublicKeyRequest{Algorithm: string(ocrypto.RSA2048Key)}))
 	if err != nil {
 		return fmt.Errorf("failed to get public key from KAS: %w", err)
 	}
 	var attrs []*policy.Value
 
-	simpleyKey := &policy.SimpleKasKey{
+	simpleKey := &policy.SimpleKasKey{
 		KasUri: platformEndpoint,
 		KasId:  "id",
 		PublicKey: &policy.SimpleKasPublicKey{
@@ -65,29 +74,31 @@ func runExperimentalWriterBenchmark(_ *cobra.Command, _ []string) error {
 		},
 	}
 
-	attrs = append(attrs, &policy.Value{Fqn: testAttr, KasKeys: []*policy.SimpleKasKey{simpleyKey}, Attribute: &policy.Attribute{Namespace: &policy.Namespace{Name: "example.com"}, Fqn: testAttr}})
-	writer, err := tdf.NewWriter(context.Background(), tdf.WithDefaultKASForWriter(simpleyKey), tdf.WithInitialAttributes(attrs), tdf.WithSegmentIntegrityAlgorithm(tdf.HS256))
+	attrs = append(attrs, &policy.Value{Fqn: testAttr, KasKeys: []*policy.SimpleKasKey{simpleKey}, Attribute: &policy.Attribute{Namespace: &policy.Namespace{Name: "example.com"}, Fqn: testAttr}})
+	writer, err := tdf.NewWriter(context.Background(), tdf.WithDefaultKASForWriter(simpleKey), tdf.WithInitialAttributes(attrs), tdf.WithSegmentIntegrityAlgorithm(tdf.HS256))
 	if err != nil {
 		return fmt.Errorf("failed to create writer: %w", err)
 	}
-	i := 0
+	segs := (len(payload) + segmentChunk - 1) / segmentChunk
+	segResults := make([]*tdf.SegmentResult, segs)
 	wg := sync.WaitGroup{}
-	segs := len(payload) / segmentChunk
 	wg.Add(segs)
 	start := time.Now()
-	for i < segs {
-		segment := i
-		go func() {
-			start := i * segmentChunk
-			end := min(start+segmentChunk, len(payload))
-			_, err = writer.WriteSegment(context.Background(), segment, payload[start:end])
-			if err != nil {
-				fmt.Println(err)
-				panic(err)
+	for i := 0; i < segs; i++ {
+		segStart := i * segmentChunk
+		segEnd := min(segStart+segmentChunk, len(payload))
+		// Copy the chunk: EncryptInPlace overwrites the input buffer and
+		// appends a 16-byte auth tag, which would corrupt adjacent segments.
+		chunk := make([]byte, segEnd-segStart)
+		copy(chunk, payload[segStart:segEnd])
+		go func(index int, data []byte) {
+			defer wg.Done()
+			sr, serr := writer.WriteSegment(context.Background(), index, data)
+			if serr != nil {
+				panic(serr)
 			}
-			wg.Done()
-		}()
-		i++
+			segResults[index] = sr
+		}(i, chunk)
 	}
 	wg.Wait()
 
@@ -98,12 +109,48 @@ func runExperimentalWriterBenchmark(_ *cobra.Command, _ []string) error {
 	}
 	totalTime := end.Sub(start)
 
+	// Assemble the complete TDF: segment data (in order) + finalize data
+	var tdfBuf bytes.Buffer
+	for i, sr := range segResults {
+		if _, err := io.Copy(&tdfBuf, sr.TDFData); err != nil {
+			return fmt.Errorf("failed to read segment %d TDF data: %w", i, err)
+		}
+	}
+	tdfBuf.Write(result.Data)
+
+	outPath := "/tmp/benchmark-experimental.tdf"
+	if err := os.WriteFile(outPath, tdfBuf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("failed to write TDF: %w", err)
+	}
+
 	fmt.Printf("# Benchmark Experimental TDF Writer Results:\n")
 	fmt.Printf("| Metric             | Value         |\n")
 	fmt.Printf("|--------------------|--------------|\n")
 	fmt.Printf("| Payload Size (B)   | %d |\n", payloadSize)
-	fmt.Printf("| Output Size (B)    | %d |\n", len(result.Data))
+	fmt.Printf("| Output Size (B)    | %d |\n", tdfBuf.Len())
 	fmt.Printf("| Total Time         | %s |\n", totalTime)
+	fmt.Printf("| TDF saved to       | %s |\n", outPath)
+
+	// Decrypt with production SDK to verify interoperability
+	s, err := newSDK()
+	if err != nil {
+		return fmt.Errorf("failed to create SDK: %w", err)
+	}
+	defer s.Close()
+	tdfReader, err := s.LoadTDF(bytes.NewReader(tdfBuf.Bytes()))
+	if err != nil {
+		return fmt.Errorf("failed to load TDF with production SDK: %w", err)
+	}
+	var decrypted bytes.Buffer
+	if _, err = io.Copy(&decrypted, tdfReader); err != nil {
+		return fmt.Errorf("failed to decrypt TDF with production SDK: %w", err)
+	}
+
+	if bytes.Equal(payload, decrypted.Bytes()) {
+		fmt.Println("| Decrypt Verify     | PASS - roundtrip matches |")
+	} else {
+		fmt.Printf("| Decrypt Verify     | FAIL - payload %d bytes, decrypted %d bytes |\n", len(payload), decrypted.Len())
+	}
 
 	return nil
 }

--- a/sdk/experimental/tdf/keysplit/xor_splitter.go
+++ b/sdk/experimental/tdf/keysplit/xor_splitter.go
@@ -130,11 +130,12 @@ func (x *XORSplitter) GenerateSplits(_ context.Context, attrs []*policy.Value, d
 	if x.config.defaultKAS != nil && x.config.defaultKAS.GetPublicKey() != nil {
 		kasURL := x.config.defaultKAS.GetKasUri()
 		if _, exists := allKeys[kasURL]; !exists {
+			pubKey := x.config.defaultKAS.GetPublicKey()
 			allKeys[kasURL] = KASPublicKey{
 				URL:       kasURL,
-				KID:       x.config.defaultKAS.GetPublicKey().GetKid(),
-				PEM:       x.config.defaultKAS.GetPublicKey().GetPem(),
-				Algorithm: formatAlgorithm(x.config.defaultKAS.GetPublicKey().GetAlgorithm()),
+				KID:       pubKey.GetKid(),
+				PEM:       pubKey.GetPem(),
+				Algorithm: formatAlgorithm(pubKey.GetAlgorithm()),
 			}
 		}
 	}

--- a/sdk/experimental/tdf/options.go
+++ b/sdk/experimental/tdf/options.go
@@ -42,14 +42,14 @@ type BaseConfig struct{}
 // WriterConfig contains configuration options for TDF Writer creation.
 //
 // The configuration controls cryptographic algorithms and processing behavior:
-//   - integrityAlgorithm: Algorithm for root integrity signature calculation
+//   - rootIntegrityAlgorithm: Algorithm for root integrity signature calculation
 //   - segmentIntegrityAlgorithm: Algorithm for individual segment hash calculation
 //
 // These can be set independently to optimize for different security/performance requirements.
 type WriterConfig struct {
 	BaseConfig
-	// integrityAlgorithm specifies the algorithm for root integrity verification
-	integrityAlgorithm IntegrityAlgorithm
+	// rootIntegrityAlgorithm specifies the algorithm for root integrity verification
+	rootIntegrityAlgorithm IntegrityAlgorithm
 	// segmentIntegrityAlgorithm specifies the algorithm for segment-level integrity
 	segmentIntegrityAlgorithm IntegrityAlgorithm
 
@@ -95,7 +95,7 @@ type Option[T any] func(T)
 //	writer, err := NewWriter(ctx, WithIntegrityAlgorithm(GMAC))
 func WithIntegrityAlgorithm(algo IntegrityAlgorithm) Option[*WriterConfig] {
 	return func(c *WriterConfig) {
-		c.integrityAlgorithm = algo
+		c.rootIntegrityAlgorithm = algo
 	}
 }
 

--- a/sdk/experimental/tdf/writer.go
+++ b/sdk/experimental/tdf/writer.go
@@ -156,7 +156,7 @@ type Writer struct {
 func NewWriter(_ context.Context, opts ...Option[*WriterConfig]) (*Writer, error) {
 	// Initialize Config
 	config := &WriterConfig{
-		integrityAlgorithm:        GMAC,
+		rootIntegrityAlgorithm:    HS256,
 		segmentIntegrityAlgorithm: GMAC,
 	}
 
@@ -570,12 +570,12 @@ func (w *Writer) getManifest(ctx context.Context, cfg *WriterFinalizeConfig) (*M
 	// manifests returned before any WriteSegment call leave the root
 	// signature empty.
 	if aggregateHash.Len() > 0 {
-		rootSignature, err := calculateSignature(aggregateHash.Bytes(), w.dek, w.integrityAlgorithm, false)
+		rootSignature, err := calculateSignature(aggregateHash.Bytes(), w.dek, w.rootIntegrityAlgorithm, false)
 		if err != nil {
 			return nil, 0, 0, err
 		}
 		encryptInfo.RootSignature = RootSignature{
-			Algorithm: w.integrityAlgorithm.String(),
+			Algorithm: w.rootIntegrityAlgorithm.String(),
 			Signature: string(ocrypto.Base64Encode([]byte(rootSignature))),
 		}
 	}

--- a/sdk/experimental/tdf/writer_test.go
+++ b/sdk/experimental/tdf/writer_test.go
@@ -503,7 +503,7 @@ func testMultiSegmentFlow(t *testing.T) {
 
 	// Verify root signature was calculated from all segments
 	assert.NotEmpty(t, finalizeResult.Manifest.Signature, "Root signature should be set")
-	assert.Equal(t, "GMAC", finalizeResult.Manifest.Algorithm, "Root signature algorithm should be GMAC")
+	assert.Equal(t, "HS256", finalizeResult.Manifest.Algorithm, "Root signature algorithm should be HS256")
 }
 
 // testKeySplittingWithMultipleAttributes tests XOR key splitting with complex attribute scenarios

--- a/sdk/experimental/tdf/writer_test.go
+++ b/sdk/experimental/tdf/writer_test.go
@@ -111,9 +111,9 @@ func testGetManifestIncludesInitialPolicy(t *testing.T) {
 	}
 	assert.True(t, found, "provisional policy should include initial attribute FQN")
 
-	// Pre-finalize manifest should include kaos based on initial attributes, and estimated root signature
+	// Pre-finalize manifest should include kaos based on initial attributes.
+	// Root signature is empty when no segments have been written (GMAC requires data).
 	assert.Len(t, m.KeyAccessObjs, 1)
-	assert.NotEmpty(t, m.Signature)
 }
 
 // Sparse indices end-to-end: write 0,1,2,5000,5001,5002 and verify manifest and totals.
@@ -503,7 +503,7 @@ func testMultiSegmentFlow(t *testing.T) {
 
 	// Verify root signature was calculated from all segments
 	assert.NotEmpty(t, finalizeResult.Manifest.Signature, "Root signature should be set")
-	assert.Equal(t, "HS256", finalizeResult.Manifest.Algorithm, "Root signature algorithm should be HS256")
+	assert.Equal(t, "GMAC", finalizeResult.Manifest.Algorithm, "Root signature algorithm should be GMAC")
 }
 
 // testKeySplittingWithMultipleAttributes tests XOR key splitting with complex attribute scenarios


### PR DESCRIPTION
This pull request adds comprehensive regression and compatibility tests to the experimental TDF SDK, focusing on key management edge cases and ensuring encryption format compatibility with the production SDK. The new tests verify correct handling of legacy attribute grants, segment integrity hashing, and cross-decryption between SDKs. Additionally, new imports were added to support these tests.

See xtest failure: https://github.com/opentdf/tests/pull/414

**Regression and Compatibility Testing Enhancements:**

* Added regression tests to `xor_splitter_test.go` to ensure that when an attribute grant references a KAS URL by URI only (without an embedded public key), the default KAS public key is correctly merged, and that existing keys are not overwritten by the default.
* Added end-to-end regression tests in `writer_test.go` to verify that segment hashes include both nonce and ciphertext (not just ciphertext), and that finalization succeeds for URI-only grants by leveraging the default KAS public key.

**Cross-SDK Compatibility:**

* Introduced a new test in `writer_test.go` to validate that the experimental writer's output is fully compatible with the production SDK's decryption and segment hash verification, including full TDF ZIP assembly and parsing with the production ZIP reader.

**Test Infrastructure Improvements:**

* Registered the new regression and compatibility tests in the main test suite.
* Added necessary imports for cryptographic operations and ZIP parsing to support the new tests. [[1]](diffhunk://#diff-f935252b0fdbd2ed0baff420a925250cdcfef0dd3c877aa984d449b96d93340aR7-R12) [[2]](diffhunk://#diff-f935252b0fdbd2ed0baff420a925250cdcfef0dd3c877aa984d449b96d93340aR21)