### PR TITLE
fix(sdk): require at least one FQN in ForAttributeValues

### DIFF
--- a/protocol/go/authorization/v2/resource.gen.go
+++ b/protocol/go/authorization/v2/resource.gen.go
@@ -5,7 +5,11 @@ package authorizationv2
 // ForAttributeValues returns a Resource containing the given attribute value FQNs.
 // This is the most common Resource variant, used when authorizing against
 // attribute values attached to data (e.g. those on a TDF).
+// At least one FQN is required; calling with zero arguments panics.
 func ForAttributeValues(fqns ...string) *Resource {
+	if len(fqns) == 0 {
+		panic("ForAttributeValues requires at least one FQN")
+	}
 	return &Resource{
 		Resource: &Resource_AttributeValues_{
 			AttributeValues: &Resource_AttributeValues{

--- a/protocol/go/internal/authorization/v2/resource.go
+++ b/protocol/go/internal/authorization/v2/resource.go
@@ -7,7 +7,11 @@ import (
 // ForAttributeValues returns a Resource containing the given attribute value FQNs.
 // This is the most common Resource variant, used when authorizing against
 // attribute values attached to data (e.g. those on a TDF).
+// At least one FQN is required; calling with zero arguments panics.
 func ForAttributeValues(fqns ...string) *authorizationv2.Resource {
+	if len(fqns) == 0 {
+		panic("ForAttributeValues requires at least one FQN")
+	}
 	return &authorizationv2.Resource{
 		Resource: &authorizationv2.Resource_AttributeValues_{
 			AttributeValues: &authorizationv2.Resource_AttributeValues{

--- a/protocol/go/internal/authorization/v2/resource_test.go
+++ b/protocol/go/internal/authorization/v2/resource_test.go
@@ -45,17 +45,13 @@ func TestForAttributeValues_Single(t *testing.T) {
 	}
 }
 
-func TestForAttributeValues_ZeroArgs(t *testing.T) {
-	r := ForAttributeValues()
-
-	av, ok := r.GetResource().(*authorizationv2proto.Resource_AttributeValues_)
-	if !ok {
-		t.Fatal("expected AttributeValues resource")
-	}
-	got := av.AttributeValues.GetFqns()
-	if len(got) != 0 {
-		t.Fatalf("fqns len = %d, want 0", len(got))
-	}
+func TestForAttributeValues_ZeroArgs_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for zero FQNs, but did not panic")
+		}
+	}()
+	ForAttributeValues()
 }
 
 func TestForRegisteredResourceValueFqn(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add panic guard for zero-argument calls to `ForAttributeValues`
- Aligns with Java SDK's `IllegalArgumentException` guard and the proto's `fqns.size() > 0` constraint
- Follow-up to #3337

## Test plan

- [x] `TestForAttributeValues_ZeroArgs_Panics` verifies the panic
- [x] All existing tests pass (15/15)
- [x] `golangci-lint` clean
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)