### PR TITLE
fix(core): preserve backward-compatible Loader.Watch interface

### DIFF
--- a/service/pkg/config/config.go
+++ b/service/pkg/config/config.go
@@ -155,8 +155,8 @@ func (c *Config) AddOnConfigChangeHook(hook ChangeHook) {
 	c.onConfigChangeHooks = append(c.onConfigChangeHooks, hook)
 }
 
-// Watch starts watching the configuration for changes in all config loaders.
-func (c *Config) Watch(ctx context.Context) error {
+// WatchWithNamespaces starts watching the configuration for changes in all config loaders, and provides the namespace info to the loaders.
+func (c *Config) WatchWithNamespaces(ctx context.Context, namespaces []NamespaceInfo) error {
 	if len(c.loaders) == 0 {
 		return nil
 	}
@@ -176,11 +176,22 @@ func (c *Config) Watch(ctx context.Context) error {
 			// Now call the user-provided hooks with the new configuration.
 			return c.OnChange(ctx)
 		}
+		if nsLoader, ok := loader.(NamespaceAwareLoader); ok {
+			if err := nsLoader.WatchWithNamespaces(ctx, c, onChangeCallback, namespaces); err != nil {
+				return err
+			}
+			continue
+		}
 		if err := loader.Watch(ctx, c, onChangeCallback); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// Watch starts watching the configuration for changes in all config loaders.
+func (c *Config) Watch(ctx context.Context) error {
+	return c.WatchWithNamespaces(ctx, []NamespaceInfo{})
 }
 
 // Close invokes close method on all config loaders.

--- a/service/pkg/config/config.go
+++ b/service/pkg/config/config.go
@@ -176,7 +176,13 @@ func (c *Config) WatchWithNamespaces(ctx context.Context, namespaces []Namespace
 			// Now call the user-provided hooks with the new configuration.
 			return c.OnChange(ctx)
 		}
-		if err := loader.Watch(ctx, c, onChangeCallback, namespaces); err != nil {
+		if nsLoader, ok := loader.(NamespaceAwareLoader); ok {
+			if err := nsLoader.WatchWithNamespaces(ctx, c, onChangeCallback, namespaces); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := loader.Watch(ctx, c, onChangeCallback); err != nil {
 			return err
 		}
 	}

--- a/service/pkg/config/config.go
+++ b/service/pkg/config/config.go
@@ -155,8 +155,8 @@ func (c *Config) AddOnConfigChangeHook(hook ChangeHook) {
 	c.onConfigChangeHooks = append(c.onConfigChangeHooks, hook)
 }
 
-// WatchWithNamespaces starts watching the configuration for changes in all config loaders, and provides the namespace info to the loaders.
-func (c *Config) WatchWithNamespaces(ctx context.Context, namespaces []NamespaceInfo) error {
+// Watch starts watching the configuration for changes in all config loaders.
+func (c *Config) Watch(ctx context.Context) error {
 	if len(c.loaders) == 0 {
 		return nil
 	}
@@ -176,22 +176,11 @@ func (c *Config) WatchWithNamespaces(ctx context.Context, namespaces []Namespace
 			// Now call the user-provided hooks with the new configuration.
 			return c.OnChange(ctx)
 		}
-		if nsLoader, ok := loader.(NamespaceAwareLoader); ok {
-			if err := nsLoader.WatchWithNamespaces(ctx, c, onChangeCallback, namespaces); err != nil {
-				return err
-			}
-			continue
-		}
 		if err := loader.Watch(ctx, c, onChangeCallback); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-// Watch starts watching the configuration for changes in all config loaders.
-func (c *Config) Watch(ctx context.Context) error {
-	return c.WatchWithNamespaces(ctx, []NamespaceInfo{})
 }
 
 // Close invokes close method on all config loaders.

--- a/service/pkg/config/config_file_loader.go
+++ b/service/pkg/config/config_file_loader.go
@@ -63,7 +63,7 @@ func (l *FileLoader) Load(_ Config) error {
 }
 
 // Watch starts watching the config file for configuration changes
-func (l *FileLoader) Watch(ctx context.Context, _ *Config, onChange func(context.Context) error, _ []NamespaceInfo) error {
+func (l *FileLoader) Watch(ctx context.Context, _ *Config, onChange func(context.Context) error) error {
 	l.viper.WatchConfig()
 
 	// If config changes, trigger the main config reload function

--- a/service/pkg/config/config_test.go
+++ b/service/pkg/config/config_test.go
@@ -30,23 +30,6 @@ type MockLoader struct {
 	onChangeCalled bool
 }
 
-// MockNamespaceAwareLoader extends MockLoader with NamespaceAwareLoader support
-type MockNamespaceAwareLoader struct {
-	MockLoader
-	watchWithNamespacesFn func(context.Context, *Config, func(context.Context) error, []NamespaceInfo) error
-}
-
-func (l *MockNamespaceAwareLoader) WatchWithNamespaces(ctx context.Context, config *Config, onChange func(context.Context) error, namespaces []NamespaceInfo) error {
-	l.watchCalled = true
-	if l.watchWithNamespacesFn != nil {
-		if err := l.watchWithNamespacesFn(ctx, config, onChange, namespaces); err != nil {
-			return err
-		}
-		l.onChangeCalled = true
-	}
-	return nil
-}
-
 func (l *MockLoader) Load(mostRecentConfig Config) error {
 	if l.loadFn != nil {
 		return l.loadFn(mostRecentConfig)
@@ -166,32 +149,6 @@ func TestConfig_Watch(t *testing.T) {
 		assert.Equal(t, expectedErr, err)
 		assert.True(t, loader.watchCalled)
 		assert.False(t, loader.onChangeCalled)
-	})
-
-	t.Run("Loader receives NamespaceInfo", func(t *testing.T) {
-		config := &Config{}
-		loader := &MockNamespaceAwareLoader{}
-		testNamespaces := []NamespaceInfo{
-			{
-				Name:    "test-ns",
-				Enabled: true,
-				Services: []ServiceInfo{
-					{Namespace: "test-ns", Name: "test-svc"},
-				},
-			},
-		}
-
-		var receivedNamespaces []NamespaceInfo
-		loader.watchWithNamespacesFn = func(_ context.Context, _ *Config, _ func(context.Context) error, namespaces []NamespaceInfo) error {
-			receivedNamespaces = namespaces
-			return nil
-		}
-		config.AddLoader(loader)
-
-		err := config.WatchWithNamespaces(ctx, testNamespaces)
-
-		require.NoError(t, err)
-		assert.Equal(t, testNamespaces, receivedNamespaces)
 	})
 }
 

--- a/service/pkg/config/config_test.go
+++ b/service/pkg/config/config_test.go
@@ -19,7 +19,7 @@ type MockLoader struct {
 	loadFn          func(Config) error
 	getFn           func(string) (any, error)
 	getConfigKeysFn func() ([]string, error)
-	watchFn         func(context.Context, *Config, func(context.Context) error, []NamespaceInfo) error
+	watchFn         func(context.Context, *Config, func(context.Context) error) error
 	closeFn         func() error
 	getNameFn       func() string
 
@@ -28,6 +28,23 @@ type MockLoader struct {
 	getNameCalled bool
 
 	onChangeCalled bool
+}
+
+// MockNamespaceAwareLoader extends MockLoader with NamespaceAwareLoader support
+type MockNamespaceAwareLoader struct {
+	MockLoader
+	watchWithNamespacesFn func(context.Context, *Config, func(context.Context) error, []NamespaceInfo) error
+}
+
+func (l *MockNamespaceAwareLoader) WatchWithNamespaces(ctx context.Context, config *Config, onChange func(context.Context) error, namespaces []NamespaceInfo) error {
+	l.watchCalled = true
+	if l.watchWithNamespacesFn != nil {
+		if err := l.watchWithNamespacesFn(ctx, config, onChange, namespaces); err != nil {
+			return err
+		}
+		l.onChangeCalled = true
+	}
+	return nil
 }
 
 func (l *MockLoader) Load(mostRecentConfig Config) error {
@@ -51,10 +68,10 @@ func (l *MockLoader) GetConfigKeys() ([]string, error) {
 	return nil, nil
 }
 
-func (l *MockLoader) Watch(ctx context.Context, config *Config, onChange func(context.Context) error, namespaces []NamespaceInfo) error {
+func (l *MockLoader) Watch(ctx context.Context, config *Config, onChange func(context.Context) error) error {
 	l.watchCalled = true
 	if l.watchFn != nil {
-		if err := l.watchFn(ctx, config, onChange, namespaces); err != nil {
+		if err := l.watchFn(ctx, config, onChange); err != nil {
 			return err
 		}
 		l.onChangeCalled = true
@@ -123,7 +140,7 @@ func TestConfig_Watch(t *testing.T) {
 		config := &Config{}
 		loader := newMockLoader()
 		// Mock loader to call onChange
-		loader.watchFn = func(_ context.Context, _ *Config, _ func(context.Context) error, _ []NamespaceInfo) error {
+		loader.watchFn = func(_ context.Context, _ *Config, _ func(context.Context) error) error {
 			return nil
 		}
 		config.AddLoader(loader)
@@ -139,7 +156,7 @@ func TestConfig_Watch(t *testing.T) {
 		config := &Config{}
 		expectedErr := errors.New("watch error")
 		loader := newMockLoader()
-		loader.watchFn = func(_ context.Context, _ *Config, _ func(context.Context) error, _ []NamespaceInfo) error {
+		loader.watchFn = func(_ context.Context, _ *Config, _ func(context.Context) error) error {
 			return expectedErr
 		}
 		config.AddLoader(loader)
@@ -153,7 +170,7 @@ func TestConfig_Watch(t *testing.T) {
 
 	t.Run("Loader receives NamespaceInfo", func(t *testing.T) {
 		config := &Config{}
-		loader := newMockLoader()
+		loader := &MockNamespaceAwareLoader{}
 		testNamespaces := []NamespaceInfo{
 			{
 				Name:    "test-ns",
@@ -165,7 +182,7 @@ func TestConfig_Watch(t *testing.T) {
 		}
 
 		var receivedNamespaces []NamespaceInfo
-		loader.watchFn = func(_ context.Context, _ *Config, _ func(context.Context) error, namespaces []NamespaceInfo) error {
+		loader.watchWithNamespacesFn = func(_ context.Context, _ *Config, _ func(context.Context) error, namespaces []NamespaceInfo) error {
 			receivedNamespaces = namespaces
 			return nil
 		}

--- a/service/pkg/config/config_test.go
+++ b/service/pkg/config/config_test.go
@@ -30,6 +30,23 @@ type MockLoader struct {
 	onChangeCalled bool
 }
 
+// MockNamespaceAwareLoader extends MockLoader with NamespaceAwareLoader support
+type MockNamespaceAwareLoader struct {
+	MockLoader
+	watchWithNamespacesFn func(context.Context, *Config, func(context.Context) error, []NamespaceInfo) error
+}
+
+func (l *MockNamespaceAwareLoader) WatchWithNamespaces(ctx context.Context, config *Config, onChange func(context.Context) error, namespaces []NamespaceInfo) error {
+	l.watchCalled = true
+	if l.watchWithNamespacesFn != nil {
+		if err := l.watchWithNamespacesFn(ctx, config, onChange, namespaces); err != nil {
+			return err
+		}
+		l.onChangeCalled = true
+	}
+	return nil
+}
+
 func (l *MockLoader) Load(mostRecentConfig Config) error {
 	if l.loadFn != nil {
 		return l.loadFn(mostRecentConfig)
@@ -149,6 +166,32 @@ func TestConfig_Watch(t *testing.T) {
 		assert.Equal(t, expectedErr, err)
 		assert.True(t, loader.watchCalled)
 		assert.False(t, loader.onChangeCalled)
+	})
+
+	t.Run("Loader receives NamespaceInfo", func(t *testing.T) {
+		config := &Config{}
+		loader := &MockNamespaceAwareLoader{}
+		testNamespaces := []NamespaceInfo{
+			{
+				Name:    "test-ns",
+				Enabled: true,
+				Services: []ServiceInfo{
+					{Namespace: "test-ns", Name: "test-svc"},
+				},
+			},
+		}
+
+		var receivedNamespaces []NamespaceInfo
+		loader.watchWithNamespacesFn = func(_ context.Context, _ *Config, _ func(context.Context) error, namespaces []NamespaceInfo) error {
+			receivedNamespaces = namespaces
+			return nil
+		}
+		config.AddLoader(loader)
+
+		err := config.WatchWithNamespaces(ctx, testNamespaces)
+
+		require.NoError(t, err)
+		assert.Equal(t, testNamespaces, receivedNamespaces)
 	})
 }
 

--- a/service/pkg/config/default_settings_loader.go
+++ b/service/pkg/config/default_settings_loader.go
@@ -90,7 +90,7 @@ func (l *DefaultSettingsLoader) Load(_ Config) error {
 	return nil
 }
 
-func (l *DefaultSettingsLoader) Watch(_ context.Context, _ *Config, _ func(context.Context) error, _ []NamespaceInfo) error {
+func (l *DefaultSettingsLoader) Watch(_ context.Context, _ *Config, _ func(context.Context) error) error {
 	return nil
 }
 

--- a/service/pkg/config/environment_value_loader.go
+++ b/service/pkg/config/environment_value_loader.go
@@ -95,7 +95,7 @@ func (l *EnvironmentValueLoader) Load(_ Config) error {
 }
 
 // Watch starts watching the config file for configuration changes
-func (l *EnvironmentValueLoader) Watch(_ context.Context, _ *Config, _ func(context.Context) error, _ []NamespaceInfo) error {
+func (l *EnvironmentValueLoader) Watch(_ context.Context, _ *Config, _ func(context.Context) error) error {
 	// Environment variables can't be watched.
 	return nil
 }

--- a/service/pkg/config/legacy_loader.go
+++ b/service/pkg/config/legacy_loader.go
@@ -75,7 +75,7 @@ func (l *LegacyLoader) Load(cfg Config) error {
 }
 
 // Watch starts watching the config file for configuration changes
-func (l *LegacyLoader) Watch(ctx context.Context, _ *Config, onChange func(context.Context) error, _ []NamespaceInfo) error {
+func (l *LegacyLoader) Watch(ctx context.Context, _ *Config, onChange func(context.Context) error) error {
 	l.viper.WatchConfig()
 
 	// If config changes, trigger the main config reload function

--- a/service/pkg/config/loader.go
+++ b/service/pkg/config/loader.go
@@ -26,11 +26,19 @@ type Loader interface {
 	// Load is called to load/refresh the configuration from its source
 	Load(mostRecentConfig Config) error
 	// Watch starts watching for configuration changes and invokes an onChange callback.
-	// It receives information about the registered namespaces and services to determine
-	// if watching is required for this loader.
-	Watch(ctx context.Context, cfg *Config, onChange func(context.Context) error, namespaces []NamespaceInfo) error
+	Watch(ctx context.Context, cfg *Config, onChange func(context.Context) error) error
 	// Close closes the configuration loader
 	Close() error
 	// Name returns the name of the configuration loader
 	Name() string
+}
+
+// NamespaceAwareLoader extends Loader with namespace-aware watching.
+// Loaders that need information about registered namespaces and services
+// should implement this interface.
+type NamespaceAwareLoader interface {
+	Loader
+	// WatchWithNamespaces starts watching for configuration changes with
+	// information about the registered namespaces and services.
+	WatchWithNamespaces(ctx context.Context, cfg *Config, onChange func(context.Context) error, namespaces []NamespaceInfo) error
 }

--- a/service/pkg/config/loader.go
+++ b/service/pkg/config/loader.go
@@ -4,6 +4,19 @@ import (
 	"context"
 )
 
+// ServiceInfo represents minimal information about a service for configuration loaders
+type ServiceInfo struct {
+	Namespace string
+	Name      string
+}
+
+// NamespaceInfo represents minimal information about a namespace for configuration loaders
+type NamespaceInfo struct {
+	Name     string
+	Enabled  bool
+	Services []ServiceInfo
+}
+
 // Loader defines the interface for loading and managing configuration
 type Loader interface {
 	// Get fetches a particular config value by dot-delimited key
@@ -18,4 +31,14 @@ type Loader interface {
 	Close() error
 	// Name returns the name of the configuration loader
 	Name() string
+}
+
+// NamespaceAwareLoader extends Loader with namespace-aware watching.
+// Loaders that need information about registered namespaces and services
+// should implement this interface.
+type NamespaceAwareLoader interface {
+	Loader
+	// WatchWithNamespaces starts watching for configuration changes with
+	// information about the registered namespaces and services.
+	WatchWithNamespaces(ctx context.Context, cfg *Config, onChange func(context.Context) error, namespaces []NamespaceInfo) error
 }

--- a/service/pkg/config/loader.go
+++ b/service/pkg/config/loader.go
@@ -4,19 +4,6 @@ import (
 	"context"
 )
 
-// ServiceInfo represents minimal information about a service for configuration loaders
-type ServiceInfo struct {
-	Namespace string
-	Name      string
-}
-
-// NamespaceInfo represents minimal information about a namespace for configuration loaders
-type NamespaceInfo struct {
-	Name     string
-	Enabled  bool
-	Services []ServiceInfo
-}
-
 // Loader defines the interface for loading and managing configuration
 type Loader interface {
 	// Get fetches a particular config value by dot-delimited key
@@ -31,14 +18,4 @@ type Loader interface {
 	Close() error
 	// Name returns the name of the configuration loader
 	Name() string
-}
-
-// NamespaceAwareLoader extends Loader with namespace-aware watching.
-// Loaders that need information about registered namespaces and services
-// should implement this interface.
-type NamespaceAwareLoader interface {
-	Loader
-	// WatchWithNamespaces starts watching for configuration changes with
-	// information about the registered namespaces and services.
-	WatchWithNamespaces(ctx context.Context, cfg *Config, onChange func(context.Context) error, namespaces []NamespaceInfo) error
 }

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -299,7 +299,23 @@ func Start(f ...StartOptions) error {
 	defer gatewayCleanup()
 
 	// Start watching the configuration for changes with registered config change service hooks
-	if err := cfg.Watch(ctx); err != nil {
+	var watchInfo []config.NamespaceInfo
+	for _, nsInfo := range svcRegistry.GetNamespaces() {
+		var services []config.ServiceInfo
+		for _, svc := range nsInfo.Namespace.Services {
+			services = append(services, config.ServiceInfo{
+				Namespace: svc.GetNamespace(),
+				Name:      svc.GetServiceDesc().ServiceName,
+			})
+		}
+		watchInfo = append(watchInfo, config.NamespaceInfo{
+			Name:     nsInfo.Name,
+			Enabled:  nsInfo.Namespace.IsEnabled(cfg.Mode),
+			Services: services,
+		})
+	}
+
+	if err := cfg.WatchWithNamespaces(ctx, watchInfo); err != nil {
 		return fmt.Errorf("failed to watch configuration: %w", err)
 	}
 	defer cfg.Close(ctx)

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -299,23 +299,7 @@ func Start(f ...StartOptions) error {
 	defer gatewayCleanup()
 
 	// Start watching the configuration for changes with registered config change service hooks
-	var watchInfo []config.NamespaceInfo
-	for _, nsInfo := range svcRegistry.GetNamespaces() {
-		var services []config.ServiceInfo
-		for _, svc := range nsInfo.Namespace.Services {
-			services = append(services, config.ServiceInfo{
-				Namespace: svc.GetNamespace(),
-				Name:      svc.GetServiceDesc().ServiceName,
-			})
-		}
-		watchInfo = append(watchInfo, config.NamespaceInfo{
-			Name:     nsInfo.Name,
-			Enabled:  nsInfo.Namespace.IsEnabled(cfg.Mode),
-			Services: services,
-		})
-	}
-
-	if err := cfg.WatchWithNamespaces(ctx, watchInfo); err != nil {
+	if err := cfg.Watch(ctx); err != nil {
 		return fmt.Errorf("failed to watch configuration: %w", err)
 	}
 	defer cfg.Close(ctx)


### PR DESCRIPTION
## Summary
- Reverts `Loader.Watch` to its original 3-arg signature `(ctx, cfg, onChange)` to maintain backward compatibility for downstream consumers that implement `Loader` directly
- Introduces an optional `NamespaceAwareLoader` interface for loaders that want namespace/service information during watch, added via `WatchWithNamespaces(ctx, cfg, onChange, namespaces)`
- `Config.WatchWithNamespaces` type-asserts each loader and routes to `WatchWithNamespaces` when the loader opts in, otherwise falls back to plain `Watch`

## Guidance for downstream implementers

If your custom loader does not need namespace/service info, implement `config.Loader` as before — no change required.

If your custom loader wants namespace/service info (e.g. a remote config source scoped to enabled services), implement `config.NamespaceAwareLoader`:

```go
type MyLoader struct{ /* ... */ }

// Required by Loader
func (l *MyLoader) Watch(ctx context.Context, cfg *config.Config, onChange func(context.Context) error) error {
    // fallback path — used when the caller invokes cfg.Watch(ctx) without namespace info
    return nil
}

// Required by NamespaceAwareLoader
func (l *MyLoader) WatchWithNamespaces(
    ctx context.Context,
    cfg *config.Config,
    onChange func(context.Context) error,
    namespaces []config.NamespaceInfo,
) error {
    // preferred path — invoked when the host calls cfg.WatchWithNamespaces(ctx, ns)
    return nil
}
```

Callers that need namespace-aware behavior must invoke `cfg.WatchWithNamespaces(ctx, namespaces)` — `cfg.Watch(ctx)` passes an empty slice and will not deliver namespace info to `NamespaceAwareLoader` implementers.

## Test plan
- [x] `go build ./service/...` passes
- [x] `go test ./service/pkg/config/...` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced configuration loading system architecture by separating standard configuration loading from namespace-aware functionality, improving code organization and enabling more efficient configuration management across loader implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->