### PR TITLE
fix(docs): correct boolean logic for multiple SubjectMappings

### DIFF
--- a/service/policy/db/migrations/20240305000000_add_subject_condition_sets.md
+++ b/service/policy/db/migrations/20240305000000_add_subject_condition_sets.md
@@ -29,15 +29,16 @@ all the way back up the tree to an internal Platform-ABAC `Attribute Value`.
 
 ### Note: PDPs
 
-    A PDP should consider all of the following joined by an AND relationship:
-    - more than one SubjectMapping for an Attribute Value
-    - more than one SubjectSet in the JSONB of a SubjectConditionSet
-    - more than one ConditionGroup on a SubjectSet
+    A PDP evaluates subject mappings with the following boolean logic:
+    - more than one SubjectMapping for an Attribute Value: OR (any matching mapping entitles the subject)
+    - more than one SubjectSet in the JSONB of a SubjectConditionSet: AND
+    - more than one ConditionGroup on a SubjectSet: AND
 
-    For now, ConditionGroups are the only place a policy platform administrator has control over the boolean
-    operator to associate Conditions via AND or OR. If an admin needs to OR together multiple ConditionGroups
-    in a SubjectSet, or multiple SubjectSets in a SubjectMapping, that can be accomplished with multiple
-    AttributeValues and an AttributeDefinition rule of ANY_OF associating them together.
+    ConditionGroups are the only place a policy platform administrator has direct control over the boolean
+    operator to associate Conditions via AND or OR. If an admin needs OR logic across SubjectSets
+    in a SubjectConditionSet, that can be accomplished with multiple SubjectMappings for the same
+    AttributeValue (since SubjectMappings are ORed), or with multiple AttributeValues and an
+    AttributeDefinition rule of ANY_OF associating them together.
 
 # ERD
 


### PR DESCRIPTION
## Summary
- The migration doc for SubjectConditionSets incorrectly stated that multiple SubjectMappings for the same AttributeValue are **ANDed** together
- The actual PDP implementation (`subject_mapping_builtin_actions.go`) **ORs** them: if any SubjectMapping evaluates to true, the subject is entitled to the AttributeValue
- Updated the doc to accurately describe the boolean logic at each level

## Test plan
- [ ] Verify the updated doc matches the behavior in `service/internal/subjectmappingbuiltin/subject_mapping_builtin_actions.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified policy evaluation documentation with refined boolean logic specifications, detailing updated semantics for how conditions are combined during policy decision processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->