### PR TITLE
chore: establish community contribution process

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+support@opentdf.io. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,101 @@
 # Contributing to OpenTDF
 
-This project requires two things from every commit:
+Thank you for your interest in contributing to OpenTDF! This document describes
+how to engage with the community, report issues, request features, and contribute
+code.
 
-1. **DCO sign-off** — a `Signed-off-by` trailer asserting your right to contribute the code
-2. **Commit signature verification** — a cryptographic (GPG or SSH) signature proving the commit came from you
+## Code of Conduct
 
-Both are enforced by CI and org-level rulesets. The combined command is:
+This project is governed by the OpenTDF [Code of Conduct](CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code.
 
-```bash
-git commit -s -S -m "Your descriptive commit message here"
+## Community Feedback
+
+| Goal | Where to go |
+|---|---|
+| Report a bug | [Open an issue](https://github.com/opentdf/platform/issues/new/choose) |
+| Request a feature or share an idea | [Start a Discussion](https://github.com/opentdf/platform/discussions) |
+| Ask a question | [GitHub Discussions — Q&A](https://github.com/opentdf/platform/discussions/categories/q-a) |
+| Suggest a docs improvement | [Open an issue in opentdf/docs](https://github.com/opentdf/docs/issues/new) |
+
+Feature requests and questions from all OpenTDF repos are welcome here —
+platform Discussions is the central community space for the project.
+
+## How to Contribute
+
+1. **Check first**: look at [open issues](https://github.com/opentdf/platform/issues)
+   and [Discussions](https://github.com/opentdf/platform/discussions) to avoid
+   duplicating effort.
+2. **Align before building**: for anything non-trivial, open an issue or Discussion
+   to agree on approach before investing in a PR.
+3. **Fork and branch**: fork the repository and create a branch from `main`
+   (see [Branch Naming](#branch-naming) below).
+4. **Make your changes**: follow the [Development Setup](#development-setup) and guidelines below.
+5. **Sign off and sign your commits**: see [DCO](#developer-certificate-of-origin-dco) and [Commit Signature Verification](#commit-signature-verification) below.
+6. **Open a pull request**: a [maintainer](CODEOWNERS) will review and merge.
+
+## Development Setup
+
+For a complete walkthrough, see [docs/Contributing.md](docs/Contributing.md).
+
+Quick summary:
+1. Install [Go](https://go.dev/) (see `go.mod` for the required version).
+2. Run `.github/scripts/init-temp-keys.sh` to create local dev keys.
+3. Run `docker compose up` to start Postgres and Keycloak.
+4. Copy and configure `opentdf-dev.yaml` as your `opentdf.yaml`.
+5. Run `go run github.com/opentdf/platform/service start` to start the server.
+
+## Branch Naming
+
+Use `<type>/<short-description>`:
+
+| Type | When to use |
+|---|---|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `chore` | Maintenance, dependency updates, CI |
+| `docs` | Documentation only |
+| `refactor` | Code restructuring without behavior change |
+| `test` | Adding or updating tests |
+
+If the branch is tied to a ticket, you may prefix it with the ticket ID:
+`feat/DSPX-1234-short-description`.
+
+Examples: `feat/attribute-wildcard`, `fix/kas-timeout`, `docs/contributing-guide`
+
+## Commit Messages
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+
+[optional footer(s)]
 ```
 
-Read on for setup details.
+- **type**: same values as branch naming above
+- **scope**: optional, the subsystem affected (e.g., `sdk`, `kas`, `policy`)
+- **description**: present tense, lowercase, no trailing period
+- **body**: explain *why*, not *what* — the diff shows what changed
+
+Examples:
+```
+feat(sdk): add wildcard support for attribute values
+
+fix(kas): correct timeout handling on rewrap requests
+
+docs: add branch naming and commit format guide
+```
+
+## Pull Request Guidelines
+
+- Reference the relevant issue or Discussion in the PR description.
+- Keep PRs focused — one logical change per PR is easier to review and revert.
+- Update documentation for any interface or behavior changes.
+- Ensure all CI checks pass before requesting review.
+- Run `make lint` and `make test` before pushing.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `CODE_OF_CONDUCT.md` (Contributor Covenant v2.0) as the canonical CoC for the OpenTDF project — other repos link here
- Replaces the bare DCO-only `CONTRIBUTING.md` with a full guide covering:
  - Community feedback channels (bugs → issues, features/questions → platform Discussions)
  - Contribution workflow
  - Branch naming conventions
  - Commit message format (Conventional Commits)
  - PR guidelines
  - DCO (unchanged)
  - Integrates commit signature verification guidance from #3169

## Test plan

- [ ] Review rendered Markdown on GitHub
- [ ] Verify all links resolve correctly
- [ ] Confirm `support@opentdf.io` is the correct enforcement contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)