### PR TITLE
chore: add @opentdf/documentation as codeowners for documentation files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,8 +17,8 @@
 
 ### Documentation
 
-*.md            @opentdf/maintainers
-/docs/          @opentdf/maintainers
+*.md            @opentdf/maintainers @opentdf/documentation
+/docs/          @opentdf/maintainers @opentdf/documentation
 /examples/      @opentdf/maintainers
 /examples/go.*  @opentdf/maintainers @opentdf/security
 


### PR DESCRIPTION
## Summary

- Adds `@opentdf/documentation` team as required reviewers for all Markdown files (`*.md`) and the `/docs/` directory
- Documentation team review is required alongside `@opentdf/maintainers` for these paths

## Changes

In the `### Documentation` section of CODEOWNERS:
- `*.md` — added `@opentdf/documentation`
- `/docs/` — added `@opentdf/documentation`

The `/examples/` and `/examples/go.*` paths are unchanged as they are code-adjacent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration to expand review responsibilities for documentation-related files and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->