### PR TITLE
feat(cli): Interactive review for RR.

### DIFF
--- a/otdfctl/cmd/migrate/namespaced_policy.go
+++ b/otdfctl/cmd/migrate/namespaced_policy.go
@@ -41,11 +41,20 @@ func migrateNamespacedPolicy(cmd *cobra.Command, args []string) {
 	if err != nil {
 		cli.ExitWithError("could not read --commit flag", err)
 	}
+	interactive, err := cmd.InheritedFlags().GetBool("interactive")
+	if err != nil {
+		cli.ExitWithError("could not read --interactive flag", err)
+	}
 
 	h := otdfctl.NewHandler(c)
 	defer h.Close()
 
-	planner, err := namespacedpolicy.NewPlanner(&h, scopeCSV)
+	var plannerOpts []namespacedpolicy.Option
+	if interactive {
+		plannerOpts = append(plannerOpts, namespacedpolicy.WithInteractiveReviewer(namespacedpolicy.NewHuhInteractiveReviewer(&h, nil)))
+	}
+
+	planner, err := namespacedpolicy.NewPlanner(&h, scopeCSV, plannerOpts...)
 	if err != nil {
 		cli.ExitWithError("could not create namespaced-policy planner", err)
 	}

--- a/otdfctl/migrations/namespacedpolicy/execute.go
+++ b/otdfctl/migrations/namespacedpolicy/execute.go
@@ -30,6 +30,7 @@ var (
 const (
 	migrationLabelMigratedFrom = "migrated_from"
 	migrationLabelRun          = "migration_run"
+	unknownLabel               = "<unknown>"
 )
 
 type ExecutorHandler interface {
@@ -133,7 +134,7 @@ func namespaceIdentifier(namespace *policy.Namespace) string {
 
 func namespaceLabel(namespace *policy.Namespace) string {
 	if namespace == nil {
-		return "<unknown>"
+		return unknownLabel
 	}
 	if fqn := strings.TrimSpace(namespace.GetFqn()); fqn != "" {
 		return fqn
@@ -141,5 +142,5 @@ func namespaceLabel(namespace *policy.Namespace) string {
 	if id := strings.TrimSpace(namespace.GetId()); id != "" {
 		return id
 	}
-	return "<unknown>"
+	return unknownLabel
 }

--- a/otdfctl/migrations/namespacedpolicy/interactive_prompt.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_prompt.go
@@ -1,0 +1,126 @@
+package namespacedpolicy
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+)
+
+var ErrInteractiveReviewAborted = errors.New("interactive review aborted by user")
+
+// ConfirmPrompt is a generic confirmation prompt for planner-owned review flows.
+type ConfirmPrompt struct {
+	Title        string
+	Description  []string
+	ConfirmLabel string
+	CancelLabel  string
+}
+
+// PromptOption is one selectable value in a generic interactive prompt.
+type PromptOption struct {
+	Label       string
+	Value       string
+	Description string
+}
+
+// SelectPrompt is a generic single-select prompt for planner-owned review flows.
+type SelectPrompt struct {
+	Title       string
+	Description []string
+	Options     []PromptOption
+}
+
+// InteractivePrompter abstracts the concrete prompt implementation so review
+// orchestration stays planner-owned and testable.
+type InteractivePrompter interface {
+	Confirm(context.Context, ConfirmPrompt) error
+	Select(context.Context, SelectPrompt) (string, error)
+}
+
+// HuhPrompter implements InteractivePrompter using charmbracelet/huh forms.
+type HuhPrompter struct{}
+
+func (p *HuhPrompter) Confirm(_ context.Context, prompt ConfirmPrompt) error {
+	confirmLabel := strings.TrimSpace(prompt.ConfirmLabel)
+	if confirmLabel == "" {
+		confirmLabel = "Continue"
+	}
+
+	cancelLabel := strings.TrimSpace(prompt.CancelLabel)
+	if cancelLabel == "" {
+		cancelLabel = "Abort"
+	}
+
+	var choice string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(strings.TrimSpace(prompt.Title)).
+				Description(promptDescription(prompt.Description)).
+				Options(
+					huh.NewOption(confirmLabel, confirmLabel),
+					huh.NewOption(cancelLabel, cancelLabel),
+				).
+				Value(&choice),
+		),
+	)
+
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return ErrInteractiveReviewAborted
+		}
+		return err
+	}
+
+	if choice != confirmLabel {
+		return ErrInteractiveReviewAborted
+	}
+
+	return nil
+}
+
+func (p *HuhPrompter) Select(_ context.Context, prompt SelectPrompt) (string, error) {
+	options := make([]huh.Option[string], 0, len(prompt.Options))
+	for _, option := range prompt.Options {
+		label := option.Label
+		if description := strings.TrimSpace(option.Description); description != "" {
+			label += " - " + description
+		}
+		options = append(options, huh.NewOption(label, option.Value))
+	}
+
+	var choice string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(strings.TrimSpace(prompt.Title)).
+				Description(promptDescription(prompt.Description)).
+				Options(options...).
+				Value(&choice),
+		),
+	)
+
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return "", ErrInteractiveReviewAborted
+		}
+		return "", err
+	}
+
+	return choice, nil
+}
+
+func promptDescription(description []string) string {
+	lines := make([]string, 0, len(description))
+	for _, line := range description {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/otdfctl/migrations/namespacedpolicy/interactive_prompt.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_prompt.go
@@ -42,7 +42,7 @@ type InteractivePrompter interface {
 // HuhPrompter implements InteractivePrompter using charmbracelet/huh forms.
 type HuhPrompter struct{}
 
-func (p *HuhPrompter) Confirm(_ context.Context, prompt ConfirmPrompt) error {
+func (p *HuhPrompter) Confirm(ctx context.Context, prompt ConfirmPrompt) error {
 	confirmLabel := strings.TrimSpace(prompt.ConfirmLabel)
 	if confirmLabel == "" {
 		confirmLabel = "Continue"
@@ -53,35 +53,33 @@ func (p *HuhPrompter) Confirm(_ context.Context, prompt ConfirmPrompt) error {
 		cancelLabel = "Abort"
 	}
 
-	var choice string
+	var choice bool
 	form := huh.NewForm(
 		huh.NewGroup(
-			huh.NewSelect[string]().
+			huh.NewConfirm().
 				Title(strings.TrimSpace(prompt.Title)).
 				Description(promptDescription(prompt.Description)).
-				Options(
-					huh.NewOption(confirmLabel, confirmLabel),
-					huh.NewOption(cancelLabel, cancelLabel),
-				).
+				Affirmative(confirmLabel).
+				Negative(cancelLabel).
 				Value(&choice),
 		),
 	)
 
-	if err := form.Run(); err != nil {
+	if err := form.RunWithContext(ctx); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			return ErrInteractiveReviewAborted
 		}
 		return err
 	}
 
-	if choice != confirmLabel {
+	if !choice {
 		return ErrInteractiveReviewAborted
 	}
 
 	return nil
 }
 
-func (p *HuhPrompter) Select(_ context.Context, prompt SelectPrompt) (string, error) {
+func (p *HuhPrompter) Select(ctx context.Context, prompt SelectPrompt) (string, error) {
 	options := make([]huh.Option[string], 0, len(prompt.Options))
 	for _, option := range prompt.Options {
 		label := option.Label
@@ -102,7 +100,7 @@ func (p *HuhPrompter) Select(_ context.Context, prompt SelectPrompt) (string, er
 		),
 	)
 
-	if err := form.Run(); err != nil {
+	if err := form.RunWithContext(ctx); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			return "", ErrInteractiveReviewAborted
 		}

--- a/otdfctl/migrations/namespacedpolicy/interactive_review.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_review.go
@@ -311,8 +311,9 @@ func filterRegisteredResourceToNamespace(resource *policy.RegisteredResource, na
 		return nil, errors.New("could not clone registered resource")
 	}
 
-	cloned.Values = make([]*policy.RegisteredResourceValue, 0, len(cloned.GetValues()))
-	for _, value := range cloned.GetValues() {
+	clonedValues := cloned.GetValues()
+	cloned.Values = make([]*policy.RegisteredResourceValue, 0, len(clonedValues))
+	for _, value := range clonedValues {
 		if value == nil {
 			continue
 		}

--- a/otdfctl/migrations/namespacedpolicy/interactive_review.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_review.go
@@ -356,18 +356,28 @@ func ensureRegisteredResourceActionResolution(resolved *ResolvedTargets, resourc
 		return errors.New("registered resource binding action is missing")
 	}
 	if actionResolver == nil {
-		return ErrNilInteractiveReviewHandler
+		return errors.New("action resolver required for plan resolution")
 	}
 
 	item := resolvedActionByID(resolved.Actions, action.GetId())
 	if item == nil {
+		source, err := cloneAction(action)
+		if err != nil {
+			return err
+		}
+
 		item = &ResolvedAction{
-			Source:  cloneAction(action),
+			Source:  source,
 			Results: make([]*ResolvedActionResult, 0, 1),
 		}
 		resolved.Actions = append(resolved.Actions, item)
 	} else if item.Source == nil {
-		item.Source = cloneAction(action)
+		source, err := cloneAction(action)
+		if err != nil {
+			return err
+		}
+
+		item.Source = source
 	}
 
 	addActionReferenceIfMissing(item, &ActionReference{
@@ -427,20 +437,15 @@ func addActionReferenceIfMissing(action *ResolvedAction, reference *ActionRefere
 	action.References = append(action.References, reference)
 }
 
-func cloneAction(action *policy.Action) *policy.Action {
+func cloneAction(action *policy.Action) (*policy.Action, error) {
 	if action == nil {
-		return nil
+		return nil, errors.New("action is nil")
 	}
 
 	cloned, ok := proto.Clone(action).(*policy.Action)
 	if !ok {
-		return &policy.Action{
-			Id:        action.GetId(),
-			Name:      action.GetName(),
-			Metadata:  action.GetMetadata(),
-			Namespace: action.GetNamespace(),
-		}
+		return nil, fmt.Errorf("clone action %q: unexpected proto clone type", action.GetId())
 	}
 
-	return cloned
+	return cloned, nil
 }

--- a/otdfctl/migrations/namespacedpolicy/interactive_review.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_review.go
@@ -30,14 +30,14 @@ type InteractiveReviewer interface {
 // registered resources whose action-attribute-values span multiple namespaces.
 type HuhInteractiveReviewer struct {
 	handler  PolicyClient
-	Prompter InteractivePrompter
+	prompter InteractivePrompter
 	pageSize int32
 }
 
 func NewHuhInteractiveReviewer(handler PolicyClient, prompter InteractivePrompter) *HuhInteractiveReviewer {
 	return &HuhInteractiveReviewer{
 		handler:  handler,
-		Prompter: prompter,
+		prompter: prompter,
 		pageSize: defaultPlannerPageSize,
 	}
 }
@@ -47,11 +47,20 @@ func (r *HuhInteractiveReviewer) Review(ctx context.Context, resolved *ResolvedT
 		return nil
 	}
 
+	var retriever *Retriever
+	namespaceCache := make(map[string]*interactiveReviewNamespaceState)
 	for _, resource := range resolved.RegisteredResources {
 		if !isConflictingRegisteredResource(resource) {
 			continue
 		}
-		if err := r.reviewRegisteredResource(ctx, resolved, resource, namespaces); err != nil {
+		if retriever == nil {
+			var err error
+			retriever, err = r.retriever()
+			if err != nil {
+				return err
+			}
+		}
+		if err := r.reviewRegisteredResource(ctx, resolved, resource, namespaces, retriever, namespaceCache); err != nil {
 			return err
 		}
 	}
@@ -59,14 +68,16 @@ func (r *HuhInteractiveReviewer) Review(ctx context.Context, resolved *ResolvedT
 	return nil
 }
 
-func (r *HuhInteractiveReviewer) reviewRegisteredResource(ctx context.Context, resolved *ResolvedTargets, resource *ResolvedRegisteredResource, namespaces []*policy.Namespace) error {
+func (r *HuhInteractiveReviewer) reviewRegisteredResource(
+	ctx context.Context,
+	resolved *ResolvedTargets,
+	resource *ResolvedRegisteredResource,
+	namespaces []*policy.Namespace,
+	retriever *Retriever,
+	namespaceCache map[string]*interactiveReviewNamespaceState,
+) error {
 	if resource == nil || resource.Source == nil {
 		return nil
-	}
-
-	retriever, err := r.retriever()
-	if err != nil {
-		return err
 	}
 
 	candidates, err := registeredResourceCandidateNamespaces(resource.Source, namespaces)
@@ -74,10 +85,12 @@ func (r *HuhInteractiveReviewer) reviewRegisteredResource(ctx context.Context, r
 		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
 	}
 
-	selected, err := r.prompter().Select(ctx, registeredResourceConflictPrompt(resource.Source, candidates))
+	selected, err := r.resolvePrompter().Select(ctx, registeredResourceConflictPrompt(resource.Source, candidates))
 	if err != nil {
 		return err
 	}
+	// registeredResourceConflictPrompt appends interactiveReviewAbortOption to SelectPrompt.Options,
+	// but selectedNamespace only searches candidates, so this short-circuit must remain in place.
 	if selected == interactiveReviewAbortOption {
 		return ErrInteractiveReviewAborted
 	}
@@ -92,26 +105,14 @@ func (r *HuhInteractiveReviewer) reviewRegisteredResource(ctx context.Context, r
 		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
 	}
 
-	customActions, standardActions, err := retriever.listActionsForNamespaces(ctx, []*policy.Namespace{chosen})
+	namespaceState, err := reviewNamespaceState(ctx, retriever, chosen, namespaceCache)
 	if err != nil {
 		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
-	}
-
-	registeredResources, err := retriever.listRegisteredResourcesForNamespaces(ctx, []*policy.Namespace{chosen})
-	if err != nil {
-		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
-	}
-
-	actionResolver := &resolver{
-		existing: &ExistingTargets{
-			CustomActions:   customActions,
-			StandardActions: standardActions,
-		},
 	}
 
 	for _, value := range filtered.GetValues() {
 		for _, aav := range value.GetActionAttributeValues() {
-			if err := ensureRegisteredResourceActionResolution(resolved, resource.Source.GetId(), chosen, aav.GetAction(), actionResolver); err != nil {
+			if err := ensureRegisteredResourceActionResolution(resolved, resource.Source.GetId(), chosen, aav.GetAction(), namespaceState.actionResolver); err != nil {
 				return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
 			}
 		}
@@ -119,11 +120,12 @@ func (r *HuhInteractiveReviewer) reviewRegisteredResource(ctx context.Context, r
 
 	resource.Source = filtered
 	resource.Namespace = chosen
+	// Reset planner state before re-resolving against registeredResources[chosen.GetId()] so AlreadyMigrated/NeedsCreate matches resolver.resolveRegisteredResource semantics for the chosen namespace.
 	resource.Unresolved = nil
 	resource.AlreadyMigrated = nil
 	resource.NeedsCreate = false
 
-	existing, found, err := resolveExistingRegisteredResource(filtered, registeredResources[chosen.GetId()])
+	existing, found, err := resolveExistingRegisteredResource(filtered, namespaceState.registeredResources)
 	switch {
 	case found:
 		resource.AlreadyMigrated = existing
@@ -136,9 +138,57 @@ func (r *HuhInteractiveReviewer) reviewRegisteredResource(ctx context.Context, r
 	return nil
 }
 
-func (r *HuhInteractiveReviewer) prompter() InteractivePrompter {
-	if r != nil && r.Prompter != nil {
-		return r.Prompter
+type interactiveReviewNamespaceState struct {
+	actionResolver      *resolver
+	registeredResources []*policy.RegisteredResource
+}
+
+func reviewNamespaceState(
+	ctx context.Context,
+	retriever *Retriever,
+	chosen *policy.Namespace,
+	namespaceCache map[string]*interactiveReviewNamespaceState,
+) (*interactiveReviewNamespaceState, error) {
+	if chosen == nil {
+		return nil, fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping)
+	}
+	if retriever == nil {
+		return nil, ErrNilInteractiveReviewHandler
+	}
+
+	key := chosen.GetId()
+	if state, ok := namespaceCache[key]; ok {
+		return state, nil
+	}
+
+	customActions, standardActions, err := retriever.listActionsForNamespaces(ctx, []*policy.Namespace{chosen})
+	if err != nil {
+		return nil, err
+	}
+
+	registeredResources, err := retriever.listRegisteredResourcesForNamespaces(ctx, []*policy.Namespace{chosen})
+	if err != nil {
+		return nil, err
+	}
+
+	state := &interactiveReviewNamespaceState{
+		actionResolver: &resolver{
+			existing: &ExistingTargets{
+				CustomActions:   customActions,
+				StandardActions: standardActions,
+			},
+			actionResultsByKey: make(map[string]*ResolvedActionResult),
+			scsResultsByKey:    make(map[string]*ResolvedSubjectConditionSetResult),
+		},
+		registeredResources: registeredResources[chosen.GetId()],
+	}
+	namespaceCache[key] = state
+	return state, nil
+}
+
+func (r *HuhInteractiveReviewer) resolvePrompter() InteractivePrompter {
+	if r != nil && r.prompter != nil {
+		return r.prompter
 	}
 
 	return &HuhPrompter{}
@@ -214,35 +264,10 @@ func registeredResourceConflictPrompt(resource *policy.RegisteredResource, names
 	})
 
 	return SelectPrompt{
-		Title:       fmt.Sprintf("Registered resource %s spans multiple target namespaces.", registeredResourceFQN(resource)),
+		Title:       fmt.Sprintf("Registered resource (name: %s, id: %s) spans multiple target namespaces.", resource.GetName(), resource.GetId()),
 		Description: description,
 		Options:     options,
 	}
-}
-
-func registeredResourceFQN(resource *policy.RegisteredResource) string {
-	if resource == nil {
-		return unknownLabel
-	}
-
-	name := strings.TrimSpace(resource.GetName())
-	if name == "" {
-		if id := strings.TrimSpace(resource.GetId()); id != "" {
-			return id
-		}
-		return unknownLabel
-	}
-
-	if namespace := resource.GetNamespace(); namespace != nil {
-		if fqn := strings.TrimSpace(namespace.GetFqn()); fqn != "" {
-			return strings.TrimRight(fqn, "/") + "/reg_res/" + name
-		}
-		if namespaceName := strings.TrimSpace(namespace.GetName()); namespaceName != "" {
-			return "https://" + namespaceName + "/reg_res/" + name
-		}
-	}
-
-	return "https://reg_res/" + name
 }
 
 func registeredResourceConflictLines(resource *policy.RegisteredResource) []string {

--- a/otdfctl/migrations/namespacedpolicy/interactive_review.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_review.go
@@ -1,0 +1,445 @@
+package namespacedpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	interactiveReviewAbortOption              = "__abort_interactive_review__"
+	minimumRegisteredResourceReviewNamespaces = 2
+)
+
+var ErrNilInteractiveReviewHandler = errors.New("interactive review handler is required")
+
+// InteractiveReviewer owns planner-time interactive review. It mutates
+// resolved planner state before finalization when interactive review is enabled.
+type InteractiveReviewer interface {
+	Review(context.Context, *ResolvedTargets, []*policy.Namespace) error
+}
+
+// HuhInteractiveReviewer is the planner-owned interactive review entrypoint for
+// `migrate namespaced-policy --interactive`.
+//
+// The only actionable planner-time review currently supported is resolving
+// registered resources whose action-attribute-values span multiple namespaces.
+type HuhInteractiveReviewer struct {
+	handler  PolicyClient
+	Prompter InteractivePrompter
+	pageSize int32
+}
+
+func NewHuhInteractiveReviewer(handler PolicyClient, prompter InteractivePrompter) *HuhInteractiveReviewer {
+	return &HuhInteractiveReviewer{
+		handler:  handler,
+		Prompter: prompter,
+		pageSize: defaultPlannerPageSize,
+	}
+}
+
+func (r *HuhInteractiveReviewer) Review(ctx context.Context, resolved *ResolvedTargets, namespaces []*policy.Namespace) error {
+	if resolved == nil {
+		return nil
+	}
+
+	for _, resource := range resolved.RegisteredResources {
+		if !isConflictingRegisteredResource(resource) {
+			continue
+		}
+		if err := r.reviewRegisteredResource(ctx, resolved, resource, namespaces); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *HuhInteractiveReviewer) reviewRegisteredResource(ctx context.Context, resolved *ResolvedTargets, resource *ResolvedRegisteredResource, namespaces []*policy.Namespace) error {
+	if resource == nil || resource.Source == nil {
+		return nil
+	}
+
+	retriever, err := r.retriever()
+	if err != nil {
+		return err
+	}
+
+	candidates, err := registeredResourceCandidateNamespaces(resource.Source, namespaces)
+	if err != nil {
+		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
+	}
+
+	selected, err := r.prompter().Select(ctx, registeredResourceConflictPrompt(resource.Source, candidates))
+	if err != nil {
+		return err
+	}
+	if selected == interactiveReviewAbortOption {
+		return ErrInteractiveReviewAborted
+	}
+
+	chosen := selectedNamespace(candidates, selected)
+	if chosen == nil {
+		return fmt.Errorf("registered resource %q: invalid namespace choice %q", resource.Source.GetId(), selected)
+	}
+
+	filtered, err := filterRegisteredResourceToNamespace(resource.Source, chosen)
+	if err != nil {
+		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
+	}
+
+	customActions, standardActions, err := retriever.listActionsForNamespaces(ctx, []*policy.Namespace{chosen})
+	if err != nil {
+		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
+	}
+
+	registeredResources, err := retriever.listRegisteredResourcesForNamespaces(ctx, []*policy.Namespace{chosen})
+	if err != nil {
+		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
+	}
+
+	actionResolver := &resolver{
+		existing: &ExistingTargets{
+			CustomActions:   customActions,
+			StandardActions: standardActions,
+		},
+	}
+
+	for _, value := range filtered.GetValues() {
+		for _, aav := range value.GetActionAttributeValues() {
+			if err := ensureRegisteredResourceActionResolution(resolved, resource.Source.GetId(), chosen, aav.GetAction(), actionResolver); err != nil {
+				return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
+			}
+		}
+	}
+
+	resource.Source = filtered
+	resource.Namespace = chosen
+	resource.Unresolved = nil
+	resource.AlreadyMigrated = nil
+	resource.NeedsCreate = false
+
+	existing, found, err := resolveExistingRegisteredResource(filtered, registeredResources[chosen.GetId()])
+	switch {
+	case found:
+		resource.AlreadyMigrated = existing
+	case err != nil:
+		return fmt.Errorf("registered resource %q in namespace %q: %w", filtered.GetId(), chosen.GetId(), err)
+	default:
+		resource.NeedsCreate = true
+	}
+
+	return nil
+}
+
+func (r *HuhInteractiveReviewer) prompter() InteractivePrompter {
+	if r != nil && r.Prompter != nil {
+		return r.Prompter
+	}
+
+	return &HuhPrompter{}
+}
+
+func (r *HuhInteractiveReviewer) retriever() (*Retriever, error) {
+	if r == nil || r.handler == nil {
+		return nil, ErrNilInteractiveReviewHandler
+	}
+
+	pageSize := r.pageSize
+	if pageSize <= 0 {
+		pageSize = defaultPlannerPageSize
+	}
+
+	return newRetriever(r.handler, pageSize), nil
+}
+
+func isConflictingRegisteredResource(resource *ResolvedRegisteredResource) bool {
+	if resource == nil || resource.Unresolved == nil {
+		return false
+	}
+
+	return resource.Unresolved.Reason == UnresolvedReasonRegisteredResourceConflictingNamespaces
+}
+
+func registeredResourceCandidateNamespaces(resource *policy.RegisteredResource, namespaces []*policy.Namespace) ([]*policy.Namespace, error) {
+	if resource == nil {
+		return nil, fmt.Errorf("%w: registered resource is empty", ErrUndeterminedTargetMapping)
+	}
+
+	deriver := newTargetDeriver(namespaces)
+	ordered := newNamespaceAccumulator()
+
+	for _, value := range resource.GetValues() {
+		for _, aav := range value.GetActionAttributeValues() {
+			namespace, err := deriver.resolveNamespace(namespaceFromAttributeValue(aav.GetAttributeValue()))
+			if err != nil {
+				return nil, err
+			}
+			ordered.add(namespace)
+		}
+	}
+
+	candidates := ordered.slice()
+	if len(candidates) < minimumRegisteredResourceReviewNamespaces {
+		return nil, fmt.Errorf("%w: registered resource review requires multiple candidate namespaces", ErrUndeterminedTargetMapping)
+	}
+
+	return candidates, nil
+}
+
+func registeredResourceConflictPrompt(resource *policy.RegisteredResource, namespaces []*policy.Namespace) SelectPrompt {
+	description := []string{
+		fmt.Sprintf("Registered resource: %s (%s)", strings.TrimSpace(resource.GetName()), resource.GetId()),
+		"Choose one target namespace for this registered resource.",
+		"Bindings for other namespaces will be removed from the reviewed RR.",
+	}
+	description = append(description, registeredResourceConflictLines(resource)...)
+
+	options := make([]PromptOption, 0, len(namespaces)+1)
+	for _, namespace := range namespaces {
+		options = append(options, PromptOption{
+			Label:       namespaceLabel(namespace),
+			Value:       namespaceSelectionValue(namespace),
+			Description: "migrate to this namespace",
+		})
+	}
+	options = append(options, PromptOption{
+		Label:       "Abort run",
+		Value:       interactiveReviewAbortOption,
+		Description: "stop planning without changing this RR",
+	})
+
+	return SelectPrompt{
+		Title:       fmt.Sprintf("Registered resource %s spans multiple target namespaces.", registeredResourceFQN(resource)),
+		Description: description,
+		Options:     options,
+	}
+}
+
+func registeredResourceFQN(resource *policy.RegisteredResource) string {
+	if resource == nil {
+		return unknownLabel
+	}
+
+	name := strings.TrimSpace(resource.GetName())
+	if name == "" {
+		if id := strings.TrimSpace(resource.GetId()); id != "" {
+			return id
+		}
+		return unknownLabel
+	}
+
+	if namespace := resource.GetNamespace(); namespace != nil {
+		if fqn := strings.TrimSpace(namespace.GetFqn()); fqn != "" {
+			return strings.TrimRight(fqn, "/") + "/reg_res/" + name
+		}
+		if namespaceName := strings.TrimSpace(namespace.GetName()); namespaceName != "" {
+			return "https://" + namespaceName + "/reg_res/" + name
+		}
+	}
+
+	return "https://reg_res/" + name
+}
+
+func registeredResourceConflictLines(resource *policy.RegisteredResource) []string {
+	lines := make([]string, 0)
+	for _, value := range resource.GetValues() {
+		if value == nil {
+			continue
+		}
+		if len(value.GetActionAttributeValues()) == 0 {
+			lines = append(lines, fmt.Sprintf("Value %q has no action bindings.", value.GetValue()))
+			continue
+		}
+		for _, aav := range value.GetActionAttributeValues() {
+			if aav == nil {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf(
+				"Value %q: action %q -> %s",
+				value.GetValue(),
+				actionLabel(aav.GetAction()),
+				namespaceLabel(namespaceFromAttributeValue(aav.GetAttributeValue())),
+			))
+		}
+	}
+
+	return lines
+}
+
+func actionLabel(action *policy.Action) string {
+	if action == nil {
+		return unknownLabel
+	}
+	if name := strings.TrimSpace(action.GetName()); name != "" {
+		return name
+	}
+	if id := strings.TrimSpace(action.GetId()); id != "" {
+		return id
+	}
+	return unknownLabel
+}
+
+func namespaceSelectionValue(namespace *policy.Namespace) string {
+	return namespaceRefKey(namespace)
+}
+
+func selectedNamespace(candidates []*policy.Namespace, value string) *policy.Namespace {
+	for _, namespace := range candidates {
+		if namespaceSelectionValue(namespace) == value {
+			return namespace
+		}
+	}
+
+	return nil
+}
+
+func filterRegisteredResourceToNamespace(resource *policy.RegisteredResource, namespace *policy.Namespace) (*policy.RegisteredResource, error) {
+	if resource == nil {
+		return nil, fmt.Errorf("%w: registered resource is empty", ErrUndeterminedTargetMapping)
+	}
+	if namespace == nil {
+		return nil, fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping)
+	}
+
+	cloned, ok := proto.Clone(resource).(*policy.RegisteredResource)
+	if !ok {
+		return nil, errors.New("could not clone registered resource")
+	}
+
+	cloned.Values = make([]*policy.RegisteredResourceValue, 0, len(cloned.GetValues()))
+	for _, value := range cloned.GetValues() {
+		if value == nil {
+			continue
+		}
+
+		if len(value.GetActionAttributeValues()) == 0 {
+			cloned.Values = append(cloned.Values, value)
+			continue
+		}
+
+		filteredAAVs := make([]*policy.RegisteredResourceValue_ActionAttributeValue, 0, len(value.GetActionAttributeValues()))
+		for _, aav := range value.GetActionAttributeValues() {
+			if aav == nil || !sameNamespace(namespaceFromAttributeValue(aav.GetAttributeValue()), namespace) {
+				continue
+			}
+			filteredAAVs = append(filteredAAVs, aav)
+		}
+
+		if len(filteredAAVs) == 0 {
+			continue
+		}
+
+		value.ActionAttributeValues = filteredAAVs
+		cloned.Values = append(cloned.Values, value)
+	}
+
+	return cloned, nil
+}
+
+// ensureRegisteredResourceActionResolution may append or update entries in
+// resolved.Actions so the reviewed registered resource's action bindings remain
+// executable after namespace-specific filtering.
+func ensureRegisteredResourceActionResolution(resolved *ResolvedTargets, resourceID string, namespace *policy.Namespace, action *policy.Action, actionResolver *resolver) error {
+	if resolved == nil {
+		return ErrNilResolvedTargets
+	}
+	if namespace == nil {
+		return fmt.Errorf("%w: empty namespace reference", ErrUndeterminedTargetMapping)
+	}
+	if action == nil || strings.TrimSpace(action.GetId()) == "" {
+		return errors.New("registered resource binding action is missing")
+	}
+	if actionResolver == nil {
+		return ErrNilInteractiveReviewHandler
+	}
+
+	item := resolvedActionByID(resolved.Actions, action.GetId())
+	if item == nil {
+		item = &ResolvedAction{
+			Source:  cloneAction(action),
+			Results: make([]*ResolvedActionResult, 0, 1),
+		}
+		resolved.Actions = append(resolved.Actions, item)
+	} else if item.Source == nil {
+		item.Source = cloneAction(action)
+	}
+
+	addActionReferenceIfMissing(item, &ActionReference{
+		Kind:      ActionReferenceKindRegisteredResource,
+		ID:        resourceID,
+		Namespace: namespace,
+	})
+
+	if resolvedActionResultForNamespace(item, namespace) != nil {
+		return nil
+	}
+
+	result, err := actionResolver.resolveActionTargetFromExisting(item.Source, namespace)
+	if err != nil {
+		return fmt.Errorf("action %q in namespace %q: %w", item.Source.GetId(), namespace.GetId(), err)
+	}
+
+	item.Results = append(item.Results, result)
+	return nil
+}
+
+func resolvedActionByID(actions []*ResolvedAction, sourceID string) *ResolvedAction {
+	for _, action := range actions {
+		if action != nil && action.Source != nil && action.Source.GetId() == sourceID {
+			return action
+		}
+	}
+
+	return nil
+}
+
+func resolvedActionResultForNamespace(action *ResolvedAction, namespace *policy.Namespace) *ResolvedActionResult {
+	if action == nil || namespace == nil {
+		return nil
+	}
+
+	for _, result := range action.Results {
+		if result != nil && sameNamespace(result.Namespace, namespace) {
+			return result
+		}
+	}
+
+	return nil
+}
+
+func addActionReferenceIfMissing(action *ResolvedAction, reference *ActionReference) {
+	if action == nil || reference == nil {
+		return
+	}
+
+	for _, existing := range action.References {
+		if actionReferenceKey(existing) == actionReferenceKey(reference) {
+			return
+		}
+	}
+
+	action.References = append(action.References, reference)
+}
+
+func cloneAction(action *policy.Action) *policy.Action {
+	if action == nil {
+		return nil
+	}
+
+	cloned, ok := proto.Clone(action).(*policy.Action)
+	if !ok {
+		return &policy.Action{
+			Id:        action.GetId(),
+			Name:      action.GetName(),
+			Metadata:  action.GetMetadata(),
+			Namespace: action.GetNamespace(),
+		}
+	}
+
+	return cloned
+}

--- a/otdfctl/migrations/namespacedpolicy/interactive_review_test.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_review_test.go
@@ -81,7 +81,7 @@ func TestHuhInteractiveReviewerResolvesConflictingRegisteredResource(t *testing.
 
 	require.Equal(t, 1, prompter.selectCalls)
 	require.NotNil(t, prompter.lastSelectPrompt)
-	assert.Equal(t, "Registered resource https://reg_res/documents spans multiple target namespaces.", prompter.lastSelectPrompt.Title)
+	assert.Equal(t, "Registered resource (name: documents, id: resource-1) spans multiple target namespaces.", prompter.lastSelectPrompt.Title)
 	require.Len(t, prompter.lastSelectPrompt.Options, 3)
 
 	require.Len(t, resolved.RegisteredResources, 1)
@@ -205,6 +205,95 @@ func TestHuhInteractiveReviewerRequiresHandlerForConflictingReview(t *testing.T)
 		},
 	}, []*policy.Namespace{leftNamespace, rightNamespace})
 	require.ErrorIs(t, err, ErrNilInteractiveReviewHandler)
+}
+
+func TestHuhInteractiveReviewerCachesNamespaceLookupsWithinReview(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			leftNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		registeredResourcesByNamespace: map[string]*registeredresources.ListRegisteredResourcesResponse{
+			leftNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{leftNamespace, rightNamespace},
+			Pagination: emptyPageResponse(),
+		},
+	}
+	prompter := &testInteractivePrompter{
+		selectValue: namespaceSelectionValue(leftNamespace),
+	}
+	reviewer := NewHuhInteractiveReviewer(handler, prompter)
+	resolved := &ResolvedTargets{
+		Scopes: []Scope{ScopeRegisteredResources},
+		RegisteredResources: []*ResolvedRegisteredResource{
+			{
+				Source: testRegisteredResource(
+					"resource-1",
+					"documents",
+					testRegisteredResourceValue(
+						"prod",
+						testActionAttributeValue(
+							"action-1",
+							"decrypt",
+							testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-2",
+							"encrypt",
+							testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+						),
+					),
+				),
+				Unresolved: &Unresolved{
+					Reason: UnresolvedReasonRegisteredResourceConflictingNamespaces,
+				},
+			},
+			{
+				Source: testRegisteredResource(
+					"resource-2",
+					"records",
+					testRegisteredResourceValue(
+						"stage",
+						testActionAttributeValue(
+							"action-3",
+							"review_records",
+							testAttributeValue("https://example.com/attr/classification/value/internal", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-4",
+							"publish_records",
+							testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+						),
+					),
+				),
+				Unresolved: &Unresolved{
+					Reason: UnresolvedReasonRegisteredResourceConflictingNamespaces,
+				},
+			},
+		},
+	}
+
+	err := reviewer.Review(t.Context(), resolved, []*policy.Namespace{leftNamespace, rightNamespace})
+	require.NoError(t, err)
+	assert.Equal(t, 2, prompter.selectCalls)
+	assert.Equal(t, []string{leftNamespace.GetId()}, handler.actionCalls)
+	assert.Equal(t, []string{leftNamespace.GetId()}, handler.registeredResourceCalls)
 }
 
 type testInteractivePrompter struct {

--- a/otdfctl/migrations/namespacedpolicy/interactive_review_test.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_review_test.go
@@ -1,0 +1,230 @@
+package namespacedpolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/actions"
+	"github.com/opentdf/platform/protocol/go/policy/namespaces"
+	"github.com/opentdf/platform/protocol/go/policy/registeredresources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHuhInteractiveReviewerResolvesConflictingRegisteredResource(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			leftNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		registeredResourcesByNamespace: map[string]*registeredresources.ListRegisteredResourcesResponse{
+			leftNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{leftNamespace, rightNamespace},
+			Pagination: emptyPageResponse(),
+		},
+	}
+	prompter := &testInteractivePrompter{
+		selectValue: namespaceSelectionValue(leftNamespace),
+	}
+	reviewer := NewHuhInteractiveReviewer(handler, prompter)
+	resolved := &ResolvedTargets{
+		Scopes: []Scope{ScopeRegisteredResources},
+		RegisteredResources: []*ResolvedRegisteredResource{
+			{
+				Source: testRegisteredResource(
+					"resource-1",
+					"documents",
+					testRegisteredResourceValue(
+						"prod",
+						testActionAttributeValue(
+							"action-1",
+							"decrypt",
+							testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-2",
+							"encrypt",
+							testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+						),
+					),
+					&policy.RegisteredResourceValue{
+						Value: "shared",
+					},
+				),
+				Unresolved: &Unresolved{
+					Reason:  UnresolvedReasonRegisteredResourceConflictingNamespaces,
+					Message: "could not determine target namespace: registered resource spans multiple target namespaces",
+				},
+			},
+		},
+	}
+
+	err := reviewer.Review(t.Context(), resolved, []*policy.Namespace{leftNamespace, rightNamespace})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, prompter.selectCalls)
+	require.NotNil(t, prompter.lastSelectPrompt)
+	assert.Equal(t, "Registered resource https://reg_res/documents spans multiple target namespaces.", prompter.lastSelectPrompt.Title)
+	require.Len(t, prompter.lastSelectPrompt.Options, 3)
+
+	require.Len(t, resolved.RegisteredResources, 1)
+	resource := resolved.RegisteredResources[0]
+	require.NotNil(t, resource)
+	assert.Nil(t, resource.Unresolved)
+	assert.True(t, resource.NeedsCreate)
+	assert.Nil(t, resource.AlreadyMigrated)
+	require.True(t, sameNamespace(leftNamespace, resource.Namespace))
+	require.Len(t, resource.Source.GetValues(), 2)
+	require.Len(t, resource.Source.GetValues()[0].GetActionAttributeValues(), 1)
+	assert.Equal(t, "action-1", resource.Source.GetValues()[0].GetActionAttributeValues()[0].GetAction().GetId())
+	assert.Empty(t, resource.Source.GetValues()[1].GetActionAttributeValues())
+
+	require.Len(t, resolved.Actions, 1)
+	action := resolved.Actions[0]
+	require.NotNil(t, action.Source)
+	assert.Equal(t, "action-1", action.Source.GetId())
+	require.Len(t, action.Results, 1)
+	assert.True(t, sameNamespace(leftNamespace, action.Results[0].Namespace))
+	assert.True(t, action.Results[0].NeedsCreate)
+	require.Len(t, action.References, 1)
+	assert.Equal(t, ActionReferenceKindRegisteredResource, action.References[0].Kind)
+	assert.Equal(t, "resource-1", action.References[0].ID)
+	assert.True(t, sameNamespace(leftNamespace, action.References[0].Namespace))
+}
+
+func TestHuhInteractiveReviewerReturnsAbortWhenPromptAborts(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+	reviewer := NewHuhInteractiveReviewer(
+		&plannerTestHandler{},
+		&testInteractivePrompter{selectErr: ErrInteractiveReviewAborted},
+	)
+
+	err := reviewer.Review(t.Context(), &ResolvedTargets{
+		RegisteredResources: []*ResolvedRegisteredResource{
+			{
+				Source: testRegisteredResource(
+					"resource-1",
+					"documents",
+					testRegisteredResourceValue(
+						"prod",
+						testActionAttributeValue(
+							"action-1",
+							"decrypt",
+							testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-2",
+							"encrypt",
+							testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+						),
+					),
+				),
+				Unresolved: &Unresolved{
+					Reason: UnresolvedReasonRegisteredResourceConflictingNamespaces,
+				},
+			},
+		},
+	}, []*policy.Namespace{leftNamespace, rightNamespace})
+	require.ErrorIs(t, err, ErrInteractiveReviewAborted)
+}
+
+func TestHuhInteractiveReviewerReturnsNilForNilResolvedTargets(t *testing.T) {
+	t.Parallel()
+
+	reviewer := NewHuhInteractiveReviewer(&plannerTestHandler{}, &testInteractivePrompter{})
+
+	err := reviewer.Review(t.Context(), nil, nil)
+	require.NoError(t, err)
+}
+
+func TestHuhInteractiveReviewerRequiresHandlerForConflictingReview(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+	reviewer := NewHuhInteractiveReviewer(nil, &testInteractivePrompter{
+		selectValue: namespaceSelectionValue(leftNamespace),
+	})
+
+	err := reviewer.Review(t.Context(), &ResolvedTargets{
+		RegisteredResources: []*ResolvedRegisteredResource{
+			{
+				Source: testRegisteredResource(
+					"resource-1",
+					"documents",
+					testRegisteredResourceValue(
+						"prod",
+						testActionAttributeValue(
+							"action-1",
+							"decrypt",
+							testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-2",
+							"encrypt",
+							testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+						),
+					),
+				),
+				Unresolved: &Unresolved{
+					Reason: UnresolvedReasonRegisteredResourceConflictingNamespaces,
+				},
+			},
+		},
+	}, []*policy.Namespace{leftNamespace, rightNamespace})
+	require.ErrorIs(t, err, ErrNilInteractiveReviewHandler)
+}
+
+type testInteractivePrompter struct {
+	confirmCalls      int
+	lastConfirmPrompt *ConfirmPrompt
+	confirmErr        error
+	selectCalls       int
+	lastSelectPrompt  *SelectPrompt
+	selectValue       string
+	selectErr         error
+}
+
+func (p *testInteractivePrompter) Confirm(_ context.Context, prompt ConfirmPrompt) error {
+	p.confirmCalls++
+	p.lastConfirmPrompt = &prompt
+	return p.confirmErr
+}
+
+func (p *testInteractivePrompter) Select(_ context.Context, prompt SelectPrompt) (string, error) {
+	p.selectCalls++
+	p.lastSelectPrompt = &prompt
+	return p.selectValue, p.selectErr
+}

--- a/otdfctl/migrations/namespacedpolicy/planner.go
+++ b/otdfctl/migrations/namespacedpolicy/planner.go
@@ -30,6 +30,7 @@ type Planner struct {
 	retriever       *Retriever
 	requestedScopes scopeSet
 	expandedScopes  scopeSet
+	reviewer        InteractiveReviewer
 }
 
 type Option func(*Planner)
@@ -92,6 +93,12 @@ func WithPageSize(pageSize int32) Option {
 	}
 }
 
+func WithInteractiveReviewer(reviewer InteractiveReviewer) Option {
+	return func(planner *Planner) {
+		planner.reviewer = reviewer
+	}
+}
+
 func (p *Planner) Plan(ctx context.Context) (*Plan, error) {
 	retrieved, err := p.retrieve(ctx)
 	if err != nil {
@@ -116,6 +123,12 @@ func (p *Planner) Plan(ctx context.Context) (*Plan, error) {
 	resolved, err := resolveExisting(derived, existingTargets)
 	if err != nil {
 		return nil, err
+	}
+
+	if p.reviewer != nil {
+		if err := p.reviewer.Review(ctx, resolved, namespaces); err != nil {
+			return nil, err
+		}
 	}
 
 	return finalizePlan(resolved, namespaces)

--- a/otdfctl/migrations/namespacedpolicy/planner_test.go
+++ b/otdfctl/migrations/namespacedpolicy/planner_test.go
@@ -2,6 +2,7 @@ package namespacedpolicy
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/opentdf/platform/protocol/go/common"
@@ -70,7 +71,7 @@ func TestPlannerPlanMarksActionAlreadyMigratedWithoutMetadata(t *testing.T) {
 	planner, err := NewPlanner(handler, "actions")
 	require.NoError(t, err)
 
-	plan, err := planner.Plan(context.Background())
+	plan, err := planner.Plan(t.Context())
 	require.NoError(t, err)
 	require.Len(t, plan.Actions, 1)
 	require.Len(t, plan.Actions[0].Targets, 1)
@@ -201,7 +202,7 @@ func TestPlannerPlanDoesNotLeakSupportSubjectMappingsIntoActionScope(t *testing.
 	planner, err := NewPlanner(handler, "subject-condition-sets,registered-resources")
 	require.NoError(t, err)
 
-	plan, err := planner.Plan(context.Background())
+	plan, err := planner.Plan(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, []Scope{ScopeActions, ScopeSubjectConditionSets, ScopeRegisteredResources}, plan.Scopes)
@@ -363,7 +364,7 @@ func TestPlannerRetrieveUsesRequestedScopeBoundaries(t *testing.T) {
 			planner, err := NewPlanner(handler, tt.scopeCSV)
 			require.NoError(t, err)
 
-			retrieved, err := planner.retrieve(context.Background())
+			retrieved, err := planner.retrieve(t.Context())
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.expectedScopes, retrieved.Scopes)
@@ -490,7 +491,7 @@ func TestPlannerPlanAllScopesBuildsAllPlanSections(t *testing.T) {
 	planner, err := NewPlanner(handler, "actions,subject-condition-sets,subject-mappings,registered-resources,obligation-triggers")
 	require.NoError(t, err)
 
-	plan, err := planner.Plan(context.Background())
+	plan, err := planner.Plan(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, []Scope{
@@ -544,6 +545,274 @@ func TestPlannerPlanAllScopesBuildsAllPlanSections(t *testing.T) {
 	assert.Equal(t, []string{"", targetNamespace.GetId()}, handler.subjectMappingCalls)
 	assert.Equal(t, []string{"", targetNamespace.GetId()}, handler.registeredResourceCalls)
 	assert.Equal(t, []string{"", targetNamespace.GetId()}, handler.obligationTriggerCalls)
+}
+
+func TestPlannerPlanInvokesInteractiveReviewerWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	targetNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	legacyAction := &policy.Action{
+		Id:   "action-legacy",
+		Name: "decrypt",
+	}
+	legacyMapping := &policy.SubjectMapping{
+		Id: "mapping-legacy",
+		Actions: []*policy.Action{
+			{
+				Id:   legacyAction.GetId(),
+				Name: legacyAction.GetName(),
+			},
+		},
+		AttributeValue: &policy.Value{
+			Fqn: "https://example.com/attr/classification/value/secret",
+		},
+	}
+	reviewer := &plannerTestReviewer{}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			"": {
+				ActionsCustom: []*policy.Action{legacyAction},
+				Pagination:    emptyPageResponse(),
+			},
+			targetNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		subjectMappingsByNamespace: map[string]*subjectmapping.ListSubjectMappingsResponse{
+			"": {
+				SubjectMappings: []*policy.SubjectMapping{legacyMapping},
+				Pagination:      emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{targetNamespace},
+			Pagination: emptyPageResponse(),
+		},
+	}
+
+	planner, err := NewPlanner(handler, "actions", WithInteractiveReviewer(reviewer))
+	require.NoError(t, err)
+
+	plan, err := planner.Plan(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, 1, reviewer.calls)
+	assert.NotNil(t, reviewer.lastResolved)
+}
+
+func TestPlannerPlanPropagatesInteractiveReviewerError(t *testing.T) {
+	t.Parallel()
+
+	targetNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	legacyAction := &policy.Action{
+		Id:   "action-legacy",
+		Name: "decrypt",
+	}
+	legacyMapping := &policy.SubjectMapping{
+		Id: "mapping-legacy",
+		Actions: []*policy.Action{
+			{
+				Id:   legacyAction.GetId(),
+				Name: legacyAction.GetName(),
+			},
+		},
+		AttributeValue: &policy.Value{
+			Fqn: "https://example.com/attr/classification/value/secret",
+		},
+	}
+	reviewerErr := errors.New("review failed")
+	reviewer := &plannerTestReviewer{err: reviewerErr}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			"": {
+				ActionsCustom: []*policy.Action{legacyAction},
+				Pagination:    emptyPageResponse(),
+			},
+			targetNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		subjectMappingsByNamespace: map[string]*subjectmapping.ListSubjectMappingsResponse{
+			"": {
+				SubjectMappings: []*policy.SubjectMapping{legacyMapping},
+				Pagination:      emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{targetNamespace},
+			Pagination: emptyPageResponse(),
+		},
+	}
+
+	planner, err := NewPlanner(handler, "actions", WithInteractiveReviewer(reviewer))
+	require.NoError(t, err)
+
+	_, err = planner.Plan(t.Context())
+	require.ErrorIs(t, err, reviewerErr)
+	assert.Equal(t, 1, reviewer.calls)
+}
+
+func TestPlannerPlanInteractiveReviewerLeavesCurrentUnresolvedPlanShapeUntouched(t *testing.T) {
+	t.Parallel()
+
+	namespaceOne := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	namespaceTwo := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+	legacyAction := &policy.Action{
+		Id:   "action-legacy",
+		Name: "decrypt",
+	}
+	legacyResource := testRegisteredResource(
+		"resource-1",
+		"documents",
+		testRegisteredResourceValue(
+			"prod",
+			testActionAttributeValue(
+				legacyAction.GetId(),
+				legacyAction.GetName(),
+				testAttributeValue("https://example.com/attr/classification/value/secret", namespaceOne),
+			),
+			testActionAttributeValue(
+				legacyAction.GetId(),
+				legacyAction.GetName(),
+				testAttributeValue("https://example.org/attr/classification/value/restricted", namespaceTwo),
+			),
+		),
+	)
+	reviewer := &plannerTestReviewer{}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			"": {
+				ActionsCustom: []*policy.Action{legacyAction},
+				Pagination:    emptyPageResponse(),
+			},
+		},
+		registeredResourcesByNamespace: map[string]*registeredresources.ListRegisteredResourcesResponse{
+			"": {
+				Resources:  []*policy.RegisteredResource{legacyResource},
+				Pagination: emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{namespaceOne, namespaceTwo},
+			Pagination: emptyPageResponse(),
+		},
+	}
+
+	planner, err := NewPlanner(handler, "registered-resources", WithInteractiveReviewer(reviewer))
+	require.NoError(t, err)
+
+	plan, err := planner.Plan(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, reviewer.calls)
+	require.Len(t, plan.RegisteredResources, 1)
+	assert.Equal(t, ErrUndeterminedTargetMapping.Error()+": registered resource spans multiple target namespaces", plan.RegisteredResources[0].Unresolved)
+	assert.Empty(t, plan.RegisteredResources[0].Targets)
+	require.NotNil(t, plan.Unresolved)
+	require.Len(t, plan.Unresolved.RegisteredResources, 1)
+	assert.Equal(t, legacyResource.GetId(), plan.Unresolved.RegisteredResources[0].Resource.GetId())
+	assert.Equal(t, plan.RegisteredResources[0].Unresolved, plan.Unresolved.RegisteredResources[0].Reason)
+}
+
+func TestPlannerPlanHuhInteractiveReviewerResolvesRegisteredResourceConflict(t *testing.T) {
+	t.Parallel()
+
+	namespaceOne := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	namespaceTwo := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+	legacyAction := &policy.Action{
+		Id:   "action-legacy",
+		Name: "decrypt",
+	}
+	legacyResource := testRegisteredResource(
+		"resource-1",
+		"documents",
+		testRegisteredResourceValue(
+			"prod",
+			testActionAttributeValue(
+				legacyAction.GetId(),
+				legacyAction.GetName(),
+				testAttributeValue("https://example.com/attr/classification/value/secret", namespaceOne),
+			),
+			testActionAttributeValue(
+				legacyAction.GetId(),
+				legacyAction.GetName(),
+				testAttributeValue("https://example.org/attr/classification/value/restricted", namespaceTwo),
+			),
+		),
+	)
+	prompter := &testInteractivePrompter{
+		selectValue: namespaceSelectionValue(namespaceOne),
+	}
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			"": {
+				ActionsCustom: []*policy.Action{legacyAction},
+				Pagination:    emptyPageResponse(),
+			},
+			namespaceOne.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		registeredResourcesByNamespace: map[string]*registeredresources.ListRegisteredResourcesResponse{
+			"": {
+				Resources:  []*policy.RegisteredResource{legacyResource},
+				Pagination: emptyPageResponse(),
+			},
+			namespaceOne.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{namespaceOne, namespaceTwo},
+			Pagination: emptyPageResponse(),
+		},
+	}
+
+	planner, err := NewPlanner(handler, "registered-resources", WithInteractiveReviewer(NewHuhInteractiveReviewer(handler, prompter)))
+	require.NoError(t, err)
+
+	plan, err := planner.Plan(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, prompter.selectCalls)
+	require.Len(t, plan.RegisteredResources, 1)
+	assert.Empty(t, plan.RegisteredResources[0].Unresolved)
+	require.Len(t, plan.RegisteredResources[0].Targets, 1)
+	assert.Equal(t, TargetStatusCreate, plan.RegisteredResources[0].Targets[0].Status)
+	assert.True(t, sameNamespace(namespaceOne, plan.RegisteredResources[0].Targets[0].Namespace))
+	require.Len(t, plan.RegisteredResources[0].Targets[0].Values, 1)
+	require.Len(t, plan.RegisteredResources[0].Targets[0].Values[0].ActionBindings, 1)
+	assert.Equal(t, "action-legacy", plan.RegisteredResources[0].Targets[0].Values[0].ActionBindings[0].SourceActionID)
+	require.NotNil(t, plan.RegisteredResources[0].Targets[0].Values[0].ActionBindings[0].ActionTargetRef)
+	assert.Equal(t, TargetStatusCreate, plan.RegisteredResources[0].Targets[0].Values[0].ActionBindings[0].ActionTargetRef.Status)
+	assert.Nil(t, plan.Unresolved)
+	require.Len(t, plan.Actions, 1)
+	require.Len(t, plan.Actions[0].Targets, 1)
+	assert.Equal(t, TargetStatusCreate, plan.Actions[0].Targets[0].Status)
+	assert.True(t, sameNamespace(namespaceOne, plan.Actions[0].Targets[0].Namespace))
 }
 
 type plannerTestHandler struct {
@@ -621,4 +890,16 @@ func actionSourceIDs(actions []*ActionPlan) []string {
 	}
 
 	return ids
+}
+
+type plannerTestReviewer struct {
+	calls        int
+	lastResolved *ResolvedTargets
+	err          error
+}
+
+func (r *plannerTestReviewer) Review(_ context.Context, resolved *ResolvedTargets, _ []*policy.Namespace) error {
+	r.calls++
+	r.lastResolved = resolved
+	return r.err
 }


### PR DESCRIPTION
 ## Summary

  This PR adds planner-time interactive review for registered resources that span multiple namespaces during namespaced policy migration.

  When --interactive is enabled, the planner now:

  - detects conflicting registered resources,
  - prompts the user to choose the target namespace,
  - filters the resource down to bindings for that namespace,
  - updates any required action resolution so the final plan can proceed cleanly.

  ## Prompt updates

  The interactive prompt was also cleaned up so that:

  - titles and descriptions render separately,
  - the registered resource identifier is shown in the title,
  - namespace options read clearly as migration choices.

  ## Scope

  This change is intentionally limited to registered resource conflict review only.

  It does not add:

  - broader planner summaries,
  - other interactive resolution flows,
  - non-RR interactive review behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive migration mode now available via `--interactive` flag. When enabled, users are prompted to manually review and resolve namespace conflicts for policy resources during migration. Users can select the appropriate destination namespace for each affected resource, with clear feedback on migration status.

* **Tests**
  * Added comprehensive test coverage for interactive migration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->