### PR TITLE
feat(cli): Add e2e tests and fix bugs.

### DIFF
--- a/otdfctl/e2e/migrate-namespaced-policy.bats
+++ b/otdfctl/e2e/migrate-namespaced-policy.bats
@@ -55,7 +55,6 @@ sql_escape_literal() {
 
 run_policy_db_sql() {
   local sql="$1"
-  local schema="${OPENTDF_DB_SCHEMA:-opentdf_policy}"
 
   run env \
     PGPASSWORD="${OPENTDF_DB_PASSWORD:-changeme}" \
@@ -66,7 +65,7 @@ run_policy_db_sql() {
     -d "${OPENTDF_DB_DATABASE:-opentdf}" \
     -X \
     -v ON_ERROR_STOP=1 \
-    -Atqc "SET search_path TO ${schema}, public; ${sql}"
+    -Atqc "SET search_path TO \"opentdf_policy\", public; ${sql}"
 }
 
 build_metadata_json_from_labels() {

--- a/otdfctl/e2e/migrate-namespaced-policy.bats
+++ b/otdfctl/e2e/migrate-namespaced-policy.bats
@@ -29,9 +29,84 @@ run_otdfctl_scs() {
   run ./otdfctl --host http://localhost:8080 --with-client-creds-file ./creds.json policy scs "$@"
 }
 
+run_otdfctl_registered_resources() {
+  run ./otdfctl --host http://localhost:8080 --with-client-creds-file ./creds.json policy registered-resources "$@"
+}
+
+run_otdfctl_registered_resource_values() {
+  run ./otdfctl --host http://localhost:8080 --with-client-creds-file ./creds.json policy registered-resources values "$@"
+}
+
+run_otdfctl_obligations() {
+  run ./otdfctl --host http://localhost:8080 --with-client-creds-file ./creds.json policy obligations "$@"
+}
+
+run_otdfctl_obligation_values() {
+  run ./otdfctl --host http://localhost:8080 --with-client-creds-file ./creds.json policy obligations values "$@"
+}
+
+run_otdfctl_obligation_triggers() {
+  run ./otdfctl --host http://localhost:8080 --with-client-creds-file ./creds.json policy obligations triggers "$@"
+}
+
+sql_escape_literal() {
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+run_policy_db_sql() {
+  local sql="$1"
+  local schema="${OPENTDF_DB_SCHEMA:-opentdf_policy}"
+
+  run env \
+    PGPASSWORD="${OPENTDF_DB_PASSWORD:-changeme}" \
+    psql \
+    -h "${OPENTDF_DB_HOST:-localhost}" \
+    -p "${OPENTDF_DB_PORT:-5432}" \
+    -U "${OPENTDF_DB_USER:-postgres}" \
+    -d "${OPENTDF_DB_DATABASE:-opentdf}" \
+    -X \
+    -v ON_ERROR_STOP=1 \
+    -Atqc "SET search_path TO ${schema}, public; ${sql}"
+}
+
+build_metadata_json_from_labels() {
+  if [ "$#" -eq 0 ]; then
+    printf '{}'
+    return
+  fi
+
+  local metadata_json='{"labels":{}}'
+  local label
+  local key
+  local value
+
+  for label in "$@"; do
+    key="${label%%=*}"
+    if [ "$key" = "$label" ]; then
+      value=""
+    else
+      value="${label#*=}"
+    fi
+
+    metadata_json=$(jq -c --arg key "$key" --arg value "$value" '.labels[$key] = $value' <<< "$metadata_json")
+  done
+
+  printf '%s' "$metadata_json"
+}
+
 track_action_id() {
   local action_id="$1"
   TRACKED_ACTION_IDS="${TRACKED_ACTION_IDS}${action_id}"$'\n'
+}
+
+track_registered_resource_id() {
+  local resource_id="$1"
+  TRACKED_REGISTERED_RESOURCE_IDS="${TRACKED_REGISTERED_RESOURCE_IDS}${resource_id}"$'\n'
+}
+
+track_registered_resource_value_id() {
+  local resource_value_id="$1"
+  TRACKED_REGISTERED_RESOURCE_VALUE_IDS="${TRACKED_REGISTERED_RESOURCE_VALUE_IDS}${resource_value_id}"$'\n'
 }
 
 track_scs_id() {
@@ -44,6 +119,11 @@ track_subject_mapping_id() {
   TRACKED_SUBJECT_MAPPING_IDS="${TRACKED_SUBJECT_MAPPING_IDS}${subject_mapping_id}"$'\n'
 }
 
+track_obligation_trigger_id() {
+  local obligation_trigger_id="$1"
+  TRACKED_OBLIGATION_TRIGGER_IDS="${TRACKED_OBLIGATION_TRIGGER_IDS}${obligation_trigger_id}"$'\n'
+}
+
 create_global_action() {
   local result_var="$1"
   local action_name="$2"
@@ -52,12 +132,12 @@ create_global_action() {
   run ./otdfctl --host http://localhost:8080 --with-client-creds-file ./creds.json policy actions create --name "$action_name" "$@" --json
   assert_success
 
-  local action_id
-  action_id=$(echo "$output" | jq -r '.id // empty')
-  assert_not_equal "$action_id" ""
+  local created_action_id
+  created_action_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$created_action_id" ""
 
-  track_action_id "$action_id"
-  printf -v "$result_var" '%s' "$action_id"
+  track_action_id "$created_action_id"
+  printf -v "$result_var" '%s' "$created_action_id"
 }
 
 create_global_scs() {
@@ -68,12 +148,12 @@ create_global_scs() {
   run ./otdfctl --host http://localhost:8080 --with-client-creds-file ./creds.json policy scs create --subject-sets "$subject_sets_json" "$@" --json
   assert_success
 
-  local scs_id
-  scs_id=$(echo "$output" | jq -r '.id // empty')
-  assert_not_equal "$scs_id" ""
+  local created_scs_id
+  created_scs_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$created_scs_id" ""
 
-  track_scs_id "$scs_id"
-  printf -v "$result_var" '%s' "$scs_id"
+  track_scs_id "$created_scs_id"
+  printf -v "$result_var" '%s' "$created_scs_id"
 }
 
 create_namespaced_scs() {
@@ -85,12 +165,12 @@ create_namespaced_scs() {
   run ./otdfctl --host http://localhost:8080 --with-client-creds-file ./creds.json policy scs create --namespace "$namespace_id" --subject-sets "$subject_sets_json" "$@" --json
   assert_success
 
-  local scs_id
-  scs_id=$(echo "$output" | jq -r '.id // empty')
-  assert_not_equal "$scs_id" ""
+  local created_scs_id
+  created_scs_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$created_scs_id" ""
 
-  track_scs_id "$scs_id"
-  printf -v "$result_var" '%s' "$scs_id"
+  track_scs_id "$created_scs_id"
+  printf -v "$result_var" '%s' "$created_scs_id"
 }
 
 create_legacy_subject_mapping() {
@@ -103,12 +183,156 @@ create_legacy_subject_mapping() {
   run ./otdfctl --host http://localhost:8080 --with-client-creds-file ./creds.json policy subject-mappings create --attribute-value-id "$attribute_value_id" --action "$action_id" --subject-condition-set-id "$subject_condition_set_id" "$@" --json
   assert_success
 
-  local subject_mapping_id
-  subject_mapping_id=$(echo "$output" | jq -r '.id // empty')
-  assert_not_equal "$subject_mapping_id" ""
+  local created_subject_mapping_id
+  created_subject_mapping_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$created_subject_mapping_id" ""
 
-  track_subject_mapping_id "$subject_mapping_id"
-  printf -v "$result_var" '%s' "$subject_mapping_id"
+  track_subject_mapping_id "$created_subject_mapping_id"
+  printf -v "$result_var" '%s' "$created_subject_mapping_id"
+}
+
+create_global_registered_resource() {
+  local result_var="$1"
+  local resource_name="$2"
+  shift 2
+
+  run_otdfctl_registered_resources create --name "$resource_name" "$@" --json
+  assert_success
+
+  local created_resource_id
+  created_resource_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$created_resource_id" ""
+
+  track_registered_resource_id "$created_resource_id"
+  printf -v "$result_var" '%s' "$created_resource_id"
+}
+
+create_registered_resource_value() {
+  local result_var="$1"
+  local resource_id="$2"
+  local resource_value="$3"
+  shift 3
+
+  run_otdfctl_registered_resource_values create --resource "$resource_id" --value "$resource_value" "$@" --json
+  assert_success
+
+  local created_resource_value_id
+  created_resource_value_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$created_resource_value_id" ""
+
+  track_registered_resource_value_id "$created_resource_value_id"
+  printf -v "$result_var" '%s' "$created_resource_value_id"
+}
+
+create_namespaced_obligation() {
+  local result_var="$1"
+  local namespace_id="$2"
+  local obligation_name="$3"
+  shift 3
+
+  run_otdfctl_obligations create --namespace "$namespace_id" --name "$obligation_name" "$@" --json
+  assert_success
+
+  local created_obligation_id
+  created_obligation_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$created_obligation_id" ""
+
+  printf -v "$result_var" '%s' "$created_obligation_id"
+}
+
+create_obligation_value() {
+  local result_var="$1"
+  local obligation_id="$2"
+  local obligation_value="$3"
+  shift 3
+
+  run_otdfctl_obligation_values create --obligation "$obligation_id" --value "$obligation_value" "$@" --json
+  assert_success
+
+  local created_obligation_value_id
+  created_obligation_value_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$created_obligation_value_id" ""
+
+  printf -v "$result_var" '%s' "$created_obligation_value_id"
+}
+
+create_legacy_obligation_trigger() {
+  local result_var="$1"
+  local attribute_value_id="$2"
+  local action_id="$3"
+  local obligation_value_id="$4"
+  shift 4
+
+  local client_id=""
+  local labels=()
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --client-id)
+        client_id="$2"
+        shift 2
+        ;;
+      --label)
+        labels+=("$2")
+        shift 2
+        ;;
+      *)
+        echo "unsupported create_legacy_obligation_trigger arg: $1" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  local metadata_json
+  metadata_json=$(build_metadata_json_from_labels "${labels[@]}")
+
+  local client_id_sql="NULL"
+  if [ -n "$client_id" ]; then
+    client_id_sql="'$(sql_escape_literal "$client_id")'"
+  fi
+
+  # The API now rejects action/obligation namespace mismatches, but this test
+  # needs a legacy/global action bound to a namespaced obligation. Seed the row
+  # directly to exercise the migration flow against persisted legacy data.
+  run_policy_db_sql "
+    INSERT INTO obligation_triggers (
+      obligation_value_id,
+      action_id,
+      attribute_value_id,
+      metadata,
+      client_id
+    )
+    VALUES (
+      '$(sql_escape_literal "$obligation_value_id")'::uuid,
+      '$(sql_escape_literal "$action_id")'::uuid,
+      '$(sql_escape_literal "$attribute_value_id")'::uuid,
+      '$(sql_escape_literal "$metadata_json")'::jsonb,
+      ${client_id_sql}
+    )
+    RETURNING id;
+  "
+  assert_success
+
+  local created_obligation_trigger_id
+  created_obligation_trigger_id=$(echo "$output" | tail -n 1)
+  assert_not_equal "$created_obligation_trigger_id" ""
+
+  track_obligation_trigger_id "$created_obligation_trigger_id"
+  printf -v "$result_var" '%s' "$created_obligation_trigger_id"
+}
+
+lookup_namespaced_action_id() {
+  local result_var="$1"
+  local action_name="$2"
+  local namespace_id="$3"
+
+  run sh -c "./otdfctl $HOST $WITH_CREDS policy actions get --name \"$action_name\" --namespace \"$namespace_id\" --json"
+  assert_success
+
+  local looked_up_action_id
+  looked_up_action_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$looked_up_action_id" ""
+
+  printf -v "$result_var" '%s' "$looked_up_action_id"
 }
 
 subject_mapping_plan_target_count() {
@@ -304,6 +528,137 @@ assert_no_subject_mappings_in_namespace() {
   run sh -c "./otdfctl $HOST $WITH_CREDS policy subject-mappings list --namespace \"$namespace_id\" --json"
   assert_success
   assert_equal "$(echo "$output" | jq -r '.subject_mappings | length')" "0"
+}
+
+registered_resource_plan_target_count() {
+  local output_file="$1"
+  local source_resource_id="$2"
+  jq -er --arg source_resource_id "$source_resource_id" '
+    [
+      .registered_resources[]
+      | select(.source.id == $source_resource_id)
+      | .targets[]
+    ] | length
+  ' "$output_file"
+}
+
+registered_resource_plan_target_status() {
+  local output_file="$1"
+  local source_resource_id="$2"
+  local namespace_fqn="$3"
+  jq -er --arg source_resource_id "$source_resource_id" --arg namespace_fqn "$namespace_fqn" '
+    .registered_resources[]
+    | select(.source.id == $source_resource_id)
+    | .targets[]
+    | select(.namespace.fqn == $namespace_fqn)
+    | .status
+  ' "$output_file"
+}
+
+registered_resource_plan_target_effective_id() {
+  local output_file="$1"
+  local source_resource_id="$2"
+  local namespace_fqn="$3"
+  jq -er --arg source_resource_id "$source_resource_id" --arg namespace_fqn "$namespace_fqn" '
+    .registered_resources[]
+    | select(.source.id == $source_resource_id)
+    | .targets[]
+    | select(.namespace.fqn == $namespace_fqn)
+    | (.execution.created_target_id // .existing.id // empty)
+  ' "$output_file"
+}
+
+registered_resource_value_plan_effective_id() {
+  local output_file="$1"
+  local source_resource_id="$2"
+  local namespace_fqn="$3"
+  local source_value_id="$4"
+  jq -er --arg source_resource_id "$source_resource_id" --arg namespace_fqn "$namespace_fqn" --arg source_value_id "$source_value_id" '
+    .registered_resources[]
+    | select(.source.id == $source_resource_id)
+    | .targets[]
+    | select(.namespace.fqn == $namespace_fqn)
+    | .values[]
+    | select(.source.id == $source_value_id)
+    | (.execution.created_target_id // empty)
+  ' "$output_file"
+}
+
+registered_resource_plan_action_status() {
+  local output_file="$1"
+  local source_resource_id="$2"
+  local namespace_fqn="$3"
+  local source_value_id="$4"
+  local source_action_id="$5"
+  jq -er --arg source_resource_id "$source_resource_id" --arg namespace_fqn "$namespace_fqn" --arg source_value_id "$source_value_id" --arg source_action_id "$source_action_id" '
+    .registered_resources[]
+    | select(.source.id == $source_resource_id)
+    | .targets[]
+    | select(.namespace.fqn == $namespace_fqn)
+    | .values[]
+    | select(.source.id == $source_value_id)
+    | .action_bindings[]
+    | select(.source_action_id == $source_action_id)
+    | .action_target.status
+  ' "$output_file"
+}
+
+obligation_trigger_plan_target_count() {
+  local output_file="$1"
+  local source_trigger_id="$2"
+  jq -er --arg source_trigger_id "$source_trigger_id" '
+    [
+      .obligation_triggers[]
+      | select(.source.id == $source_trigger_id)
+      | .targets[]
+    ] | length
+  ' "$output_file"
+}
+
+obligation_trigger_plan_target_status() {
+  local output_file="$1"
+  local source_trigger_id="$2"
+  local namespace_fqn="$3"
+  jq -er --arg source_trigger_id "$source_trigger_id" --arg namespace_fqn "$namespace_fqn" '
+    .obligation_triggers[]
+    | select(.source.id == $source_trigger_id)
+    | .targets[]
+    | select(.namespace.fqn == $namespace_fqn)
+    | .status
+  ' "$output_file"
+}
+
+obligation_trigger_plan_target_effective_id() {
+  local output_file="$1"
+  local source_trigger_id="$2"
+  local namespace_fqn="$3"
+  jq -er --arg source_trigger_id "$source_trigger_id" --arg namespace_fqn "$namespace_fqn" '
+    .obligation_triggers[]
+    | select(.source.id == $source_trigger_id)
+    | .targets[]
+    | select(.namespace.fqn == $namespace_fqn)
+    | (.execution.created_target_id // .existing.id // empty)
+  ' "$output_file"
+}
+
+obligation_trigger_plan_action_status() {
+  local output_file="$1"
+  local source_trigger_id="$2"
+  local namespace_fqn="$3"
+  jq -er --arg source_trigger_id "$source_trigger_id" --arg namespace_fqn "$namespace_fqn" '
+    .obligation_triggers[]
+    | select(.source.id == $source_trigger_id)
+    | .targets[]
+    | select(.namespace.fqn == $namespace_fqn)
+    | .action.status
+  ' "$output_file"
+}
+
+obligation_trigger_json_by_id() {
+  local trigger_id="$1"
+  local namespace_filter="$2"
+
+  ./otdfctl $HOST $WITH_CREDS policy obligations triggers list --namespace "$namespace_filter" --limit 100 --offset 0 --json | jq -cer --arg trigger_id "$trigger_id" '.triggers[] | select(.id == $trigger_id)'
 }
 
 assert_metadata_labels_preserved() {
@@ -574,6 +929,266 @@ assert_scs_created_in_namespace() {
   assert_not_equal "$(echo "$created_scs_json" | jq -r '.metadata.labels.migration_run // empty')" ""
 }
 
+assert_registered_resource_target_count() {
+  local output_file="$1"
+  local source_resource_id="$2"
+  local expected_count="$3"
+
+  run registered_resource_plan_target_count "$output_file" "$source_resource_id"
+  assert_success
+  assert_equal "$output" "$expected_count"
+}
+
+assert_registered_resource_created_in_namespace() {
+  local output_file="$1"
+  local source_resource_id="$2"
+  local source_value_id="$3"
+  local namespace_id="$4"
+  local namespace_fqn="$5"
+  local resource_name="$6"
+  local resource_value="$7"
+  local action_name="$8"
+  local source_action_id="$9"
+  local expected_action_status="${10}"
+  local expected_action_count="${11}"
+  local attribute_value_id="${12}"
+
+  run registered_resource_plan_target_status "$output_file" "$source_resource_id" "$namespace_fqn"
+  assert_success
+  assert_equal "$output" "create"
+
+  assert_action_target_count "$output_file" "$action_name" "$expected_action_count"
+  case "$expected_action_status" in
+    create)
+      assert_custom_action_created_in_namespace "$output_file" "$action_name" "$source_action_id" "$namespace_id" "$namespace_fqn"
+      ;;
+    existing_standard)
+      assert_standard_action_resolved_in_namespace "$output_file" "$action_name" "$namespace_id" "$namespace_fqn"
+      ;;
+    *)
+      false
+      ;;
+  esac
+
+  run registered_resource_plan_action_status "$output_file" "$source_resource_id" "$namespace_fqn" "$source_value_id" "$source_action_id"
+  assert_success
+  assert_equal "$output" "$expected_action_status"
+
+  local expected_action_target_id
+  expected_action_target_id=$(action_plan_target_effective_id "$output_file" "$action_name" "$namespace_fqn")
+  assert_not_equal "$expected_action_target_id" ""
+
+  local created_resource_id
+  created_resource_id=$(registered_resource_plan_target_effective_id "$output_file" "$source_resource_id" "$namespace_fqn")
+  assert_not_equal "$created_resource_id" ""
+  assert_not_equal "$created_resource_id" "$source_resource_id"
+
+  local source_resource_json
+  source_resource_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources get --id "$source_resource_id" --json)
+
+  local created_resource_json
+  created_resource_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources get --id "$created_resource_id" --json)
+
+  assert_equal "$(echo "$created_resource_json" | jq -r '.id')" "$created_resource_id"
+  assert_equal "$(echo "$created_resource_json" | jq -r '.name')" "$resource_name"
+  assert_equal "$(echo "$created_resource_json" | jq -r '.namespace.id')" "$namespace_id"
+  assert_metadata_labels_preserved "$source_resource_json" "$created_resource_json"
+  assert_equal "$(echo "$created_resource_json" | jq -r '.metadata.labels.migrated_from')" "$source_resource_id"
+  assert_not_equal "$(echo "$created_resource_json" | jq -r '.metadata.labels.migration_run // empty')" ""
+
+  local created_resource_value_id
+  created_resource_value_id=$(registered_resource_value_plan_effective_id "$output_file" "$source_resource_id" "$namespace_fqn" "$source_value_id")
+  assert_not_equal "$created_resource_value_id" ""
+  assert_not_equal "$created_resource_value_id" "$source_value_id"
+
+  local source_resource_value_json
+  source_resource_value_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources values get --id "$source_value_id" --json)
+
+  local created_resource_value_json
+  created_resource_value_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources values get --id "$created_resource_value_id" --json)
+
+  assert_equal "$(echo "$created_resource_value_json" | jq -r '.id')" "$created_resource_value_id"
+  assert_equal "$(echo "$created_resource_value_json" | jq -r '.value')" "$resource_value"
+  assert_equal "$(echo "$created_resource_value_json" | jq -r '.action_attribute_values | length')" "1"
+  assert_equal "$(echo "$created_resource_value_json" | jq -r '.action_attribute_values[0].action.id')" "$expected_action_target_id"
+  assert_equal "$(echo "$created_resource_value_json" | jq -r '.action_attribute_values[0].attribute_value.id')" "$attribute_value_id"
+  assert_metadata_labels_preserved "$source_resource_value_json" "$created_resource_value_json"
+  assert_equal "$(echo "$created_resource_value_json" | jq -r '.metadata.labels.migrated_from')" "$source_value_id"
+  assert_not_equal "$(echo "$created_resource_value_json" | jq -r '.metadata.labels.migration_run // empty')" ""
+}
+
+assert_registered_resource_already_migrated_in_namespace() {
+  local output_file="$1"
+  local source_resource_id="$2"
+  local namespace_id="$3"
+  local namespace_fqn="$4"
+  local existing_resource_id="$5"
+
+  assert_not_equal "$existing_resource_id" ""
+
+  run registered_resource_plan_target_status "$output_file" "$source_resource_id" "$namespace_fqn"
+  assert_success
+  assert_equal "$output" "already_migrated"
+
+  local effective_target_id
+  effective_target_id=$(registered_resource_plan_target_effective_id "$output_file" "$source_resource_id" "$namespace_fqn")
+  assert_not_equal "$effective_target_id" ""
+  assert_equal "$effective_target_id" "$existing_resource_id"
+
+  local existing_resource_json
+  existing_resource_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources get --id "$existing_resource_id" --json)
+
+  assert_equal "$(echo "$existing_resource_json" | jq -r '.id // empty')" "$existing_resource_id"
+  assert_equal "$(echo "$existing_resource_json" | jq -r '.namespace.id')" "$namespace_id"
+}
+
+assert_legacy_registered_resource_still_exists() {
+  local source_resource_id="$1"
+  local source_value_id="$2"
+  local resource_name="$3"
+  local resource_value="$4"
+
+  assert_not_equal "$source_resource_id" ""
+  assert_not_equal "$source_value_id" ""
+
+  local legacy_resource_json
+  legacy_resource_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources get --id "$source_resource_id" --json)
+
+  assert_equal "$(echo "$legacy_resource_json" | jq -r '.id // empty')" "$source_resource_id"
+  assert_equal "$(echo "$legacy_resource_json" | jq -r '.name')" "$resource_name"
+  assert_equal "$(echo "$legacy_resource_json" | jq -r '.namespace.id // empty')" ""
+
+  local legacy_resource_value_json
+  legacy_resource_value_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources values get --id "$source_value_id" --json)
+
+  assert_equal "$(echo "$legacy_resource_value_json" | jq -r '.id // empty')" "$source_value_id"
+  assert_equal "$(echo "$legacy_resource_value_json" | jq -r '.value')" "$resource_value"
+}
+
+assert_obligation_trigger_target_count() {
+  local output_file="$1"
+  local source_trigger_id="$2"
+  local expected_count="$3"
+
+  run obligation_trigger_plan_target_count "$output_file" "$source_trigger_id"
+  assert_success
+  assert_equal "$output" "$expected_count"
+}
+
+assert_obligation_trigger_created_in_namespace() {
+  local output_file="$1"
+  local source_trigger_id="$2"
+  local namespace_id="$3"
+  local namespace_fqn="$4"
+  local attribute_value_id="$5"
+  local obligation_value_id="$6"
+  local action_name="$7"
+  local source_action_id="$8"
+  local expected_action_status="$9"
+  local expected_action_count="${10}"
+  local client_id="${11}"
+
+  run obligation_trigger_plan_target_status "$output_file" "$source_trigger_id" "$namespace_fqn"
+  assert_success
+  assert_equal "$output" "create"
+
+  assert_action_target_count "$output_file" "$action_name" "$expected_action_count"
+  case "$expected_action_status" in
+    create)
+      assert_custom_action_created_in_namespace "$output_file" "$action_name" "$source_action_id" "$namespace_id" "$namespace_fqn"
+      ;;
+    existing_standard)
+      assert_standard_action_resolved_in_namespace "$output_file" "$action_name" "$namespace_id" "$namespace_fqn"
+      ;;
+    *)
+      false
+      ;;
+  esac
+
+  run obligation_trigger_plan_action_status "$output_file" "$source_trigger_id" "$namespace_fqn"
+  assert_success
+  assert_equal "$output" "$expected_action_status"
+
+  local expected_action_target_id
+  expected_action_target_id=$(action_plan_target_effective_id "$output_file" "$action_name" "$namespace_fqn")
+  assert_not_equal "$expected_action_target_id" ""
+
+  local created_trigger_id
+  created_trigger_id=$(obligation_trigger_plan_target_effective_id "$output_file" "$source_trigger_id" "$namespace_fqn")
+  assert_not_equal "$created_trigger_id" ""
+  assert_not_equal "$created_trigger_id" "$source_trigger_id"
+
+  local source_trigger_json
+  source_trigger_json=$(obligation_trigger_json_by_id "$source_trigger_id" "$namespace_id")
+
+  local created_trigger_json
+  created_trigger_json=$(obligation_trigger_json_by_id "$created_trigger_id" "$namespace_id")
+
+  assert_equal "$(echo "$created_trigger_json" | jq -r '.id')" "$created_trigger_id"
+  assert_equal "$(echo "$created_trigger_json" | jq -r '.attribute_value.id')" "$attribute_value_id"
+  assert_equal "$(echo "$created_trigger_json" | jq -r '.action.id')" "$expected_action_target_id"
+  assert_equal "$(echo "$created_trigger_json" | jq -r '.obligation_value.id')" "$obligation_value_id"
+  assert_equal "$(echo "$created_trigger_json" | jq -r '.context | length')" "1"
+  assert_equal "$(echo "$created_trigger_json" | jq -r '.context[0].pep.client_id')" "$client_id"
+  assert_metadata_labels_preserved "$source_trigger_json" "$created_trigger_json"
+  assert_equal "$(echo "$created_trigger_json" | jq -r '.metadata.labels.migrated_from')" "$source_trigger_id"
+  assert_not_equal "$(echo "$created_trigger_json" | jq -r '.metadata.labels.migration_run // empty')" ""
+}
+
+assert_obligation_trigger_already_migrated_in_namespace() {
+  local output_file="$1"
+  local source_trigger_id="$2"
+  local namespace_id="$3"
+  local namespace_fqn="$4"
+  local existing_trigger_id="$5"
+
+  assert_not_equal "$existing_trigger_id" ""
+
+  run obligation_trigger_plan_target_status "$output_file" "$source_trigger_id" "$namespace_fqn"
+  assert_success
+  assert_equal "$output" "already_migrated"
+
+  local effective_target_id
+  effective_target_id=$(obligation_trigger_plan_target_effective_id "$output_file" "$source_trigger_id" "$namespace_fqn")
+  assert_not_equal "$effective_target_id" ""
+  assert_equal "$effective_target_id" "$existing_trigger_id"
+
+  local existing_trigger_json
+  existing_trigger_json=$(obligation_trigger_json_by_id "$existing_trigger_id" "$namespace_id")
+
+  assert_equal "$(echo "$existing_trigger_json" | jq -r '.id // empty')" "$existing_trigger_id"
+  local existing_action_id
+  existing_action_id=$(echo "$existing_trigger_json" | jq -r '.action.id // empty')
+  assert_not_equal "$existing_action_id" ""
+
+  local existing_action_json
+  existing_action_json=$(./otdfctl $HOST $WITH_CREDS policy actions get --id "$existing_action_id" --json)
+
+  assert_equal "$(echo "$existing_action_json" | jq -r '.id // empty')" "$existing_action_id"
+  assert_equal "$(echo "$existing_action_json" | jq -r '.namespace.id')" "$namespace_id"
+}
+
+assert_legacy_obligation_trigger_still_exists() {
+  local source_trigger_id="$1"
+  local namespace_id="$2"
+  local attribute_value_id="$3"
+  local action_id="$4"
+  local obligation_value_id="$5"
+  local client_id="$6"
+
+  assert_not_equal "$source_trigger_id" ""
+
+  local legacy_trigger_json
+  legacy_trigger_json=$(obligation_trigger_json_by_id "$source_trigger_id" "$namespace_id")
+
+  assert_equal "$(echo "$legacy_trigger_json" | jq -r '.id // empty')" "$source_trigger_id"
+  assert_equal "$(echo "$legacy_trigger_json" | jq -r '.attribute_value.id')" "$attribute_value_id"
+  assert_equal "$(echo "$legacy_trigger_json" | jq -r '.action.id')" "$action_id"
+  assert_equal "$(echo "$legacy_trigger_json" | jq -r '.action.namespace.id // empty')" ""
+  assert_equal "$(echo "$legacy_trigger_json" | jq -r '.obligation_value.id')" "$obligation_value_id"
+  assert_equal "$(echo "$legacy_trigger_json" | jq -r '.context[0].pep.client_id')" "$client_id"
+}
+
 assert_scs_already_migrated_in_namespace() {
   local output_file="$1"
   local source_scs_id="$2"
@@ -625,8 +1240,11 @@ run_namespaced_policy_commit() {
 setup() {
   export TEST_PREFIX="${MIGRATION_TEST_PREFIX}-t${BATS_TEST_NUMBER}"
   export TRACKED_ACTION_IDS=""
+  export TRACKED_REGISTERED_RESOURCE_IDS=""
+  export TRACKED_REGISTERED_RESOURCE_VALUE_IDS=""
   export TRACKED_SCS_IDS=""
   export TRACKED_SUBJECT_MAPPING_IDS=""
+  export TRACKED_OBLIGATION_TRIGGER_IDS=""
 }
 
 setup_file() {
@@ -691,9 +1309,42 @@ setup_file() {
 }
 
 teardown() {
-  local subject_mapping_id
+  local obligation_trigger_id
   local delete_output
   local delete_status
+  while IFS= read -r obligation_trigger_id; do
+    [ -n "$obligation_trigger_id" ] || continue
+    if delete_output=$(./otdfctl $HOST $WITH_CREDS policy obligations triggers delete --id "$obligation_trigger_id" --force 2>&1); then
+      :
+    else
+      delete_status=$?
+      echo "warning: failed to delete obligation trigger fixture $obligation_trigger_id during teardown (exit $delete_status): $delete_output" >&2
+    fi
+  done <<< "$TRACKED_OBLIGATION_TRIGGER_IDS"
+
+  local resource_value_id
+  while IFS= read -r resource_value_id; do
+    [ -n "$resource_value_id" ] || continue
+    if delete_output=$(./otdfctl $HOST $WITH_CREDS policy registered-resources values delete --id "$resource_value_id" --force 2>&1); then
+      :
+    else
+      delete_status=$?
+      echo "warning: failed to delete registered resource value fixture $resource_value_id during teardown (exit $delete_status): $delete_output" >&2
+    fi
+  done <<< "$TRACKED_REGISTERED_RESOURCE_VALUE_IDS"
+
+  local resource_id
+  while IFS= read -r resource_id; do
+    [ -n "$resource_id" ] || continue
+    if delete_output=$(./otdfctl $HOST $WITH_CREDS policy registered-resources delete --id "$resource_id" --force 2>&1); then
+      :
+    else
+      delete_status=$?
+      echo "warning: failed to delete registered resource fixture $resource_id during teardown (exit $delete_status): $delete_output" >&2
+    fi
+  done <<< "$TRACKED_REGISTERED_RESOURCE_IDS"
+
+  local subject_mapping_id
   while IFS= read -r subject_mapping_id; do
     [ -n "$subject_mapping_id" ] || continue
     if delete_output=$(./otdfctl $HOST $WITH_CREDS policy subject-mappings delete --id "$subject_mapping_id" --force 2>&1); then
@@ -737,7 +1388,8 @@ teardown_file() {
   unset NS_A_NAME NS_B_NAME NS_A_FQN NS_B_FQN NS_A_ID NS_B_ID
   unset ATTR_A_ID ATTR_A_VAL_1_ID ATTR_A_VAL_2_ID ATTR_B_ID ATTR_B_VAL_1_ID
   unset GLOBAL_READ_ID
-  unset TRACKED_ACTION_IDS TRACKED_SCS_IDS TRACKED_SUBJECT_MAPPING_IDS
+  unset TRACKED_ACTION_IDS TRACKED_REGISTERED_RESOURCE_IDS TRACKED_REGISTERED_RESOURCE_VALUE_IDS
+  unset TRACKED_SCS_IDS TRACKED_SUBJECT_MAPPING_IDS TRACKED_OBLIGATION_TRIGGER_IDS
 }
 
 # Asserts action-scope migration resolves shared standard actions in-place,
@@ -758,9 +1410,10 @@ teardown_file() {
   # should be derived from the referenced attribute value during migration.
   local ignored_mapping_id
   create_legacy_subject_mapping ignored_mapping_id "$ATTR_A_VAL_1_ID" "$GLOBAL_READ_ID" "$shared_scs_id"
-  # TODO(DSPX-2717): Replace the custom-action namespace anchor with a
-  # registered-resource or obligation-trigger fixture once those scope tests
-  # land, so action-scope coverage is not driven entirely by subject mappings.
+  # Subject mappings remain the most direct action-scope anchor here even with
+  # dedicated registered-resource and obligation-trigger migration coverage
+  # below, because this test is focused on action placement rather than
+  # downstream object rewriting.
   create_legacy_subject_mapping ignored_mapping_id "$ATTR_A_VAL_2_ID" "$custom_action_id" "$shared_scs_id"
   create_legacy_subject_mapping ignored_mapping_id "$ATTR_B_VAL_1_ID" "$GLOBAL_READ_ID" "$shared_scs_id"
 
@@ -937,4 +1590,223 @@ teardown_file() {
   assert_subject_mapping_already_migrated_in_namespace "$rerun_output_file" "$mapping_a_id" "$NS_A_ID" "$NS_A_FQN" "$mapping_a_target_id"
   assert_subject_mapping_target_count "$rerun_output_file" "$mapping_b_id" 1
   assert_subject_mapping_already_migrated_in_namespace "$rerun_output_file" "$mapping_b_id" "$NS_B_ID" "$NS_B_FQN" "$mapping_b_target_id"
+}
+
+# Asserts registered-resource migration creates missing namespaced targets,
+# rewrites action-attribute-value bindings to migrated action IDs, reuses an
+# already-migrated canonical RR target when present, preserves metadata on both
+# the parent RR and value, and is idempotent on rerun.
+@test "migrate namespaced-policy registered-resources rewrites action bindings and reuses canonical targets" {
+  local custom_action_name="${TEST_PREFIX}-download"
+  local rr_a_name="${TEST_PREFIX}-repo-a"
+  local rr_b_name="${TEST_PREFIX}-repo-b"
+  local rr_a_value="${TEST_PREFIX}-repo-a-main"
+  local rr_b_value="${TEST_PREFIX}-repo-b-main"
+  local custom_action_labels=(--label "test_case=registered-resources" --label "fixture=${TEST_PREFIX}-custom-action")
+  local rr_a_labels=(--label "test_case=registered-resources" --label "fixture=${TEST_PREFIX}-rr-a")
+  local rr_b_labels=(--label "test_case=registered-resources" --label "fixture=${TEST_PREFIX}-rr-b")
+  local rr_a_value_labels=(--label "test_case=registered-resources" --label "fixture=${TEST_PREFIX}-rr-a-value")
+  local rr_b_value_labels=(--label "test_case=registered-resources" --label "fixture=${TEST_PREFIX}-rr-b-value")
+  local custom_action_id
+  local rr_a_id
+  local rr_b_id
+  local rr_a_value_id
+  local rr_b_value_id
+  local ns_b_read_action_id
+  local existing_rr_b_id
+  local existing_rr_b_value_id
+
+  create_global_action custom_action_id "$custom_action_name" "${custom_action_labels[@]}"
+  create_global_registered_resource rr_a_id "$rr_a_name" "${rr_a_labels[@]}"
+  create_global_registered_resource rr_b_id "$rr_b_name" "${rr_b_labels[@]}"
+  create_registered_resource_value rr_a_value_id "$rr_a_id" "$rr_a_value" --action-attribute-value "$custom_action_id;$ATTR_A_VAL_1_ID" "${rr_a_value_labels[@]}"
+  create_registered_resource_value rr_b_value_id "$rr_b_id" "$rr_b_value" --action-attribute-value "$GLOBAL_READ_ID;$ATTR_B_VAL_1_ID" "${rr_b_value_labels[@]}"
+
+  lookup_namespaced_action_id ns_b_read_action_id "read" "$NS_B_ID"
+
+  run_otdfctl_registered_resources create --name "$rr_b_name" --namespace "$NS_B_ID" --label "test_case=registered-resources" --label "fixture=${TEST_PREFIX}-existing-rr-b" --json
+  assert_success
+  existing_rr_b_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$existing_rr_b_id" ""
+
+  run_otdfctl_registered_resource_values create --resource "$existing_rr_b_id" --value "$rr_b_value" --action-attribute-value "$ns_b_read_action_id;$ATTR_B_VAL_1_ID" --label "test_case=registered-resources" --label "fixture=${TEST_PREFIX}-existing-rr-b-value" --json
+  assert_success
+  existing_rr_b_value_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$existing_rr_b_value_id" ""
+
+  local output_file="${MIGRATION_OUTPUT_DIR}/registered-resources-plan.json"
+
+  run_namespaced_policy_commit "registered-resources" "$output_file"
+  assert_success
+
+  assert_registered_resource_target_count "$output_file" "$rr_a_id" 1
+  assert_registered_resource_created_in_namespace "$output_file" "$rr_a_id" "$rr_a_value_id" "$NS_A_ID" "$NS_A_FQN" "$rr_a_name" "$rr_a_value" "$custom_action_name" "$custom_action_id" "create" 1 "$ATTR_A_VAL_1_ID"
+
+  assert_registered_resource_target_count "$output_file" "$rr_b_id" 1
+  assert_registered_resource_already_migrated_in_namespace "$output_file" "$rr_b_id" "$NS_B_ID" "$NS_B_FQN" "$existing_rr_b_id"
+  assert_action_target_count "$output_file" "read" 1
+  assert_standard_action_resolved_in_namespace "$output_file" "read" "$NS_B_ID" "$NS_B_FQN"
+  run registered_resource_plan_action_status "$output_file" "$rr_b_id" "$NS_B_FQN" "$rr_b_value_id" "$GLOBAL_READ_ID"
+  assert_success
+  assert_equal "$output" "existing_standard"
+
+  assert_legacy_registered_resource_still_exists "$rr_a_id" "$rr_a_value_id" "$rr_a_name" "$rr_a_value"
+  assert_legacy_registered_resource_still_exists "$rr_b_id" "$rr_b_value_id" "$rr_b_name" "$rr_b_value"
+
+  # Re-running the same migration should be idempotent. The previously created
+  # RR target should now resolve as already_migrated, while the existing
+  # canonical RR target continues to resolve as already_migrated.
+  local rerun_output_file="${MIGRATION_OUTPUT_DIR}/registered-resources-rerun-plan.json"
+  local custom_action_target_id
+  local rr_a_target_id
+  custom_action_target_id=$(action_plan_target_effective_id "$output_file" "$custom_action_name" "$NS_A_FQN")
+  rr_a_target_id=$(registered_resource_plan_target_effective_id "$output_file" "$rr_a_id" "$NS_A_FQN")
+
+  run_namespaced_policy_commit "registered-resources" "$rerun_output_file"
+  assert_success
+
+  assert_action_target_count "$rerun_output_file" "$custom_action_name" 1
+  assert_action_already_migrated_in_namespace "$rerun_output_file" "$custom_action_name" "$NS_A_ID" "$NS_A_FQN" "$custom_action_target_id"
+  assert_action_target_count "$rerun_output_file" "read" 1
+  assert_standard_action_resolved_in_namespace "$rerun_output_file" "read" "$NS_B_ID" "$NS_B_FQN"
+  assert_registered_resource_target_count "$rerun_output_file" "$rr_a_id" 1
+  assert_registered_resource_already_migrated_in_namespace "$rerun_output_file" "$rr_a_id" "$NS_A_ID" "$NS_A_FQN" "$rr_a_target_id"
+  assert_registered_resource_target_count "$rerun_output_file" "$rr_b_id" 1
+  assert_registered_resource_already_migrated_in_namespace "$rerun_output_file" "$rr_b_id" "$NS_B_ID" "$NS_B_FQN" "$existing_rr_b_id"
+}
+
+# Asserts obligation-trigger migration creates missing namespaced trigger
+# targets, rewrites the referenced action to the migrated action target,
+# reuses an already-migrated canonical trigger when present, preserves source
+# metadata, and is idempotent on rerun.
+@test "migrate namespaced-policy obligation-triggers rewrites action dependencies and reuses canonical targets" {
+  local custom_action_name="${TEST_PREFIX}-download"
+  local obligation_a_name="${TEST_PREFIX}-notify-a"
+  local obligation_b_name="${TEST_PREFIX}-notify-b"
+  local obligation_a_value="${TEST_PREFIX}-notify-a-default"
+  local obligation_b_value="${TEST_PREFIX}-notify-b-default"
+  local trigger_a_client_id="${TEST_PREFIX}-client-a"
+  local trigger_b_client_id="${TEST_PREFIX}-client-b"
+  local custom_action_labels=(--label "test_case=obligation-triggers" --label "fixture=${TEST_PREFIX}-custom-action")
+  local trigger_a_labels=(--label "test_case=obligation-triggers" --label "fixture=${TEST_PREFIX}-trigger-a")
+  local custom_action_id
+  local obligation_a_id
+  local obligation_b_id
+  local obligation_a_value_id
+  local obligation_b_value_id
+  local trigger_a_id
+  local trigger_b_id
+  local ns_b_read_action_id
+  local existing_trigger_b_id
+
+  create_global_action custom_action_id "$custom_action_name" "${custom_action_labels[@]}"
+  create_namespaced_obligation obligation_a_id "$NS_A_ID" "$obligation_a_name" --label "test_case=obligation-triggers" --label "fixture=${TEST_PREFIX}-obligation-a"
+  create_namespaced_obligation obligation_b_id "$NS_B_ID" "$obligation_b_name" --label "test_case=obligation-triggers" --label "fixture=${TEST_PREFIX}-obligation-b"
+  create_obligation_value obligation_a_value_id "$obligation_a_id" "$obligation_a_value" --label "test_case=obligation-triggers" --label "fixture=${TEST_PREFIX}-obligation-a-value"
+  create_obligation_value obligation_b_value_id "$obligation_b_id" "$obligation_b_value" --label "test_case=obligation-triggers" --label "fixture=${TEST_PREFIX}-obligation-b-value"
+
+  create_legacy_obligation_trigger trigger_a_id "$ATTR_A_VAL_1_ID" "$custom_action_id" "$obligation_a_value_id" --client-id "$trigger_a_client_id" "${trigger_a_labels[@]}"
+  create_legacy_obligation_trigger trigger_b_id "$ATTR_B_VAL_1_ID" "$GLOBAL_READ_ID" "$obligation_b_value_id" --client-id "$trigger_b_client_id" --label "test_case=obligation-triggers" --label "fixture=${TEST_PREFIX}-trigger-b"
+
+  lookup_namespaced_action_id ns_b_read_action_id "read" "$NS_B_ID"
+
+  run_otdfctl_obligation_triggers create --attribute-value "$ATTR_B_VAL_1_ID" --action "$ns_b_read_action_id" --obligation-value "$obligation_b_value_id" --client-id "$trigger_b_client_id" --label "test_case=obligation-triggers" --label "fixture=${TEST_PREFIX}-existing-trigger-b" --json
+  assert_success
+  existing_trigger_b_id=$(echo "$output" | jq -r '.id // empty')
+  assert_not_equal "$existing_trigger_b_id" ""
+
+  local output_file="${MIGRATION_OUTPUT_DIR}/obligation-triggers-plan.json"
+
+  run_namespaced_policy_commit "obligation-triggers" "$output_file"
+  assert_success
+
+  assert_obligation_trigger_target_count "$output_file" "$trigger_a_id" 1
+  assert_obligation_trigger_created_in_namespace "$output_file" "$trigger_a_id" "$NS_A_ID" "$NS_A_FQN" "$ATTR_A_VAL_1_ID" "$obligation_a_value_id" "$custom_action_name" "$custom_action_id" "create" 1 "$trigger_a_client_id"
+
+  assert_obligation_trigger_target_count "$output_file" "$trigger_b_id" 1
+  assert_obligation_trigger_already_migrated_in_namespace "$output_file" "$trigger_b_id" "$NS_B_ID" "$NS_B_FQN" "$existing_trigger_b_id"
+  assert_action_target_count "$output_file" "read" 1
+  assert_standard_action_resolved_in_namespace "$output_file" "read" "$NS_B_ID" "$NS_B_FQN"
+  run obligation_trigger_plan_action_status "$output_file" "$trigger_b_id" "$NS_B_FQN"
+  assert_success
+  assert_equal "$output" "existing_standard"
+
+  assert_legacy_obligation_trigger_still_exists "$trigger_a_id" "$NS_A_ID" "$ATTR_A_VAL_1_ID" "$custom_action_id" "$obligation_a_value_id" "$trigger_a_client_id"
+  assert_legacy_obligation_trigger_still_exists "$trigger_b_id" "$NS_B_ID" "$ATTR_B_VAL_1_ID" "$GLOBAL_READ_ID" "$obligation_b_value_id" "$trigger_b_client_id"
+
+  # Re-running the same migration should be idempotent. The previously created
+  # custom action target and trigger target should resolve as already_migrated,
+  # while the pre-existing canonical trigger remains already_migrated.
+  local rerun_output_file="${MIGRATION_OUTPUT_DIR}/obligation-triggers-rerun-plan.json"
+  local custom_action_target_id
+  local trigger_a_target_id
+  custom_action_target_id=$(action_plan_target_effective_id "$output_file" "$custom_action_name" "$NS_A_FQN")
+  trigger_a_target_id=$(obligation_trigger_plan_target_effective_id "$output_file" "$trigger_a_id" "$NS_A_FQN")
+
+  run_namespaced_policy_commit "obligation-triggers" "$rerun_output_file"
+  assert_success
+
+  assert_action_target_count "$rerun_output_file" "$custom_action_name" 1
+  assert_action_already_migrated_in_namespace "$rerun_output_file" "$custom_action_name" "$NS_A_ID" "$NS_A_FQN" "$custom_action_target_id"
+  assert_action_target_count "$rerun_output_file" "read" 1
+  assert_standard_action_resolved_in_namespace "$rerun_output_file" "read" "$NS_B_ID" "$NS_B_FQN"
+  assert_obligation_trigger_target_count "$rerun_output_file" "$trigger_a_id" 1
+  assert_obligation_trigger_already_migrated_in_namespace "$rerun_output_file" "$trigger_a_id" "$NS_A_ID" "$NS_A_FQN" "$trigger_a_target_id"
+  assert_obligation_trigger_target_count "$rerun_output_file" "$trigger_b_id" 1
+  assert_obligation_trigger_already_migrated_in_namespace "$rerun_output_file" "$trigger_b_id" "$NS_B_ID" "$NS_B_FQN" "$existing_trigger_b_id"
+}
+
+# Asserts selecting every migration scope together creates one namespaced
+# target for each supported object type in a simple single-namespace graph.
+@test "migrate namespaced-policy all scopes creates one target for each object type" {
+  local custom_action_name="${TEST_PREFIX}-download"
+  local all_scopes_scs='[{"condition_groups":[{"conditions":[{"operator":1,"subject_external_values":["'"${TEST_PREFIX}"'-all-scopes"],"subject_external_selector_value":".org.name"}],"boolean_operator":1}]}]'
+  local rr_name="${TEST_PREFIX}-repo"
+  local rr_value="${TEST_PREFIX}-repo-main"
+  local obligation_name="${TEST_PREFIX}-notify"
+  local obligation_value="${TEST_PREFIX}-notify-default"
+  local trigger_client_id="${TEST_PREFIX}-client"
+  local custom_action_id
+  local scs_id
+  local mapping_id
+  local rr_id
+  local rr_value_id
+  local obligation_id
+  local obligation_value_id
+  local trigger_id
+
+  create_global_action custom_action_id "$custom_action_name" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-custom-action"
+  create_global_scs scs_id "$all_scopes_scs" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-scs"
+  create_legacy_subject_mapping mapping_id "$ATTR_A_VAL_1_ID" "$custom_action_id" "$scs_id" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-mapping"
+  create_global_registered_resource rr_id "$rr_name" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-rr"
+  create_registered_resource_value rr_value_id "$rr_id" "$rr_value" --action-attribute-value "$custom_action_id;$ATTR_A_VAL_2_ID" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-rr-value"
+  create_namespaced_obligation obligation_id "$NS_A_ID" "$obligation_name" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-obligation"
+  create_obligation_value obligation_value_id "$obligation_id" "$obligation_value" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-obligation-value"
+  create_legacy_obligation_trigger trigger_id "$ATTR_A_VAL_1_ID" "$custom_action_id" "$obligation_value_id" --client-id "$trigger_client_id" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-trigger"
+
+  local output_file="${MIGRATION_OUTPUT_DIR}/all-scopes-plan.json"
+
+  run_namespaced_policy_commit "actions,subject-condition-sets,subject-mappings,registered-resources,obligation-triggers" "$output_file"
+  assert_success
+
+  assert_action_target_count "$output_file" "$custom_action_name" 1
+  assert_custom_action_created_in_namespace "$output_file" "$custom_action_name" "$custom_action_id" "$NS_A_ID" "$NS_A_FQN"
+
+  assert_scs_target_count "$output_file" "$scs_id" 1
+  assert_scs_created_in_namespace "$output_file" "$scs_id" "$NS_A_ID" "$NS_A_FQN"
+
+  assert_subject_mapping_target_count "$output_file" "$mapping_id" 1
+  assert_subject_mapping_created_in_namespace "$output_file" "$mapping_id" "$NS_A_ID" "$NS_A_FQN" "$ATTR_A_VAL_1_ID" "$custom_action_name" "$custom_action_id" "create" 1 "$scs_id" 1
+
+  assert_registered_resource_target_count "$output_file" "$rr_id" 1
+  assert_registered_resource_created_in_namespace "$output_file" "$rr_id" "$rr_value_id" "$NS_A_ID" "$NS_A_FQN" "$rr_name" "$rr_value" "$custom_action_name" "$custom_action_id" "create" 1 "$ATTR_A_VAL_2_ID"
+
+  assert_obligation_trigger_target_count "$output_file" "$trigger_id" 1
+  assert_obligation_trigger_created_in_namespace "$output_file" "$trigger_id" "$NS_A_ID" "$NS_A_FQN" "$ATTR_A_VAL_1_ID" "$obligation_value_id" "$custom_action_name" "$custom_action_id" "create" 1 "$trigger_client_id"
+
+  assert_legacy_custom_action_still_exists "$custom_action_id" "$custom_action_name"
+  assert_legacy_scs_still_exists "$scs_id"
+  assert_legacy_subject_mapping_still_exists "$ATTR_A_VAL_1_ID" "$mapping_id"
+  assert_legacy_registered_resource_still_exists "$rr_id" "$rr_value_id" "$rr_name" "$rr_value"
+  assert_legacy_obligation_trigger_still_exists "$trigger_id" "$NS_A_ID" "$ATTR_A_VAL_1_ID" "$custom_action_id" "$obligation_value_id" "$trigger_client_id"
 }

--- a/otdfctl/migrations/namespacedpolicy/planner.go
+++ b/otdfctl/migrations/namespacedpolicy/planner.go
@@ -22,6 +22,7 @@ type PolicyClient interface {
 	ListSubjectConditionSets(ctx context.Context, limit, offset int32, namespace string) (*subjectmapping.ListSubjectConditionSetsResponse, error)
 	ListSubjectMappings(ctx context.Context, limit, offset int32, namespace string) (*subjectmapping.ListSubjectMappingsResponse, error)
 	ListRegisteredResources(ctx context.Context, limit, offset int32, namespace string) (*registeredresources.ListRegisteredResourcesResponse, error)
+	ListRegisteredResourceValues(ctx context.Context, resourceID string, limit, offset int32) (*registeredresources.ListRegisteredResourceValuesResponse, error)
 	ListObligationTriggers(ctx context.Context, namespace string, limit, offset int32) (*obligations.ListObligationTriggersResponse, error)
 	ListNamespaces(ctx context.Context, state common.ActiveStateEnum, limit, offset int32) (*namespaces.ListNamespacesResponse, error)
 }

--- a/otdfctl/migrations/namespacedpolicy/planner_test.go
+++ b/otdfctl/migrations/namespacedpolicy/planner_test.go
@@ -816,17 +816,19 @@ func TestPlannerPlanHuhInteractiveReviewerResolvesRegisteredResourceConflict(t *
 }
 
 type plannerTestHandler struct {
-	actionsByNamespace              map[string]*actions.ListActionsResponse
-	subjectConditionSetsByNamespace map[string]*subjectmapping.ListSubjectConditionSetsResponse
-	subjectMappingsByNamespace      map[string]*subjectmapping.ListSubjectMappingsResponse
-	registeredResourcesByNamespace  map[string]*registeredresources.ListRegisteredResourcesResponse
-	obligationTriggersByNamespace   map[string]*obligations.ListObligationTriggersResponse
-	namespacesResponse              *namespaces.ListNamespacesResponse
-	actionCalls                     []string
-	subjectConditionSetCalls        []string
-	subjectMappingCalls             []string
-	registeredResourceCalls         []string
-	obligationTriggerCalls          []string
+	actionsByNamespace                   map[string]*actions.ListActionsResponse
+	subjectConditionSetsByNamespace      map[string]*subjectmapping.ListSubjectConditionSetsResponse
+	subjectMappingsByNamespace           map[string]*subjectmapping.ListSubjectMappingsResponse
+	registeredResourcesByNamespace       map[string]*registeredresources.ListRegisteredResourcesResponse
+	registeredResourceValuesByResourceID map[string]*registeredresources.ListRegisteredResourceValuesResponse
+	obligationTriggersByNamespace        map[string]*obligations.ListObligationTriggersResponse
+	namespacesResponse                   *namespaces.ListNamespacesResponse
+	actionCalls                          []string
+	subjectConditionSetCalls             []string
+	subjectMappingCalls                  []string
+	registeredResourceCalls              []string
+	registeredResourceValueCalls         []string
+	obligationTriggerCalls               []string
 }
 
 func (h *plannerTestHandler) ListActions(_ context.Context, limit, offset int32, namespace string) (*actions.ListActionsResponse, error) {
@@ -859,6 +861,27 @@ func (h *plannerTestHandler) ListRegisteredResources(_ context.Context, limit, o
 		return resp, nil
 	}
 	return &registeredresources.ListRegisteredResourcesResponse{Pagination: emptyPageResponse()}, nil
+}
+
+func (h *plannerTestHandler) ListRegisteredResourceValues(_ context.Context, resourceID string, limit, offset int32) (*registeredresources.ListRegisteredResourceValuesResponse, error) {
+	h.registeredResourceValueCalls = append(h.registeredResourceValueCalls, resourceID)
+	if resp, ok := h.registeredResourceValuesByResourceID[resourceID]; ok {
+		return resp, nil
+	}
+
+	for _, resp := range h.registeredResourcesByNamespace {
+		for _, resource := range resp.GetResources() {
+			if resource.GetId() != resourceID {
+				continue
+			}
+			return &registeredresources.ListRegisteredResourceValuesResponse{
+				Values:     resource.GetValues(),
+				Pagination: emptyPageResponse(),
+			}, nil
+		}
+	}
+
+	return &registeredresources.ListRegisteredResourceValuesResponse{Pagination: emptyPageResponse()}, nil
 }
 
 func (h *plannerTestHandler) ListObligationTriggers(_ context.Context, namespace string, limit, offset int32) (*obligations.ListObligationTriggersResponse, error) {

--- a/otdfctl/migrations/namespacedpolicy/retrieve.go
+++ b/otdfctl/migrations/namespacedpolicy/retrieve.go
@@ -363,7 +363,7 @@ func (r *Retriever) retrieveObligationTriggers(ctx context.Context, legacyAction
 			if trigger.GetId() == "" || trigger.GetAction().GetId() == "" || hasObject(candidates, trigger.GetId()) {
 				continue
 			}
-			// ! If triggers action id is not within the candidate set, it is not a legacy obligation trigger.
+			// ! If the trigger action id is not within the candidate set, it is not a legacy obligation trigger.
 			if _, ok := legacyActionIDs[trigger.GetAction().GetId()]; !ok {
 				continue
 			}
@@ -394,7 +394,7 @@ func objectIDSet[T interface{ GetId() string }](items []T) map[string]struct{} {
 }
 
 func actionIDsByNamespace(namespaces []*policy.Namespace, customByNamespace, standardByNamespace map[string][]*policy.Action) map[string]map[string]struct{} {
-	idsByNamespace := make(map[string]map[string]struct{}, len(namespaces)+len(customByNamespace)+len(standardByNamespace))
+	idsByNamespace := make(map[string]map[string]struct{}, len(namespaces))
 	for _, namespace := range dedupeTargetNamespaces(namespaces) {
 		idsByNamespace[namespace.GetId()] = make(map[string]struct{})
 	}
@@ -616,7 +616,7 @@ func (r *Retriever) listRegisteredResourceValues(ctx context.Context, resourceID
 // * where the obligation trigger has an action that has a namespace.
 // *
 // * ListRPCs do not return namespace information for non-target objects (i.e. actions for triggers)
-// * so we must lookup the action from the ListActionsExisting to decern whether or not the action tied
+// * so we must lookup the action from ListActionsExisting to discern whether or not the action tied
 // * to the Obligation Trigger is legacy or not.
 func (r *Retriever) listObligationTriggersForNamespaces(ctx context.Context, namespaces []*policy.Namespace, actionIDsByNamespace map[string]map[string]struct{}) (map[string][]*policy.ObligationTrigger, error) {
 	byNamespace := make(map[string][]*policy.ObligationTrigger)

--- a/otdfctl/migrations/namespacedpolicy/retrieve.go
+++ b/otdfctl/migrations/namespacedpolicy/retrieve.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy/obligations"
 	"github.com/opentdf/platform/protocol/go/policy/registeredresources"
 	"github.com/opentdf/platform/protocol/go/policy/subjectmapping"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -19,6 +20,7 @@ var (
 	_ pagedResponse = (*subjectmapping.ListSubjectConditionSetsResponse)(nil)
 	_ pagedResponse = (*subjectmapping.ListSubjectMappingsResponse)(nil)
 	_ pagedResponse = (*registeredresources.ListRegisteredResourcesResponse)(nil)
+	_ pagedResponse = (*registeredresources.ListRegisteredResourceValuesResponse)(nil)
 	_ pagedResponse = (*obligations.ListObligationTriggersResponse)(nil)
 	_ pagedResponse = (*namespaces.ListNamespacesResponse)(nil)
 )
@@ -75,7 +77,7 @@ func (r *Retriever) retrieve(ctx context.Context, scopes scopeSet) (*Retrieved, 
 	}
 
 	if scopes.requiresObligationTriggers() {
-		candidates, err := r.retrieveObligationTriggers(ctx)
+		candidates, err := r.retrieveObligationTriggers(ctx, objectIDSet(retrieved.Candidates.Actions))
 		if err != nil {
 			return nil, err
 		}
@@ -119,9 +121,14 @@ func (r *Retriever) listNamespaces(ctx context.Context) ([]*policy.Namespace, er
 
 func (r *Retriever) listExistingTargets(ctx context.Context, scopes scopeSet, derived *DerivedTargets) (*ExistingTargets, error) {
 	existing := newExistingTargets()
+	var (
+		customActions   map[string][]*policy.Action
+		standardActions map[string][]*policy.Action
+	)
 
 	if scopes.requiresActions() {
-		customActions, standardActions, err := r.listActionsForNamespaces(ctx, derivedActionNamespaces(derived))
+		var err error
+		customActions, standardActions, err = r.listActionsForNamespaces(ctx, derivedActionNamespaces(derived))
 		if err != nil {
 			return nil, err
 		}
@@ -154,7 +161,11 @@ func (r *Retriever) listExistingTargets(ctx context.Context, scopes scopeSet, de
 	}
 
 	if scopes.has(ScopeObligationTriggers) {
-		obligationTriggers, err := r.listObligationTriggersForNamespaces(ctx, derivedObligationTriggerNamespaces(derived))
+		obligationTriggers, err := r.listObligationTriggersForNamespaces(
+			ctx,
+			derivedObligationTriggerNamespaces(derived),
+			actionIDsByNamespace(derivedActionNamespaces(derived), customActions, standardActions),
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -259,7 +270,12 @@ func (r *Retriever) retrieveRegisteredResources(ctx context.Context) ([]*policy.
 			if resource.GetId() == "" || !isLegacyNamespace(resource.GetNamespace()) || hasObject(candidates, resource.GetId()) {
 				continue
 			}
-			candidates = append(candidates, resource)
+
+			hydrated, err := r.hydrateRegisteredResource(ctx, resource)
+			if err != nil {
+				return nil, fmt.Errorf("list registered resource values for resource %s: %w", resource.GetId(), err)
+			}
+			candidates = append(candidates, hydrated)
 		}
 
 		nextOffset, err := nextOffsetFromPage(resp)
@@ -326,7 +342,7 @@ func (r *Retriever) retrieveActions(ctx context.Context) ([]*policy.Action, erro
 	return candidates, nil
 }
 
-func (r *Retriever) retrieveObligationTriggers(ctx context.Context) ([]*policy.ObligationTrigger, error) {
+func (r *Retriever) retrieveObligationTriggers(ctx context.Context, legacyActionIDs map[string]struct{}) ([]*policy.ObligationTrigger, error) {
 	var (
 		candidates []*policy.ObligationTrigger
 		offset     int32
@@ -344,7 +360,11 @@ func (r *Retriever) retrieveObligationTriggers(ctx context.Context) ([]*policy.O
 		}
 
 		for _, trigger := range items {
-			if trigger.GetId() == "" || trigger.GetAction() == nil || !isLegacyNamespace(trigger.GetAction().GetNamespace()) || hasObject(candidates, trigger.GetId()) {
+			if trigger.GetId() == "" || trigger.GetAction().GetId() == "" || hasObject(candidates, trigger.GetId()) {
+				continue
+			}
+			// ! If triggers action id is not within the candidate set, it is not a legacy obligation trigger.
+			if _, ok := legacyActionIDs[trigger.GetAction().GetId()]; !ok {
 				continue
 			}
 			candidates = append(candidates, trigger)
@@ -361,6 +381,46 @@ func (r *Retriever) retrieveObligationTriggers(ctx context.Context) ([]*policy.O
 	}
 
 	return candidates, nil
+}
+
+func objectIDSet[T interface{ GetId() string }](items []T) map[string]struct{} {
+	ids := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if id := item.GetId(); id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	return ids
+}
+
+func actionIDsByNamespace(namespaces []*policy.Namespace, customByNamespace, standardByNamespace map[string][]*policy.Action) map[string]map[string]struct{} {
+	idsByNamespace := make(map[string]map[string]struct{}, len(namespaces)+len(customByNamespace)+len(standardByNamespace))
+	for _, namespace := range dedupeTargetNamespaces(namespaces) {
+		idsByNamespace[namespace.GetId()] = make(map[string]struct{})
+	}
+	add := func(namespaceID string, actions []*policy.Action) {
+		if namespaceID == "" {
+			return
+		}
+		if idsByNamespace[namespaceID] == nil {
+			idsByNamespace[namespaceID] = make(map[string]struct{}, len(actions))
+		}
+		for _, action := range actions {
+			if action == nil || action.GetId() == "" {
+				continue
+			}
+			idsByNamespace[namespaceID][action.GetId()] = struct{}{}
+		}
+	}
+
+	for namespaceID, actions := range customByNamespace {
+		add(namespaceID, actions)
+	}
+	for namespaceID, actions := range standardByNamespace {
+		add(namespaceID, actions)
+	}
+
+	return idsByNamespace
 }
 
 func (r *Retriever) listActionsForNamespaces(ctx context.Context, namespaces []*policy.Namespace) (map[string][]*policy.Action, map[string][]*policy.Action, error) {
@@ -481,7 +541,12 @@ func (r *Retriever) listRegisteredResourcesForNamespaces(ctx context.Context, na
 				if resource.GetId() == "" || hasObject(byNamespace[namespace.GetId()], resource.GetId()) {
 					continue
 				}
-				byNamespace[namespace.GetId()] = append(byNamespace[namespace.GetId()], resource)
+
+				hydrated, err := r.hydrateRegisteredResource(ctx, resource)
+				if err != nil {
+					return nil, fmt.Errorf("list registered resource values for resource %s in namespace %s: %w", resource.GetId(), namespace.GetId(), err)
+				}
+				byNamespace[namespace.GetId()] = append(byNamespace[namespace.GetId()], hydrated)
 			}
 
 			nextOffset, err := nextOffsetFromPage(resp)
@@ -498,10 +563,70 @@ func (r *Retriever) listRegisteredResourcesForNamespaces(ctx context.Context, na
 	return byNamespace, nil
 }
 
-func (r *Retriever) listObligationTriggersForNamespaces(ctx context.Context, namespaces []*policy.Namespace) (map[string][]*policy.ObligationTrigger, error) {
+func (r *Retriever) hydrateRegisteredResource(ctx context.Context, resource *policy.RegisteredResource) (*policy.RegisteredResource, error) {
+	if resource == nil || resource.GetId() == "" {
+		return resource, nil
+	}
+
+	values, err := r.listRegisteredResourceValues(ctx, resource.GetId())
+	if err != nil {
+		return nil, err
+	}
+
+	hydrated, ok := proto.Clone(resource).(*policy.RegisteredResource)
+	if !ok {
+		return nil, errors.New("clone registered resource: unexpected type")
+	}
+	hydrated.Values = values
+	return hydrated, nil
+}
+
+func (r *Retriever) listRegisteredResourceValues(ctx context.Context, resourceID string) ([]*policy.RegisteredResourceValue, error) {
+	if resourceID == "" {
+		return nil, nil
+	}
+
+	var (
+		values []*policy.RegisteredResourceValue
+		offset int32
+	)
+
+	for {
+		resp, err := r.handler.ListRegisteredResourceValues(ctx, resourceID, r.pageSize, offset)
+		if err != nil {
+			return nil, err
+		}
+
+		values = append(values, resp.GetValues()...)
+
+		nextOffset, err := nextOffsetFromPage(resp)
+		if err != nil {
+			return nil, err
+		}
+		if nextOffset <= 0 {
+			break
+		}
+		offset = nextOffset
+	}
+
+	return values, nil
+}
+
+// * Getting an existing trigger means to retrieve all triggers for a set of namespaces
+// * where the obligation trigger has an action that has a namespace.
+// *
+// * ListRPCs do not return namespace information for non-target objects (i.e. actions for triggers)
+// * so we must lookup the action from the ListActionsExisting to decern whether or not the action tied
+// * to the Obligation Trigger is legacy or not.
+func (r *Retriever) listObligationTriggersForNamespaces(ctx context.Context, namespaces []*policy.Namespace, actionIDsByNamespace map[string]map[string]struct{}) (map[string][]*policy.ObligationTrigger, error) {
 	byNamespace := make(map[string][]*policy.ObligationTrigger)
 
 	for _, namespace := range dedupeTargetNamespaces(namespaces) {
+		allowedActionIDs, hasActionNamespace := actionIDsByNamespace[namespace.GetId()]
+		// ! Actions should always include the derived obligation trigger namespaces.
+		if !hasActionNamespace {
+			return nil, fmt.Errorf("obligation trigger existing-target lookup for namespace %q is missing action candidates", namespace.GetId())
+		}
 		var offset int32
 		for {
 			resp, err := r.handler.ListObligationTriggers(ctx, namespace.GetId(), r.pageSize, offset)
@@ -510,7 +635,11 @@ func (r *Retriever) listObligationTriggersForNamespaces(ctx context.Context, nam
 			}
 
 			for _, trigger := range resp.GetTriggers() {
-				if trigger.GetId() == "" || hasObject(byNamespace[namespace.GetId()], trigger.GetId()) {
+				if trigger.GetId() == "" || trigger.GetAction().GetId() == "" || hasObject(byNamespace[namespace.GetId()], trigger.GetId()) {
+					continue
+				}
+				// ! Check that the trigger action is one with a namespace.
+				if _, actionAllowed := allowedActionIDs[trigger.GetAction().GetId()]; !actionAllowed {
 					continue
 				}
 				byNamespace[namespace.GetId()] = append(byNamespace[namespace.GetId()], trigger)

--- a/otdfctl/migrations/namespacedpolicy/retrieve_test.go
+++ b/otdfctl/migrations/namespacedpolicy/retrieve_test.go
@@ -45,30 +45,45 @@ func TestRetrieverRetrieveActionsFiltersLegacyAndDedupes(t *testing.T) {
 	assert.Equal(t, []string{""}, handler.actionCalls)
 }
 
-func TestRetrieverListRegisteredResourcesForNamespacesDedupesNamespacesAndUsesInlineValues(t *testing.T) {
+func TestRetrieverListRegisteredResourcesForNamespacesDedupesNamespacesAndHydratesValues(t *testing.T) {
 	t.Parallel()
 
 	namespace := &policy.Namespace{
 		Id:  "ns-1",
 		Fqn: "https://example.com",
 	}
-	value := testRegisteredResourceValue(
-		"prod",
-		testActionAttributeValue(
-			"action-1",
-			"decrypt",
-			testAttributeValue("https://example.com/attr/classification/value/secret", nil),
-		),
-	)
+	inlineValue := &policy.RegisteredResourceValue{Value: "inline-value"}
+	value := &policy.RegisteredResourceValue{
+		Id:    "value-1",
+		Value: "prod",
+		Metadata: &common.Metadata{
+			Labels: map[string]string{
+				"owner": "platform",
+			},
+		},
+		ActionAttributeValues: []*policy.RegisteredResourceValue_ActionAttributeValue{
+			testActionAttributeValue(
+				"action-1",
+				"decrypt",
+				testAttributeValue("https://example.com/attr/classification/value/secret", nil),
+			),
+		},
+	}
 	resource := &policy.RegisteredResource{
 		Id:     "resource-1",
 		Name:   "documents",
-		Values: []*policy.RegisteredResourceValue{value},
+		Values: []*policy.RegisteredResourceValue{inlineValue},
 	}
 	handler := &plannerTestHandler{
 		registeredResourcesByNamespace: map[string]*registeredresources.ListRegisteredResourcesResponse{
 			namespace.GetId(): {
 				Resources:  []*policy.RegisteredResource{resource},
+				Pagination: emptyPageResponse(),
+			},
+		},
+		registeredResourceValuesByResourceID: map[string]*registeredresources.ListRegisteredResourceValuesResponse{
+			resource.GetId(): {
+				Values:     []*policy.RegisteredResourceValue{value},
 				Pagination: emptyPageResponse(),
 			},
 		},
@@ -85,7 +100,9 @@ func TestRetrieverListRegisteredResourcesForNamespacesDedupesNamespacesAndUsesIn
 	assert.Equal(t, resource.GetId(), resources[namespace.GetId()][0].GetId())
 	require.Len(t, resources[namespace.GetId()][0].GetValues(), 1)
 	assert.Equal(t, "prod", resources[namespace.GetId()][0].GetValues()[0].GetValue())
+	assert.Equal(t, map[string]string{"owner": "platform"}, resources[namespace.GetId()][0].GetValues()[0].GetMetadata().GetLabels())
 	assert.Equal(t, []string{namespace.GetId()}, handler.registeredResourceCalls)
+	assert.Equal(t, []string{resource.GetId()}, handler.registeredResourceValueCalls)
 }
 
 func TestRetrieverRetrieveSubjectMappingsDedupesAcrossPages(t *testing.T) {
@@ -123,11 +140,20 @@ func TestRetrieverRetrieveSubjectMappingsDedupesAcrossPages(t *testing.T) {
 func TestRetrieverRetrieveRegisteredResourcesDedupesAcrossPages(t *testing.T) {
 	t.Parallel()
 
+	valueDup := &policy.RegisteredResourceValue{
+		Id:    "resource-dup-value-1",
+		Value: "prod",
+		Metadata: &common.Metadata{
+			Labels: map[string]string{
+				"owner": "policy-team",
+			},
+		},
+	}
 	handler := &pagedRetrieveTestHandler{
 		registeredResourcePages: map[int32]*registeredresources.ListRegisteredResourcesResponse{
 			0: {
 				Resources: []*policy.RegisteredResource{
-					{Id: "resource-dup", Name: "documents"},
+					{Id: "resource-dup", Name: "documents", Values: []*policy.RegisteredResourceValue{{Value: "inline"}}},
 					{
 						Id:        "resource-namespaced",
 						Name:      "contracts",
@@ -145,18 +171,131 @@ func TestRetrieverRetrieveRegisteredResourcesDedupesAcrossPages(t *testing.T) {
 				Pagination: emptyPageResponse(),
 			},
 		},
+		registeredResourceValuePages: map[string]map[int32]*registeredresources.ListRegisteredResourceValuesResponse{
+			"resource-dup": {
+				0: {
+					Values:     []*policy.RegisteredResourceValue{valueDup},
+					Pagination: emptyPageResponse(),
+				},
+			},
+			"resource-new": {
+				0: {
+					Values:     []*policy.RegisteredResourceValue{{Id: "resource-new-value-1", Value: "reports"}},
+					Pagination: emptyPageResponse(),
+				},
+			},
+		},
 	}
 
 	resources, err := newRetriever(handler, 25).retrieveRegisteredResources(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"resource-dup", "resource-new"}, policyObjectIDs(resources))
+	require.Len(t, resources[0].GetValues(), 1)
+	assert.Equal(t, "prod", resources[0].GetValues()[0].GetValue())
+	assert.Equal(t, map[string]string{"owner": "policy-team"}, resources[0].GetValues()[0].GetMetadata().GetLabels())
+	assert.Equal(t, []string{"resource-dup", "resource-new"}, handler.registeredResourceValueCalls)
 }
 
-func TestRetrieverRetrieveObligationTriggersDedupesAcrossPages(t *testing.T) {
+func TestRetrieverListExistingTargetsFiltersObligationTriggersByNamespacedActionIDs(t *testing.T) {
+	t.Parallel()
+
+	namespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+	handler := &plannerTestHandler{
+		actionsByNamespace: map[string]*actions.ListActionsResponse{
+			namespace.GetId(): {
+				ActionsCustom: []*policy.Action{
+					{
+						Id:        "action-target",
+						Name:      "decrypt",
+						Namespace: namespace,
+					},
+				},
+				Pagination: emptyPageResponse(),
+			},
+		},
+		obligationTriggersByNamespace: map[string]*obligations.ListObligationTriggersResponse{
+			namespace.GetId(): {
+				Triggers: []*policy.ObligationTrigger{
+					{
+						Id: "trigger-legacy-action",
+						Action: &policy.Action{
+							Id:   "action-legacy",
+							Name: "decrypt-2",
+						},
+					},
+					{
+						Id: "trigger-target-action",
+						Action: &policy.Action{
+							Id:   "action-target",
+							Name: "decrypt",
+						},
+					},
+				},
+				Pagination: emptyPageResponse(),
+			},
+		},
+	}
+
+	scopes, err := normalizeScopes([]Scope{ScopeActions, ScopeObligationTriggers})
+	require.NoError(t, err)
+
+	existing, err := newRetriever(handler, 25).listExistingTargets(t.Context(), scopes, &DerivedTargets{
+		Actions: []*DerivedAction{
+			{Targets: []*policy.Namespace{namespace}},
+		},
+		ObligationTriggers: []*DerivedObligationTrigger{
+			{Target: namespace},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, existing.ObligationTriggers, namespace.GetId())
+	assert.Equal(t, []string{"trigger-target-action"}, policyObjectIDs(existing.ObligationTriggers[namespace.GetId()]))
+	assert.Equal(t, []string{namespace.GetId()}, handler.actionCalls)
+	assert.Equal(t, []string{namespace.GetId()}, handler.obligationTriggerCalls)
+}
+
+func TestRetrieverListObligationTriggersForNamespacesFailsWhenNamespaceMissingFromActionMap(t *testing.T) {
+	t.Parallel()
+
+	namespace := &policy.Namespace{
+		Id:  "ns-1",
+		Fqn: "https://example.com",
+	}
+
+	_, err := newRetriever(&pagedRetrieveTestHandler{}, 25).listObligationTriggersForNamespaces(
+		context.Background(),
+		[]*policy.Namespace{namespace},
+		map[string]map[string]struct{}{},
+	)
+	require.Error(t, err)
+	assert.EqualError(t, err, `obligation trigger existing-target lookup for namespace "ns-1" is missing action candidates`)
+}
+
+func TestRetrieverRetrieveObligationTriggersUsesListActionsToFilterLegacyActionIDs(t *testing.T) {
 	t.Parallel()
 
 	handler := &pagedRetrieveTestHandler{
+		actionPages: map[int32]*actions.ListActionsResponse{
+			0: {
+				ActionsCustom: []*policy.Action{
+					{Id: "action-1", Name: "decrypt"},
+					{Id: "action-3", Name: "encrypt"},
+				},
+				ActionsStandard: []*policy.Action{
+					{
+						Id:        "action-2",
+						Name:      "decrypt",
+						Namespace: &policy.Namespace{Id: "ns-1", Fqn: "https://example.com"},
+					},
+				},
+				Pagination: emptyPageResponse(),
+			},
+		},
 		obligationTriggerPages: map[int32]*obligations.ListObligationTriggersResponse{
 			0: {
 				Triggers: []*policy.ObligationTrigger{
@@ -165,8 +304,8 @@ func TestRetrieverRetrieveObligationTriggersDedupesAcrossPages(t *testing.T) {
 						Action: &policy.Action{Id: "action-1", Name: "decrypt"},
 					},
 					{
-						Id:     "trigger-namespaced",
-						Action: &policy.Action{Id: "action-2", Name: "decrypt", Namespace: &policy.Namespace{Id: "ns-1", Fqn: "https://example.com"}},
+						Id:     "trigger-non-legacy",
+						Action: &policy.Action{Id: "action-2", Name: "decrypt"},
 					},
 				},
 				Pagination: pageResponse(1),
@@ -191,10 +330,14 @@ func TestRetrieverRetrieveObligationTriggersDedupesAcrossPages(t *testing.T) {
 		},
 	}
 
-	triggers, err := newRetriever(handler, 25).retrieveObligationTriggers(t.Context())
+	scopes, err := normalizeScopes([]Scope{ScopeObligationTriggers})
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"trigger-dup", "trigger-new"}, policyObjectIDs(triggers))
+	retrieved, err := newRetriever(handler, 25).retrieve(t.Context(), scopes)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"action-1", "action-3"}, policyObjectIDs(retrieved.Candidates.Actions))
+	assert.Equal(t, []string{"trigger-dup", "trigger-new"}, policyObjectIDs(retrieved.Candidates.ObligationTriggers))
 }
 
 func policyObjectIDs[T interface{ GetId() string }](items []T) []string {
@@ -210,12 +353,18 @@ func policyObjectIDs[T interface{ GetId() string }](items []T) []string {
 }
 
 type pagedRetrieveTestHandler struct {
-	subjectMappingPages     map[int32]*subjectmapping.ListSubjectMappingsResponse
-	registeredResourcePages map[int32]*registeredresources.ListRegisteredResourcesResponse
-	obligationTriggerPages  map[int32]*obligations.ListObligationTriggersResponse
+	actionPages                  map[int32]*actions.ListActionsResponse
+	subjectMappingPages          map[int32]*subjectmapping.ListSubjectMappingsResponse
+	registeredResourcePages      map[int32]*registeredresources.ListRegisteredResourcesResponse
+	registeredResourceValuePages map[string]map[int32]*registeredresources.ListRegisteredResourceValuesResponse
+	obligationTriggerPages       map[int32]*obligations.ListObligationTriggersResponse
+	registeredResourceValueCalls []string
 }
 
 func (h *pagedRetrieveTestHandler) ListActions(_ context.Context, limit, offset int32, namespace string) (*actions.ListActionsResponse, error) {
+	if resp, ok := h.actionPages[offset]; ok {
+		return resp, nil
+	}
 	return &actions.ListActionsResponse{Pagination: emptyPageResponse()}, nil
 }
 
@@ -235,6 +384,29 @@ func (h *pagedRetrieveTestHandler) ListRegisteredResources(_ context.Context, li
 		return resp, nil
 	}
 	return &registeredresources.ListRegisteredResourcesResponse{Pagination: emptyPageResponse()}, nil
+}
+
+func (h *pagedRetrieveTestHandler) ListRegisteredResourceValues(_ context.Context, resourceID string, limit, offset int32) (*registeredresources.ListRegisteredResourceValuesResponse, error) {
+	h.registeredResourceValueCalls = append(h.registeredResourceValueCalls, resourceID)
+	if pages, ok := h.registeredResourceValuePages[resourceID]; ok {
+		if resp, exists := pages[offset]; exists {
+			return resp, nil
+		}
+	}
+
+	for _, resp := range h.registeredResourcePages {
+		for _, resource := range resp.GetResources() {
+			if resource.GetId() != resourceID {
+				continue
+			}
+			return &registeredresources.ListRegisteredResourceValuesResponse{
+				Values:     resource.GetValues(),
+				Pagination: emptyPageResponse(),
+			}, nil
+		}
+	}
+
+	return &registeredresources.ListRegisteredResourceValuesResponse{Pagination: emptyPageResponse()}, nil
 }
 
 func (h *pagedRetrieveTestHandler) ListObligationTriggers(_ context.Context, namespace string, limit, offset int32) (*obligations.ListObligationTriggersResponse, error) {


### PR DESCRIPTION
##  Summary

  Adds end-to-end coverage for namespaced-policy migration of registered resources and obligation triggers, plus a simple all-scopes migration test. This also fixes namespaced-policy planner/retriever bugs uncovered by the new tests.

  What changed

  - Added migrate-namespaced-policy.bats coverage for:
      - registered resource migration
      - obligation trigger migration
      - a simple all-scopes migration flow with one object of each type
  - Updated the BATS helpers/assertions to:
      - handle registered resource values and obligation triggers
      - verify migrated obligation-trigger actions by fetching the action directly
      - seed legacy obligation triggers directly in Postgres when API validation blocks the legacy test shape
      - fix helper output-variable scoping so created IDs propagate correctly to callers
  - Fixed namespaced-policy retrieval for registered resources by hydrating values from ListRegisteredResourceValues instead of relying on partial ListRegisteredResources responses
  - Fixed obligation-trigger retrieval/planning to use action IDs, not action namespace fields from ListObligationTriggers, since that payload does not reliably include action namespace data
  - Reused the existing listActionsForNamespaces results when resolving existing obligation triggers and filtered existing triggers by allowed action IDs per namespace
  - Added an explicit invariant/error when obligation-trigger existing-target lookup is attempted for a namespace missing from the action lookup map
  - Added/updated unit tests for:
      - RR value hydration
      - source obligation-trigger filtering using ListActions
      - existing obligation-trigger filtering by namespaced action IDs
      - missing action-map namespace error handling

##  Why

  The new e2e cases exposed two main issues:

  - registered resource value metadata was missing because RR values were not being fully hydrated
  - obligation-trigger planning could misclassify or duplicate matches because ListObligationTriggers does not provide enough action namespace information to use action.namespace safely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced migration test coverage for policy registered resources and obligation triggers, including action-attribute binding rewrites, metadata preservation, and idempotency validation.
  * Expanded test infrastructure with new fixture creation and tracking utilities for comprehensive migration scenario validation across all supported policy object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->