### PR TITLE
fix(ci): prevent code injection in release-otdfctl workflow

### DIFF
--- a/.github/workflows/release-otdfctl.yaml
+++ b/.github/workflows/release-otdfctl.yaml
@@ -23,8 +23,9 @@ jobs:
 
       - name: Extract version from tag
         id: version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#otdfctl/v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -38,4 +39,5 @@ jobs:
       - name: Upload release artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.event.release.tag_name }}" ./otdfctl/output/*
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" ./otdfctl/output/*


### PR DESCRIPTION
### Proposed Changes

* Fix two zizmor-flagged code injection vulnerabilities in `release-otdfctl.yaml` by passing `github.event.release.tag_name` through `env:` variables instead of direct template expansion in `run:` blocks.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

No functional change — the workflow behaves identically, but tag name values are now injected as environment variables rather than interpolated into shell scripts.