### PR TITLE
feat(docs): Add namespaced policy option to configuration docs

### DIFF
--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -540,7 +540,7 @@ Root level key `policy`
 | ---------------------------- | ------------------------------------------------------ | ------- | -------------------------------------------------- |
 | `list_request_limit_default` | Policy List request limit default when not provided    | 1000    | OPENTDF_SERVICES_POLICY_LIST_REQUEST_LIMIT_DEFAULT |
 | `list_request_limit_max`     | Policy List request limit maximum enforced by services | 2500    | OPENTDF_SERVICES_POLICY_LIST_REQUEST_LIMIT_MAX     |
-| `namespaced_policy`          | When enabled, new actions, subject mappings, subject condition sets, and registered resources require a namespace. Non-namespaced versions are deprecated. | `false` | OPENTDF_SERVICES_POLICY_NAMESPACED_POLICY          |
+| `namespaced_policy`          | When enabled, new actions, subject mappings, subject condition sets, and registered resources require a namespace. When disabled (default), namespace fields are accepted but not enforced — objects may be created without a namespace (legacy behavior). Non-namespaced versions are deprecated and this flag will become the default in a future version. | `false` | OPENTDF_SERVICES_POLICY_NAMESPACED_POLICY          |
 
 Example:
 

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -540,6 +540,7 @@ Root level key `policy`
 | ---------------------------- | ------------------------------------------------------ | ------- | -------------------------------------------------- |
 | `list_request_limit_default` | Policy List request limit default when not provided    | 1000    | OPENTDF_SERVICES_POLICY_LIST_REQUEST_LIMIT_DEFAULT |
 | `list_request_limit_max`     | Policy List request limit maximum enforced by services | 2500    | OPENTDF_SERVICES_POLICY_LIST_REQUEST_LIMIT_MAX     |
+| `namespaced_policy`          | When enabled, new actions, subject mappings, subject condition sets, and registered resources require a namespace. Non-namespaced versions are deprecated. | `false` | OPENTDF_SERVICES_POLICY_NAMESPACED_POLICY          |
 
 Example:
 
@@ -548,6 +549,7 @@ services:
   policy:
     list_request_limit_default: 1000
     list_request_limit_max: 2500
+    namespaced_policy: false
 ```
 
 ### Casbin Endpoint Authorization


### PR DESCRIPTION
### Proposed Changes

* document namespaced policy feature flag

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the new `namespaced_policy` configuration option, which enables namespace requirements for newly created actions, subject mappings, subject condition sets, and registered resources. Non-namespaced variants are now marked as deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->