### PR TITLE
chore(ci): expand dependabot coverage to all Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,12 @@ updates:
 
   # Dependabot for internal deps
   # Add explicit entry as any go.mods need internal dep checks
+
+  # examples + BDD tests grouped together
   - package-ecosystem: gomod
-    directory: "/examples"
+    directories:
+      - "/examples"
+      - "/tests-bdd"
     commit-message:
       prefix: "fix(deps)"
     groups:
@@ -25,6 +29,23 @@ updates:
           - "github.com/opentdf/*"
     schedule:
       interval: daily
+
+  # lib/* modules grouped together
+  - package-ecosystem: gomod
+    directories:
+      - "/lib/fixtures"
+      - "/lib/flattening"
+      - "/lib/identifier"
+      - "/lib/ocrypto"
+    commit-message:
+      prefix: "fix(deps)"
+    groups:
+      external:
+        exclude-patterns:
+          - "github.com/opentdf/*"
+    schedule:
+      interval: daily
+
   - package-ecosystem: gomod
     directory: "/sdk"
     commit-message:
@@ -35,8 +56,20 @@ updates:
           - "github.com/opentdf/*"
     schedule:
       interval: daily
+
   - package-ecosystem: gomod
     directory: "/service"
+    commit-message:
+      prefix: "fix(deps)"
+    groups:
+      external:
+        exclude-patterns:
+          - "github.com/opentdf/*"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: gomod
+    directory: "/protocol/go"
     commit-message:
       prefix: "fix(deps)"
     groups:


### PR DESCRIPTION
## Summary

- Add missing go.mod entries for `lib/fixtures`, `lib/flattening`, `lib/identifier`, `lib/ocrypto`, `protocol/go`, and `tests-bdd`
- Group `examples` + `tests-bdd` into a single dependabot entry
- Group all `lib/*` modules into a single dependabot entry
- Keep `sdk`, `service`, and `protocol/go` as individual entries

Previously only 3 of 9 Go modules were covered by dependabot.

## Test plan

- [x] YAML syntax is valid
- [x] All 9 go.mod paths covered: `/examples`, `/tests-bdd`, `/lib/fixtures`, `/lib/flattening`, `/lib/identifier`, `/lib/ocrypto`, `/sdk`, `/service`, `/protocol/go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)