### PR TITLE
fix(ci): Prefer go.work for toolchain info

### DIFF
--- a/.github/scripts/work-init.sh
+++ b/.github/scripts/work-init.sh
@@ -36,10 +36,16 @@ if ! cd "$ROOT_DIR"; then
   exit 1
 fi
 
+# Preserve the toolchain directive from the original go.work so that CI steps
+# reading go-version-file: go.work (e.g. govulncheck) continue to use the
+# correct Go version after the workspace is regenerated.
+ORIG_TOOLCHAIN=$(awk '/^toolchain / {print $2; exit}' go.work 2>/dev/null)
+
 echo "[INFO] Rebuilding partial go.work for [${component}]"
 case $component in
 lib/ocrypto | lib/fixtures | lib/flattening | lib/identifier | protocol/go)
   echo "[INFO] skipping for leaf package"
+  exit 0
   ;;
 sdk)
   rm -f go.work go.work.sum &&
@@ -72,3 +78,12 @@ otdfctl)
   exit 1
   ;;
 esac
+
+# Restore the toolchain directive if it was present in the original go.work.
+if [[ -n "${ORIG_TOOLCHAIN:-}" ]]; then
+  if ! go work edit -toolchain="$ORIG_TOOLCHAIN"; then
+    echo "[ERROR] unable to restore original toolchain [${ORIG_TOOLCHAIN}] in go.work"
+    exit 1
+  fi
+  echo "[INFO] Restored toolchain ${ORIG_TOOLCHAIN} in go.work"
+fi

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -84,7 +84,8 @@ jobs:
         continue-on-error: true
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: "1.25.9"
+          go-version-input: ""
+          go-version-file: go.work
           work-dir: ${{ matrix.directory }}
       - if: steps.govulncheck.outcome == 'failure'
         run: echo "$MODULE_DIR" > "/tmp/govulncheck-failure-${JOB_INDEX}.txt"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -56,7 +56,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: ${{ matrix.directory }}/go.mod
+          go-version-file: go.work
           check-latest: false
           cache-dependency-path: |
             examples/go.sum
@@ -196,7 +196,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: "service/go.mod"
+          go-version-file: go.work
           check-latest: false
           cache-dependency-path: |
             service/go.sum
@@ -275,7 +275,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: "service/go.mod"
+          go-version-file: go.work
           check-latest: false
           cache-dependency-path: |
             service/go.sum
@@ -524,7 +524,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: ./tests-bdd/go.mod
+          go-version-file: go.work
           cache: false
 
       - name: Build local platform-cukes image for testing
@@ -609,7 +609,7 @@ jobs:
           against: "https://github.com/opentdf/platform.git#branch=${{ github.event.pull_request.base.ref || github.base_ref || 'main' }},subdir=service"
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: "service/go.mod"
+          go-version-file: go.work
           check-latest: false
           cache-dependency-path: |
             service/go.sum
@@ -667,7 +667,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: "service/go.mod"
+          go-version-file: go.work
           check-latest: false
           cache: false
       - name: check service licenses

--- a/.github/workflows/friendly-reminders.yaml
+++ b/.github/workflows/friendly-reminders.yaml
@@ -18,7 +18,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: "service/go.mod"
+          go-version-file: go.work
 
       - name: Check Go Mod Tidy
         id: go-mod-tidy

--- a/.github/workflows/nightly-checks.yaml
+++ b/.github/workflows/nightly-checks.yaml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: "platform/service/go.mod"
+          go-version-file: "platform/go.work"
           check-latest: false
           cache-dependency-path: |
             platform/examples/go.sum

--- a/.github/workflows/release-otdfctl.yaml
+++ b/.github/workflows/release-otdfctl.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version-file: otdfctl/go.mod
+          go-version-file: go.work
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,7 +26,7 @@ jobs:
       - name: "Setup Go"
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.25.9"
+          go-version-file: go.work
           check-latest: false
           cache-dependency-path: |
             service/go.sum

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -2,8 +2,6 @@ module github.com/opentdf/platform/examples
 
 go 1.25.0
 
