### PR TITLE
fix(ci): handle otdfctl component in work-init.sh

### DIFF
--- a/.github/scripts/work-init.sh
+++ b/.github/scripts/work-init.sh
@@ -59,6 +59,11 @@ examples)
     go work init &&
     go work use ./examples
   ;;
+otdfctl)
+  rm -f go.work go.work.sum &&
+    go work init &&
+    go work use ./otdfctl
+  ;;
 *)
   echo "[ERROR] unknown component [${component}]"
   exit 1


### PR DESCRIPTION
### Proposed Changes

* Add an `otdfctl)` case to `.github/scripts/work-init.sh` so the script no longer fails with `unknown component [otdfctl]` on the release-please branch for otdfctl. The new case mirrors the `examples)` handler — otdfctl is a leaf consumer with no in-workspace dependents, so the partial `go.work` only needs `./otdfctl`.

`otdfctl` was migrated into the monorepo in #3205 and added to the `go` CI matrix and release-please configs, but `work-init.sh` was not updated. The `chore(main): release otdfctl 0.31.0` release-please PR fails every matrix job at the `prevent depending on unreleased upstream changes` step until this is fixed.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

Local dry-run:

```
GITHUB_HEAD_REF=release-please--branches--main--components--otdfctl \
  ./.github/scripts/work-init.sh
```

Expected: exits 0 and writes a `go.work` containing only `./otdfctl`.

End-to-end: once merged, the next release-please otdfctl PR should pass the `go` matrix checks (the `prevent depending on unreleased upstream changes` step in `.github/workflows/checks.yaml`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment initialization to support additional component configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->