### PR TITLE
feat(cli): Cleanup planner, handle unresolved RRs interactively.

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: ${{ matrix.directory }}/go.mod
           check-latest: false
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "service/go.mod"
           check-latest: false
@@ -261,7 +261,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "service/go.mod"
           check-latest: false
@@ -510,7 +510,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: ./tests-bdd/go.mod
           cache: false
@@ -592,7 +592,7 @@ jobs:
         with:
           input: service
           against: "https://github.com/opentdf/platform.git#branch=${{ github.event.pull_request.base.ref || github.base_ref || 'main' }},subdir=service"
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "service/go.mod"
           check-latest: false
@@ -650,7 +650,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "service/go.mod"
           check-latest: false

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: ${{ matrix.directory }}/go.mod
           check-latest: false
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: "service/go.mod"
           check-latest: false
@@ -261,7 +261,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: "service/go.mod"
           check-latest: false
@@ -510,7 +510,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: ./tests-bdd/go.mod
           cache: false
@@ -592,7 +592,7 @@ jobs:
         with:
           input: service
           against: "https://github.com/opentdf/platform.git#branch=${{ github.event.pull_request.base.ref || github.base_ref || 'main' }},subdir=service"
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: "service/go.mod"
           check-latest: false
@@ -650,7 +650,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: "service/go.mod"
           check-latest: false

