### PR TITLE
fix(deps): bump testcontainers-go to v0.41.0 in tests-bdd

### DIFF
--- a/tests-bdd/go.mod
+++ b/tests-bdd/go.mod
@@ -239,7 +239,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
-	golang.org/x/net v0.50.0 // indirect
+	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/tests-bdd/go.sum
+++ b/tests-bdd/go.sum
@@ -680,8 +680,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
-golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
+golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
+golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
## Summary

- Bumps `testcontainers-go` from v0.39.0 to v0.41.0 and `modules/compose` from v0.39.1 to v0.41.0 in the `tests-bdd` module
- Transitively upgrades `docker/cli` from v28.5.1 to v29.2.1, resolving govulncheck failure [GO-2026-4610](https://pkg.go.dev/vuln/GO-2026-4610) (Docker CLI plugins: uncontrolled search path element leads to local privilege escalation on Windows)
- Also upgrades `docker/buildx` (v0.29.1 → v0.31.1) and `docker/compose` (v2 → v5) for compatibility with the new docker/cli

## Test plan

- [ ] CI `go (tests-bdd)` govulncheck passes (was failing on main)
- [ ] BDD Cucumber tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)