-toolchain go1.25.9
-
 require (
 	connectrpc.com/connect v1.20.0
 	github.com/opentdf/platform/lib/ocrypto v0.10.0

--- a/lib/fixtures/go.mod
+++ b/lib/fixtures/go.mod
@@ -2,8 +2,6 @@ module github.com/opentdf/platform/lib/fixtures
 
 go 1.25.0
 
-toolchain go1.25.9
-
 require github.com/Nerzal/gocloak/v13 v13.9.0
 
 require (

--- a/lib/flattening/go.mod
+++ b/lib/flattening/go.mod
@@ -2,8 +2,6 @@ module github.com/opentdf/platform/lib/flattening
 
 go 1.25.0
 
-toolchain go1.25.9
-
 require github.com/stretchr/testify v1.11.1
 
 require (

--- a/lib/identifier/go.mod
+++ b/lib/identifier/go.mod
@@ -2,8 +2,6 @@ module github.com/opentdf/platform/lib/identifier
 
 go 1.25.0
 
-toolchain go1.25.9
-
 require github.com/stretchr/testify v1.11.1
 
 require (

--- a/lib/ocrypto/go.mod
+++ b/lib/ocrypto/go.mod
@@ -2,8 +2,6 @@ module github.com/opentdf/platform/lib/ocrypto
 
 go 1.25.0
 
-toolchain go1.25.9
-
 require (
 	github.com/cloudflare/circl v1.6.3
 	github.com/stretchr/testify v1.11.1

--- a/otdfctl/e2e/action.yaml
+++ b/otdfctl/e2e/action.yaml
@@ -13,7 +13,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
-        go-version-file: otdfctl/go.mod
+        go-version-file: go.work
     - name: Build the CLI
       shell: bash
       run: go build .

--- a/otdfctl/go.mod
+++ b/otdfctl/go.mod
@@ -2,8 +2,6 @@ module github.com/opentdf/platform/otdfctl
 
 go 1.25.0
 
-toolchain go1.25.9
-
 require (
 	github.com/adrg/frontmatter v0.2.0
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7

--- a/protocol/go/go.mod
+++ b/protocol/go/go.mod
@@ -2,8 +2,6 @@ module github.com/opentdf/platform/protocol/go
 
 go 1.25.0
 
-toolchain go1.25.9
-
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1
 	connectrpc.com/connect v1.20.0

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,8 +2,6 @@ module github.com/opentdf/platform/sdk
 
 go 1.25.0
 
-toolchain go1.25.9
-
 require (
 	connectrpc.com/connect v1.19.2
 	connectrpc.com/grpchealth v1.4.0

--- a/service/go.mod
+++ b/service/go.mod
@@ -2,8 +2,6 @@ module github.com/opentdf/platform/service
 
 go 1.25.0
 
-toolchain go1.25.9
-
 require (
 	buf.build/go/protovalidate v1.0.0
 	connectrpc.com/connect v1.19.2

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -2,8 +2,6 @@ module github.com/opentdf/platform/test/integration
 
 go 1.25.0
 
-toolchain go1.25.9
-
 replace (
 	github.com/opentdf/platform/lib/fixtures => ../../lib/fixtures
 	github.com/opentdf/platform/lib/ocrypto => ../../lib/ocrypto

--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -57,7 +57,7 @@ runs:
       id: setup-go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
-        go-version-file: 'otdf-test-platform/service/go.mod'
+        go-version-file: 'otdf-test-platform/go.work'
         check-latest: false
         cache-dependency-path: |
           otdf-test-platform/service/go.sum

--- a/tests-bdd/go.mod
+++ b/tests-bdd/go.mod
@@ -2,8 +2,6 @@ module github.com/opentdf/platform/tests-bdd
 
 go 1.25.5
 
-toolchain go1.25.9
-
 require (
 	github.com/cucumber/godog v0.15.1
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
### Proposed Changes

* We have been setting toolchain explicitly to satisfy `govulncheck`
* Setting it in the `go.work` file lets us keep everything up to date while only editing one file
* Updates toolchain to latest on current minor branch: 1.25.9


### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed explicit per-module toolchain pins in favor of the workspace-specified toolchain.
  * CI workflows now derive the Go toolchain from the workspace file instead of hardcoded versions.
  * Workspace regeneration preserves and conditionally restores the original toolchain when present, and skips unnecessary work for leaf modules to avoid unintended changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->