### PR TITLE
feat(sdk): add OTel trace context propagation to Connect RPC clients

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/opentdf/platform/protocol/go v0.23.0
 	github.com/stretchr/testify v1.11.1
 	github.com/xeipuuv/gojsonschema v1.2.0
+	go.opentelemetry.io/otel v1.40.0
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/text v0.34.0
 	golang.org/x/tools v0.41.0
@@ -24,8 +25,11 @@ require (
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250603165357-b52ab10f4468.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
@@ -34,12 +38,13 @@ require (
 	github.com/lestrrat-go/iter v1.0.2 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	go.opentelemetry.io/otel v1.40.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
+	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.51.0 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -11,6 +11,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -189,6 +189,9 @@ func New(platformEndpoint string, opts ...Option) (*SDK, error) {
 
 	var uci []connect.Interceptor
 
+	// Propagate OTel trace context on outbound Connect RPCs
+	uci = append(uci, TraceContextInterceptor())
+
 	// Add request ID interceptor
 	uci = append(uci, audit.MetadataAddingConnectInterceptor())
 

--- a/sdk/tracing.go
+++ b/sdk/tracing.go
@@ -1,0 +1,23 @@
+package sdk
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// TraceContextInterceptor returns a Connect unary interceptor that injects
+// OpenTelemetry trace context (traceparent/tracestate) into outbound HTTP
+// request headers, enabling distributed trace propagation across Connect RPCs.
+func TraceContextInterceptor() connect.UnaryInterceptorFunc {
+	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if req.Spec().IsClient {
+				otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header()))
+			}
+			return next(ctx, req)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `TraceContextInterceptor()` that injects `traceparent`/`tracestate` headers into outbound Connect RPC requests using `otel.GetTextMapPropagator().Inject()`
- Wires it as the first interceptor in the SDK client chain, before audit and auth interceptors
- Enables distributed trace propagation across service boundaries for all SDK Connect RPC calls

## Context
Distributed traces break when the SDK makes Connect RPC calls — no trace context headers are injected into outbound HTTP requests, so downstream handlers start new, disconnected traces. This is the client-side half of the fix; a companion service-side PR will add server-side extraction and IPC wiring.

## Test plan
- [ ] `cd sdk && go build ./...` compiles
- [ ] `cd sdk && go test ./...` passes
- [ ] `golangci-lint run ./tracing/` clean
- [ ] No new module dependencies (promotes existing indirect `go.opentelemetry.io/otel` to direct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distributed tracing support to the SDK with automatic trace context propagation across RPC calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->