### PR TITLE
feat(cli): RR commit.

### DIFF
--- a/otdfctl/migrations/namespacedpolicy/derived.go
+++ b/otdfctl/migrations/namespacedpolicy/derived.go
@@ -158,6 +158,9 @@ func (d *targetDeriver) deriveRegisteredResource(resource *policy.RegisteredReso
 
 	namespaceRef, ok := registeredResourceNamespaceRef(resource)
 	if !ok {
+		// Registered resources only resolve when their action-attribute values
+		// imply exactly one target namespace. No AAV-derived namespace, or AAVs
+		// spanning multiple namespaces, leaves the RR unresolved here.
 		if hasRegisteredResourceActionAttributeValues(resource) {
 			item.Unresolved = fmt.Errorf("%w: registered resource spans multiple target namespaces", ErrUndeterminedTargetMapping).Error()
 			return item, nil

--- a/otdfctl/migrations/namespacedpolicy/execute.go
+++ b/otdfctl/migrations/namespacedpolicy/execute.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/registeredresources"
 	"github.com/opentdf/platform/protocol/go/policy/subjectmapping"
 )
 
@@ -36,6 +37,8 @@ type ExecutorHandler interface {
 	CreateSubjectConditionSet(ctx context.Context, ss []*policy.SubjectSet, metadata *common.MetadataMutable, namespace string) (*policy.SubjectConditionSet, error)
 	CreateNewSubjectMapping(ctx context.Context, attrValID string, actions []*policy.Action, existingSCSId string, newScs *subjectmapping.SubjectConditionSetCreate, metadata *common.MetadataMutable, namespace string) (*policy.SubjectMapping, error)
 	CreateObligationTrigger(ctx context.Context, attributeValue, action, obligationValue, clientID string, metadata *common.MetadataMutable) (*policy.ObligationTrigger, error)
+	CreateRegisteredResource(ctx context.Context, namespace string, name string, values []string, metadata *common.MetadataMutable) (*policy.RegisteredResource, error)
+	CreateRegisteredResourceValue(ctx context.Context, resourceID string, value string, actionAttributeValues []*registeredresources.ActionAttributeValue, metadata *common.MetadataMutable) (*policy.RegisteredResourceValue, error)
 }
 
 type Executor struct {

--- a/otdfctl/migrations/namespacedpolicy/execute_test_helpers_test.go
+++ b/otdfctl/migrations/namespacedpolicy/execute_test_helpers_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/registeredresources"
 	"github.com/opentdf/platform/protocol/go/policy/subjectmapping"
 )
 
@@ -15,6 +16,8 @@ var (
 	errMissingMockSubjectConditionSetResult = errors.New("missing mock subject condition set result")
 	errMissingMockSubjectMappingResult      = errors.New("missing mock subject mapping result")
 	errMissingMockObligationTriggerResult   = errors.New("missing mock obligation trigger result")
+	errMissingMockRegisteredResourceResult  = errors.New("missing mock registered resource result")
+	errMissingMockRegisteredResourceValue   = errors.New("missing mock registered resource value result")
 )
 
 type expectedError struct {
@@ -30,18 +33,24 @@ func wantError(is error, format string, args ...any) *expectedError {
 }
 
 type mockExecutorHandler struct {
-	created                   map[string]map[string]*createdActionCall
-	results                   map[string]map[string]*policy.Action // ! Should be renamed to actionResults
-	errs                      map[string]map[string]error
-	createdSubjectConditions  map[string]map[string]*createdSubjectConditionSetCall
-	subjectConditionSetResult map[string]map[string]*policy.SubjectConditionSet
-	subjectConditionSetErrs   map[string]map[string]error
-	createdSubjectMappings    map[string]map[string]*createdSubjectMappingCall
-	subjectMappingResults     map[string]map[string]*policy.SubjectMapping
-	subjectMappingErrs        map[string]map[string]error
-	createdObligationTriggers map[string]map[string]*createdObligationTriggerCall
-	obligationTriggerResult   map[string]map[string]*policy.ObligationTrigger
-	obligationTriggerErrs     map[string]map[string]error
+	created                         map[string]map[string]*createdActionCall
+	results                         map[string]map[string]*policy.Action // ! Should be renamed to actionResults
+	errs                            map[string]map[string]error
+	createdSubjectConditions        map[string]map[string]*createdSubjectConditionSetCall
+	subjectConditionSetResult       map[string]map[string]*policy.SubjectConditionSet
+	subjectConditionSetErrs         map[string]map[string]error
+	createdSubjectMappings          map[string]map[string]*createdSubjectMappingCall
+	subjectMappingResults           map[string]map[string]*policy.SubjectMapping
+	subjectMappingErrs              map[string]map[string]error
+	createdObligationTriggers       map[string]map[string]*createdObligationTriggerCall
+	obligationTriggerResult         map[string]map[string]*policy.ObligationTrigger
+	obligationTriggerErrs           map[string]map[string]error
+	createdRegisteredResources      map[string]map[string]*createdRegisteredResourceCall
+	registeredResourceResult        map[string]map[string]*policy.RegisteredResource
+	registeredResourceErrs          map[string]map[string]error
+	createdRegisteredResourceValues map[string]map[string]*createdRegisteredResourceValueCall
+	registeredResourceValueResult   map[string]map[string]*policy.RegisteredResourceValue
+	registeredResourceValueErrs     map[string]map[string]error
 }
 
 type createdActionCall struct {
@@ -70,6 +79,20 @@ type createdObligationTriggerCall struct {
 	ObligationValue string
 	ClientID        string
 	Metadata        *common.MetadataMutable
+}
+
+type createdRegisteredResourceCall struct {
+	Name      string
+	Namespace string
+	Values    []string
+	Metadata  *common.MetadataMutable
+}
+
+type createdRegisteredResourceValueCall struct {
+	ResourceID            string
+	Value                 string
+	ActionAttributeValues []*registeredresources.ActionAttributeValue
+	Metadata              *common.MetadataMutable
 }
 
 func (m *mockExecutorHandler) CreateAction(_ context.Context, name string, namespace string, metadata *common.MetadataMutable) (*policy.Action, error) {
@@ -193,4 +216,66 @@ func (m *mockExecutorHandler) CreateObligationTrigger(_ context.Context, attribu
 	}
 
 	return nil, errMissingMockObligationTriggerResult
+}
+
+func (m *mockExecutorHandler) CreateRegisteredResource(_ context.Context, namespace string, name string, values []string, metadata *common.MetadataMutable) (*policy.RegisteredResource, error) {
+	sourceID := metadata.GetLabels()[migrationLabelMigratedFrom]
+
+	if m.createdRegisteredResources == nil {
+		m.createdRegisteredResources = make(map[string]map[string]*createdRegisteredResourceCall)
+	}
+	if m.createdRegisteredResources[sourceID] == nil {
+		m.createdRegisteredResources[sourceID] = make(map[string]*createdRegisteredResourceCall)
+	}
+
+	m.createdRegisteredResources[sourceID][namespace] = &createdRegisteredResourceCall{
+		Name:      name,
+		Namespace: namespace,
+		Values:    values,
+		Metadata:  metadata,
+	}
+
+	if m.registeredResourceErrs != nil && m.registeredResourceErrs[sourceID] != nil {
+		if err := m.registeredResourceErrs[sourceID][namespace]; err != nil {
+			return nil, err
+		}
+	}
+	if m.registeredResourceResult != nil && m.registeredResourceResult[sourceID] != nil {
+		if result := m.registeredResourceResult[sourceID][namespace]; result != nil {
+			return result, nil
+		}
+	}
+
+	return nil, errMissingMockRegisteredResourceResult
+}
+
+func (m *mockExecutorHandler) CreateRegisteredResourceValue(_ context.Context, resourceID string, value string, actionAttributeValues []*registeredresources.ActionAttributeValue, metadata *common.MetadataMutable) (*policy.RegisteredResourceValue, error) {
+	sourceID := metadata.GetLabels()[migrationLabelMigratedFrom]
+
+	if m.createdRegisteredResourceValues == nil {
+		m.createdRegisteredResourceValues = make(map[string]map[string]*createdRegisteredResourceValueCall)
+	}
+	if m.createdRegisteredResourceValues[sourceID] == nil {
+		m.createdRegisteredResourceValues[sourceID] = make(map[string]*createdRegisteredResourceValueCall)
+	}
+
+	m.createdRegisteredResourceValues[sourceID][resourceID] = &createdRegisteredResourceValueCall{
+		ResourceID:            resourceID,
+		Value:                 value,
+		ActionAttributeValues: actionAttributeValues,
+		Metadata:              metadata,
+	}
+
+	if m.registeredResourceValueErrs != nil && m.registeredResourceValueErrs[sourceID] != nil {
+		if err := m.registeredResourceValueErrs[sourceID][resourceID]; err != nil {
+			return nil, err
+		}
+	}
+	if m.registeredResourceValueResult != nil && m.registeredResourceValueResult[sourceID] != nil {
+		if result := m.registeredResourceValueResult[sourceID][resourceID]; result != nil {
+			return result, nil
+		}
+	}
+
+	return nil, errMissingMockRegisteredResourceValue
 }

--- a/otdfctl/migrations/namespacedpolicy/plan.go
+++ b/otdfctl/migrations/namespacedpolicy/plan.go
@@ -124,9 +124,13 @@ type RegisteredResourcePlan struct {
 }
 
 type RegisteredResourceTargetPlan struct {
-	Namespace *policy.Namespace              `json:"namespace"`
-	Status    TargetStatus                   `json:"status"`
+	Namespace *policy.Namespace `json:"namespace"`
+	Status    TargetStatus      `json:"status"`
+	// For registered resources, Existing is also used on create targets to mean
+	// "reuse this parent RR and reconcile missing values under it" rather than
+	// creating a new top-level RR.
 	Existing  *policy.RegisteredResource     `json:"existing,omitempty"`
+	Execution *ExecutionResult               `json:"execution,omitempty"`
 	Reason    string                         `json:"reason,omitempty"`
 	Values    []*RegisteredResourceValuePlan `json:"values,omitempty"`
 }
@@ -134,6 +138,7 @@ type RegisteredResourceTargetPlan struct {
 type RegisteredResourceValuePlan struct {
 	Source         *policy.RegisteredResourceValue    `json:"source"`
 	ActionBindings []*RegisteredResourceActionBinding `json:"action_bindings,omitempty"`
+	Execution      *ExecutionResult                   `json:"execution,omitempty"`
 }
 
 type RegisteredResourceActionBinding struct {
@@ -351,10 +356,23 @@ func (t *SubjectMappingTargetPlan) TargetID() string {
 }
 
 func (t *RegisteredResourceTargetPlan) TargetID() string {
-	if t == nil || t.Existing == nil {
+	if t == nil {
+		return ""
+	}
+	if t.Execution != nil && t.Execution.CreatedTargetID != "" {
+		return t.Execution.CreatedTargetID
+	}
+	if t.Existing == nil {
 		return ""
 	}
 	return t.Existing.GetId()
+}
+
+func (p *RegisteredResourceValuePlan) TargetID() string {
+	if p == nil || p.Execution == nil {
+		return ""
+	}
+	return p.Execution.CreatedTargetID
 }
 
 func (t *ObligationTriggerTargetPlan) TargetID() string {

--- a/otdfctl/migrations/namespacedpolicy/registered_resources_execute.go
+++ b/otdfctl/migrations/namespacedpolicy/registered_resources_execute.go
@@ -2,13 +2,254 @@ package namespacedpolicy
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/registeredresources"
 )
 
-func (e *Executor) executeRegisteredResources(_ context.Context, plans []*RegisteredResourcePlan) error {
+func (e *Executor) executeRegisteredResources(ctx context.Context, plans []*RegisteredResourcePlan) error {
 	if len(plans) == 0 {
 		return nil
 	}
 
-	return fmt.Errorf("%w: %s", ErrExecutionPhaseNotImplemented, ScopeRegisteredResources)
+	for _, plan := range plans {
+		if plan == nil || plan.Source == nil {
+			continue
+		}
+
+		for _, target := range plan.Targets {
+			if target == nil {
+				continue
+			}
+
+			if err := e.executeRegisteredResourceTarget(ctx, plan, target); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (e *Executor) executeRegisteredResourceTarget(ctx context.Context, plan *RegisteredResourcePlan, target *RegisteredResourceTargetPlan) error {
+	switch target.Status {
+	case TargetStatusAlreadyMigrated:
+		if target.TargetID() == "" {
+			return fmt.Errorf("%w: registered resource %q target %q", ErrMissingMigratedTarget, plan.Source.GetId(), namespaceLabel(target.Namespace))
+		}
+		return nil
+	case TargetStatusCreate:
+		return e.createRegisteredResourceTarget(ctx, plan, target)
+	case TargetStatusExistingStandard:
+		return fmt.Errorf("%w: registered resource %q target %q has unsupported status %q", ErrUnsupportedStatus, plan.Source.GetId(), namespaceLabel(target.Namespace), target.Status)
+	case TargetStatusUnresolved:
+		return fmt.Errorf("%w: registered resource %q target %q is unresolved: %s", ErrPlanNotExecutable, plan.Source.GetId(), namespaceLabel(target.Namespace), target.Reason)
+	default:
+		return fmt.Errorf("%w: registered resource %q target %q has unsupported status %q", ErrUnsupportedStatus, plan.Source.GetId(), namespaceLabel(target.Namespace), target.Status)
+	}
+}
+
+func (e *Executor) createRegisteredResourceTarget(ctx context.Context, plan *RegisteredResourcePlan, target *RegisteredResourceTargetPlan) error {
+	namespace := namespaceIdentifier(target.Namespace)
+	if namespace == "" {
+		return fmt.Errorf("%w: registered resource %q", ErrTargetNamespaceRequired, plan.Source.GetId())
+	}
+
+	// Create the parent RR only when the plan did not already select an existing
+	// target RR to reuse for this namespace.
+	created := target.Existing
+	if created == nil {
+		var err error
+		created, err = e.handler.CreateRegisteredResource(
+			ctx,
+			namespace,
+			plan.Source.GetName(),
+			nil,
+			metadataForCreate(
+				plan.Source.GetId(),
+				metadataLabels(plan.Source.GetMetadata()),
+				e.runID,
+			),
+		)
+		if err != nil {
+			target.Execution = &ExecutionResult{
+				RunID:   e.runID,
+				Failure: err.Error(),
+			}
+			return fmt.Errorf("%w: create registered resource %q in namespace %q", err, plan.Source.GetId(), namespaceLabel(target.Namespace))
+		}
+	}
+	if created == nil {
+		target.Execution = &ExecutionResult{
+			RunID:   e.runID,
+			Failure: ErrMissingCreatedTargetID.Error(),
+		}
+		return fmt.Errorf("%w: registered resource %q target %q", ErrMissingCreatedTargetID, plan.Source.GetId(), namespaceLabel(target.Namespace))
+	}
+	if created.GetId() == "" {
+		target.Execution = &ExecutionResult{
+			RunID:   e.runID,
+			Failure: ErrMissingCreatedTargetID.Error(),
+		}
+		return fmt.Errorf("%w: registered resource %q target %q", ErrMissingCreatedTargetID, plan.Source.GetId(), namespaceLabel(target.Namespace))
+	}
+
+	target.Execution = &ExecutionResult{
+		RunID:           e.runID,
+		Applied:         true,
+		CreatedTargetID: created.GetId(),
+	}
+
+	existingValues := registeredResourceValueIDsByValue(created)
+	for _, valuePlan := range target.Values {
+		if valuePlan == nil || valuePlan.Source == nil {
+			continue
+		}
+
+		// RR values are reconciled at runtime so explicit parent reuse can skip
+		// values that already exist on the chosen parent RR.
+		if existingID := existingValues[registeredResourceValueKey(valuePlan.Source.GetValue())]; existingID != "" {
+			valuePlan.Execution = &ExecutionResult{
+				RunID:           e.runID,
+				Applied:         true,
+				CreatedTargetID: existingID,
+			}
+			continue
+		}
+
+		if err := e.createRegisteredResourceValue(ctx, target, valuePlan); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *Executor) createRegisteredResourceValue(ctx context.Context, target *RegisteredResourceTargetPlan, valuePlan *RegisteredResourceValuePlan) error {
+	actionAttributeValues, err := e.registeredResourceActionAttributeValues(target.Namespace, valuePlan)
+	if err != nil {
+		valuePlan.Execution = &ExecutionResult{
+			RunID:   e.runID,
+			Failure: err.Error(),
+		}
+		return fmt.Errorf("%w: build registered resource value %q action bindings for namespace %q", err, valuePlan.Source.GetId(), namespaceLabel(target.Namespace))
+	}
+
+	created, err := e.handler.CreateRegisteredResourceValue(
+		ctx,
+		target.TargetID(),
+		valuePlan.Source.GetValue(),
+		actionAttributeValues,
+		metadataForCreate(
+			valuePlan.Source.GetId(),
+			metadataLabels(valuePlan.Source.GetMetadata()),
+			e.runID,
+		),
+	)
+	if err != nil {
+		valuePlan.Execution = &ExecutionResult{
+			RunID:   e.runID,
+			Failure: err.Error(),
+		}
+		return fmt.Errorf("%w: create registered resource value %q for resource %q in namespace %q", err, valuePlan.Source.GetId(), target.TargetID(), namespaceLabel(target.Namespace))
+	}
+	if created.GetId() == "" {
+		valuePlan.Execution = &ExecutionResult{
+			RunID:   e.runID,
+			Failure: ErrMissingCreatedTargetID.Error(),
+		}
+		return fmt.Errorf("%w: registered resource value %q for target %q", ErrMissingCreatedTargetID, valuePlan.Source.GetId(), namespaceLabel(target.Namespace))
+	}
+
+	valuePlan.Execution = &ExecutionResult{
+		RunID:           e.runID,
+		Applied:         true,
+		CreatedTargetID: created.GetId(),
+	}
+
+	return nil
+}
+
+func (e *Executor) registeredResourceActionAttributeValues(namespace *policy.Namespace, valuePlan *RegisteredResourceValuePlan) ([]*registeredresources.ActionAttributeValue, error) {
+	if valuePlan == nil {
+		return nil, nil
+	}
+
+	actionAttributeValues := make([]*registeredresources.ActionAttributeValue, 0, len(valuePlan.ActionBindings))
+	for _, binding := range valuePlan.ActionBindings {
+		if binding == nil {
+			continue
+		}
+
+		if binding.SourceActionID == "" {
+			return nil, fmt.Errorf("%w: action source id is missing", ErrPlanNotExecutable)
+		}
+
+		actionID := e.cachedActionTargetID(binding.SourceActionID, namespace)
+		if actionID == "" {
+			return nil, fmt.Errorf("%w: action %q target %q", ErrMissingMigratedTarget, binding.SourceActionID, namespaceLabel(namespace))
+		}
+
+		actionAttributeValue, err := registeredResourceActionAttributeValue(actionID, binding.AttributeValue)
+		if err != nil {
+			return nil, fmt.Errorf("registered resource value %q binding action %q: %w", valuePlan.Source.GetId(), binding.SourceActionID, err)
+		}
+		actionAttributeValues = append(actionAttributeValues, actionAttributeValue)
+	}
+
+	return actionAttributeValues, nil
+}
+
+func registeredResourceActionAttributeValue(actionID string, attributeValue *policy.Value) (*registeredresources.ActionAttributeValue, error) {
+	if strings.TrimSpace(actionID) == "" {
+		return nil, errors.New("action target id is empty")
+	}
+	if attributeValue == nil {
+		return nil, errors.New("attribute value is missing")
+	}
+
+	actionAttributeValue := &registeredresources.ActionAttributeValue{
+		ActionIdentifier: &registeredresources.ActionAttributeValue_ActionId{
+			ActionId: actionID,
+		},
+	}
+
+	if attributeValueID := strings.TrimSpace(attributeValue.GetId()); attributeValueID != "" {
+		actionAttributeValue.AttributeValueIdentifier = &registeredresources.ActionAttributeValue_AttributeValueId{
+			AttributeValueId: attributeValueID,
+		}
+		return actionAttributeValue, nil
+	}
+
+	if attributeValueFQN := strings.TrimSpace(attributeValue.GetFqn()); attributeValueFQN != "" {
+		actionAttributeValue.AttributeValueIdentifier = &registeredresources.ActionAttributeValue_AttributeValueFqn{
+			AttributeValueFqn: attributeValueFQN,
+		}
+		return actionAttributeValue, nil
+	}
+
+	return nil, errors.New("attribute value identifier is missing")
+}
+
+func registeredResourceValueIDsByValue(resource *policy.RegisteredResource) map[string]string {
+	valueIDs := make(map[string]string)
+	if resource == nil {
+		return valueIDs
+	}
+
+	for _, value := range resource.GetValues() {
+		if value == nil {
+			continue
+		}
+		valueIDs[registeredResourceValueKey(value.GetValue())] = value.GetId()
+	}
+
+	return valueIDs
+}
+
+func registeredResourceValueKey(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
 }

--- a/otdfctl/migrations/namespacedpolicy/registered_resources_execute_test.go
+++ b/otdfctl/migrations/namespacedpolicy/registered_resources_execute_test.go
@@ -234,7 +234,7 @@ func TestExecuteRegisteredResources(t *testing.T) {
 				ErrPlanNotExecutable,
 				`registered resource %q target %q is unresolved: %s`,
 				"rr-1",
-				"ns-1",
+				namespace1.GetFqn(),
 				errDuplicateCanonicalMatch,
 			),
 			assert: func(t *testing.T, err error, _ *Executor, handler *mockExecutorHandler, _ *Plan) {
@@ -360,7 +360,7 @@ func TestExecuteRegisteredResources(t *testing.T) {
 					},
 				},
 			},
-			wantErr: wantError(errBoom, `create registered resource %q in namespace %q`, "rr-1", "ns-1"),
+			wantErr: wantError(errBoom, `create registered resource %q in namespace %q`, "rr-1", namespace1.GetFqn()),
 			assert: func(t *testing.T, err error, _ *Executor, handler *mockExecutorHandler, plan *Plan) {
 				t.Helper()
 
@@ -413,9 +413,9 @@ func TestExecuteRegisteredResources(t *testing.T) {
 				ErrMissingMigratedTarget,
 				`action %q target %q: build registered resource value %q action bindings for namespace %q`,
 				"missing-action",
-				"ns-1",
+				namespace1.GetFqn(),
 				"rrv-1",
-				"ns-1",
+				namespace1.GetFqn(),
 			),
 			assert: func(t *testing.T, err error, _ *Executor, handler *mockExecutorHandler, plan *Plan) {
 				t.Helper()
@@ -426,7 +426,7 @@ func TestExecuteRegisteredResources(t *testing.T) {
 				require.NotNil(t, plan.RegisteredResources[0].Targets[0].Execution)
 				assert.True(t, plan.RegisteredResources[0].Targets[0].Execution.Applied)
 				require.NotNil(t, plan.RegisteredResources[0].Targets[0].Values[0].Execution)
-				assert.Contains(t, plan.RegisteredResources[0].Targets[0].Values[0].Execution.Failure, `missing migrated target: action "missing-action" target "ns-1"`)
+				assert.Contains(t, plan.RegisteredResources[0].Targets[0].Values[0].Execution.Failure, `missing migrated target: action "missing-action" target "https://example.com"`)
 			},
 		},
 		{
@@ -489,7 +489,7 @@ func TestExecuteRegisteredResources(t *testing.T) {
 					},
 				},
 			},
-			wantErr: wantError(errBoom, `create registered resource value %q for resource %q in namespace %q`, "rrv-1", "created-rr-1", "ns-1"),
+			wantErr: wantError(errBoom, `create registered resource value %q for resource %q in namespace %q`, "rrv-1", "created-rr-1", namespace1.GetFqn()),
 			assert: func(t *testing.T, err error, _ *Executor, handler *mockExecutorHandler, plan *Plan) {
 				t.Helper()
 

--- a/otdfctl/migrations/namespacedpolicy/registered_resources_execute_test.go
+++ b/otdfctl/migrations/namespacedpolicy/registered_resources_execute_test.go
@@ -1,0 +1,530 @@
+package namespacedpolicy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/opentdf/platform/protocol/go/common"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteRegisteredResources(t *testing.T) {
+	t.Parallel()
+
+	namespace1 := &policy.Namespace{Id: "ns-1", Fqn: "https://example.com"}
+	errBoom := errors.New("boom")
+
+	tests := []struct {
+		name    string
+		plan    *Plan
+		handler *mockExecutorHandler
+		runID   string
+		wantErr *expectedError
+		assert  func(t *testing.T, err error, executor *Executor, handler *mockExecutorHandler, plan *Plan)
+	}{
+		{
+			name: "creates registered resource shell and values with authoritative action target ids",
+			plan: &Plan{
+				Scopes: []Scope{ScopeActions, ScopeRegisteredResources},
+				Actions: []*ActionPlan{
+					{
+						Source: &policy.Action{Id: "action-1", Name: "read"},
+						Targets: []*ActionTargetPlan{
+							{
+								Namespace: namespace1,
+								Status:    TargetStatusCreate,
+							},
+						},
+					},
+					{
+						Source: &policy.Action{Id: "action-2", Name: "standard-read"},
+						Targets: []*ActionTargetPlan{
+							{
+								Namespace: namespace1,
+								Status:    TargetStatusExistingStandard,
+								Existing:  &policy.Action{Id: "existing-standard-action-2", Name: "standard-read"},
+							},
+						},
+					},
+				},
+				RegisteredResources: []*RegisteredResourcePlan{
+					{
+						Source: &policy.RegisteredResource{
+							Id:   "rr-1",
+							Name: "repo",
+							Metadata: &common.Metadata{
+								Labels: map[string]string{
+									"owner": "policy-team",
+								},
+							},
+						},
+						Targets: []*RegisteredResourceTargetPlan{
+							{
+								Namespace: namespace1,
+								Status:    TargetStatusCreate,
+								Values: []*RegisteredResourceValuePlan{
+									{
+										Source: &policy.RegisteredResourceValue{
+											Id:    "rrv-1",
+											Value: "repo-a",
+											Metadata: &common.Metadata{
+												Labels: map[string]string{
+													"classification": "secret",
+												},
+											},
+										},
+										ActionBindings: []*RegisteredResourceActionBinding{
+											{
+												SourceActionID: "action-1",
+												AttributeValue: &policy.Value{
+													Id:  "attribute-value-id-1",
+													Fqn: "https://example.com/attr/classification/value/secret",
+												},
+												ActionTargetRef: &ActionBinding{
+													SourceID:  "action-1",
+													Namespace: namespace1,
+													Status:    TargetStatusCreate,
+													TargetID:  "stale-created-action-id",
+												},
+											},
+											{
+												SourceActionID: "action-2",
+												AttributeValue: &policy.Value{
+													Fqn: "https://example.com/attr/project/value/apollo",
+												},
+												ActionTargetRef: &ActionBinding{
+													SourceID:  "action-2",
+													Namespace: namespace1,
+													Status:    TargetStatusExistingStandard,
+													TargetID:  "stale-standard-action-id",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			handler: &mockExecutorHandler{
+				results: map[string]map[string]*policy.Action{
+					"read": {
+						"ns-1": {Id: "created-action-1", Name: "read"},
+					},
+				},
+				registeredResourceResult: map[string]map[string]*policy.RegisteredResource{
+					"rr-1": {
+						"ns-1": {Id: "created-rr-1", Name: "repo"},
+					},
+				},
+				registeredResourceValueResult: map[string]map[string]*policy.RegisteredResourceValue{
+					"rrv-1": {
+						"created-rr-1": {Id: "created-rrv-1", Value: "repo-a"},
+					},
+				},
+			},
+			runID: "run-rr-123",
+			assert: func(t *testing.T, err error, executor *Executor, handler *mockExecutorHandler, plan *Plan) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				require.Contains(t, handler.createdRegisteredResources, "rr-1")
+				require.Contains(t, handler.createdRegisteredResources["rr-1"], "ns-1")
+				resourceCall := handler.createdRegisteredResources["rr-1"]["ns-1"]
+				assert.Equal(t, "repo", resourceCall.Name)
+				assert.Equal(t, "ns-1", resourceCall.Namespace)
+				assert.Empty(t, resourceCall.Values)
+				assert.Equal(t, map[string]string{
+					"owner":                    "policy-team",
+					migrationLabelMigratedFrom: "rr-1",
+					migrationLabelRun:          "run-rr-123",
+				}, resourceCall.Metadata.GetLabels())
+
+				require.Contains(t, handler.createdRegisteredResourceValues, "rrv-1")
+				require.Contains(t, handler.createdRegisteredResourceValues["rrv-1"], "created-rr-1")
+				valueCall := handler.createdRegisteredResourceValues["rrv-1"]["created-rr-1"]
+				assert.Equal(t, "created-rr-1", valueCall.ResourceID)
+				assert.Equal(t, "repo-a", valueCall.Value)
+				assert.Equal(t, map[string]string{
+					"classification":           "secret",
+					migrationLabelMigratedFrom: "rrv-1",
+					migrationLabelRun:          "run-rr-123",
+				}, valueCall.Metadata.GetLabels())
+				require.Len(t, valueCall.ActionAttributeValues, 2)
+				assert.Equal(t, "created-action-1", valueCall.ActionAttributeValues[0].GetActionId())
+				assert.Equal(t, "attribute-value-id-1", valueCall.ActionAttributeValues[0].GetAttributeValueId())
+				assert.Equal(t, "existing-standard-action-2", valueCall.ActionAttributeValues[1].GetActionId())
+				assert.Equal(t, "https://example.com/attr/project/value/apollo", valueCall.ActionAttributeValues[1].GetAttributeValueFqn())
+
+				resourceTarget := plan.RegisteredResources[0].Targets[0]
+				require.NotNil(t, resourceTarget.Execution)
+				assert.True(t, resourceTarget.Execution.Applied)
+				assert.Equal(t, "created-rr-1", resourceTarget.Execution.CreatedTargetID)
+				assert.Equal(t, "run-rr-123", resourceTarget.Execution.RunID)
+				assert.Equal(t, "created-rr-1", resourceTarget.TargetID())
+
+				valueTarget := plan.RegisteredResources[0].Targets[0].Values[0]
+				require.NotNil(t, valueTarget.Execution)
+				assert.True(t, valueTarget.Execution.Applied)
+				assert.Equal(t, "created-rrv-1", valueTarget.Execution.CreatedTargetID)
+				assert.Equal(t, "run-rr-123", valueTarget.Execution.RunID)
+				assert.Equal(t, "created-rrv-1", valueTarget.TargetID())
+
+				assert.Equal(t, "created-action-1", executor.cachedActionTargetID("action-1", namespace1))
+				assert.Equal(t, "existing-standard-action-2", executor.cachedActionTargetID("action-2", namespace1))
+			},
+		},
+		{
+			name: "skips already migrated registered resource targets",
+			plan: &Plan{
+				Scopes: []Scope{ScopeActions, ScopeRegisteredResources},
+				RegisteredResources: []*RegisteredResourcePlan{
+					{
+						Source: &policy.RegisteredResource{Id: "rr-1", Name: "repo"},
+						Targets: []*RegisteredResourceTargetPlan{
+							{
+								Namespace: namespace1,
+								Status:    TargetStatusAlreadyMigrated,
+								Existing:  &policy.RegisteredResource{Id: "migrated-rr-1", Name: "repo"},
+								Values: []*RegisteredResourceValuePlan{
+									{
+										Source: &policy.RegisteredResourceValue{Id: "rrv-1", Value: "repo-a"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			handler: &mockExecutorHandler{},
+			assert: func(t *testing.T, err error, _ *Executor, handler *mockExecutorHandler, plan *Plan) {
+				t.Helper()
+
+				require.NoError(t, err)
+				assert.Nil(t, handler.createdRegisteredResources)
+				assert.Nil(t, handler.createdRegisteredResourceValues)
+				assert.Equal(t, "migrated-rr-1", plan.RegisteredResources[0].Targets[0].TargetID())
+				assert.Nil(t, plan.RegisteredResources[0].Targets[0].Execution)
+				assert.Nil(t, plan.RegisteredResources[0].Targets[0].Values[0].Execution)
+			},
+		},
+		{
+			name: "returns not executable for unresolved target status",
+			plan: &Plan{
+				Scopes: []Scope{ScopeActions, ScopeRegisteredResources},
+				RegisteredResources: []*RegisteredResourcePlan{
+					{
+						Source: &policy.RegisteredResource{Id: "rr-1", Name: "repo"},
+						Targets: []*RegisteredResourceTargetPlan{
+							{
+								Namespace: namespace1,
+								Status:    TargetStatusUnresolved,
+								Reason:    errDuplicateCanonicalMatch,
+							},
+						},
+					},
+				},
+			},
+			handler: &mockExecutorHandler{},
+			wantErr: wantError(
+				ErrPlanNotExecutable,
+				`registered resource %q target %q is unresolved: %s`,
+				"rr-1",
+				"ns-1",
+				errDuplicateCanonicalMatch,
+			),
+			assert: func(t *testing.T, err error, _ *Executor, handler *mockExecutorHandler, _ *Plan) {
+				t.Helper()
+
+				require.Error(t, err)
+				assert.Nil(t, handler.createdRegisteredResources)
+				assert.Nil(t, handler.createdRegisteredResourceValues)
+			},
+		},
+		{
+			name: "reuses existing registered resource parent on create targets",
+			plan: &Plan{
+				Scopes: []Scope{ScopeActions, ScopeRegisteredResources},
+				Actions: []*ActionPlan{
+					{
+						Source: &policy.Action{Id: "action-1", Name: "read"},
+						Targets: []*ActionTargetPlan{
+							{
+								Namespace: namespace1,
+								Status:    TargetStatusCreate,
+							},
+						},
+					},
+				},
+				RegisteredResources: []*RegisteredResourcePlan{
+					{
+						Source: &policy.RegisteredResource{Id: "rr-1", Name: "repo"},
+						Targets: []*RegisteredResourceTargetPlan{
+							{
+								Namespace: namespace1,
+								Status:    TargetStatusCreate,
+								Existing: &policy.RegisteredResource{
+									Id:   "existing-rr-1",
+									Name: "repo",
+									Values: []*policy.RegisteredResourceValue{
+										{Id: "existing-rrv-1", Value: "repo-a"},
+									},
+								},
+								Values: []*RegisteredResourceValuePlan{
+									{
+										Source: &policy.RegisteredResourceValue{Id: "rrv-1", Value: "repo-a"},
+										ActionBindings: []*RegisteredResourceActionBinding{
+											{
+												SourceActionID: "action-1",
+												AttributeValue: &policy.Value{Id: "attribute-value-id-1"},
+											},
+										},
+									},
+									{
+										Source: &policy.RegisteredResourceValue{Id: "rrv-2", Value: "repo-b"},
+										ActionBindings: []*RegisteredResourceActionBinding{
+											{
+												SourceActionID: "action-1",
+												AttributeValue: &policy.Value{Id: "attribute-value-id-2"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			handler: &mockExecutorHandler{
+				results: map[string]map[string]*policy.Action{
+					"read": {
+						"ns-1": {Id: "created-action-1", Name: "read"},
+					},
+				},
+				registeredResourceValueResult: map[string]map[string]*policy.RegisteredResourceValue{
+					"rrv-2": {
+						"existing-rr-1": {Id: "created-rrv-2", Value: "repo-b"},
+					},
+				},
+			},
+			assert: func(t *testing.T, err error, _ *Executor, handler *mockExecutorHandler, plan *Plan) {
+				t.Helper()
+
+				require.NoError(t, err)
+				assert.Nil(t, handler.createdRegisteredResources)
+				require.Contains(t, handler.createdRegisteredResourceValues, "rrv-2")
+				require.Contains(t, handler.createdRegisteredResourceValues["rrv-2"], "existing-rr-1")
+				assert.NotContains(t, handler.createdRegisteredResourceValues, "rrv-1")
+
+				target := plan.RegisteredResources[0].Targets[0]
+				require.NotNil(t, target.Execution)
+				assert.True(t, target.Execution.Applied)
+				assert.Equal(t, "existing-rr-1", target.Execution.CreatedTargetID)
+				assert.Equal(t, "existing-rr-1", target.TargetID())
+
+				existingValue := target.Values[0]
+				require.NotNil(t, existingValue.Execution)
+				assert.True(t, existingValue.Execution.Applied)
+				assert.Equal(t, "existing-rrv-1", existingValue.Execution.CreatedTargetID)
+
+				createdValue := target.Values[1]
+				require.NotNil(t, createdValue.Execution)
+				assert.True(t, createdValue.Execution.Applied)
+				assert.Equal(t, "created-rrv-2", createdValue.Execution.CreatedTargetID)
+			},
+		},
+		{
+			name: "records shell creation failures on the target",
+			plan: &Plan{
+				Scopes: []Scope{ScopeActions, ScopeRegisteredResources},
+				RegisteredResources: []*RegisteredResourcePlan{
+					{
+						Source: &policy.RegisteredResource{Id: "rr-1", Name: "repo"},
+						Targets: []*RegisteredResourceTargetPlan{
+							{
+								Namespace: namespace1,
+								Status:    TargetStatusCreate,
+							},
+						},
+					},
+				},
+			},
+			handler: &mockExecutorHandler{
+				registeredResourceErrs: map[string]map[string]error{
+					"rr-1": {
+						"ns-1": errBoom,
+					},
+				},
+			},
+			wantErr: wantError(errBoom, `create registered resource %q in namespace %q`, "rr-1", "ns-1"),
+			assert: func(t *testing.T, err error, _ *Executor, handler *mockExecutorHandler, plan *Plan) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.Contains(t, handler.createdRegisteredResources, "rr-1")
+				require.NotNil(t, plan.RegisteredResources[0].Targets[0].Execution)
+				assert.Equal(t, "boom", plan.RegisteredResources[0].Targets[0].Execution.Failure)
+			},
+		},
+		{
+			name: "stops when a registered resource value cannot resolve its migrated action target",
+			plan: &Plan{
+				Scopes: []Scope{ScopeActions, ScopeRegisteredResources},
+				RegisteredResources: []*RegisteredResourcePlan{
+					{
+						Source: &policy.RegisteredResource{Id: "rr-1", Name: "repo"},
+						Targets: []*RegisteredResourceTargetPlan{
+							{
+								Namespace: namespace1,
+								Status:    TargetStatusCreate,
+								Values: []*RegisteredResourceValuePlan{
+									{
+										Source: &policy.RegisteredResourceValue{Id: "rrv-1", Value: "repo-a"},
+										ActionBindings: []*RegisteredResourceActionBinding{
+											{
+												SourceActionID: "missing-action",
+												AttributeValue: &policy.Value{Id: "attribute-value-id-1"},
+												ActionTargetRef: &ActionBinding{
+													SourceID:  "missing-action",
+													Namespace: namespace1,
+													Status:    TargetStatusCreate,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			handler: &mockExecutorHandler{
+				registeredResourceResult: map[string]map[string]*policy.RegisteredResource{
+					"rr-1": {
+						"ns-1": {Id: "created-rr-1", Name: "repo"},
+					},
+				},
+			},
+			wantErr: wantError(
+				ErrMissingMigratedTarget,
+				`action %q target %q: build registered resource value %q action bindings for namespace %q`,
+				"missing-action",
+				"ns-1",
+				"rrv-1",
+				"ns-1",
+			),
+			assert: func(t *testing.T, err error, _ *Executor, handler *mockExecutorHandler, plan *Plan) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.Contains(t, handler.createdRegisteredResources, "rr-1")
+				assert.Nil(t, handler.createdRegisteredResourceValues)
+				require.NotNil(t, plan.RegisteredResources[0].Targets[0].Execution)
+				assert.True(t, plan.RegisteredResources[0].Targets[0].Execution.Applied)
+				require.NotNil(t, plan.RegisteredResources[0].Targets[0].Values[0].Execution)
+				assert.Contains(t, plan.RegisteredResources[0].Targets[0].Values[0].Execution.Failure, `missing migrated target: action "missing-action" target "ns-1"`)
+			},
+		},
+		{
+			name: "records value creation failures on the value target",
+			plan: &Plan{
+				Scopes: []Scope{ScopeActions, ScopeRegisteredResources},
+				Actions: []*ActionPlan{
+					{
+						Source: &policy.Action{Id: "action-1", Name: "read"},
+						Targets: []*ActionTargetPlan{
+							{
+								Namespace: namespace1,
+								Status:    TargetStatusCreate,
+							},
+						},
+					},
+				},
+				RegisteredResources: []*RegisteredResourcePlan{
+					{
+						Source: &policy.RegisteredResource{Id: "rr-1", Name: "repo"},
+						Targets: []*RegisteredResourceTargetPlan{
+							{
+								Namespace: namespace1,
+								Status:    TargetStatusCreate,
+								Values: []*RegisteredResourceValuePlan{
+									{
+										Source: &policy.RegisteredResourceValue{Id: "rrv-1", Value: "repo-a"},
+										ActionBindings: []*RegisteredResourceActionBinding{
+											{
+												SourceActionID: "action-1",
+												AttributeValue: &policy.Value{Id: "attribute-value-id-1"},
+												ActionTargetRef: &ActionBinding{
+													SourceID:  "action-1",
+													Namespace: namespace1,
+													Status:    TargetStatusCreate,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			handler: &mockExecutorHandler{
+				results: map[string]map[string]*policy.Action{
+					"read": {
+						"ns-1": {Id: "created-action-1", Name: "read"},
+					},
+				},
+				registeredResourceResult: map[string]map[string]*policy.RegisteredResource{
+					"rr-1": {
+						"ns-1": {Id: "created-rr-1", Name: "repo"},
+					},
+				},
+				registeredResourceValueErrs: map[string]map[string]error{
+					"rrv-1": {
+						"created-rr-1": errBoom,
+					},
+				},
+			},
+			wantErr: wantError(errBoom, `create registered resource value %q for resource %q in namespace %q`, "rrv-1", "created-rr-1", "ns-1"),
+			assert: func(t *testing.T, err error, _ *Executor, handler *mockExecutorHandler, plan *Plan) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.Contains(t, handler.createdRegisteredResourceValues, "rrv-1")
+				require.NotNil(t, plan.RegisteredResources[0].Targets[0].Execution)
+				assert.True(t, plan.RegisteredResources[0].Targets[0].Execution.Applied)
+				require.NotNil(t, plan.RegisteredResources[0].Targets[0].Values[0].Execution)
+				assert.Equal(t, "boom", plan.RegisteredResources[0].Targets[0].Values[0].Execution.Failure)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			executor, err := NewExecutor(tt.handler)
+			require.NoError(t, err)
+			if tt.runID != "" {
+				executor.runID = tt.runID
+			}
+
+			err = executor.Execute(t.Context(), tt.plan)
+			switch {
+			case tt.wantErr != nil:
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.wantErr.is)
+				require.EqualError(t, err, tt.wantErr.message)
+			default:
+				require.NoError(t, err)
+			}
+
+			tt.assert(t, err, executor, tt.handler, tt.plan)
+		})
+	}
+}


### PR DESCRIPTION
### Proposed Changes

1.) Add ability to commit `registered_resources`
2.) Call out that for partially migrated objects that cause collisions that we use a combination of `Existing` and `Status` to determine if the parent has already been migrated but the values need updates.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

