### PR TITLE
refactor(policy): rename integration test helper

### DIFF
--- a/service/integration/actions_test.go
+++ b/service/integration/actions_test.go
@@ -119,7 +119,7 @@ func (s *ActionsSuite) Test_ListActions_OrdersByCreatedAt_Succeeds() {
 	s.Require().NoError(err)
 	s.NotNil(list)
 
-	assertIDsInDescendingOrder(s.T(), list.GetActionsCustom(), func(a *policy.Action) string { return a.GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), list.GetActionsCustom(), func(a *policy.Action) string { return a.GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *ActionsSuite) Test_ListActions_Pagination_Succeeds() {

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -505,7 +505,7 @@ func (s *AttributesSuite) Test_ListAttributes_OrdersByCreatedAt_Succeeds() {
 	s.Require().NoError(err)
 	s.NotNil(listRsp)
 
-	assertIDsInDescendingOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *AttributesSuite) Test_ListAttributes_SortByName_ASC() {
@@ -522,7 +522,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByName_ASC() {
 	s.NotNil(listRsp)
 
 	// aaa < bbb < ccc in ASC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[0], ids[1], ids[2])
+	assertIDsInOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[0], ids[1], ids[2])
 }
 
 func (s *AttributesSuite) Test_ListAttributes_SortByName_DESC() {
@@ -539,7 +539,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByName_DESC() {
 	s.NotNil(listRsp)
 
 	// ccc > bbb > aaa in DESC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[2], ids[1], ids[0])
+	assertIDsInOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_ASC() {
@@ -556,7 +556,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_ASC() {
 	s.NotNil(listRsp)
 
 	// oldest first in ASC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[0], ids[1], ids[2])
+	assertIDsInOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[0], ids[1], ids[2])
 }
 
 func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_DESC() {
@@ -573,7 +573,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_DESC() {
 	s.NotNil(listRsp)
 
 	// newest first in DESC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[2], ids[1], ids[0])
+	assertIDsInOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_DESC() {
@@ -601,7 +601,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_DESC() {
 	s.NotNil(listRsp)
 
 	// The updated attribute (ids[0]) should appear before the others
-	assertIDsInDescendingOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[0], ids[2], ids[1])
+	assertIDsInOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[0], ids[2], ids[1])
 }
 
 func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_ASC() {
@@ -629,7 +629,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_ASC() {
 	s.NotNil(listRsp)
 
 	// The updated attribute (ids[2]) should appear last in ASC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[0], ids[1], ids[2])
+	assertIDsInOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[0], ids[1], ids[2])
 }
 
 func (s *AttributesSuite) Test_ListAttributes_SortByUnspecifiedField_FallsBackToDefault() {
@@ -646,7 +646,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUnspecifiedField_FallsBackTo
 	s.NotNil(listRsp)
 
 	// Falls back to default created_at DESC ordering
-	assertIDsInDescendingOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[2], ids[1], ids[0])
+	assertIDsInOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *AttributesSuite) Test_ListAttributes_Limit_Succeeds() {

--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -525,7 +525,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_OrdersByCreatedAt_Succeeds() {
 	s.Require().NoError(err)
 	s.NotNil(resp)
 
-	assertIDsInDescendingOrder(s.T(), resp.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), resp.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_KasID_Success() {
@@ -1504,7 +1504,7 @@ func (s *KasRegistryKeySuite) Test_ListKeyMappings_OrdersByCreatedAt_Succeeds() 
 	s.Require().NoError(err)
 	s.NotNil(resp)
 
-	assertIDsInDescendingOrder(
+	assertIDsInOrder(
 		s.T(),
 		resp.GetKeyMappings(),
 		func(m *kasregistry.KeyMapping) string { return m.GetKid() },

--- a/service/integration/kas_registry_test.go
+++ b/service/integration/kas_registry_test.go
@@ -97,7 +97,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_OrdersByCreatedAt_Succeeds(
 	s.Require().NoError(err)
 	s.NotNil(listRsp)
 
-	assertIDsInDescendingOrder(s.T(), listRsp.GetKeyAccessServers(), func(kas *policy.KeyAccessServer) string { return kas.GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), listRsp.GetKeyAccessServers(), func(kas *policy.KeyAccessServer) string { return kas.GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_Limit_Succeeds() {

--- a/service/integration/keymanagement_test.go
+++ b/service/integration/keymanagement_test.go
@@ -218,7 +218,7 @@ func (s *KeyManagementSuite) Test_ListProviderConfig_OrdersByCreatedAt_Succeeds(
 	s.Require().NoError(err)
 	s.NotNil(resp)
 
-	assertIDsInDescendingOrder(s.T(), resp.GetProviderConfigs(), func(pc *policy.KeyProviderConfig) string { return pc.GetId() }, pc3.GetId(), pc2.GetId(), pc1.GetId())
+	assertIDsInOrder(s.T(), resp.GetProviderConfigs(), func(pc *policy.KeyProviderConfig) string { return pc.GetId() }, pc3.GetId(), pc2.GetId(), pc1.GetId())
 }
 
 func (s *KeyManagementSuite) Test_ListProviderConfig_PaginationLimit_Succeeds() {

--- a/service/integration/namespaces_test.go
+++ b/service/integration/namespaces_test.go
@@ -267,7 +267,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_OrdersByCreatedAt_Succeeds() {
 	s.Require().NoError(err)
 	s.NotNil(listNamespacesRsp)
 
-	assertIDsInDescendingOrder(s.T(), listNamespacesRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), listNamespacesRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByName_ASC() {
@@ -283,7 +283,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByName_ASC() {
 	s.NotNil(listRsp)
 
 	// aaa < bbb < ccc in ASC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[0], ids[1], ids[2])
+	assertIDsInOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[0], ids[1], ids[2])
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByName_DESC() {
@@ -299,7 +299,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByName_DESC() {
 	s.NotNil(listRsp)
 
 	// ccc > bbb > aaa in DESC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[2], ids[1], ids[0])
+	assertIDsInOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_ASC() {
@@ -315,7 +315,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_ASC() {
 	s.NotNil(listRsp)
 
 	// oldest first in ASC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[0], ids[1], ids[2])
+	assertIDsInOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[0], ids[1], ids[2])
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_DESC() {
@@ -331,7 +331,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_DESC() {
 	s.NotNil(listRsp)
 
 	// newest first in DESC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[2], ids[1], ids[0])
+	assertIDsInOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_ASC() {
@@ -347,7 +347,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_ASC() {
 	s.NotNil(listRsp)
 
 	// fqn is https://<name>, so aaa < bbb < ccc in ASC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[0], ids[1], ids[2])
+	assertIDsInOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[0], ids[1], ids[2])
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_DESC() {
@@ -363,7 +363,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_DESC() {
 	s.NotNil(listRsp)
 
 	// fqn is https://<name>, so ccc > bbb > aaa in DESC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[2], ids[1], ids[0])
+	assertIDsInOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_DESC() {
@@ -390,7 +390,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_DESC() {
 	s.NotNil(listRsp)
 
 	// The updated namespace (ids[0]) should appear before the others
-	assertIDsInDescendingOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[0], ids[2], ids[1])
+	assertIDsInOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[0], ids[2], ids[1])
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_ASC() {
@@ -417,7 +417,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_ASC() {
 	s.NotNil(listRsp)
 
 	// The updated namespace (ids[2]) should appear last in ASC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[0], ids[1], ids[2])
+	assertIDsInOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[0], ids[1], ids[2])
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUnspecifiedField_FallsBackToDefault() {
@@ -433,7 +433,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUnspecifiedField_FallsBackTo
 	s.NotNil(listRsp)
 
 	// Falls back to default created_at DESC ordering
-	assertIDsInDescendingOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[2], ids[1], ids[0])
+	assertIDsInOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_Limit_Succeeds() {

--- a/service/integration/obligation_triggers_test.go
+++ b/service/integration/obligation_triggers_test.go
@@ -469,7 +469,7 @@ func (s *ObligationTriggersSuite) Test_ListObligationTriggers_OrdersByCreatedAt_
 	s.Require().NoError(err)
 	s.NotNil(triggers)
 
-	assertIDsInDescendingOrder(s.T(), triggers, func(t *policy.ObligationTrigger) string { return t.GetId() }, third.GetId(), second.GetId(), first.GetId())
+	assertIDsInOrder(s.T(), triggers, func(t *policy.ObligationTrigger) string { return t.GetId() }, third.GetId(), second.GetId(), first.GetId())
 }
 
 func (s *ObligationTriggersSuite) Test_ListObligationTriggers_NoTriggersWithNamespaceId_Success() {

--- a/service/integration/obligations_test.go
+++ b/service/integration/obligations_test.go
@@ -522,7 +522,7 @@ func (s *ObligationsSuite) Test_ListObligations_OrdersByCreatedAt_Succeeds() {
 	s.Require().NoError(err)
 	s.NotNil(oblList)
 
-	assertIDsInDescendingOrder(s.T(), oblList, func(obl *policy.Obligation) string { return obl.GetId() }, third.GetId(), second.GetId(), first.GetId())
+	assertIDsInOrder(s.T(), oblList, func(obl *policy.Obligation) string { return obl.GetId() }, third.GetId(), second.GetId(), first.GetId())
 }
 
 func (s *ObligationsSuite) Test_ListObligations_Fails() {

--- a/service/integration/registered_resources_test.go
+++ b/service/integration/registered_resources_test.go
@@ -287,7 +287,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_OrdersByCreatedA
 	s.Require().NoError(err)
 	s.NotNil(list)
 
-	assertIDsInDescendingOrder(s.T(), list.GetResources(), func(r *policy.RegisteredResource) string { return r.GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), list.GetResources(), func(r *policy.RegisteredResource) string { return r.GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_RegResValuesContainActionAttributeValues() {
@@ -1097,7 +1097,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResourceValues_OrdersByCre
 	s.Require().NoError(err)
 	s.NotNil(list)
 
-	assertIDsInDescendingOrder(s.T(), list.GetValues(), func(v *policy.RegisteredResourceValue) string { return v.GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), list.GetValues(), func(v *policy.RegisteredResourceValue) string { return v.GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResourceValues_Limit_Succeeds() {

--- a/service/integration/resource_mappings_test.go
+++ b/service/integration/resource_mappings_test.go
@@ -102,7 +102,7 @@ func (s *ResourceMappingsSuite) Test_ListResourceMappingGroups_OrdersByCreatedAt
 	s.Require().NoError(err)
 	s.NotNil(listRsp)
 
-	assertIDsInDescendingOrder(s.T(), listRsp.GetResourceMappingGroups(), func(g *policy.ResourceMappingGroup) string { return g.GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), listRsp.GetResourceMappingGroups(), func(g *policy.ResourceMappingGroup) string { return g.GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *ResourceMappingsSuite) Test_ListResourceMappingGroups_Limit_Succeeds() {
@@ -730,7 +730,7 @@ func (s *ResourceMappingsSuite) Test_ListResourceMappings_OrdersByCreatedAt_Succ
 	s.Require().NoError(err)
 	s.NotNil(listRsp)
 
-	assertIDsInDescendingOrder(s.T(), listRsp.GetResourceMappings(), func(rm *policy.ResourceMapping) string { return rm.GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), listRsp.GetResourceMappings(), func(rm *policy.ResourceMapping) string { return rm.GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *ResourceMappingsSuite) Test_ListResourceMappingsByGroupFqns_OrdersByCreatedAt_Succeeds() {
@@ -793,7 +793,7 @@ func (s *ResourceMappingsSuite) Test_ListResourceMappingsByGroupFqns_OrdersByCre
 	s.Require().True(ok)
 	s.Require().NotNil(groupMappings)
 
-	assertIDsInDescendingOrder(s.T(), groupMappings.GetMappings(), func(rm *policy.ResourceMapping) string { return rm.GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), groupMappings.GetMappings(), func(rm *policy.ResourceMapping) string { return rm.GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *ResourceMappingsSuite) Test_ListResourceMappings_Limit_Succeeds() {

--- a/service/integration/subject_mappings_test.go
+++ b/service/integration/subject_mappings_test.go
@@ -595,7 +595,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_OrdersByCreatedAt_Succee
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(context.Background(), &subjectmapping.ListSubjectMappingsRequest{})
 	s.Require().NoError(err)
 
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_ASC() {
@@ -610,7 +610,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_ASC() {
 	s.NotNil(listRsp)
 
 	// oldest first in ASC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, ids[0], ids[1], ids[2])
+	assertIDsInOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, ids[0], ids[1], ids[2])
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_DESC() {
@@ -625,7 +625,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_DESC() {
 	s.NotNil(listRsp)
 
 	// newest first in DESC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, ids[2], ids[1], ids[0])
+	assertIDsInOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_DESC() {
@@ -651,7 +651,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_DESC() {
 	s.NotNil(listRsp)
 
 	// The updated mapping (ids[0]) should appear before the others
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, ids[0], ids[2], ids[1])
+	assertIDsInOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, ids[0], ids[2], ids[1])
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_ASC() {
@@ -677,7 +677,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_ASC() {
 	s.NotNil(listRsp)
 
 	// The updated mapping (ids[2]) should appear last in ASC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, ids[0], ids[1], ids[2])
+	assertIDsInOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, ids[0], ids[1], ids[2])
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUnspecified_FallsBackToDefault() {
@@ -692,7 +692,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUnspecified_FallsB
 	s.NotNil(listRsp)
 
 	// Falls back to default created_at DESC ordering
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, ids[2], ids[1], ids[0])
+	assertIDsInOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_Limit_Succeeds() {
@@ -1175,7 +1175,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSet_OrdersByCreatedAt_Su
 	s.Require().NoError(err)
 	s.NotNil(listRsp)
 
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, thirdID, secondID, firstID)
+	assertIDsInOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, thirdID, secondID, firstID)
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSet_Limit_Succeeds() {
@@ -1393,7 +1393,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_ASC
 	s.NotNil(listRsp)
 
 	// oldest first in ASC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, ids[0], ids[1], ids[2])
+	assertIDsInOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, ids[0], ids[1], ids[2])
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_DESC() {
@@ -1408,7 +1408,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_DES
 	s.NotNil(listRsp)
 
 	// newest first in DESC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, ids[2], ids[1], ids[0])
+	assertIDsInOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_DESC() {
@@ -1434,7 +1434,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_DES
 	s.NotNil(listRsp)
 
 	// The updated SCS (ids[0]) should appear before the others
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, ids[0], ids[2], ids[1])
+	assertIDsInOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, ids[0], ids[2], ids[1])
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_ASC() {
@@ -1460,7 +1460,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_ASC
 	s.NotNil(listRsp)
 
 	// The updated SCS (ids[2]) should appear last in ASC order
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, ids[0], ids[1], ids[2])
+	assertIDsInOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, ids[0], ids[1], ids[2])
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecified_FallsBackToDefault() {
@@ -1475,7 +1475,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecified_F
 	s.NotNil(listRsp)
 
 	// Falls back to default created_at DESC ordering
-	assertIDsInDescendingOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, ids[2], ids[1], ids[0])
+	assertIDsInOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *SubjectMappingsSuite) TestDeleteSubjectConditionSet() {

--- a/service/integration/utils.go
+++ b/service/integration/utils.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func assertIDsInDescendingOrder[T any](tb testing.TB, items []T, getID func(T) string, ids ...string) {
+func assertIDsInOrder[T any](tb testing.TB, items []T, getID func(T) string, ids ...string) {
 	tb.Helper()
 
 	targets := make(map[string]struct{}, len(ids))


### PR DESCRIPTION
### Proposed Changes

assertIDsInDescendingOrder is order agnostic and should be assertIDsInOrder instead, this was an oversight that carried over multiple PRs. This helper simply compares the position of IDs returned from an integration test (name based or time based). When a integration test (createSortTestKeyAccessServers, etc) returns IDs in the sorted order it is testing, it needs a standardized way to confirm that the resulting IDs are in the right order, hence this helper. 

The problem was that it was named inDescendingOrder which is wrong because it doesn't care about asc/desc (in a real sorting sense)

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored integration test assertions across multiple service modules to use an updated helper function for validating list ordering. Changes applied to tests for actions, attributes, key management, namespaces, obligations, registered resources, resource mappings, and subject mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->