--- a/otdfctl/cmd/migrate/namespaced_policy.go
+++ b/otdfctl/cmd/migrate/namespaced_policy.go
@@ -41,11 +41,20 @@ func migrateNamespacedPolicy(cmd *cobra.Command, args []string) {
 	if err != nil {
 		cli.ExitWithError("could not read --commit flag", err)
 	}
+	interactive, err := cmd.InheritedFlags().GetBool("interactive")
+	if err != nil {
+		cli.ExitWithError("could not read --interactive flag", err)
+	}
 
 	h := otdfctl.NewHandler(c)
 	defer h.Close()
 
-	planner, err := namespacedpolicy.NewPlanner(&h, scopeCSV)
+	var plannerOpts []namespacedpolicy.Option
+	if interactive {
+		plannerOpts = append(plannerOpts, namespacedpolicy.WithInteractiveReviewer(namespacedpolicy.NewHuhInteractiveReviewer(&h, nil)))
+	}
+
+	planner, err := namespacedpolicy.NewPlanner(&h, scopeCSV, plannerOpts...)
 	if err != nil {
 		cli.ExitWithError("could not create namespaced-policy planner", err)
 	}

--- a/otdfctl/migrations/namespacedpolicy/derived.go
+++ b/otdfctl/migrations/namespacedpolicy/derived.go
@@ -20,31 +20,27 @@ type DerivedAction struct {
 	Source     *policy.Action
 	References []*ActionReference
 	Targets    []*policy.Namespace
-	Unresolved string
 }
 
 type DerivedSubjectConditionSet struct {
-	Source     *policy.SubjectConditionSet
-	Targets    []*policy.Namespace
-	Unresolved string
+	Source  *policy.SubjectConditionSet
+	Targets []*policy.Namespace
 }
 
 type DerivedSubjectMapping struct {
-	Source     *policy.SubjectMapping
-	Target     *policy.Namespace
-	Unresolved string
+	Source *policy.SubjectMapping
+	Target *policy.Namespace
 }
 
 type DerivedRegisteredResource struct {
 	Source     *policy.RegisteredResource
 	Target     *policy.Namespace
-	Unresolved string
+	Unresolved *Unresolved
 }
 
 type DerivedObligationTrigger struct {
-	Source     *policy.ObligationTrigger
-	Target     *policy.Namespace
-	Unresolved string
+	Source *policy.ObligationTrigger
+	Target *policy.Namespace
 }
 
 type targetDeriver struct {
@@ -55,6 +51,8 @@ type targetDeriver struct {
 	actionRefsByID    map[string]*actionReferenceAccumulator
 	scsTargetsByID    map[string]*namespaceAccumulator
 }
+
+var errSkipRegisteredResource = errors.New("skip registered resource")
 
 func deriveTargets(retrieved *Retrieved, namespaces []*policy.Namespace) (*DerivedTargets, error) {
 	if retrieved == nil {
@@ -83,6 +81,9 @@ func deriveTargets(retrieved *Retrieved, namespaces []*policy.Namespace) (*Deriv
 	for _, resource := range retrieved.Candidates.RegisteredResources {
 		item, err := deriver.deriveRegisteredResource(resource)
 		if err != nil {
+			if errors.Is(err, errSkipRegisteredResource) {
+				continue
+			}
 			return nil, err
 		}
 		derived.RegisteredResources = append(derived.RegisteredResources, item)
@@ -99,11 +100,19 @@ func deriveTargets(retrieved *Retrieved, namespaces []*policy.Namespace) (*Deriv
 	}
 
 	for _, action := range retrieved.Candidates.Actions {
-		derived.Actions = append(derived.Actions, deriver.deriveAction(action))
+		item, err := deriver.deriveAction(action)
+		if err != nil {
+			return nil, err
+		}
+		derived.Actions = append(derived.Actions, item)
 	}
 
 	for _, scs := range retrieved.Candidates.SubjectConditionSets {
-		derived.SubjectConditionSets = append(derived.SubjectConditionSets, deriver.deriveSubjectConditionSet(scs))
+		item, err := deriver.deriveSubjectConditionSet(scs)
+		if err != nil {
+			return nil, err
+		}
+		derived.SubjectConditionSets = append(derived.SubjectConditionSets, item)
 	}
 
 	return derived, nil
@@ -138,11 +147,7 @@ func (d *targetDeriver) deriveSubjectMapping(mapping *policy.SubjectMapping) (*D
 	item := &DerivedSubjectMapping{Source: mapping}
 	namespace, err := d.resolveNamespace(namespaceFromAttributeValue(mapping.GetAttributeValue()))
 	if err != nil {
-		item.Unresolved = err.Error()
-		if errors.Is(err, ErrMissingTargetNamespace) {
-			return item, err
-		}
-		return item, nil
+		return nil, fmt.Errorf("subject mapping %q: %w", mapping.GetId(), err)
 	}
 
 	item.Target = namespace
@@ -152,8 +157,7 @@ func (d *targetDeriver) deriveSubjectMapping(mapping *policy.SubjectMapping) (*D
 func (d *targetDeriver) deriveRegisteredResource(resource *policy.RegisteredResource) (*DerivedRegisteredResource, error) {
 	item := &DerivedRegisteredResource{Source: resource}
 	if resource == nil {
-		item.Unresolved = fmt.Errorf("%w: registered resource is empty", ErrUndeterminedTargetMapping).Error()
-		return item, nil
+		return nil, fmt.Errorf("%w: registered resource is empty", ErrUndeterminedTargetMapping)
 	}
 
 	namespaceRef, ok := registeredResourceNamespaceRef(resource)
@@ -162,20 +166,19 @@ func (d *targetDeriver) deriveRegisteredResource(resource *policy.RegisteredReso
 		// imply exactly one target namespace. No AAV-derived namespace, or AAVs
 		// spanning multiple namespaces, leaves the RR unresolved here.
 		if hasRegisteredResourceActionAttributeValues(resource) {
-			item.Unresolved = fmt.Errorf("%w: registered resource spans multiple target namespaces", ErrUndeterminedTargetMapping).Error()
+			item.Unresolved = &Unresolved{
+				Reason:  UnresolvedReasonRegisteredResourceConflictingNamespaces,
+				Message: fmt.Errorf("%w: registered resource spans multiple target namespaces", ErrUndeterminedTargetMapping).Error(),
+			}
 			return item, nil
 		}
-		item.Unresolved = fmt.Errorf("%w: no action-attribute values resolve a namespace", ErrUndeterminedTargetMapping).Error()
-		return item, nil
+		// Skip registered resources that have no action-attribute values because they do not provide a derivable namespace target.
+		return nil, errSkipRegisteredResource
 	}
 
 	namespace, err := d.resolveNamespace(namespaceRef)
 	if err != nil {
-		item.Unresolved = err.Error()
-		if errors.Is(err, ErrMissingTargetNamespace) {
-			return item, err
-		}
-		return item, nil
+		return nil, fmt.Errorf("registered resource %q: %w", resource.GetId(), err)
 	}
 
 	item.Target = namespace
@@ -186,20 +189,19 @@ func (d *targetDeriver) deriveObligationTrigger(trigger *policy.ObligationTrigge
 	item := &DerivedObligationTrigger{Source: trigger}
 	namespace, err := d.resolveNamespace(namespaceFromObligationValue(trigger.GetObligationValue()))
 	if err != nil {
-		item.Unresolved = err.Error()
-		if errors.Is(err, ErrMissingTargetNamespace) {
-			return item, err
-		}
-		return item, nil
+		return nil, fmt.Errorf("obligation trigger %q: %w", trigger.GetId(), err)
 	}
 
 	item.Target = namespace
 	return item, nil
 }
 
-func (d *targetDeriver) deriveAction(action *policy.Action) *DerivedAction {
+func (d *targetDeriver) deriveAction(action *policy.Action) (*DerivedAction, error) {
 	item := &DerivedAction{
 		Source: action,
+	}
+	if action == nil {
+		return nil, fmt.Errorf("%w: empty action candidate", ErrUndeterminedTargetMapping)
 	}
 	if refs := d.actionRefsByID[action.GetId()]; refs != nil {
 		item.References = refs.slice()
@@ -207,25 +209,27 @@ func (d *targetDeriver) deriveAction(action *policy.Action) *DerivedAction {
 	targets := d.targets(d.actionTargetsByID[action.GetId()])
 	if len(targets) == 0 {
 		if len(item.References) > 0 {
-			item.Unresolved = fmt.Errorf("%w: no target namespaces were discovered", ErrUndeterminedTargetMapping).Error()
+			return nil, fmt.Errorf("%w: no target namespaces were discovered for action %q", ErrUndeterminedTargetMapping, action.GetId())
 		}
-		return item
+		return item, nil
 	}
 
 	item.Targets = targets
-	return item
+	return item, nil
 }
 
-func (d *targetDeriver) deriveSubjectConditionSet(scs *policy.SubjectConditionSet) *DerivedSubjectConditionSet {
+func (d *targetDeriver) deriveSubjectConditionSet(scs *policy.SubjectConditionSet) (*DerivedSubjectConditionSet, error) {
 	item := &DerivedSubjectConditionSet{Source: scs}
+	if scs == nil {
+		return nil, fmt.Errorf("%w: empty subject condition set candidate", ErrUndeterminedTargetMapping)
+	}
 	targets := d.targets(d.scsTargetsByID[scs.GetId()])
 	if len(targets) == 0 {
-		item.Unresolved = fmt.Errorf("%w: no target namespaces were discovered", ErrUndeterminedTargetMapping).Error()
-		return item
+		return nil, fmt.Errorf("%w: no target namespaces were discovered for subject condition set %q", ErrUndeterminedTargetMapping, scs.GetId())
 	}
 
 	item.Targets = targets
-	return item
+	return item, nil
 }
 
 func (d *targetDeriver) observeSubjectMapping(item *DerivedSubjectMapping) {

--- a/otdfctl/migrations/namespacedpolicy/derived_test.go
+++ b/otdfctl/migrations/namespacedpolicy/derived_test.go
@@ -94,6 +94,103 @@ func TestDeriveTargetsCollectsTargetsAndReferencesFromDependencies(t *testing.T)
 	assert.Equal(t, namespace.GetId(), derived.ObligationTriggers[0].Target.GetId())
 }
 
+func TestDeriveTargetsFailsWhenSubjectMappingNamespaceCannotBeDerived(t *testing.T) {
+	t.Parallel()
+
+	retrieved := &Retrieved{
+		Scopes: []Scope{ScopeSubjectMappings},
+		Candidates: Candidates{
+			SubjectMappings: []*policy.SubjectMapping{
+				{
+					Id:             "mapping-1",
+					AttributeValue: &policy.Value{},
+				},
+			},
+		},
+	}
+
+	derived, err := deriveTargets(retrieved, nil)
+	require.Error(t, err)
+	assert.Nil(t, derived)
+	assert.EqualError(t, err, `subject mapping "mapping-1": could not determine target namespace: empty namespace reference`)
+}
+
+func TestDeriveTargetsKeepsRegisteredResourceNamespaceConflictUnresolved(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://other.example.com",
+	}
+	retrieved := &Retrieved{
+		Scopes: []Scope{ScopeRegisteredResources},
+		Candidates: Candidates{
+			RegisteredResources: []*policy.RegisteredResource{
+				testRegisteredResource(
+					"resource-1",
+					"documents",
+					testRegisteredResourceValue(
+						"prod",
+						testActionAttributeValue(
+							"action-1",
+							"decrypt",
+							testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-2",
+							"encrypt",
+							testAttributeValue("https://other.example.com/attr/classification/value/secret", rightNamespace),
+						),
+					),
+				),
+			},
+		},
+	}
+
+	derived, err := deriveTargets(retrieved, []*policy.Namespace{leftNamespace, rightNamespace})
+	require.NoError(t, err)
+	require.Len(t, derived.RegisteredResources, 1)
+	require.NotNil(t, derived.RegisteredResources[0].Unresolved)
+	assert.Equal(t, UnresolvedReasonRegisteredResourceConflictingNamespaces, derived.RegisteredResources[0].Unresolved.Reason)
+	assert.Equal(
+		t,
+		"could not determine target namespace: registered resource spans multiple target namespaces",
+		derived.RegisteredResources[0].Unresolved.Message,
+	)
+	assert.Nil(t, derived.RegisteredResources[0].Target)
+}
+
+func TestDeriveTargetsSkipsRegisteredResourceWithoutActionAttributeValues(t *testing.T) {
+	t.Parallel()
+
+	namespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	retrieved := &Retrieved{
+		Scopes: []Scope{ScopeRegisteredResources},
+		Candidates: Candidates{
+			RegisteredResources: []*policy.RegisteredResource{
+				testRegisteredResource(
+					"resource-1",
+					"documents",
+					&policy.RegisteredResourceValue{
+						Value: "prod",
+					},
+				),
+			},
+		},
+	}
+
+	derived, err := deriveTargets(retrieved, []*policy.Namespace{namespace})
+	require.NoError(t, err)
+	assert.Empty(t, derived.RegisteredResources)
+}
+
 func actionReferenceKindsAndIDs(references []*ActionReference) []string {
 	keys := make([]string, 0, len(references))
 	for _, reference := range references {

--- a/otdfctl/migrations/namespacedpolicy/execute.go
+++ b/otdfctl/migrations/namespacedpolicy/execute.go
@@ -30,6 +30,7 @@ var (
 const (
 	migrationLabelMigratedFrom = "migrated_from"
 	migrationLabelRun          = "migration_run"
+	unknownLabel               = "<unknown>"
 )
 
 type ExecutorHandler interface {
@@ -133,7 +134,7 @@ func namespaceIdentifier(namespace *policy.Namespace) string {
 
 func namespaceLabel(namespace *policy.Namespace) string {
 	if namespace == nil {
-		return "<unknown>"
+		return unknownLabel
 	}
 	if fqn := strings.TrimSpace(namespace.GetFqn()); fqn != "" {
 		return fqn
@@ -141,5 +142,5 @@ func namespaceLabel(namespace *policy.Namespace) string {
 	if id := strings.TrimSpace(namespace.GetId()); id != "" {
 		return id
 	}
-	return "<unknown>"
+	return unknownLabel
 }

--- a/otdfctl/migrations/namespacedpolicy/finalize_plan.go
+++ b/otdfctl/migrations/namespacedpolicy/finalize_plan.go
@@ -120,7 +120,7 @@ func (f *planFinalizer) addResolvedAction(item *ResolvedAction) {
 		return
 	}
 
-	if item.Unresolved == "" && len(item.Results) == 0 && len(item.References) == 0 {
+	if len(item.Results) == 0 && len(item.References) == 0 {
 		f.addUnusedAction(item.Source, item.References, unusedActionReason)
 		return
 	}
@@ -129,10 +129,6 @@ func (f *planFinalizer) addResolvedAction(item *ResolvedAction) {
 		Source:     item.Source,
 		References: append([]*ActionReference(nil), item.References...),
 		Targets:    make([]*ActionTargetPlan, 0, len(item.Results)),
-	}
-	if item.Unresolved != "" {
-		actionPlan.Unresolved = item.Unresolved
-		f.addActionIssue(item.Source, nil, item.Unresolved)
 	}
 
 	for _, result := range item.Results {
@@ -143,10 +139,6 @@ func (f *planFinalizer) addResolvedAction(item *ResolvedAction) {
 		actionPlan.Targets = append(actionPlan.Targets, target)
 		f.storeActionTarget(item.Source.GetId(), target)
 
-		if target.Status == TargetStatusUnresolved {
-			f.addActionIssue(item.Source, target.Namespace, target.Reason)
-			continue
-		}
 		f.addNamespacePlacement(target.Namespace, ScopeActions, item.Source.GetId())
 	}
 
@@ -162,10 +154,6 @@ func (f *planFinalizer) addResolvedSubjectConditionSet(item *ResolvedSubjectCond
 		Source:  item.Source,
 		Targets: make([]*SubjectConditionSetTargetPlan, 0, len(item.Results)),
 	}
-	if item.Unresolved != "" {
-		scsPlan.Unresolved = item.Unresolved
-		f.addSubjectConditionSetIssue(item.Source, nil, item.Unresolved)
-	}
 
 	for _, result := range item.Results {
 		target := newSubjectConditionSetTargetPlan(result)
@@ -175,10 +163,6 @@ func (f *planFinalizer) addResolvedSubjectConditionSet(item *ResolvedSubjectCond
 		scsPlan.Targets = append(scsPlan.Targets, target)
 		f.storeSubjectConditionSetTarget(item.Source.GetId(), target)
 
-		if target.Status == TargetStatusUnresolved {
-			f.addSubjectConditionSetIssue(item.Source, target.Namespace, target.Reason)
-			continue
-		}
 		f.addNamespacePlacement(target.Namespace, ScopeSubjectConditionSets, item.Source.GetId())
 	}
 
@@ -191,20 +175,11 @@ func (f *planFinalizer) addResolvedSubjectMapping(item *ResolvedSubjectMapping) 
 	}
 
 	mappingPlan := &SubjectMappingPlan{Source: item.Source}
-	if item.Unresolved != "" {
-		mappingPlan.Unresolved = item.Unresolved
-	}
 
 	target := f.newSubjectMappingTarget(item)
 	if target != nil {
 		mappingPlan.Targets = append(mappingPlan.Targets, target)
-		if target.Status == TargetStatusUnresolved {
-			f.addSubjectMappingIssue(item.Source, target.Namespace, target.Reason)
-		} else {
-			f.addNamespacePlacement(target.Namespace, ScopeSubjectMappings, item.Source.GetId())
-		}
-	} else if item.Unresolved != "" {
-		f.addSubjectMappingIssue(item.Source, item.Namespace, item.Unresolved)
+		f.addNamespacePlacement(target.Namespace, ScopeSubjectMappings, item.Source.GetId())
 	}
 
 	f.subjectMappings = append(f.subjectMappings, mappingPlan)
@@ -216,8 +191,8 @@ func (f *planFinalizer) addResolvedRegisteredResource(item *ResolvedRegisteredRe
 	}
 
 	resourcePlan := &RegisteredResourcePlan{Source: item.Source}
-	if item.Unresolved != "" {
-		resourcePlan.Unresolved = item.Unresolved
+	if item.Unresolved != nil {
+		resourcePlan.Unresolved = item.Unresolved.Message
 	}
 
 	target := f.newRegisteredResourceTarget(item)
@@ -228,8 +203,8 @@ func (f *planFinalizer) addResolvedRegisteredResource(item *ResolvedRegisteredRe
 		} else {
 			f.addNamespacePlacement(target.Namespace, ScopeRegisteredResources, item.Source.GetId())
 		}
-	} else if item.Unresolved != "" {
-		f.addRegisteredResourceIssue(item.Source, item.Namespace, item.Unresolved)
+	} else if item.Unresolved != nil {
+		f.addRegisteredResourceIssue(item.Source, item.Namespace, item.Unresolved.Message)
 	}
 
 	f.registeredResources = append(f.registeredResources, resourcePlan)
@@ -241,20 +216,11 @@ func (f *planFinalizer) addResolvedObligationTrigger(item *ResolvedObligationTri
 	}
 
 	triggerPlan := &ObligationTriggerPlan{Source: item.Source}
-	if item.Unresolved != "" {
-		triggerPlan.Unresolved = item.Unresolved
-	}
 
 	target := f.newObligationTriggerTarget(item)
 	if target != nil {
 		triggerPlan.Targets = append(triggerPlan.Targets, target)
-		if target.Status == TargetStatusUnresolved {
-			f.addObligationTriggerIssue(item.Source, target.Namespace, target.Reason)
-		} else {
-			f.addNamespacePlacement(target.Namespace, ScopeObligationTriggers, item.Source.GetId())
-		}
-	} else if item.Unresolved != "" {
-		f.addObligationTriggerIssue(item.Source, item.Namespace, item.Unresolved)
+		f.addNamespacePlacement(target.Namespace, ScopeObligationTriggers, item.Source.GetId())
 	}
 
 	f.obligationTriggers = append(f.obligationTriggers, triggerPlan)
@@ -331,9 +297,6 @@ func (f *planFinalizer) newSubjectMappingTarget(item *ResolvedSubjectMapping) *S
 		target.Existing = item.AlreadyMigrated
 	case item.NeedsCreate:
 		target.Status = TargetStatusCreate
-	case item.Unresolved != "":
-		target.Status = TargetStatusUnresolved
-		target.Reason = item.Unresolved
 	default:
 		return nil
 	}
@@ -362,9 +325,6 @@ func (f *planFinalizer) newRegisteredResourceTarget(item *ResolvedRegisteredReso
 		target.Existing = item.AlreadyMigrated
 	case item.NeedsCreate:
 		target.Status = TargetStatusCreate
-	case item.Unresolved != "":
-		target.Status = TargetStatusUnresolved
-		target.Reason = item.Unresolved
 	default:
 		return nil
 	}
@@ -407,9 +367,6 @@ func (f *planFinalizer) newObligationTriggerTarget(item *ResolvedObligationTrigg
 		target.Existing = item.AlreadyMigrated
 	case item.NeedsCreate:
 		target.Status = TargetStatusCreate
-	case item.Unresolved != "":
-		target.Status = TargetStatusUnresolved
-		target.Reason = item.Unresolved
 	default:
 		return nil
 	}
@@ -466,20 +423,6 @@ func (f *planFinalizer) subjectConditionSetBinding(sourceID string, namespace *p
 	}
 }
 
-func (f *planFinalizer) addActionIssue(action *policy.Action, namespace *policy.Namespace, reason string) {
-	if action == nil || reason == "" {
-		return
-	}
-	// TODO: Replace this linear dedupe scan with a set if unresolved issue counts
-	// grow enough for this path to matter.
-	for _, issue := range f.unresolved.Actions {
-		if issue != nil && issue.Source != nil && issue.Source.GetId() == action.GetId() && sameNamespace(issue.Namespace, namespace) && issue.Reason == reason {
-			return
-		}
-	}
-	f.unresolved.Actions = append(f.unresolved.Actions, &ActionIssue{Source: action, Namespace: namespace, Reason: reason})
-}
-
 func (f *planFinalizer) addUnusedAction(action *policy.Action, references []*ActionReference, reason string) {
 	if action == nil || reason == "" {
 		return
@@ -494,30 +437,6 @@ func (f *planFinalizer) addUnusedAction(action *policy.Action, references []*Act
 		References: append([]*ActionReference(nil), references...),
 		Reason:     reason,
 	})
-}
-
-func (f *planFinalizer) addSubjectConditionSetIssue(scs *policy.SubjectConditionSet, namespace *policy.Namespace, reason string) {
-	if scs == nil || reason == "" {
-		return
-	}
-	for _, issue := range f.unresolved.SubjectConditionSets {
-		if issue != nil && issue.Source != nil && issue.Source.GetId() == scs.GetId() && sameNamespace(issue.Namespace, namespace) && issue.Reason == reason {
-			return
-		}
-	}
-	f.unresolved.SubjectConditionSets = append(f.unresolved.SubjectConditionSets, &SubjectConditionSetIssue{Source: scs, Namespace: namespace, Reason: reason})
-}
-
-func (f *planFinalizer) addSubjectMappingIssue(mapping *policy.SubjectMapping, namespace *policy.Namespace, reason string) {
-	if mapping == nil || reason == "" {
-		return
-	}
-	for _, issue := range f.unresolved.SubjectMappings {
-		if issue != nil && issue.Source != nil && issue.Source.GetId() == mapping.GetId() && sameNamespace(issue.Namespace, namespace) && issue.Reason == reason {
-			return
-		}
-	}
-	f.unresolved.SubjectMappings = append(f.unresolved.SubjectMappings, &SubjectMappingIssue{Source: mapping, Namespace: namespace, Reason: reason})
 }
 
 func (f *planFinalizer) addRegisteredResourceIssue(resource *policy.RegisteredResource, namespace *policy.Namespace, reason string) {
@@ -539,18 +458,6 @@ func (f *planFinalizer) addRegisteredResourceIssue(resource *policy.RegisteredRe
 	})
 }
 
-func (f *planFinalizer) addObligationTriggerIssue(trigger *policy.ObligationTrigger, namespace *policy.Namespace, reason string) {
-	if trigger == nil || reason == "" {
-		return
-	}
-	for _, issue := range f.unresolved.ObligationTriggers {
-		if issue != nil && issue.Source != nil && issue.Source.GetId() == trigger.GetId() && sameNamespace(issue.Namespace, namespace) && issue.Reason == reason {
-			return
-		}
-	}
-	f.unresolved.ObligationTriggers = append(f.unresolved.ObligationTriggers, &ObligationTriggerIssue{Source: trigger, Namespace: namespace, Reason: reason})
-}
-
 func newActionTargetPlan(result *ResolvedActionResult) *ActionTargetPlan {
 	if result == nil || result.Namespace == nil {
 		return nil
@@ -566,9 +473,6 @@ func newActionTargetPlan(result *ResolvedActionResult) *ActionTargetPlan {
 		target.Existing = result.ExistingStandard
 	case result.NeedsCreate:
 		target.Status = TargetStatusCreate
-	case result.Unresolved != "":
-		target.Status = TargetStatusUnresolved
-		target.Reason = result.Unresolved
 	default:
 		return nil
 	}
@@ -588,9 +492,6 @@ func newSubjectConditionSetTargetPlan(result *ResolvedSubjectConditionSetResult)
 		target.Existing = result.AlreadyMigrated
 	case result.NeedsCreate:
 		target.Status = TargetStatusCreate
-	case result.Unresolved != "":
-		target.Status = TargetStatusUnresolved
-		target.Reason = result.Unresolved
 	default:
 		return nil
 	}

--- a/otdfctl/migrations/namespacedpolicy/interactive_prompt.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_prompt.go
@@ -1,0 +1,124 @@
+package namespacedpolicy
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+)
+
+var ErrInteractiveReviewAborted = errors.New("interactive review aborted by user")
+
+// ConfirmPrompt is a generic confirmation prompt for planner-owned review flows.
+type ConfirmPrompt struct {
+	Title        string
+	Description  []string
+	ConfirmLabel string
+	CancelLabel  string
+}
+
+// PromptOption is one selectable value in a generic interactive prompt.
+type PromptOption struct {
+	Label       string
+	Value       string
+	Description string
+}
+
+// SelectPrompt is a generic single-select prompt for planner-owned review flows.
+type SelectPrompt struct {
+	Title       string
+	Description []string
+	Options     []PromptOption
+}
+
+// InteractivePrompter abstracts the concrete prompt implementation so review
+// orchestration stays planner-owned and testable.
+type InteractivePrompter interface {
+	Confirm(context.Context, ConfirmPrompt) error
+	Select(context.Context, SelectPrompt) (string, error)
+}
+
+// HuhPrompter implements InteractivePrompter using charmbracelet/huh forms.
+type HuhPrompter struct{}
+
+func (p *HuhPrompter) Confirm(ctx context.Context, prompt ConfirmPrompt) error {
+	confirmLabel := strings.TrimSpace(prompt.ConfirmLabel)
+	if confirmLabel == "" {
+		confirmLabel = "Continue"
+	}
+
+	cancelLabel := strings.TrimSpace(prompt.CancelLabel)
+	if cancelLabel == "" {
+		cancelLabel = "Abort"
+	}
+
+	var choice bool
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(strings.TrimSpace(prompt.Title)).
+				Description(promptDescription(prompt.Description)).
+				Affirmative(confirmLabel).
+				Negative(cancelLabel).
+				Value(&choice),
+		),
+	)
+
+	if err := form.RunWithContext(ctx); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return ErrInteractiveReviewAborted
+		}
+		return err
+	}
+
+	if !choice {
+		return ErrInteractiveReviewAborted
+	}
+
+	return nil
+}
+
+func (p *HuhPrompter) Select(ctx context.Context, prompt SelectPrompt) (string, error) {
+	options := make([]huh.Option[string], 0, len(prompt.Options))
+	for _, option := range prompt.Options {
+		label := option.Label
+		if description := strings.TrimSpace(option.Description); description != "" {
+			label += " - " + description
+		}
+		options = append(options, huh.NewOption(label, option.Value))
+	}
+
+	var choice string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(strings.TrimSpace(prompt.Title)).
+				Description(promptDescription(prompt.Description)).
+				Options(options...).
+				Value(&choice),
+		),
+	)
+
+	if err := form.RunWithContext(ctx); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return "", ErrInteractiveReviewAborted
+		}
+		return "", err
+	}
+
+	return choice, nil
+}
+
+func promptDescription(description []string) string {
+	lines := make([]string, 0, len(description))
+	for _, line := range description {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/otdfctl/migrations/namespacedpolicy/interactive_review.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_review.go
@@ -1,0 +1,476 @@
+package namespacedpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	interactiveReviewAbortOption              = "__abort_interactive_review__"
+	minimumRegisteredResourceReviewNamespaces = 2
+)
+
+var ErrNilInteractiveReviewHandler = errors.New("interactive review handler is required")
+
+// InteractiveReviewer owns planner-time interactive review. It mutates
+// resolved planner state before finalization when interactive review is enabled.
+type InteractiveReviewer interface {
+	Review(context.Context, *ResolvedTargets, []*policy.Namespace) error
+}
+
+// HuhInteractiveReviewer is the planner-owned interactive review entrypoint for
+// `migrate namespaced-policy --interactive`.
+//
+// The only actionable planner-time review currently supported is resolving
+// registered resources whose action-attribute-values span multiple namespaces.
+type HuhInteractiveReviewer struct {
+	handler  PolicyClient
+	prompter InteractivePrompter
+	pageSize int32
+}
+
+func NewHuhInteractiveReviewer(handler PolicyClient, prompter InteractivePrompter) *HuhInteractiveReviewer {
+	return &HuhInteractiveReviewer{
+		handler:  handler,
+		prompter: prompter,
+		pageSize: defaultPlannerPageSize,
+	}
+}
+
+func (r *HuhInteractiveReviewer) Review(ctx context.Context, resolved *ResolvedTargets, namespaces []*policy.Namespace) error {
+	if resolved == nil {
+		return nil
+	}
+
+	var retriever *Retriever
+	namespaceCache := make(map[string]*interactiveReviewNamespaceState)
+	for _, resource := range resolved.RegisteredResources {
+		if !isConflictingRegisteredResource(resource) {
+			continue
+		}
+		if retriever == nil {
+			var err error
+			retriever, err = r.retriever()
+			if err != nil {
+				return err
+			}
+		}
+		if err := r.reviewRegisteredResource(ctx, resolved, resource, namespaces, retriever, namespaceCache); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *HuhInteractiveReviewer) reviewRegisteredResource(
+	ctx context.Context,
+	resolved *ResolvedTargets,
+	resource *ResolvedRegisteredResource,
+	namespaces []*policy.Namespace,
+	retriever *Retriever,
+	namespaceCache map[string]*interactiveReviewNamespaceState,
+) error {
+	if resource == nil || resource.Source == nil {
+		return nil
+	}
+
+	candidates, err := registeredResourceCandidateNamespaces(resource.Source, namespaces)
+	if err != nil {
+		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
+	}
+
+	selected, err := r.resolvePrompter().Select(ctx, registeredResourceConflictPrompt(resource.Source, candidates))
+	if err != nil {
+		return err
+	}
+	// registeredResourceConflictPrompt appends interactiveReviewAbortOption to SelectPrompt.Options,
+	// but selectedNamespace only searches candidates, so this short-circuit must remain in place.
+	if selected == interactiveReviewAbortOption {
+		return ErrInteractiveReviewAborted
+	}
+
+	chosen := selectedNamespace(candidates, selected)
+	if chosen == nil {
+		return fmt.Errorf("registered resource %q: invalid namespace choice %q", resource.Source.GetId(), selected)
+	}
+
+	filtered, err := filterRegisteredResourceToNamespace(resource.Source, chosen)
+	if err != nil {
+		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
+	}
+
+	namespaceState, err := reviewNamespaceState(ctx, retriever, chosen, namespaceCache)
+	if err != nil {
+		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
+	}
+
+	for _, value := range filtered.GetValues() {
+		for _, aav := range value.GetActionAttributeValues() {
+			if err := ensureRegisteredResourceActionResolution(resolved, resource.Source.GetId(), chosen, aav.GetAction(), namespaceState.actionResolver); err != nil {
+				return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
+			}
+		}
+	}
+
+	resource.Source = filtered
+	resource.Namespace = chosen
+	// Reset planner state before re-resolving against registeredResources[chosen.GetId()] so AlreadyMigrated/NeedsCreate matches resolver.resolveRegisteredResource semantics for the chosen namespace.
+	resource.Unresolved = nil
+	resource.AlreadyMigrated = nil
+	resource.NeedsCreate = false
+
+	existing, found, err := resolveExistingRegisteredResource(filtered, namespaceState.registeredResources)
+	switch {
+	case found:
+		resource.AlreadyMigrated = existing
+	case err != nil:
+		return fmt.Errorf("registered resource %q in namespace %q: %w", filtered.GetId(), chosen.GetId(), err)
+	default:
+		resource.NeedsCreate = true
+	}
+
+	return nil
+}
+
+type interactiveReviewNamespaceState struct {
+	actionResolver      *resolver
+	registeredResources []*policy.RegisteredResource
+}
+
+func reviewNamespaceState(
+	ctx context.Context,
+	retriever *Retriever,
+	chosen *policy.Namespace,
+	namespaceCache map[string]*interactiveReviewNamespaceState,
+) (*interactiveReviewNamespaceState, error) {
+	if chosen == nil {
+		return nil, fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping)
+	}
+	if retriever == nil {
+		return nil, ErrNilInteractiveReviewHandler
+	}
+
+	key := chosen.GetId()
+	if state, ok := namespaceCache[key]; ok {
+		return state, nil
+	}
+
+	customActions, standardActions, err := retriever.listActionsForNamespaces(ctx, []*policy.Namespace{chosen})
+	if err != nil {
+		return nil, err
+	}
+
+	registeredResources, err := retriever.listRegisteredResourcesForNamespaces(ctx, []*policy.Namespace{chosen})
+	if err != nil {
+		return nil, err
+	}
+
+	state := &interactiveReviewNamespaceState{
+		actionResolver: &resolver{
+			existing: &ExistingTargets{
+				CustomActions:   customActions,
+				StandardActions: standardActions,
+			},
+			actionResultsByKey: make(map[string]*ResolvedActionResult),
+			scsResultsByKey:    make(map[string]*ResolvedSubjectConditionSetResult),
+		},
+		registeredResources: registeredResources[chosen.GetId()],
+	}
+	namespaceCache[key] = state
+	return state, nil
+}
+
+func (r *HuhInteractiveReviewer) resolvePrompter() InteractivePrompter {
+	if r != nil && r.prompter != nil {
+		return r.prompter
+	}
+
+	return &HuhPrompter{}
+}
+
+func (r *HuhInteractiveReviewer) retriever() (*Retriever, error) {
+	if r == nil || r.handler == nil {
+		return nil, ErrNilInteractiveReviewHandler
+	}
+
+	pageSize := r.pageSize
+	if pageSize <= 0 {
+		pageSize = defaultPlannerPageSize
+	}
+
+	return newRetriever(r.handler, pageSize), nil
+}
+
+func isConflictingRegisteredResource(resource *ResolvedRegisteredResource) bool {
+	if resource == nil || resource.Unresolved == nil {
+		return false
+	}
+
+	return resource.Unresolved.Reason == UnresolvedReasonRegisteredResourceConflictingNamespaces
+}
+
+func registeredResourceCandidateNamespaces(resource *policy.RegisteredResource, namespaces []*policy.Namespace) ([]*policy.Namespace, error) {
+	if resource == nil {
+		return nil, fmt.Errorf("%w: registered resource is empty", ErrUndeterminedTargetMapping)
+	}
+
+	deriver := newTargetDeriver(namespaces)
+	ordered := newNamespaceAccumulator()
+
+	for _, value := range resource.GetValues() {
+		for _, aav := range value.GetActionAttributeValues() {
+			namespace, err := deriver.resolveNamespace(namespaceFromAttributeValue(aav.GetAttributeValue()))
+			if err != nil {
+				return nil, err
+			}
+			ordered.add(namespace)
+		}
+	}
+
+	candidates := ordered.slice()
+	if len(candidates) < minimumRegisteredResourceReviewNamespaces {
+		return nil, fmt.Errorf("%w: registered resource review requires multiple candidate namespaces", ErrUndeterminedTargetMapping)
+	}
+
+	return candidates, nil
+}
+
+func registeredResourceConflictPrompt(resource *policy.RegisteredResource, namespaces []*policy.Namespace) SelectPrompt {
+	description := []string{
+		fmt.Sprintf("Registered resource: %s (%s)", strings.TrimSpace(resource.GetName()), resource.GetId()),
+		"Choose one target namespace for this registered resource.",
+		"Bindings for other namespaces will be removed from the reviewed RR.",
+	}
+	description = append(description, registeredResourceConflictLines(resource)...)
+
+	options := make([]PromptOption, 0, len(namespaces)+1)
+	for _, namespace := range namespaces {
+		options = append(options, PromptOption{
+			Label:       namespaceLabel(namespace),
+			Value:       namespaceSelectionValue(namespace),
+			Description: "migrate to this namespace",
+		})
+	}
+	options = append(options, PromptOption{
+		Label:       "Abort run",
+		Value:       interactiveReviewAbortOption,
+		Description: "stop planning without changing this RR",
+	})
+
+	return SelectPrompt{
+		Title:       fmt.Sprintf("Registered resource (name: %s, id: %s) spans multiple target namespaces.", resource.GetName(), resource.GetId()),
+		Description: description,
+		Options:     options,
+	}
+}
+
+func registeredResourceConflictLines(resource *policy.RegisteredResource) []string {
+	lines := make([]string, 0)
+	for _, value := range resource.GetValues() {
+		if value == nil {
+			continue
+		}
+		if len(value.GetActionAttributeValues()) == 0 {
+			lines = append(lines, fmt.Sprintf("Value %q has no action bindings.", value.GetValue()))
+			continue
+		}
+		for _, aav := range value.GetActionAttributeValues() {
+			if aav == nil {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf(
+				"Value %q: action %q -> %s",
+				value.GetValue(),
+				actionLabel(aav.GetAction()),
+				namespaceLabel(namespaceFromAttributeValue(aav.GetAttributeValue())),
+			))
+		}
+	}
+
+	return lines
+}
+
+func actionLabel(action *policy.Action) string {
+	if action == nil {
+		return unknownLabel
+	}
+	if name := strings.TrimSpace(action.GetName()); name != "" {
+		return name
+	}
+	if id := strings.TrimSpace(action.GetId()); id != "" {
+		return id
+	}
+	return unknownLabel
+}
+
+func namespaceSelectionValue(namespace *policy.Namespace) string {
+	return namespaceRefKey(namespace)
+}
+
+func selectedNamespace(candidates []*policy.Namespace, value string) *policy.Namespace {
+	for _, namespace := range candidates {
+		if namespaceSelectionValue(namespace) == value {
+			return namespace
+		}
+	}
+
+	return nil
+}
+
+func filterRegisteredResourceToNamespace(resource *policy.RegisteredResource, namespace *policy.Namespace) (*policy.RegisteredResource, error) {
+	if resource == nil {
+		return nil, fmt.Errorf("%w: registered resource is empty", ErrUndeterminedTargetMapping)
+	}
+	if namespace == nil {
+		return nil, fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping)
+	}
+
+	cloned, ok := proto.Clone(resource).(*policy.RegisteredResource)
+	if !ok {
+		return nil, errors.New("could not clone registered resource")
+	}
+
+	clonedValues := cloned.GetValues()
+	cloned.Values = make([]*policy.RegisteredResourceValue, 0, len(clonedValues))
+	for _, value := range clonedValues {
+		if value == nil {
+			continue
+		}
+
+		if len(value.GetActionAttributeValues()) == 0 {
+			cloned.Values = append(cloned.Values, value)
+			continue
+		}
+
+		filteredAAVs := make([]*policy.RegisteredResourceValue_ActionAttributeValue, 0, len(value.GetActionAttributeValues()))
+		for _, aav := range value.GetActionAttributeValues() {
+			if aav == nil || !sameNamespace(namespaceFromAttributeValue(aav.GetAttributeValue()), namespace) {
+				continue
+			}
+			filteredAAVs = append(filteredAAVs, aav)
+		}
+
+		if len(filteredAAVs) == 0 {
+			continue
+		}
+
+		value.ActionAttributeValues = filteredAAVs
+		cloned.Values = append(cloned.Values, value)
+	}
+
+	return cloned, nil
+}
+
+// ensureRegisteredResourceActionResolution may append or update entries in
+// resolved.Actions so the reviewed registered resource's action bindings remain
+// executable after namespace-specific filtering.
+func ensureRegisteredResourceActionResolution(resolved *ResolvedTargets, resourceID string, namespace *policy.Namespace, action *policy.Action, actionResolver *resolver) error {
+	if resolved == nil {
+		return ErrNilResolvedTargets
+	}
+	if namespace == nil {
+		return fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping)
+	}
+	if action == nil || strings.TrimSpace(action.GetId()) == "" {
+		return errors.New("registered resource binding action is missing")
+	}
+	if actionResolver == nil {
+		return errors.New("action resolver required for plan resolution")
+	}
+
+	item := resolvedActionByID(resolved.Actions, action.GetId())
+	if item == nil {
+		source, err := cloneAction(action)
+		if err != nil {
+			return err
+		}
+
+		item = &ResolvedAction{
+			Source:  source,
+			Results: make([]*ResolvedActionResult, 0, 1),
+		}
+		resolved.Actions = append(resolved.Actions, item)
+	} else if item.Source == nil {
+		source, err := cloneAction(action)
+		if err != nil {
+			return err
+		}
+
+		item.Source = source
+	}
+
+	addActionReferenceIfMissing(item, &ActionReference{
+		Kind:      ActionReferenceKindRegisteredResource,
+		ID:        resourceID,
+		Namespace: namespace,
+	})
+
+	if resolvedActionResultForNamespace(item, namespace) != nil {
+		return nil
+	}
+
+	result, err := actionResolver.resolveActionTargetFromExisting(item.Source, namespace)
+	if err != nil {
+		return fmt.Errorf("action %q in namespace %q: %w", item.Source.GetId(), namespace.GetId(), err)
+	}
+
+	item.Results = append(item.Results, result)
+	return nil
+}
+
+func resolvedActionByID(actions []*ResolvedAction, sourceID string) *ResolvedAction {
+	for _, action := range actions {
+		if action != nil && action.Source != nil && action.Source.GetId() == sourceID {
+			return action
+		}
+	}
+
+	return nil
+}
+
+func resolvedActionResultForNamespace(action *ResolvedAction, namespace *policy.Namespace) *ResolvedActionResult {
+	if action == nil || namespace == nil {
+		return nil
+	}
+
+	for _, result := range action.Results {
+		if result != nil && sameNamespace(result.Namespace, namespace) {
+			return result
+		}
+	}
+
+	return nil
+}
+
+func addActionReferenceIfMissing(action *ResolvedAction, reference *ActionReference) {
+	if action == nil || reference == nil {
+		return
+	}
+
+	for _, existing := range action.References {
+		if actionReferenceKey(existing) == actionReferenceKey(reference) {
+			return
+		}
+	}
+
+	action.References = append(action.References, reference)
+}
+
+func cloneAction(action *policy.Action) (*policy.Action, error) {
+	if action == nil {
+		return nil, errors.New("action is nil")
+	}
+
+	cloned, ok := proto.Clone(action).(*policy.Action)
+	if !ok {
+		return nil, fmt.Errorf("clone action %q: unexpected proto clone type", action.GetId())
+	}
+
+	return cloned, nil
+}

--- a/otdfctl/migrations/namespacedpolicy/interactive_review_test.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_review_test.go
@@ -1,0 +1,319 @@
+package namespacedpolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/actions"
+	"github.com/opentdf/platform/protocol/go/policy/namespaces"
+	"github.com/opentdf/platform/protocol/go/policy/registeredresources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHuhInteractiveReviewerResolvesConflictingRegisteredResource(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			leftNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		registeredResourcesByNamespace: map[string]*registeredresources.ListRegisteredResourcesResponse{
+			leftNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{leftNamespace, rightNamespace},
+			Pagination: emptyPageResponse(),
+		},
+	}
+	prompter := &testInteractivePrompter{
+		selectValue: namespaceSelectionValue(leftNamespace),
+	}
+	reviewer := NewHuhInteractiveReviewer(handler, prompter)
+	resolved := &ResolvedTargets{
+		Scopes: []Scope{ScopeRegisteredResources},
+		RegisteredResources: []*ResolvedRegisteredResource{
+			{
+				Source: testRegisteredResource(
+					"resource-1",
+					"documents",
+					testRegisteredResourceValue(
+						"prod",
+						testActionAttributeValue(
+							"action-1",
+							"decrypt",
+							testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-2",
+							"encrypt",
+							testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+						),
+					),
+					&policy.RegisteredResourceValue{
+						Value: "shared",
+					},
+				),
+				Unresolved: &Unresolved{
+					Reason:  UnresolvedReasonRegisteredResourceConflictingNamespaces,
+					Message: "could not determine target namespace: registered resource spans multiple target namespaces",
+				},
+			},
+		},
+	}
+
+	err := reviewer.Review(t.Context(), resolved, []*policy.Namespace{leftNamespace, rightNamespace})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, prompter.selectCalls)
+	require.NotNil(t, prompter.lastSelectPrompt)
+	assert.Equal(t, "Registered resource (name: documents, id: resource-1) spans multiple target namespaces.", prompter.lastSelectPrompt.Title)
+	require.Len(t, prompter.lastSelectPrompt.Options, 3)
+
+	require.Len(t, resolved.RegisteredResources, 1)
+	resource := resolved.RegisteredResources[0]
+	require.NotNil(t, resource)
+	assert.Nil(t, resource.Unresolved)
+	assert.True(t, resource.NeedsCreate)
+	assert.Nil(t, resource.AlreadyMigrated)
+	require.True(t, sameNamespace(leftNamespace, resource.Namespace))
+	require.Len(t, resource.Source.GetValues(), 2)
+	require.Len(t, resource.Source.GetValues()[0].GetActionAttributeValues(), 1)
+	assert.Equal(t, "action-1", resource.Source.GetValues()[0].GetActionAttributeValues()[0].GetAction().GetId())
+	assert.Empty(t, resource.Source.GetValues()[1].GetActionAttributeValues())
+
+	require.Len(t, resolved.Actions, 1)
+	action := resolved.Actions[0]
+	require.NotNil(t, action.Source)
+	assert.Equal(t, "action-1", action.Source.GetId())
+	require.Len(t, action.Results, 1)
+	assert.True(t, sameNamespace(leftNamespace, action.Results[0].Namespace))
+	assert.True(t, action.Results[0].NeedsCreate)
+	require.Len(t, action.References, 1)
+	assert.Equal(t, ActionReferenceKindRegisteredResource, action.References[0].Kind)
+	assert.Equal(t, "resource-1", action.References[0].ID)
+	assert.True(t, sameNamespace(leftNamespace, action.References[0].Namespace))
+}
+
+func TestHuhInteractiveReviewerReturnsAbortWhenPromptAborts(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+	reviewer := NewHuhInteractiveReviewer(
+		&plannerTestHandler{},
+		&testInteractivePrompter{selectErr: ErrInteractiveReviewAborted},
+	)
+
+	err := reviewer.Review(t.Context(), &ResolvedTargets{
+		RegisteredResources: []*ResolvedRegisteredResource{
+			{
+				Source: testRegisteredResource(
+					"resource-1",
+					"documents",
+					testRegisteredResourceValue(
+						"prod",
+						testActionAttributeValue(
+							"action-1",
+							"decrypt",
+							testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-2",
+							"encrypt",
+							testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+						),
+					),
+				),
+				Unresolved: &Unresolved{
+					Reason: UnresolvedReasonRegisteredResourceConflictingNamespaces,
+				},
+			},
+		},
+	}, []*policy.Namespace{leftNamespace, rightNamespace})
+	require.ErrorIs(t, err, ErrInteractiveReviewAborted)
+}
+
+func TestHuhInteractiveReviewerReturnsNilForNilResolvedTargets(t *testing.T) {
+	t.Parallel()
+
+	reviewer := NewHuhInteractiveReviewer(&plannerTestHandler{}, &testInteractivePrompter{})
+
+	err := reviewer.Review(t.Context(), nil, nil)
+	require.NoError(t, err)
+}
+
+func TestHuhInteractiveReviewerRequiresHandlerForConflictingReview(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+	reviewer := NewHuhInteractiveReviewer(nil, &testInteractivePrompter{
+		selectValue: namespaceSelectionValue(leftNamespace),
+	})
+
+	err := reviewer.Review(t.Context(), &ResolvedTargets{
+		RegisteredResources: []*ResolvedRegisteredResource{
+			{
+				Source: testRegisteredResource(
+					"resource-1",
+					"documents",
+					testRegisteredResourceValue(
+						"prod",
+						testActionAttributeValue(
+							"action-1",
+							"decrypt",
+							testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-2",
+							"encrypt",
+							testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+						),
+					),
+				),
+				Unresolved: &Unresolved{
+					Reason: UnresolvedReasonRegisteredResourceConflictingNamespaces,
+				},
+			},
+		},
+	}, []*policy.Namespace{leftNamespace, rightNamespace})
+	require.ErrorIs(t, err, ErrNilInteractiveReviewHandler)
+}
+
+func TestHuhInteractiveReviewerCachesNamespaceLookupsWithinReview(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			leftNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		registeredResourcesByNamespace: map[string]*registeredresources.ListRegisteredResourcesResponse{
+			leftNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{leftNamespace, rightNamespace},
+			Pagination: emptyPageResponse(),
+		},
+	}
+	prompter := &testInteractivePrompter{
+		selectValue: namespaceSelectionValue(leftNamespace),
+	}
+	reviewer := NewHuhInteractiveReviewer(handler, prompter)
+	resolved := &ResolvedTargets{
+		Scopes: []Scope{ScopeRegisteredResources},
+		RegisteredResources: []*ResolvedRegisteredResource{
+			{
+				Source: testRegisteredResource(
+					"resource-1",
+					"documents",
+					testRegisteredResourceValue(
+						"prod",
+						testActionAttributeValue(
+							"action-1",
+							"decrypt",
+							testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-2",
+							"encrypt",
+							testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+						),
+					),
+				),
+				Unresolved: &Unresolved{
+					Reason: UnresolvedReasonRegisteredResourceConflictingNamespaces,
+				},
+			},
+			{
+				Source: testRegisteredResource(
+					"resource-2",
+					"records",
+					testRegisteredResourceValue(
+						"stage",
+						testActionAttributeValue(
+							"action-3",
+							"review_records",
+							testAttributeValue("https://example.com/attr/classification/value/internal", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-4",
+							"publish_records",
+							testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+						),
+					),
+				),
+				Unresolved: &Unresolved{
+					Reason: UnresolvedReasonRegisteredResourceConflictingNamespaces,
+				},
+			},
+		},
+	}
+
+	err := reviewer.Review(t.Context(), resolved, []*policy.Namespace{leftNamespace, rightNamespace})
+	require.NoError(t, err)
+	assert.Equal(t, 2, prompter.selectCalls)
+	assert.Equal(t, []string{leftNamespace.GetId()}, handler.actionCalls)
+	assert.Equal(t, []string{leftNamespace.GetId()}, handler.registeredResourceCalls)
+}
+
+type testInteractivePrompter struct {
+	confirmCalls      int
+	lastConfirmPrompt *ConfirmPrompt
+	confirmErr        error
+	selectCalls       int
+	lastSelectPrompt  *SelectPrompt
+	selectValue       string
+	selectErr         error
+}
+
+func (p *testInteractivePrompter) Confirm(_ context.Context, prompt ConfirmPrompt) error {
+	p.confirmCalls++
+	p.lastConfirmPrompt = &prompt
+	return p.confirmErr
+}
+
+func (p *testInteractivePrompter) Select(_ context.Context, prompt SelectPrompt) (string, error) {
+	p.selectCalls++
+	p.lastSelectPrompt = &prompt
+	return p.selectValue, p.selectErr
+}

--- a/otdfctl/migrations/namespacedpolicy/plan.go
+++ b/otdfctl/migrations/namespacedpolicy/plan.go
@@ -12,11 +12,19 @@ var (
 	ErrNilRetrieved              = errors.New("planner retrieved state is required")
 	ErrMissingTargetNamespace    = errors.New("missing target namespace")
 	ErrUndeterminedTargetMapping = errors.New("could not determine target namespace")
+	ErrDuplicateCanonincalMatch  = errors.New("multiple existing target objects match canonical equality in the target namespace")
 )
 
+type UnresolvedReason string
+
 const (
-	errDuplicateCanonicalMatch = "multiple existing target objects match canonical equality in the target namespace"
+	UnresolvedReasonRegisteredResourceConflictingNamespaces UnresolvedReason = "registered_resource_conflicting_namespaces"
 )
+
+type Unresolved struct {
+	Reason  UnresolvedReason
+	Message string
+}
 
 type Plan struct {
 	Scopes               []Scope                    `json:"scopes"`
@@ -62,7 +70,6 @@ type ActionPlan struct {
 	// actions.
 	References []*ActionReference  `json:"references,omitempty"`
 	Targets    []*ActionTargetPlan `json:"targets,omitempty"`
-	Unresolved string              `json:"unresolved,omitempty"`
 }
 
 type ActionReferenceKind string
@@ -88,9 +95,8 @@ type ActionTargetPlan struct {
 }
 
 type SubjectConditionSetPlan struct {
-	Source     *policy.SubjectConditionSet      `json:"source"`
-	Targets    []*SubjectConditionSetTargetPlan `json:"targets,omitempty"`
-	Unresolved string                           `json:"unresolved,omitempty"`
+	Source  *policy.SubjectConditionSet      `json:"source"`
+	Targets []*SubjectConditionSetTargetPlan `json:"targets,omitempty"`
 }
 
 type SubjectConditionSetTargetPlan struct {
@@ -102,9 +108,8 @@ type SubjectConditionSetTargetPlan struct {
 }
 
 type SubjectMappingPlan struct {
-	Source     *policy.SubjectMapping      `json:"source"`
-	Targets    []*SubjectMappingTargetPlan `json:"targets,omitempty"`
-	Unresolved string                      `json:"unresolved,omitempty"`
+	Source  *policy.SubjectMapping      `json:"source"`
+	Targets []*SubjectMappingTargetPlan `json:"targets,omitempty"`
 }
 
 type SubjectMappingTargetPlan struct {
@@ -148,9 +153,8 @@ type RegisteredResourceActionBinding struct {
 }
 
 type ObligationTriggerPlan struct {
-	Source     *policy.ObligationTrigger      `json:"source"`
-	Targets    []*ObligationTriggerTargetPlan `json:"targets,omitempty"`
-	Unresolved string                         `json:"unresolved,omitempty"`
+	Source  *policy.ObligationTrigger      `json:"source"`
+	Targets []*ObligationTriggerTargetPlan `json:"targets,omitempty"`
 }
 
 type ObligationTriggerTargetPlan struct {
@@ -190,41 +194,13 @@ type UnusedAction struct {
 }
 
 type UnresolvedPlan struct {
-	Actions              []*ActionIssue              `json:"actions,omitempty"`
-	SubjectConditionSets []*SubjectConditionSetIssue `json:"subject_condition_sets,omitempty"`
-	SubjectMappings      []*SubjectMappingIssue      `json:"subject_mappings,omitempty"`
-	RegisteredResources  []*RegisteredResourceIssue  `json:"registered_resources,omitempty"`
-	ObligationTriggers   []*ObligationTriggerIssue   `json:"obligation_triggers,omitempty"`
-}
-
-type ActionIssue struct {
-	Source    *policy.Action    `json:"source"`
-	Namespace *policy.Namespace `json:"namespace,omitempty"`
-	Reason    string            `json:"reason"`
-}
-
-type SubjectConditionSetIssue struct {
-	Source    *policy.SubjectConditionSet `json:"source"`
-	Namespace *policy.Namespace           `json:"namespace,omitempty"`
-	Reason    string                      `json:"reason"`
-}
-
-type SubjectMappingIssue struct {
-	Source    *policy.SubjectMapping `json:"source"`
-	Namespace *policy.Namespace      `json:"namespace,omitempty"`
-	Reason    string                 `json:"reason"`
+	RegisteredResources []*RegisteredResourceIssue `json:"registered_resources,omitempty"`
 }
 
 type RegisteredResourceIssue struct {
 	Resource  *policy.RegisteredResource `json:"resource"`
 	Namespace *policy.Namespace          `json:"namespace,omitempty"`
 	Reason    string                     `json:"reason"`
-}
-
-type ObligationTriggerIssue struct {
-	Source    *policy.ObligationTrigger `json:"source"`
-	Namespace *policy.Namespace         `json:"namespace,omitempty"`
-	Reason    string                    `json:"reason"`
 }
 
 func namespaceFromAttributeValue(value *policy.Value) *policy.Namespace {
@@ -277,11 +253,7 @@ func hasObject[T interface{ GetId() string }](items []T, id string) bool {
 }
 
 func hasUnresolved(plan UnresolvedPlan) bool {
-	return len(plan.Actions) > 0 ||
-		len(plan.SubjectConditionSets) > 0 ||
-		len(plan.SubjectMappings) > 0 ||
-		len(plan.RegisteredResources) > 0 ||
-		len(plan.ObligationTriggers) > 0
+	return len(plan.RegisteredResources) > 0
 }
 
 func hasUnused(plan UnusedPlan) bool {

--- a/otdfctl/migrations/namespacedpolicy/plan.go
+++ b/otdfctl/migrations/namespacedpolicy/plan.go
@@ -12,7 +12,7 @@ var (
 	ErrNilRetrieved              = errors.New("planner retrieved state is required")
 	ErrMissingTargetNamespace    = errors.New("missing target namespace")
 	ErrUndeterminedTargetMapping = errors.New("could not determine target namespace")
-	ErrDuplicateCanonincalMatch  = errors.New("multiple existing target objects match canonical equality in the target namespace")
+	ErrDuplicateCanonicalMatch   = errors.New("multiple existing target objects match canonical equality in the target namespace")
 )
 
 type UnresolvedReason string

--- a/otdfctl/migrations/namespacedpolicy/planner.go
+++ b/otdfctl/migrations/namespacedpolicy/planner.go
@@ -113,7 +113,10 @@ func (p *Planner) Plan(ctx context.Context) (*Plan, error) {
 		return nil, err
 	}
 
-	resolved := resolveExisting(derived, existingTargets)
+	resolved, err := resolveExisting(derived, existingTargets)
+	if err != nil {
+		return nil, err
+	}
 
 	return finalizePlan(resolved, namespaces)
 }

--- a/otdfctl/migrations/namespacedpolicy/planner.go
+++ b/otdfctl/migrations/namespacedpolicy/planner.go
@@ -30,6 +30,7 @@ type Planner struct {
 	retriever       *Retriever
 	requestedScopes scopeSet
 	expandedScopes  scopeSet
+	reviewer        InteractiveReviewer
 }
 
 type Option func(*Planner)
@@ -92,6 +93,12 @@ func WithPageSize(pageSize int32) Option {
 	}
 }
 
+func WithInteractiveReviewer(reviewer InteractiveReviewer) Option {
+	return func(planner *Planner) {
+		planner.reviewer = reviewer
+	}
+}
+
 func (p *Planner) Plan(ctx context.Context) (*Plan, error) {
 	retrieved, err := p.retrieve(ctx)
 	if err != nil {
@@ -116,6 +123,12 @@ func (p *Planner) Plan(ctx context.Context) (*Plan, error) {
 	resolved, err := resolveExisting(derived, existingTargets)
 	if err != nil {
 		return nil, err
+	}
+
+	if p.reviewer != nil {
+		if err := p.reviewer.Review(ctx, resolved, namespaces); err != nil {
+			return nil, err
+		}
 	}
 
 	return finalizePlan(resolved, namespaces)

--- a/otdfctl/migrations/namespacedpolicy/planner_test.go
+++ b/otdfctl/migrations/namespacedpolicy/planner_test.go
@@ -2,6 +2,7 @@ package namespacedpolicy
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/opentdf/platform/protocol/go/common"
@@ -70,7 +71,7 @@ func TestPlannerPlanMarksActionAlreadyMigratedWithoutMetadata(t *testing.T) {
 	planner, err := NewPlanner(handler, "actions")
 	require.NoError(t, err)
 
-	plan, err := planner.Plan(context.Background())
+	plan, err := planner.Plan(t.Context())
 	require.NoError(t, err)
 	require.Len(t, plan.Actions, 1)
 	require.Len(t, plan.Actions[0].Targets, 1)
@@ -201,7 +202,7 @@ func TestPlannerPlanDoesNotLeakSupportSubjectMappingsIntoActionScope(t *testing.
 	planner, err := NewPlanner(handler, "subject-condition-sets,registered-resources")
 	require.NoError(t, err)
 
-	plan, err := planner.Plan(context.Background())
+	plan, err := planner.Plan(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, []Scope{ScopeActions, ScopeSubjectConditionSets, ScopeRegisteredResources}, plan.Scopes)
@@ -363,7 +364,7 @@ func TestPlannerRetrieveUsesRequestedScopeBoundaries(t *testing.T) {
 			planner, err := NewPlanner(handler, tt.scopeCSV)
 			require.NoError(t, err)
 
-			retrieved, err := planner.retrieve(context.Background())
+			retrieved, err := planner.retrieve(t.Context())
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.expectedScopes, retrieved.Scopes)
@@ -490,7 +491,7 @@ func TestPlannerPlanAllScopesBuildsAllPlanSections(t *testing.T) {
 	planner, err := NewPlanner(handler, "actions,subject-condition-sets,subject-mappings,registered-resources,obligation-triggers")
 	require.NoError(t, err)
 
-	plan, err := planner.Plan(context.Background())
+	plan, err := planner.Plan(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, []Scope{
@@ -544,6 +545,274 @@ func TestPlannerPlanAllScopesBuildsAllPlanSections(t *testing.T) {
 	assert.Equal(t, []string{"", targetNamespace.GetId()}, handler.subjectMappingCalls)
 	assert.Equal(t, []string{"", targetNamespace.GetId()}, handler.registeredResourceCalls)
 	assert.Equal(t, []string{"", targetNamespace.GetId()}, handler.obligationTriggerCalls)
+}
+
+func TestPlannerPlanInvokesInteractiveReviewerWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	targetNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	legacyAction := &policy.Action{
+		Id:   "action-legacy",
+		Name: "decrypt",
+	}
+	legacyMapping := &policy.SubjectMapping{
+		Id: "mapping-legacy",
+		Actions: []*policy.Action{
+			{
+				Id:   legacyAction.GetId(),
+				Name: legacyAction.GetName(),
+			},
+		},
+		AttributeValue: &policy.Value{
+			Fqn: "https://example.com/attr/classification/value/secret",
+		},
+	}
+	reviewer := &plannerTestReviewer{}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			"": {
+				ActionsCustom: []*policy.Action{legacyAction},
+				Pagination:    emptyPageResponse(),
+			},
+			targetNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		subjectMappingsByNamespace: map[string]*subjectmapping.ListSubjectMappingsResponse{
+			"": {
+				SubjectMappings: []*policy.SubjectMapping{legacyMapping},
+				Pagination:      emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{targetNamespace},
+			Pagination: emptyPageResponse(),
+		},
+	}
+
+	planner, err := NewPlanner(handler, "actions", WithInteractiveReviewer(reviewer))
+	require.NoError(t, err)
+
+	plan, err := planner.Plan(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, 1, reviewer.calls)
+	assert.NotNil(t, reviewer.lastResolved)
+}
+
+func TestPlannerPlanPropagatesInteractiveReviewerError(t *testing.T) {
+	t.Parallel()
+
+	targetNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	legacyAction := &policy.Action{
+		Id:   "action-legacy",
+		Name: "decrypt",
+	}
+	legacyMapping := &policy.SubjectMapping{
+		Id: "mapping-legacy",
+		Actions: []*policy.Action{
+			{
+				Id:   legacyAction.GetId(),
+				Name: legacyAction.GetName(),
+			},
+		},
+		AttributeValue: &policy.Value{
+			Fqn: "https://example.com/attr/classification/value/secret",
+		},
+	}
+	reviewerErr := errors.New("review failed")
+	reviewer := &plannerTestReviewer{err: reviewerErr}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			"": {
+				ActionsCustom: []*policy.Action{legacyAction},
+				Pagination:    emptyPageResponse(),
+			},
+			targetNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		subjectMappingsByNamespace: map[string]*subjectmapping.ListSubjectMappingsResponse{
+			"": {
+				SubjectMappings: []*policy.SubjectMapping{legacyMapping},
+				Pagination:      emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{targetNamespace},
+			Pagination: emptyPageResponse(),
+		},
+	}
+
+	planner, err := NewPlanner(handler, "actions", WithInteractiveReviewer(reviewer))
+	require.NoError(t, err)
+
+	_, err = planner.Plan(t.Context())
+	require.ErrorIs(t, err, reviewerErr)
+	assert.Equal(t, 1, reviewer.calls)
+}
+
+func TestPlannerPlanInteractiveReviewerLeavesCurrentUnresolvedPlanShapeUntouched(t *testing.T) {
+	t.Parallel()
+
+	namespaceOne := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	namespaceTwo := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+	legacyAction := &policy.Action{
+		Id:   "action-legacy",
+		Name: "decrypt",
+	}
+	legacyResource := testRegisteredResource(
+		"resource-1",
+		"documents",
+		testRegisteredResourceValue(
+			"prod",
+			testActionAttributeValue(
+				legacyAction.GetId(),
+				legacyAction.GetName(),
+				testAttributeValue("https://example.com/attr/classification/value/secret", namespaceOne),
+			),
+			testActionAttributeValue(
+				legacyAction.GetId(),
+				legacyAction.GetName(),
+				testAttributeValue("https://example.org/attr/classification/value/restricted", namespaceTwo),
+			),
+		),
+	)
+	reviewer := &plannerTestReviewer{}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			"": {
+				ActionsCustom: []*policy.Action{legacyAction},
+				Pagination:    emptyPageResponse(),
+			},
+		},
+		registeredResourcesByNamespace: map[string]*registeredresources.ListRegisteredResourcesResponse{
+			"": {
+				Resources:  []*policy.RegisteredResource{legacyResource},
+				Pagination: emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{namespaceOne, namespaceTwo},
+			Pagination: emptyPageResponse(),
+		},
+	}
+
+	planner, err := NewPlanner(handler, "registered-resources", WithInteractiveReviewer(reviewer))
+	require.NoError(t, err)
+
+	plan, err := planner.Plan(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, reviewer.calls)
+	require.Len(t, plan.RegisteredResources, 1)
+	assert.Equal(t, ErrUndeterminedTargetMapping.Error()+": registered resource spans multiple target namespaces", plan.RegisteredResources[0].Unresolved)
+	assert.Empty(t, plan.RegisteredResources[0].Targets)
+	require.NotNil(t, plan.Unresolved)
+	require.Len(t, plan.Unresolved.RegisteredResources, 1)
+	assert.Equal(t, legacyResource.GetId(), plan.Unresolved.RegisteredResources[0].Resource.GetId())
+	assert.Equal(t, plan.RegisteredResources[0].Unresolved, plan.Unresolved.RegisteredResources[0].Reason)
+}
+
+func TestPlannerPlanHuhInteractiveReviewerResolvesRegisteredResourceConflict(t *testing.T) {
+	t.Parallel()
+
+	namespaceOne := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	namespaceTwo := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+	legacyAction := &policy.Action{
+		Id:   "action-legacy",
+		Name: "decrypt",
+	}
+	legacyResource := testRegisteredResource(
+		"resource-1",
+		"documents",
+		testRegisteredResourceValue(
+			"prod",
+			testActionAttributeValue(
+				legacyAction.GetId(),
+				legacyAction.GetName(),
+				testAttributeValue("https://example.com/attr/classification/value/secret", namespaceOne),
+			),
+			testActionAttributeValue(
+				legacyAction.GetId(),
+				legacyAction.GetName(),
+				testAttributeValue("https://example.org/attr/classification/value/restricted", namespaceTwo),
+			),
+		),
+	)
+	prompter := &testInteractivePrompter{
+		selectValue: namespaceSelectionValue(namespaceOne),
+	}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			"": {
+				ActionsCustom: []*policy.Action{legacyAction},
+				Pagination:    emptyPageResponse(),
+			},
+			namespaceOne.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		registeredResourcesByNamespace: map[string]*registeredresources.ListRegisteredResourcesResponse{
+			"": {
+				Resources:  []*policy.RegisteredResource{legacyResource},
+				Pagination: emptyPageResponse(),
+			},
+			namespaceOne.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{namespaceOne, namespaceTwo},
+			Pagination: emptyPageResponse(),
+		},
+	}
+
+	planner, err := NewPlanner(handler, "registered-resources", WithInteractiveReviewer(NewHuhInteractiveReviewer(handler, prompter)))
+	require.NoError(t, err)
+
+	plan, err := planner.Plan(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, prompter.selectCalls)
+	require.Len(t, plan.RegisteredResources, 1)
+	assert.Empty(t, plan.RegisteredResources[0].Unresolved)
+	require.Len(t, plan.RegisteredResources[0].Targets, 1)
+	assert.Equal(t, TargetStatusCreate, plan.RegisteredResources[0].Targets[0].Status)
+	assert.True(t, sameNamespace(namespaceOne, plan.RegisteredResources[0].Targets[0].Namespace))
+	require.Len(t, plan.RegisteredResources[0].Targets[0].Values, 1)
+	require.Len(t, plan.RegisteredResources[0].Targets[0].Values[0].ActionBindings, 1)
+	assert.Equal(t, "action-legacy", plan.RegisteredResources[0].Targets[0].Values[0].ActionBindings[0].SourceActionID)
+	require.NotNil(t, plan.RegisteredResources[0].Targets[0].Values[0].ActionBindings[0].ActionTargetRef)
+	assert.Equal(t, TargetStatusCreate, plan.RegisteredResources[0].Targets[0].Values[0].ActionBindings[0].ActionTargetRef.Status)
+	assert.Nil(t, plan.Unresolved)
+	require.Len(t, plan.Actions, 1)
+	require.Len(t, plan.Actions[0].Targets, 1)
+	assert.Equal(t, TargetStatusCreate, plan.Actions[0].Targets[0].Status)
+	assert.True(t, sameNamespace(namespaceOne, plan.Actions[0].Targets[0].Namespace))
 }
 
 type plannerTestHandler struct {
@@ -621,4 +890,16 @@ func actionSourceIDs(actions []*ActionPlan) []string {
 	}
 
 	return ids
+}
+
+type plannerTestReviewer struct {
+	calls        int
+	lastResolved *ResolvedTargets
+	err          error
+}
+
+func (r *plannerTestReviewer) Review(_ context.Context, resolved *ResolvedTargets, _ []*policy.Namespace) error {
+	r.calls++
+	r.lastResolved = resolved
+	return r.err
 }

--- a/otdfctl/migrations/namespacedpolicy/registered_resources_execute_test.go
+++ b/otdfctl/migrations/namespacedpolicy/registered_resources_execute_test.go
@@ -223,7 +223,7 @@ func TestExecuteRegisteredResources(t *testing.T) {
 							{
 								Namespace: namespace1,
 								Status:    TargetStatusUnresolved,
-								Reason:    errDuplicateCanonicalMatch,
+								Reason:    ErrDuplicateCanonicalMatch.Error(),
 							},
 						},
 					},
@@ -235,7 +235,7 @@ func TestExecuteRegisteredResources(t *testing.T) {
 				`registered resource %q target %q is unresolved: %s`,
 				"rr-1",
 				namespace1.GetFqn(),
-				errDuplicateCanonicalMatch,
+				ErrDuplicateCanonicalMatch,
 			),
 			assert: func(t *testing.T, err error, _ *Executor, handler *mockExecutorHandler, _ *Plan) {
 				t.Helper()

--- a/otdfctl/migrations/namespacedpolicy/resolved.go
+++ b/otdfctl/migrations/namespacedpolicy/resolved.go
@@ -148,7 +148,7 @@ func (r *resolver) resolveAction(derived *DerivedAction) (*ResolvedAction, error
 	for _, namespace := range derived.Targets {
 		result, err := r.resolveActionTargetFromExisting(derived.Source, namespace)
 		if err != nil {
-			return nil, fmt.Errorf("action %q: %w", derived.Source.GetId(), err)
+			return nil, fmt.Errorf("action %q in namespace %q: %w", derived.Source.GetId(), namespace.GetId(), err)
 		}
 		item.Results = append(item.Results, result)
 		r.addActionResult(derived.Source.GetId(), result)
@@ -233,7 +233,7 @@ func (r *resolver) resolveSubjectConditionSets() ([]*ResolvedSubjectConditionSet
 }
 
 func (r *resolver) resolveSubjectConditionSet(derived *DerivedSubjectConditionSet) (*ResolvedSubjectConditionSet, error) {
-	if derived == nil || derived.Source == nil { // ? Might want to check if derived is nil in the caller and just continue if so
+	if derived == nil || derived.Source == nil {
 		return nil, fmt.Errorf("%w: empty subject condition set candidate", ErrUndeterminedTargetMapping)
 	}
 
@@ -244,7 +244,7 @@ func (r *resolver) resolveSubjectConditionSet(derived *DerivedSubjectConditionSe
 	for _, namespace := range derived.Targets {
 		result, err := r.resolveSubjectConditionSetTargetFromExisting(derived.Source, namespace)
 		if err != nil {
-			return nil, fmt.Errorf("subject condition set %q: %w", derived.Source.GetId(), err)
+			return nil, fmt.Errorf("subject condition set %q in namespace %q: %w", derived.Source.GetId(), namespace.GetId(), err)
 		}
 		item.Results = append(item.Results, result)
 		r.addSubjectConditionSetResult(derived.Source.GetId(), result)
@@ -304,7 +304,7 @@ func (r *resolver) resolveSubjectMapping(derived *DerivedSubjectMapping) (*Resol
 	// condition set dependencies are themselves resolvable in the same target
 	// namespace. This keeps the plan graph internally consistent.
 	if err := r.resolveSubjectMappingDependencies(item.Source, item.Namespace); err != nil {
-		return nil, fmt.Errorf("subject mapping %q: %w", item.Source.GetId(), err)
+		return nil, fmt.Errorf("subject mapping %q in namespace %q: %w", item.Source.GetId(), item.Namespace.GetId(), err)
 	}
 
 	existing, found, err := resolveExistingSubjectMapping(item.Source, r.existing.SubjectMappings[item.Namespace.GetId()])
@@ -312,7 +312,7 @@ func (r *resolver) resolveSubjectMapping(derived *DerivedSubjectMapping) (*Resol
 	case found:
 		item.AlreadyMigrated = existing
 	case err != nil:
-		return nil, fmt.Errorf("subject mapping %q: %w", item.Source.GetId(), err)
+		return nil, fmt.Errorf("subject mapping %q in namespace %q: %w", item.Source.GetId(), item.Namespace.GetId(), err)
 	default:
 		item.NeedsCreate = true
 	}
@@ -360,7 +360,7 @@ func (r *resolver) resolveRegisteredResource(derived *DerivedRegisteredResource)
 	case found:
 		item.AlreadyMigrated = existing
 	case err != nil:
-		return nil, fmt.Errorf("registered resource %q: %w", item.Source.GetId(), err)
+		return nil, fmt.Errorf("registered resource %q in namespace %q: %w", item.Source.GetId(), item.Namespace.GetId(), err)
 	default:
 		item.NeedsCreate = true
 	}
@@ -401,7 +401,7 @@ func (r *resolver) resolveObligationTrigger(derived *DerivedObligationTrigger) (
 	case found:
 		item.AlreadyMigrated = existing
 	case err != nil:
-		return nil, fmt.Errorf("obligation trigger %q: %w", item.Source.GetId(), err)
+		return nil, fmt.Errorf("obligation trigger %q in namespace %q: %w", item.Source.GetId(), item.Namespace.GetId(), err)
 	default:
 		item.NeedsCreate = true
 	}
@@ -463,7 +463,7 @@ func resolveExistingAction(source *policy.Action, existing []*policy.Action) (*p
 	case 0:
 		return nil, false, nil
 	default:
-		return nil, false, ErrDuplicateCanonincalMatch
+		return nil, false, ErrDuplicateCanonicalMatch
 	}
 }
 
@@ -481,7 +481,7 @@ func resolveExistingSubjectConditionSet(source *policy.SubjectConditionSet, exis
 	case 0:
 		return nil, false, nil
 	default:
-		return nil, false, ErrDuplicateCanonincalMatch
+		return nil, false, ErrDuplicateCanonicalMatch
 	}
 }
 
@@ -499,7 +499,7 @@ func resolveExistingSubjectMapping(source *policy.SubjectMapping, existing []*po
 	case 0:
 		return nil, false, nil
 	default:
-		return nil, false, ErrDuplicateCanonincalMatch
+		return nil, false, ErrDuplicateCanonicalMatch
 	}
 }
 
@@ -517,7 +517,7 @@ func resolveExistingRegisteredResource(source *policy.RegisteredResource, existi
 	case 0:
 		return nil, false, nil
 	default:
-		return nil, false, ErrDuplicateCanonincalMatch
+		return nil, false, ErrDuplicateCanonicalMatch
 	}
 }
 
@@ -535,7 +535,7 @@ func resolveExistingObligationTrigger(source *policy.ObligationTrigger, existing
 	case 0:
 		return nil, false, nil
 	default:
-		return nil, false, ErrDuplicateCanonincalMatch
+		return nil, false, ErrDuplicateCanonicalMatch
 	}
 }
 

--- a/otdfctl/migrations/namespacedpolicy/resolved.go
+++ b/otdfctl/migrations/namespacedpolicy/resolved.go
@@ -1,6 +1,7 @@
 package namespacedpolicy
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -20,7 +21,6 @@ type ResolvedAction struct {
 	Source     *policy.Action
 	References []*ActionReference
 	Results    []*ResolvedActionResult
-	Unresolved string
 }
 
 type ResolvedActionResult struct {
@@ -28,20 +28,17 @@ type ResolvedActionResult struct {
 	AlreadyMigrated  *policy.Action
 	ExistingStandard *policy.Action
 	NeedsCreate      bool
-	Unresolved       string
 }
 
 type ResolvedSubjectConditionSet struct {
-	Source     *policy.SubjectConditionSet
-	Results    []*ResolvedSubjectConditionSetResult
-	Unresolved string
+	Source  *policy.SubjectConditionSet
+	Results []*ResolvedSubjectConditionSetResult
 }
 
 type ResolvedSubjectConditionSetResult struct {
 	Namespace       *policy.Namespace
 	AlreadyMigrated *policy.SubjectConditionSet
 	NeedsCreate     bool
-	Unresolved      string
 }
 
 type ResolvedSubjectMapping struct {
@@ -49,7 +46,6 @@ type ResolvedSubjectMapping struct {
 	Namespace       *policy.Namespace
 	AlreadyMigrated *policy.SubjectMapping
 	NeedsCreate     bool
-	Unresolved      string
 }
 
 type ResolvedRegisteredResource struct {
@@ -57,7 +53,7 @@ type ResolvedRegisteredResource struct {
 	Namespace       *policy.Namespace
 	AlreadyMigrated *policy.RegisteredResource
 	NeedsCreate     bool
-	Unresolved      string
+	Unresolved      *Unresolved
 }
 
 type ResolvedObligationTrigger struct {
@@ -65,12 +61,12 @@ type ResolvedObligationTrigger struct {
 	Namespace       *policy.Namespace
 	AlreadyMigrated *policy.ObligationTrigger
 	NeedsCreate     bool
-	Unresolved      string
 }
 
 type resolver struct {
 	derived            *DerivedTargets
 	existing           *ExistingTargets
+	scopes             scopeSet
 	actionResultsByKey map[string]*ResolvedActionResult
 	scsResultsByKey    map[string]*ResolvedSubjectConditionSetResult
 }
@@ -79,7 +75,7 @@ type resolver struct {
 // migrated, satisfied by an existing target object, needing creation, or still
 // unresolved. This is the phase that ties the derived namespace targets to live
 // target-side state before the final per-namespace plan is built.
-func resolveExisting(derived *DerivedTargets, existing *ExistingTargets) *ResolvedTargets {
+func resolveExisting(derived *DerivedTargets, existing *ExistingTargets) (*ResolvedTargets, error) {
 	if existing == nil {
 		existing = newExistingTargets()
 	}
@@ -87,92 +83,105 @@ func resolveExisting(derived *DerivedTargets, existing *ExistingTargets) *Resolv
 	r := &resolver{
 		derived:            derived,
 		existing:           existing,
+		scopes:             scopesFromSlice(derived.Scopes),
 		actionResultsByKey: make(map[string]*ResolvedActionResult),
 		scsResultsByKey:    make(map[string]*ResolvedSubjectConditionSetResult),
 	}
 
+	resolvedActions, err := r.resolveActions()
+	if err != nil {
+		return nil, err
+	}
+	resolvedSubjectConditionSets, err := r.resolveSubjectConditionSets()
+	if err != nil {
+		return nil, err
+	}
+	resolvedSubjectMappings, err := r.resolveSubjectMappings()
+	if err != nil {
+		return nil, err
+	}
+	resolvedRegisteredResources, err := r.resolveRegisteredResources()
+	if err != nil {
+		return nil, err
+	}
+	resolvedObligationTriggers, err := r.resolveObligationTriggers()
+	if err != nil {
+		return nil, err
+	}
+
 	return &ResolvedTargets{
 		Scopes:               append([]Scope(nil), derived.Scopes...),
-		Actions:              r.resolveActions(),
-		SubjectConditionSets: r.resolveSubjectConditionSets(),
-		SubjectMappings:      r.resolveSubjectMappings(),
-		RegisteredResources:  r.resolveRegisteredResources(),
-		ObligationTriggers:   r.resolveObligationTriggers(),
-	}
+		Actions:              resolvedActions,
+		SubjectConditionSets: resolvedSubjectConditionSets,
+		SubjectMappings:      resolvedSubjectMappings,
+		RegisteredResources:  resolvedRegisteredResources,
+		ObligationTriggers:   resolvedObligationTriggers,
+	}, nil
 }
 
-func (r *resolver) resolveActions() []*ResolvedAction {
+func (r *resolver) resolveActions() ([]*ResolvedAction, error) {
 	if r == nil || r.derived == nil {
-		return nil
+		return nil, nil
 	}
 
 	resolved := make([]*ResolvedAction, 0, len(r.derived.Actions))
 	for _, action := range r.derived.Actions {
-		resolved = append(resolved, r.resolveAction(action))
-	}
-	return resolved
-}
-
-func (r *resolver) resolveAction(derived *DerivedAction) *ResolvedAction {
-	item := &ResolvedAction{}
-	if derived == nil {
-		return item
-	}
-
-	item.Source = derived.Source
-	item.References = append([]*ActionReference(nil), derived.References...)
-	item.Unresolved = derived.Unresolved
-	item.Results = make([]*ResolvedActionResult, 0, len(derived.Targets))
-	for _, namespace := range derived.Targets {
-		result := r.resolveActionTarget(derived, namespace)
-		item.Results = append(item.Results, result)
-		if derived.Source != nil {
-			r.addActionResult(derived.Source.GetId(), result)
+		item, err := r.resolveAction(action)
+		if err != nil {
+			return nil, err
 		}
+		resolved = append(resolved, item)
 	}
-
-	return item
+	return resolved, nil
 }
 
-func (r *resolver) resolveActionTarget(derived *DerivedAction, namespace *policy.Namespace) *ResolvedActionResult {
-	result := &ResolvedActionResult{Namespace: namespace}
+func (r *resolver) resolveAction(derived *DerivedAction) (*ResolvedAction, error) {
 	if derived == nil || derived.Source == nil {
-		result.Unresolved = fmt.Errorf("%w: empty action candidate", ErrUndeterminedTargetMapping).Error()
-		return result
+		return nil, fmt.Errorf("%w: empty action candidate", ErrUndeterminedTargetMapping)
 	}
-	if namespace == nil {
-		result.Unresolved = fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping).Error()
-		return result
+
+	item := &ResolvedAction{
+		Source:     derived.Source,
+		References: append([]*ActionReference(nil), derived.References...),
+		Results:    make([]*ResolvedActionResult, 0, len(derived.Targets)),
 	}
-	return r.resolveActionTargetFromExisting(derived.Source, namespace)
+	for _, namespace := range derived.Targets {
+		result, err := r.resolveActionTargetFromExisting(derived.Source, namespace)
+		if err != nil {
+			return nil, fmt.Errorf("action %q: %w", derived.Source.GetId(), err)
+		}
+		item.Results = append(item.Results, result)
+		r.addActionResult(derived.Source.GetId(), result)
+	}
+
+	return item, nil
 }
 
-func (r *resolver) resolveActionTargetFromExisting(source *policy.Action, namespace *policy.Namespace) *ResolvedActionResult {
+func (r *resolver) resolveActionTargetFromExisting(source *policy.Action, namespace *policy.Namespace) (*ResolvedActionResult, error) {
+	if namespace.GetId() == "" {
+		return nil, fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping)
+	}
+
 	result := &ResolvedActionResult{Namespace: namespace}
 	if r.isStandardAction(source) {
 		return r.resolveStandardActionTarget(source, namespace)
 	}
 
-	existing, reason := resolveExistingAction(source, r.existing.CustomActions[namespace.GetId()])
+	existing, found, err := resolveExistingAction(source, r.existing.CustomActions[namespace.GetId()])
 	switch {
-	case existing != nil:
+	case found:
 		result.AlreadyMigrated = existing
-		return result
-	case reason != "":
-		result.Unresolved = reason
-		return result
+		return result, nil
+	case err != nil:
+		return nil, err
 	}
 
 	result.NeedsCreate = true
-	return result
+	return result, nil
 }
 
-func (r *resolver) resolveStandardActionTarget(source *policy.Action, namespace *policy.Namespace) *ResolvedActionResult {
+func (r *resolver) resolveStandardActionTarget(source *policy.Action, namespace *policy.Namespace) (*ResolvedActionResult, error) {
 	result := &ResolvedActionResult{Namespace: namespace}
-	if namespace == nil || namespace.GetId() == "" {
-		result.Unresolved = fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping).Error()
-		return result
-	}
 
 	matches := make([]*policy.Action, 0, 1)
 	for _, action := range r.existing.StandardActions[namespace.GetId()] {
@@ -186,19 +195,15 @@ func (r *resolver) resolveStandardActionTarget(source *policy.Action, namespace 
 	case 1:
 		result.ExistingStandard = matches[0]
 	case 0:
-		result.Unresolved = "matching standard action not found in target namespace"
+		return nil, errors.New("matching standard action not found in target namespace")
 	default:
-		result.Unresolved = "multiple standard actions match in target namespace"
+		return nil, errors.New("multiple standard actions match in target namespace")
 	}
 
-	return result
+	return result, nil
 }
 
 func (r *resolver) isStandardAction(action *policy.Action) bool {
-	if r == nil || action == nil {
-		return false
-	}
-
 	if action.GetStandard() != policy.Action_STANDARD_ACTION_UNSPECIFIED {
 		return true
 	}
@@ -211,205 +216,197 @@ func (r *resolver) isStandardAction(action *policy.Action) bool {
 	}
 }
 
-func (r *resolver) resolveSubjectConditionSets() []*ResolvedSubjectConditionSet {
+func (r *resolver) resolveSubjectConditionSets() ([]*ResolvedSubjectConditionSet, error) {
 	if r == nil || r.derived == nil {
-		return nil
+		return nil, nil
 	}
 
 	resolved := make([]*ResolvedSubjectConditionSet, 0, len(r.derived.SubjectConditionSets))
 	for _, scs := range r.derived.SubjectConditionSets {
-		resolved = append(resolved, r.resolveSubjectConditionSet(scs))
-	}
-	return resolved
-}
-
-func (r *resolver) resolveSubjectConditionSet(derived *DerivedSubjectConditionSet) *ResolvedSubjectConditionSet {
-	item := &ResolvedSubjectConditionSet{}
-	if derived == nil {
-		return item
-	}
-
-	item.Source = derived.Source
-	item.Unresolved = derived.Unresolved
-	item.Results = make([]*ResolvedSubjectConditionSetResult, 0, len(derived.Targets))
-	for _, namespace := range derived.Targets {
-		result := r.resolveSubjectConditionSetTarget(derived, namespace)
-		item.Results = append(item.Results, result)
-		if derived.Source != nil {
-			r.addSubjectConditionSetResult(derived.Source.GetId(), result)
+		item, err := r.resolveSubjectConditionSet(scs)
+		if err != nil {
+			return nil, err
 		}
+		resolved = append(resolved, item)
 	}
-
-	return item
+	return resolved, nil
 }
 
-func (r *resolver) resolveSubjectConditionSetTarget(derived *DerivedSubjectConditionSet, namespace *policy.Namespace) *ResolvedSubjectConditionSetResult {
+func (r *resolver) resolveSubjectConditionSet(derived *DerivedSubjectConditionSet) (*ResolvedSubjectConditionSet, error) {
+	if derived == nil || derived.Source == nil { // ? Might want to check if derived is nil in the caller and just continue if so
+		return nil, fmt.Errorf("%w: empty subject condition set candidate", ErrUndeterminedTargetMapping)
+	}
+
+	item := &ResolvedSubjectConditionSet{
+		Source:  derived.Source,
+		Results: make([]*ResolvedSubjectConditionSetResult, 0, len(derived.Targets)),
+	}
+	for _, namespace := range derived.Targets {
+		result, err := r.resolveSubjectConditionSetTargetFromExisting(derived.Source, namespace)
+		if err != nil {
+			return nil, fmt.Errorf("subject condition set %q: %w", derived.Source.GetId(), err)
+		}
+		item.Results = append(item.Results, result)
+		r.addSubjectConditionSetResult(derived.Source.GetId(), result)
+	}
+
+	return item, nil
+}
+
+func (r *resolver) resolveSubjectConditionSetTargetFromExisting(source *policy.SubjectConditionSet, namespace *policy.Namespace) (*ResolvedSubjectConditionSetResult, error) {
+	if namespace.GetId() == "" {
+		return nil, fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping)
+	}
 	result := &ResolvedSubjectConditionSetResult{Namespace: namespace}
-	if derived == nil || derived.Source == nil {
-		result.Unresolved = fmt.Errorf("%w: empty subject condition set candidate", ErrUndeterminedTargetMapping).Error()
-		return result
-	}
-	if namespace == nil {
-		result.Unresolved = fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping).Error()
-		return result
-	}
-	existing, reason := resolveExistingSubjectConditionSet(derived.Source, r.existing.SubjectConditionSets[namespace.GetId()])
+	existing, found, err := resolveExistingSubjectConditionSet(source, r.existing.SubjectConditionSets[namespace.GetId()])
 	switch {
-	case existing != nil:
+	case found:
 		result.AlreadyMigrated = existing
-	case reason != "":
-		result.Unresolved = reason
+	case err != nil:
+		return nil, err
 	default:
 		result.NeedsCreate = true
 	}
 
-	return result
+	return result, nil
 }
 
-func (r *resolver) resolveSubjectMappings() []*ResolvedSubjectMapping {
-	if r == nil || r.derived == nil {
-		return nil
+func (r *resolver) resolveSubjectMappings() ([]*ResolvedSubjectMapping, error) {
+	if r == nil || r.derived == nil || !r.scopes.has(ScopeSubjectMappings) {
+		return nil, nil
 	}
 
 	resolved := make([]*ResolvedSubjectMapping, 0, len(r.derived.SubjectMappings))
 	for _, mapping := range r.derived.SubjectMappings {
-		resolved = append(resolved, r.resolveSubjectMapping(mapping))
+		item, err := r.resolveSubjectMapping(mapping)
+		if err != nil {
+			return nil, err
+		}
+		resolved = append(resolved, item)
 	}
-	return resolved
+	return resolved, nil
 }
 
-func (r *resolver) resolveSubjectMapping(derived *DerivedSubjectMapping) *ResolvedSubjectMapping {
-	item := &ResolvedSubjectMapping{}
-	if derived == nil {
-		return item
+func (r *resolver) resolveSubjectMapping(derived *DerivedSubjectMapping) (*ResolvedSubjectMapping, error) {
+	if derived == nil || derived.Source == nil {
+		return nil, fmt.Errorf("%w: empty subject mapping candidate", ErrUndeterminedTargetMapping)
 	}
 
-	item.Source = derived.Source
-	item.Namespace = derived.Target
-	item.Unresolved = derived.Unresolved
+	if derived.Target == nil {
+		return nil, fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping)
+	}
 
-	if item.Unresolved != "" {
-		return item
-	}
-	if item.Source == nil {
-		item.Unresolved = fmt.Errorf("%w: empty subject mapping candidate", ErrUndeterminedTargetMapping).Error()
-		return item
-	}
-	if item.Namespace == nil {
-		item.Unresolved = fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping).Error()
-		return item
+	item := &ResolvedSubjectMapping{
+		Source:    derived.Source,
+		Namespace: derived.Target,
 	}
 	// Subject mappings are only safe to resolve once their action and subject
 	// condition set dependencies are themselves resolvable in the same target
 	// namespace. This keeps the plan graph internally consistent.
-	if reason := r.resolveSubjectMappingDependencies(item.Source, item.Namespace); reason != "" {
-		item.Unresolved = reason
-		return item
+	if err := r.resolveSubjectMappingDependencies(item.Source, item.Namespace); err != nil {
+		return nil, fmt.Errorf("subject mapping %q: %w", item.Source.GetId(), err)
 	}
 
-	existing, reason := resolveExistingSubjectMapping(item.Source, r.existing.SubjectMappings[item.Namespace.GetId()])
+	existing, found, err := resolveExistingSubjectMapping(item.Source, r.existing.SubjectMappings[item.Namespace.GetId()])
 	switch {
-	case existing != nil:
+	case found:
 		item.AlreadyMigrated = existing
-	case reason != "":
-		item.Unresolved = reason
+	case err != nil:
+		return nil, fmt.Errorf("subject mapping %q: %w", item.Source.GetId(), err)
 	default:
 		item.NeedsCreate = true
 	}
 
-	return item
+	return item, nil
 }
 
-func (r *resolver) resolveRegisteredResources() []*ResolvedRegisteredResource {
-	if r == nil || r.derived == nil {
-		return nil
+func (r *resolver) resolveRegisteredResources() ([]*ResolvedRegisteredResource, error) {
+	if r == nil || r.derived == nil || !r.scopes.has(ScopeRegisteredResources) {
+		return nil, nil
 	}
 
 	resolved := make([]*ResolvedRegisteredResource, 0, len(r.derived.RegisteredResources))
 	for _, resource := range r.derived.RegisteredResources {
-		resolved = append(resolved, r.resolveRegisteredResource(resource))
+		item, err := r.resolveRegisteredResource(resource)
+		if err != nil {
+			return nil, err
+		}
+		resolved = append(resolved, item)
 	}
-	return resolved
+	return resolved, nil
 }
 
-func (r *resolver) resolveRegisteredResource(derived *DerivedRegisteredResource) *ResolvedRegisteredResource {
+func (r *resolver) resolveRegisteredResource(derived *DerivedRegisteredResource) (*ResolvedRegisteredResource, error) {
 	item := &ResolvedRegisteredResource{}
 	if derived == nil {
-		return item
+		return item, nil
 	}
 
 	item.Source = derived.Source
 	item.Namespace = derived.Target
 	item.Unresolved = derived.Unresolved
 
-	if item.Unresolved != "" {
-		return item
+	if item.Unresolved != nil {
+		return item, nil
 	}
 	if item.Source == nil {
-		item.Unresolved = fmt.Errorf("%w: registered resource is empty", ErrUndeterminedTargetMapping).Error()
-		return item
+		return nil, fmt.Errorf("%w: registered resource is empty", ErrUndeterminedTargetMapping)
 	}
 	if item.Namespace == nil {
-		item.Unresolved = fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping).Error()
-		return item
+		return nil, fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping)
 	}
-	existing, reason := resolveExistingRegisteredResource(item.Source, r.existing.RegisteredResources[item.Namespace.GetId()])
+	existing, found, err := resolveExistingRegisteredResource(item.Source, r.existing.RegisteredResources[item.Namespace.GetId()])
 	switch {
-	case existing != nil:
+	case found:
 		item.AlreadyMigrated = existing
-	case reason != "":
-		item.Unresolved = reason
+	case err != nil:
+		return nil, fmt.Errorf("registered resource %q: %w", item.Source.GetId(), err)
 	default:
 		item.NeedsCreate = true
 	}
 
-	return item
+	return item, nil
 }
 
-func (r *resolver) resolveObligationTriggers() []*ResolvedObligationTrigger {
-	if r == nil || r.derived == nil {
-		return nil
+func (r *resolver) resolveObligationTriggers() ([]*ResolvedObligationTrigger, error) {
+	if r == nil || r.derived == nil || !r.scopes.has(ScopeObligationTriggers) {
+		return nil, nil
 	}
 
 	resolved := make([]*ResolvedObligationTrigger, 0, len(r.derived.ObligationTriggers))
 	for _, trigger := range r.derived.ObligationTriggers {
-		resolved = append(resolved, r.resolveObligationTrigger(trigger))
+		item, err := r.resolveObligationTrigger(trigger)
+		if err != nil {
+			return nil, err
+		}
+		resolved = append(resolved, item)
 	}
-	return resolved
+	return resolved, nil
 }
 
-func (r *resolver) resolveObligationTrigger(derived *DerivedObligationTrigger) *ResolvedObligationTrigger {
-	item := &ResolvedObligationTrigger{}
-	if derived == nil {
-		return item
+func (r *resolver) resolveObligationTrigger(derived *DerivedObligationTrigger) (*ResolvedObligationTrigger, error) {
+	if derived == nil || derived.Source == nil {
+		return nil, fmt.Errorf("%w: empty obligation trigger candidate", ErrUndeterminedTargetMapping)
+	}
+	if derived.Target == nil {
+		return nil, fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping)
 	}
 
-	item.Source = derived.Source
-	item.Namespace = derived.Target
-	item.Unresolved = derived.Unresolved
-
-	if item.Unresolved != "" {
-		return item
+	item := &ResolvedObligationTrigger{
+		Source:    derived.Source,
+		Namespace: derived.Target,
 	}
-	if item.Source == nil {
-		item.Unresolved = fmt.Errorf("%w: empty obligation trigger candidate", ErrUndeterminedTargetMapping).Error()
-		return item
-	}
-	if item.Namespace == nil {
-		item.Unresolved = fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping).Error()
-		return item
-	}
-	existing, reason := resolveExistingObligationTrigger(item.Source, r.existing.ObligationTriggers[item.Namespace.GetId()])
+	existing, found, err := resolveExistingObligationTrigger(item.Source, r.existing.ObligationTriggers[item.Namespace.GetId()])
 	switch {
-	case existing != nil:
+	case found:
 		item.AlreadyMigrated = existing
-	case reason != "":
-		item.Unresolved = reason
+	case err != nil:
+		return nil, fmt.Errorf("obligation trigger %q: %w", item.Source.GetId(), err)
 	default:
 		item.NeedsCreate = true
 	}
 
-	return item
+	return item, nil
 }
 
 func (r *resolver) addActionResult(sourceID string, result *ResolvedActionResult) {
@@ -426,49 +423,33 @@ func (r *resolver) addSubjectConditionSetResult(sourceID string, result *Resolve
 	r.scsResultsByKey[resolvedResultKey(sourceID, result.Namespace.GetId())] = result
 }
 
-func (r *resolver) resolveSubjectMappingDependencies(mapping *policy.SubjectMapping, namespace *policy.Namespace) string {
+func (r *resolver) resolveSubjectMappingDependencies(mapping *policy.SubjectMapping, namespace *policy.Namespace) error {
 	for _, action := range mapping.GetActions() {
 		actionID := action.GetId()
 		if actionID == "" {
-			return "subject mapping references an action without an id"
+			return errors.New("subject mapping references an action without an id")
 		}
 
 		result := r.actionResultsByKey[resolvedResultKey(actionID, namespace.GetId())]
 		if result == nil {
-			return fmt.Sprintf("subject mapping dependency action %q is not resolved in namespace %q", actionID, namespace.GetId())
-		}
-		if !resolvedActionResultSatisfied(result) {
-			if result.Unresolved != "" {
-				return fmt.Sprintf("subject mapping dependency action %q is unresolved: %s", actionID, result.Unresolved)
-			}
-			return fmt.Sprintf("subject mapping dependency action %q is not satisfiable in namespace %q", actionID, namespace.GetId())
+			return fmt.Errorf("subject mapping dependency action %q is not resolved in namespace %q", actionID, namespace.GetId())
 		}
 	}
 
 	scsID := mapping.GetSubjectConditionSet().GetId()
 	if scsID == "" {
-		return "subject mapping references a subject condition set without an id"
+		return errors.New("subject mapping references a subject condition set without an id")
 	}
 
 	result := r.scsResultsByKey[resolvedResultKey(scsID, namespace.GetId())]
 	if result == nil {
-		return fmt.Sprintf("subject mapping dependency subject condition set %q is not resolved in namespace %q", scsID, namespace.GetId())
-	}
-	if !resolvedSubjectConditionSetResultSatisfied(result) {
-		if result.Unresolved != "" {
-			return fmt.Sprintf("subject mapping dependency subject condition set %q is unresolved: %s", scsID, result.Unresolved)
-		}
-		return fmt.Sprintf("subject mapping dependency subject condition set %q is not satisfiable in namespace %q", scsID, namespace.GetId())
+		return fmt.Errorf("subject mapping dependency subject condition set %q is not resolved in namespace %q", scsID, namespace.GetId())
 	}
 
-	return ""
+	return nil
 }
 
-func resolveExistingAction(source *policy.Action, existing []*policy.Action) (*policy.Action, string) {
-	if source == nil {
-		return nil, fmt.Errorf("%w: empty action candidate", ErrUndeterminedTargetMapping).Error()
-	}
-
+func resolveExistingAction(source *policy.Action, existing []*policy.Action) (*policy.Action, bool, error) {
 	matches := make([]*policy.Action, 0, 1)
 	for _, action := range existing {
 		if actionCanonicalEqual(source, action) {
@@ -478,19 +459,15 @@ func resolveExistingAction(source *policy.Action, existing []*policy.Action) (*p
 
 	switch len(matches) {
 	case 1:
-		return matches[0], ""
+		return matches[0], true, nil
 	case 0:
-		return nil, ""
+		return nil, false, nil
 	default:
-		return nil, errDuplicateCanonicalMatch
+		return nil, false, ErrDuplicateCanonincalMatch
 	}
 }
 
-func resolveExistingSubjectConditionSet(source *policy.SubjectConditionSet, existing []*policy.SubjectConditionSet) (*policy.SubjectConditionSet, string) {
-	if source == nil {
-		return nil, fmt.Errorf("%w: empty subject condition set candidate", ErrUndeterminedTargetMapping).Error()
-	}
-
+func resolveExistingSubjectConditionSet(source *policy.SubjectConditionSet, existing []*policy.SubjectConditionSet) (*policy.SubjectConditionSet, bool, error) {
 	matches := make([]*policy.SubjectConditionSet, 0, 1)
 	for _, scs := range existing {
 		if subjectConditionSetCanonicalEqual(source, scs) {
@@ -500,19 +477,15 @@ func resolveExistingSubjectConditionSet(source *policy.SubjectConditionSet, exis
 
 	switch len(matches) {
 	case 1:
-		return matches[0], ""
+		return matches[0], true, nil
 	case 0:
-		return nil, ""
+		return nil, false, nil
 	default:
-		return nil, errDuplicateCanonicalMatch
+		return nil, false, ErrDuplicateCanonincalMatch
 	}
 }
 
-func resolveExistingSubjectMapping(source *policy.SubjectMapping, existing []*policy.SubjectMapping) (*policy.SubjectMapping, string) {
-	if source == nil {
-		return nil, fmt.Errorf("%w: empty subject mapping candidate", ErrUndeterminedTargetMapping).Error()
-	}
-
+func resolveExistingSubjectMapping(source *policy.SubjectMapping, existing []*policy.SubjectMapping) (*policy.SubjectMapping, bool, error) {
 	matches := make([]*policy.SubjectMapping, 0, 1)
 	for _, mapping := range existing {
 		if subjectMappingCanonicalEqual(source, mapping) {
@@ -522,19 +495,15 @@ func resolveExistingSubjectMapping(source *policy.SubjectMapping, existing []*po
 
 	switch len(matches) {
 	case 1:
-		return matches[0], ""
+		return matches[0], true, nil
 	case 0:
-		return nil, ""
+		return nil, false, nil
 	default:
-		return nil, errDuplicateCanonicalMatch
+		return nil, false, ErrDuplicateCanonincalMatch
 	}
 }
 
-func resolveExistingRegisteredResource(source *policy.RegisteredResource, existing []*policy.RegisteredResource) (*policy.RegisteredResource, string) {
-	if source == nil {
-		return nil, fmt.Errorf("%w: registered resource is empty", ErrUndeterminedTargetMapping).Error()
-	}
-
+func resolveExistingRegisteredResource(source *policy.RegisteredResource, existing []*policy.RegisteredResource) (*policy.RegisteredResource, bool, error) {
 	matches := make([]*policy.RegisteredResource, 0, 1)
 	for _, resource := range existing {
 		if registeredResourceCanonicalEqual(source, resource) {
@@ -544,19 +513,15 @@ func resolveExistingRegisteredResource(source *policy.RegisteredResource, existi
 
 	switch len(matches) {
 	case 1:
-		return matches[0], ""
+		return matches[0], true, nil
 	case 0:
-		return nil, ""
+		return nil, false, nil
 	default:
-		return nil, errDuplicateCanonicalMatch
+		return nil, false, ErrDuplicateCanonincalMatch
 	}
 }
 
-func resolveExistingObligationTrigger(source *policy.ObligationTrigger, existing []*policy.ObligationTrigger) (*policy.ObligationTrigger, string) {
-	if source == nil {
-		return nil, fmt.Errorf("%w: empty obligation trigger candidate", ErrUndeterminedTargetMapping).Error()
-	}
-
+func resolveExistingObligationTrigger(source *policy.ObligationTrigger, existing []*policy.ObligationTrigger) (*policy.ObligationTrigger, bool, error) {
 	matches := make([]*policy.ObligationTrigger, 0, 1)
 	for _, trigger := range existing {
 		if obligationTriggerCanonicalEqual(source, trigger) {
@@ -566,11 +531,11 @@ func resolveExistingObligationTrigger(source *policy.ObligationTrigger, existing
 
 	switch len(matches) {
 	case 1:
-		return matches[0], ""
+		return matches[0], true, nil
 	case 0:
-		return nil, ""
+		return nil, false, nil
 	default:
-		return nil, errDuplicateCanonicalMatch
+		return nil, false, ErrDuplicateCanonincalMatch
 	}
 }
 
@@ -578,16 +543,10 @@ func resolvedResultKey(sourceID, namespaceID string) string {
 	return sourceID + "|" + namespaceID
 }
 
-func resolvedActionResultSatisfied(result *ResolvedActionResult) bool {
-	if result == nil || result.Unresolved != "" {
-		return false
+func scopesFromSlice(scopes []Scope) scopeSet {
+	set := make(scopeSet, len(scopes))
+	for _, scope := range scopes {
+		set[scope] = struct{}{}
 	}
-	return result.AlreadyMigrated != nil || result.ExistingStandard != nil || result.NeedsCreate
-}
-
-func resolvedSubjectConditionSetResultSatisfied(result *ResolvedSubjectConditionSetResult) bool {
-	if result == nil || result.Unresolved != "" {
-		return false
-	}
-	return result.AlreadyMigrated != nil || result.NeedsCreate
+	return set
 }

--- a/otdfctl/migrations/namespacedpolicy/resolved_test.go
+++ b/otdfctl/migrations/namespacedpolicy/resolved_test.go
@@ -20,7 +20,7 @@ func TestResolveExistingUsesExistingStandardAction(t *testing.T) {
 		{Id: "read-target", Name: "read", Namespace: namespace},
 	}
 
-	resolved := resolveExisting(
+	resolved, err := resolveExisting(
 		&DerivedTargets{
 			Scopes: []Scope{ScopeActions},
 			Actions: []*DerivedAction{
@@ -32,15 +32,60 @@ func TestResolveExistingUsesExistingStandardAction(t *testing.T) {
 		},
 		existing,
 	)
+	require.NoError(t, err)
 
 	require.Len(t, resolved.Actions, 1)
 	require.Len(t, resolved.Actions[0].Results, 1)
 	assert.Equal(t, "read-target", resolved.Actions[0].Results[0].ExistingStandard.GetId())
 	assert.False(t, resolved.Actions[0].Results[0].NeedsCreate)
-	assert.Empty(t, resolved.Actions[0].Results[0].Unresolved)
 }
 
-func TestResolveExistingMarksSubjectMappingUnresolvedWhenActionDependencyMissing(t *testing.T) {
+func TestResolveExistingFailsWhenActionCandidateIsNil(t *testing.T) {
+	t.Parallel()
+
+	resolved, err := resolveExisting(
+		&DerivedTargets{
+			Scopes:  []Scope{ScopeActions},
+			Actions: []*DerivedAction{nil},
+		},
+		nil,
+	)
+	require.Error(t, err)
+	assert.Nil(t, resolved)
+	assert.EqualError(t, err, "could not determine target namespace: empty action candidate")
+}
+
+func TestResolveExistingFailsWhenSubjectConditionSetCandidateIsNil(t *testing.T) {
+	t.Parallel()
+
+	resolved, err := resolveExisting(
+		&DerivedTargets{
+			Scopes:               []Scope{ScopeSubjectConditionSets},
+			SubjectConditionSets: []*DerivedSubjectConditionSet{nil},
+		},
+		nil,
+	)
+	require.Error(t, err)
+	assert.Nil(t, resolved)
+	assert.EqualError(t, err, "could not determine target namespace: empty subject condition set candidate")
+}
+
+func TestResolveExistingFailsWhenSubjectMappingCandidateIsNil(t *testing.T) {
+	t.Parallel()
+
+	resolved, err := resolveExisting(
+		&DerivedTargets{
+			Scopes:          []Scope{ScopeSubjectMappings},
+			SubjectMappings: []*DerivedSubjectMapping{nil},
+		},
+		nil,
+	)
+	require.Error(t, err)
+	assert.Nil(t, resolved)
+	assert.EqualError(t, err, "could not determine target namespace: empty subject mapping candidate")
+}
+
+func TestResolveExistingFailsWhenSubjectMappingActionDependencyMissing(t *testing.T) {
 	t.Parallel()
 
 	namespace := &policy.Namespace{
@@ -48,7 +93,7 @@ func TestResolveExistingMarksSubjectMappingUnresolvedWhenActionDependencyMissing
 		Fqn: "https://example.com",
 	}
 
-	resolved := resolveExisting(
+	resolved, err := resolveExisting(
 		&DerivedTargets{
 			Scopes: []Scope{ScopeActions, ScopeSubjectConditionSets, ScopeSubjectMappings},
 			SubjectConditionSets: []*DerivedSubjectConditionSet{
@@ -72,12 +117,47 @@ func TestResolveExistingMarksSubjectMappingUnresolvedWhenActionDependencyMissing
 		},
 		nil,
 	)
+	require.Error(t, err)
+	assert.Nil(t, resolved)
+	assert.EqualError(
+		t,
+		err,
+		`subject mapping "mapping-1": subject mapping dependency action "action-1" is not resolved in namespace "ns-1"`,
+	)
+}
 
-	require.Len(t, resolved.SubjectMappings, 1)
+func TestResolveExistingKeepsRegisteredResourceConflictUnresolved(t *testing.T) {
+	t.Parallel()
+
+	namespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+
+	resolved, err := resolveExisting(
+		&DerivedTargets{
+			Scopes: []Scope{ScopeRegisteredResources},
+			RegisteredResources: []*DerivedRegisteredResource{
+				{
+					Source: &policy.RegisteredResource{Id: "resource-1", Name: "documents"},
+					Target: namespace,
+					Unresolved: &Unresolved{
+						Reason:  UnresolvedReasonRegisteredResourceConflictingNamespaces,
+						Message: "could not determine target namespace: registered resource spans multiple target namespaces",
+					},
+				},
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, resolved.RegisteredResources, 1)
+	require.NotNil(t, resolved.RegisteredResources[0].Unresolved)
+	assert.Equal(t, UnresolvedReasonRegisteredResourceConflictingNamespaces, resolved.RegisteredResources[0].Unresolved.Reason)
 	assert.Equal(
 		t,
-		`subject mapping dependency action "action-1" is not resolved in namespace "ns-1"`,
-		resolved.SubjectMappings[0].Unresolved,
+		"could not determine target namespace: registered resource spans multiple target namespaces",
+		resolved.RegisteredResources[0].Unresolved.Message,
 	)
-	assert.False(t, resolved.SubjectMappings[0].NeedsCreate)
+	assert.False(t, resolved.RegisteredResources[0].NeedsCreate)
 }

--- a/otdfctl/migrations/namespacedpolicy/resolved_test.go
+++ b/otdfctl/migrations/namespacedpolicy/resolved_test.go
@@ -122,7 +122,7 @@ func TestResolveExistingFailsWhenSubjectMappingActionDependencyMissing(t *testin
 	assert.EqualError(
 		t,
 		err,
-		`subject mapping "mapping-1": subject mapping dependency action "action-1" is not resolved in namespace "ns-1"`,
+		`subject mapping "mapping-1" in namespace "ns-1": subject mapping dependency action "action-1" is not resolved in namespace "ns-1"`,
 	)
 }
 


### PR DESCRIPTION
 ## Summary

  This PR tightens the namespacedpolicy planner so registered resources are the only construct that can remain soft-unresolved during planning. All other policy constructs now fail fast when their target namespace or required dependencies cannot be derived.

  It also cleans up resolver guard behavior so parent resolver functions own nil/source validation, while child helpers focus on namespace and existing-target resolution. For registered resources, unresolved state is now represented internally as a typed object
  with a machine-checkable reason code plus a human-readable message.

In addition, we have merged in changes for interactively handling `Registered Resources` that are unresolved. [RR Interactive](https://github.com/opentdf/platform/pull/3317)

  ## What Changed

  - Removed top-level Unresolved handling from actions, subject condition sets, subject mappings, and obligation triggers.
  - Kept registered resources as the only planner construct with soft unresolved behavior.
  - Added a typed RR unresolved model with:
      - Reason
      - Message
  - Preserved the existing artifact shape by continuing to emit the unresolved message as a string in the finalized plan.
  - Simplified action, subject condition set, and subject mapping resolver guard logic so invalid derived entries fail fast in the parent resolver.
  - Removed stale unresolved dependency/result handling from subject mapping dependency resolution.
  - Skipped registered resources with no AAVs during derivation and documented that behavior inline.

  ## Why

  The planner had accumulated multiple soft-unresolved paths that no longer matched the intended contract. This made the resolution flow harder to reason about and made tests rely on string matching for unresolved behavior.

  This change makes the model stricter and simpler:

  - non-RR derivation/resolution failures are hard failures
  - RR namespace conflicts remain the only reviewable unresolved case
  - tests can now assert a typed unresolved reason instead of brittle strings