### PR TITLE
fix(ci): Fix GCP WIF usage

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -31,6 +31,10 @@ jobs:
       - name: "Set up Cloud SDK"
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
+      - name: "Configure gcloud as Docker credential helper"
+        run: |
+          gcloud auth configure-docker us-docker.pkg.dev --quiet
+
       - name: "Install Cosign"
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # 4.0.0
 


### PR DESCRIPTION
### Proposed Changes

* Fix GCP WIF usage
  * Use central WIF project for `google-github-actions/auth`
  * Use gcloud as a docker `credentialhelpers` entry to avoid using a service account with `google-github-actions/auth`
* Format workflow

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

