### PR TITLE
feat(cli): add more unit testing around the interactive review.

### DIFF
--- a/otdfctl/migrations/namespacedpolicy/interactive_review.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_review.go
@@ -110,14 +110,6 @@ func (r *HuhInteractiveReviewer) reviewRegisteredResource(
 		return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
 	}
 
-	for _, value := range filtered.GetValues() {
-		for _, aav := range value.GetActionAttributeValues() {
-			if err := ensureRegisteredResourceActionResolution(resolved, resource.Source.GetId(), chosen, aav.GetAction(), namespaceState.actionResolver); err != nil {
-				return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
-			}
-		}
-	}
-
 	resource.Source = filtered
 	resource.Namespace = chosen
 	// Reset planner state before re-resolving against registeredResources[chosen.GetId()] so AlreadyMigrated/NeedsCreate matches resolver.resolveRegisteredResource semantics for the chosen namespace.
@@ -129,10 +121,19 @@ func (r *HuhInteractiveReviewer) reviewRegisteredResource(
 	switch {
 	case found:
 		resource.AlreadyMigrated = existing
+		return nil
 	case err != nil:
 		return fmt.Errorf("registered resource %q in namespace %q: %w", filtered.GetId(), chosen.GetId(), err)
 	default:
 		resource.NeedsCreate = true
+	}
+
+	for _, value := range filtered.GetValues() {
+		for _, aav := range value.GetActionAttributeValues() {
+			if err := ensureRegisteredResourceActionResolution(resolved, resource.Source.GetId(), chosen, aav.GetAction(), namespaceState.actionResolver); err != nil {
+				return fmt.Errorf("registered resource %q: %w", resource.Source.GetId(), err)
+			}
+		}
 	}
 
 	return nil

--- a/otdfctl/migrations/namespacedpolicy/interactive_review_test.go
+++ b/otdfctl/migrations/namespacedpolicy/interactive_review_test.go
@@ -109,6 +109,221 @@ func TestHuhInteractiveReviewerResolvesConflictingRegisteredResource(t *testing.
 	assert.True(t, sameNamespace(leftNamespace, action.References[0].Namespace))
 }
 
+func TestHuhInteractiveReviewerSkipsActionResolutionWhenFilteredResourceAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+
+	filteredExisting := testRegisteredResource(
+		"resource-existing",
+		"documents",
+		testRegisteredResourceValue(
+			"prod",
+			testActionAttributeValue(
+				"action-existing",
+				"decrypt",
+				testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+			),
+		),
+		&policy.RegisteredResourceValue{Value: "shared"},
+	)
+
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			leftNamespace.GetId(): {
+				Pagination: emptyPageResponse(),
+			},
+		},
+		registeredResourcesByNamespace: map[string]*registeredresources.ListRegisteredResourcesResponse{
+			leftNamespace.GetId(): {
+				Resources:  []*policy.RegisteredResource{filteredExisting},
+				Pagination: emptyPageResponse(),
+			},
+		},
+		namespacesResponse: &namespaces.ListNamespacesResponse{
+			Namespaces: []*policy.Namespace{leftNamespace, rightNamespace},
+			Pagination: emptyPageResponse(),
+		},
+	}
+	reviewer := NewHuhInteractiveReviewer(handler, &testInteractivePrompter{
+		selectValue: namespaceSelectionValue(leftNamespace),
+	})
+	resolved := &ResolvedTargets{
+		Scopes: []Scope{ScopeRegisteredResources},
+		RegisteredResources: []*ResolvedRegisteredResource{
+			{
+				Source: testRegisteredResource(
+					"resource-1",
+					"documents",
+					testRegisteredResourceValue(
+						"prod",
+						testActionAttributeValue(
+							"action-1",
+							"decrypt",
+							testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+						),
+						testActionAttributeValue(
+							"action-2",
+							"encrypt",
+							testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+						),
+					),
+					&policy.RegisteredResourceValue{Value: "shared"},
+				),
+				Unresolved: &Unresolved{
+					Reason: UnresolvedReasonRegisteredResourceConflictingNamespaces,
+				},
+			},
+		},
+	}
+
+	err := reviewer.Review(t.Context(), resolved, []*policy.Namespace{leftNamespace, rightNamespace})
+	require.NoError(t, err)
+
+	resource := resolved.RegisteredResources[0]
+	require.NotNil(t, resource)
+	assert.Nil(t, resource.Unresolved)
+	assert.False(t, resource.NeedsCreate)
+	require.NotNil(t, resource.AlreadyMigrated)
+	assert.Equal(t, filteredExisting.GetId(), resource.AlreadyMigrated.GetId())
+	assert.Empty(t, resolved.Actions)
+}
+
+func TestEnsureRegisteredResourceActionResolutionReusesExistingNamespaceResult(t *testing.T) {
+	t.Parallel()
+
+	namespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	resolved := &ResolvedTargets{
+		Actions: []*ResolvedAction{
+			{
+				Source: &policy.Action{
+					Id:   "action-1",
+					Name: "decrypt",
+				},
+				Results: []*ResolvedActionResult{
+					{
+						Namespace:   namespace,
+						NeedsCreate: true,
+					},
+				},
+			},
+		},
+	}
+
+	err := ensureRegisteredResourceActionResolution(
+		resolved,
+		"resource-1",
+		namespace,
+		&policy.Action{Id: "action-1", Name: "decrypt"},
+		&resolver{
+			existing: &ExistingTargets{},
+		},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, resolved.Actions, 1)
+	require.Len(t, resolved.Actions[0].Results, 1)
+	require.Len(t, resolved.Actions[0].References, 1)
+	assert.Equal(t, ActionReferenceKindRegisteredResource, resolved.Actions[0].References[0].Kind)
+	assert.Equal(t, "resource-1", resolved.Actions[0].References[0].ID)
+	assert.True(t, sameNamespace(namespace, resolved.Actions[0].References[0].Namespace))
+}
+
+func TestFilterRegisteredResourceToNamespaceRetainsUnboundValues(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+
+	filtered, err := filterRegisteredResourceToNamespace(
+		testRegisteredResource(
+			"resource-1",
+			"documents",
+			testRegisteredResourceValue(
+				"prod",
+				testActionAttributeValue(
+					"action-1",
+					"decrypt",
+					testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+				),
+				testActionAttributeValue(
+					"action-2",
+					"encrypt",
+					testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+				),
+			),
+			&policy.RegisteredResourceValue{Value: "shared"},
+		),
+		leftNamespace,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, filtered.GetValues(), 2)
+	require.Len(t, filtered.GetValues()[0].GetActionAttributeValues(), 1)
+	assert.Equal(t, "action-1", filtered.GetValues()[0].GetActionAttributeValues()[0].GetAction().GetId())
+	assert.Empty(t, filtered.GetValues()[1].GetActionAttributeValues())
+}
+
+func TestRegisteredResourceCandidateNamespacesDeduplicatesNamespaces(t *testing.T) {
+	t.Parallel()
+
+	leftNamespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	rightNamespace := &policy.Namespace{
+		Id:  "ns-2",
+		Fqn: "https://example.org",
+	}
+
+	candidates, err := registeredResourceCandidateNamespaces(
+		testRegisteredResource(
+			"resource-1",
+			"documents",
+			testRegisteredResourceValue(
+				"prod",
+				testActionAttributeValue(
+					"action-1",
+					"decrypt",
+					testAttributeValue("https://example.com/attr/classification/value/secret", leftNamespace),
+				),
+				testActionAttributeValue(
+					"action-2",
+					"decrypt-again",
+					testAttributeValue("https://example.com/attr/classification/value/internal", leftNamespace),
+				),
+				testActionAttributeValue(
+					"action-3",
+					"encrypt",
+					testAttributeValue("https://example.org/attr/classification/value/restricted", rightNamespace),
+				),
+			),
+		),
+		[]*policy.Namespace{leftNamespace, rightNamespace},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, candidates, 2)
+	assert.True(t, sameNamespace(leftNamespace, candidates[0]))
+	assert.True(t, sameNamespace(rightNamespace, candidates[1]))
+}
+
 func TestHuhInteractiveReviewerReturnsAbortWhenPromptAborts(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Proposed Changes

1.) Reorder the interactive RR review steps. Originally we would modify the resolved actions to include ones that were needed by a RR after manual intervention. This did not account for an edge case where a RR is already created, which would then require the executor and the review code to perform more logic than necessary. Fix this by checking if RR already exists, if so do not modify resolved actions.
2.) Add better unit testing for RR interactive reviews.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

