### PR TITLE
chore(ci): add pathconcat custom linter plugin

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,0 +1,5 @@
+version: v2.8.0
+name: custom-gcl
+plugins:
+  - module: github.com/jakedoublev/pathconcat
+    version: v0.1.0

--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -2,4 +2,4 @@ version: v2.8.0
 name: custom-gcl
 plugins:
   - module: github.com/jakedoublev/pathconcat
-    version: v0.1.0
+    version: v0.3.0

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -87,13 +87,16 @@ jobs:
           name: govulncheck-failure-${{ strategy.job-index }}
           path: /tmp/govulncheck-failure-${{ strategy.job-index }}.txt
           retention-days: 1
+      - name: install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
+      - name: build custom golangci-lint
+        run: golangci-lint custom
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          version: v2.8.0
-          working-directory: ${{ matrix.directory }}
-          skip-cache: true
-          only-new-issues: true
+        run: >-
+          ${{ github.workspace }}/custom-gcl run
+          -c ${{ github.workspace }}/.golangci.yaml
+          ${{ github.event_name == 'pull_request' && format('--new-from-rev={0}', github.event.pull_request.base.sha) || '' }}
+        working-directory: ${{ matrix.directory }}
       - if: matrix.directory == 'service'
         run: .github/scripts/init-temp-keys.sh
       - run: go test ./... -short

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ tmp-gen/
 /examples/examples
 /**/kas-*.pem
 /opentdf
+/custom-gcl
 /sdkjava/target
 /serviceapp
 /service/opentdf

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,6 +48,7 @@ linters:
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
+    - pathconcat
     - perfsprint
     - predeclared
     - promlinter
@@ -73,6 +74,15 @@ linters:
     - wastedassign
     - whitespace
   settings:
+    custom:
+      pathconcat:
+        type: module
+        description: "Detects string path/URL concatenation; suggests filepath.Join, path.Join, or url.JoinPath"
+        settings:
+          ignore-strings:
+            - "/attr/"
+            - "/value/"
+            - "/obl/"
     errcheck:
       check-type-assertions: true
     exhaustive:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # make
 # To run all lint checks: `LINT_OPTIONS= make lint`
 
-.PHONY: all build clean connect-wrapper-generate docker-build fix fmt go-lint license lint proto-generate proto-lint sdk/sdk test tidy toolcheck
+.PHONY: all build clean connect-wrapper-generate custom-gcl docker-build fix fmt go-lint license lint proto-generate proto-lint sdk/sdk test tidy toolcheck
 
 MODS=protocol/go lib/ocrypto lib/fixtures lib/flattening lib/identifier sdk service examples
 HAND_MODS=lib/ocrypto lib/fixtures lib/flattening lib/identifier sdk service examples
@@ -56,11 +56,14 @@ proto-lint:
 			exit $$exit_code; \
 		fi)
 
-go-lint:
+custom-gcl:
+	golangci-lint custom
+
+go-lint: custom-gcl
 	status=0; \
 	for m in $(HAND_MODS); do \
 		echo "Linting module: $$m"; \
-		(cd "$$m" && golangci-lint run $(LINT_OPTIONS) ) || status=1; \
+		(cd "$$m" && $(ROOT_DIR)/custom-gcl run $(LINT_OPTIONS) ) || status=1; \
 	done; \
 	exit $$status
 


### PR DESCRIPTION
## Summary

- Integrates [pathconcat](https://github.com/jakedoublev/pathconcat) as a golangci-lint module plugin
- Detects string-based path/URL concatenation (`x + "/" + y`, `fmt.Sprintf("%s/%s", ...)`, `strings.Join(parts, "/")`) and suggests `path.Join`, `filepath.Join`, or `url.JoinPath`
- Suppresses false positives for FQN construction (`/attr/`, `/value/`, `/obl/`), connection strings, and scheme prefixes

## Changes

- `.custom-gcl.yml` — build config for custom golangci-lint binary with the plugin
- `.golangci.yaml` — enable `pathconcat` linter with `ignore-strings` for FQN patterns
- `Makefile` — `go-lint` target now builds `custom-gcl` first, then uses it
- `.github/workflows/checks.yaml` — build custom binary in CI, restore `--new-from-rev` for PR-only issue reporting
- `.gitignore` — ignore the `custom-gcl` binary

## Test plan

- [ ] CI passes with custom binary build
- [ ] `make lint` builds `custom-gcl` and runs successfully
- [ ] PR annotations appear for lint findings via `actions/setup-go` problem matcher
- [ ] FQN patterns in `lib/identifier/obligation.go` are not flagged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new linting configuration that flags string path/URL concatenation and provides recommendations.
  * Introduced a repository-level custom lint runner and updated lint targets to use it.
  * Updated CI workflows to install and run the custom lint tooling as part of checks.
  * Updated ignore rules to exclude the custom lint runner artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->