### PR TITLE
chore(ci): AB-2181 -  otdfctl e2e ci and results integration improvements

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,6 @@ on:
     branches:
       - main
       - release/**
-      - ab-2181-otdfctl-improvements
   merge_group:
     branches:
       - main

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -19,7 +19,7 @@ on:
     types:
       - checks_requested
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '25 5 * * *' # 5:25am UTC = 12:25am EST / 8:25am EEST
   workflow_call:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,12 +13,19 @@ on:
     branches:
       - main
       - release/**
+      - ab-2181-otdfctl-improvements
   merge_group:
     branches:
       - main
     types:
       - checks_requested
   workflow_call:
+  workflow_dispatch:
+    inputs:
+      testrail-run-name-for-cli-test:
+        description: 'Name for the TestRail test run'
+        required: false
+        default: ''
 
 permissions: {}
 
@@ -567,6 +574,8 @@ jobs:
           platform-ref: ${{ github.event.pull_request.head.sha || github.sha }}
           provision-policy-fixtures: "false"
       - uses: ./otdfctl/e2e
+        with:
+          testrail-run-name-for-cli-test: ${{ inputs.testrail-run-name-for-cli-test }}
         env:
           TESTRAIL_USER: ${{ secrets.TESTRAIL_USER }}
           TESTRAIL_PASS: ${{ secrets.TESTRAIL_PASS }}

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,6 +13,7 @@ on:
     branches:
       - main
       - release/**
+      - ab-2181-otdfctl-improvements
   merge_group:
     branches:
       - main

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,12 +13,13 @@ on:
     branches:
       - main
       - release/**
-      - ab-2181-otdfctl-improvements
   merge_group:
     branches:
       - main
     types:
       - checks_requested
+  schedule:
+    - cron: '0 6 * * *'
   workflow_call:
   workflow_dispatch:
     inputs:

--- a/otdfctl/e2e/action.yaml
+++ b/otdfctl/e2e/action.yaml
@@ -73,6 +73,7 @@ runs:
         name: bats-test-results
         path: otdfctl/e2e/bats-results.tap
     - name: Integrate Bats test results into TestRail
+      if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       shell: bash
       working-directory: otdfctl
       run: |
@@ -86,6 +87,7 @@ runs:
         TESTRAIL_PASS: ${{ env.TESTRAIL_PASS }}
         TESTRAIL_CLI_RUN_NAME: ${{ inputs.testrail-run-name-for-cli-test }}
     - name: Upload TestRail mapping report
+      if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       uses: actions/upload-artifact@v4
       with:
         name: test-cases-mapping-report

--- a/otdfctl/e2e/action.yaml
+++ b/otdfctl/e2e/action.yaml
@@ -73,7 +73,6 @@ runs:
         name: bats-test-results
         path: otdfctl/e2e/bats-results.tap
     - name: Integrate Bats test results into TestRail
-      if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/ab-2181-otdfctl-improvements'
       shell: bash
       working-directory: otdfctl
       run: |
@@ -87,7 +86,6 @@ runs:
         TESTRAIL_PASS: ${{ env.TESTRAIL_PASS }}
         TESTRAIL_CLI_RUN_NAME: ${{ inputs.testrail-run-name-for-cli-test }}
     - name: Upload TestRail mapping report
-      if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/ab-2181-otdfctl-improvements'
       uses: actions/upload-artifact@v4
       with:
         name: test-cases-mapping-report

--- a/otdfctl/e2e/action.yaml
+++ b/otdfctl/e2e/action.yaml
@@ -73,6 +73,7 @@ runs:
         name: bats-test-results
         path: otdfctl/e2e/bats-results.tap
     - name: Integrate Bats test results into TestRail
+      if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       shell: bash
       working-directory: otdfctl
       run: |

--- a/otdfctl/e2e/action.yaml
+++ b/otdfctl/e2e/action.yaml
@@ -73,6 +73,7 @@ runs:
         name: bats-test-results
         path: otdfctl/e2e/bats-results.tap
     - name: Integrate Bats test results into TestRail
+      if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
       shell: bash
       working-directory: otdfctl
       run: |
@@ -86,6 +87,7 @@ runs:
         TESTRAIL_PASS: ${{ env.TESTRAIL_PASS }}
         TESTRAIL_CLI_RUN_NAME: ${{ inputs.testrail-run-name-for-cli-test }}
     - name: Upload TestRail mapping report
+      if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
       uses: actions/upload-artifact@v4
       with:
         name: test-cases-mapping-report

--- a/otdfctl/e2e/action.yaml
+++ b/otdfctl/e2e/action.yaml
@@ -73,7 +73,7 @@ runs:
         name: bats-test-results
         path: otdfctl/e2e/bats-results.tap
     - name: Integrate Bats test results into TestRail
-      if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+      if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/ab-2181-otdfctl-improvements'
       shell: bash
       working-directory: otdfctl
       run: |
@@ -87,7 +87,7 @@ runs:
         TESTRAIL_PASS: ${{ env.TESTRAIL_PASS }}
         TESTRAIL_CLI_RUN_NAME: ${{ inputs.testrail-run-name-for-cli-test }}
     - name: Upload TestRail mapping report
-      if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+      if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/ab-2181-otdfctl-improvements'
       uses: actions/upload-artifact@v4
       with:
         name: test-cases-mapping-report

--- a/otdfctl/e2e/action.yaml
+++ b/otdfctl/e2e/action.yaml
@@ -73,7 +73,6 @@ runs:
         name: bats-test-results
         path: otdfctl/e2e/bats-results.tap
     - name: Integrate Bats test results into TestRail
-      if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       shell: bash
       working-directory: otdfctl
       run: |

--- a/otdfctl/e2e/testrail-integration/samples-for-virtru-instance/testname-to-testrail-id.virtru.json
+++ b/otdfctl/e2e/testrail-integration/samples-for-virtru-instance/testname-to-testrail-id.virtru.json
@@ -192,7 +192,8 @@
     "Unsafe reactivate namespace": "C793449",
     "List namespaces - when reactivated": "C793450",
     "Unsafe delete namespace": "C793451",
-    "List namespaces - when deleted": "C793452"
+    "List namespaces - when deleted": "C793452",
+    "Direct path: policy namespaces commands are accessible": "C10294193"
   },
   "Obligations": {
     "Create a obligation - Good": "C875288",
@@ -218,6 +219,7 @@
     "Create an obligation trigger - Required Only - IDs - Success": "C875308",
     "Create an obligation trigger - Required Only - FQNs - Success": "C875309",
     "Create an obligation trigger - Optional Fields - Success": "C875310",
+    "Create an obligation trigger - Same tuple different client IDs - Success": "C10294194",
     "Create an obligation trigger - Bad": "C875311",
     "Delete an obligation trigger - Good": "C875312",
     "List obligation triggers - No filters": "C875378",
@@ -295,6 +297,9 @@
     "Update a SCS - from flag value JSON": "C794014",
     "Update a SCS - from file": "C797138",
     "List SCS": "C794015",
+    "Create a SCS with namespace id": "C10322092",
+    "Create a SCS with namespace FQN": "C10322093",
+    "List SCS with namespace filter": "C10322094",
     "Prune SCS - deletes unmapped SCS alone": "C794016"
   },
   "Subject Mapping": {
@@ -303,6 +308,9 @@
     "Get subject mapping": "C793465",
     "Update a subject mapping": "C793466",
     "List subject mappings": "C793467",
+    "Create subject mapping with namespace ID": "C10322095",
+    "Create subject mapping with namespace FQN": "C10322096",
+    "List subject mappings with namespace": "C10322097",
     "Delete subject mapping": "C793468"
   }
 }

--- a/otdfctl/e2e/testrail-integration/upload-bats-test-results-to-testrail.sh
+++ b/otdfctl/e2e/testrail-integration/upload-bats-test-results-to-testrail.sh
@@ -16,6 +16,13 @@ set -euo pipefail
 # ================================================================
 
 # -----------------------------
+# Colors
+# -----------------------------
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# -----------------------------
 # Load TestRail config
 # -----------------------------
 
@@ -73,7 +80,7 @@ lookup_case_id() {
     while IFS= read -r section; do
       id=$(jq -r --arg n "$lowercasename" --arg s "$section" '
         reduce ( .[$s] | to_entries[] ) as $item (null;
-          if ($item.key | ascii_downcase) == $n then $item.value else . end
+          if ($item.key | ascii_downcase | ltrimstr("[auto] ") | ltrimstr("(auto) ")) == $n then $item.value else . end
         )
       ' "$MAPPING_FILE")
 
@@ -86,7 +93,7 @@ lookup_case_id() {
     # Flat JSON
     id=$(jq -r --arg n "$lowercasename" '
       reduce to_entries[] as $item (null;
-        if ($item.key | ascii_downcase) == $n then $item.value else . end
+        if ($item.key | ascii_downcase | ltrimstr("[auto] ") | ltrimstr("(auto) ")) == $n then $item.value else . end
       )
     ' "$MAPPING_FILE")
 
@@ -129,12 +136,12 @@ parse_tap() {
       if [[ -n "$mapping" ]]; then
         case_id="${mapping%%|*}"
         section="${mapping##*|}"
-        echo "\"$name\" YES $case_id (Section: $section)"
-        echo "\"$name\" YES $case_id" >> "$REPORT_FILE"
+        echo -e "\"$name\" ${GREEN}YES_MAPPING_FOUND${NC} $case_id (Section: $section)"
+        echo "\"$name\" YES_MAPPING_FOUND $case_id" >> "$REPORT_FILE"
         results+=("{\"case_id\": ${case_id#C}, \"status_id\": $status_id, \"comment\": \"$name\"}")
       else
-        echo "\"$name\" NO"
-        echo "\"$name\" NO" >> "$REPORT_FILE"
+        echo -e "\"$name\" ${RED}MAPPING_NOT_FOUND${NC}"
+        echo "\"$name\" MAPPING_NOT_FOUND" >> "$REPORT_FILE"
       fi
     fi
   done < "$TAP_FILE"

--- a/otdfctl/e2e/testrail-integration/upload-bats-test-results-to-testrail.sh
+++ b/otdfctl/e2e/testrail-integration/upload-bats-test-results-to-testrail.sh
@@ -150,16 +150,23 @@ parse_tap() {
 find_existing_run() {
   curl -s -u "$TESTRAIL_USER:$TESTRAIL_PASS" \
     "$TESTRAIL_URL/index.php?/api/v2/get_runs/$PROJECT_ID" |
-    jq ".runs[] | select(.name==\"$RUN_NAME\") | .id" | head -n1
+#    jq ".runs[] | select(.name==\"$RUN_NAME\") | .id" | head -n1
+    jq --arg run_name "$RUN_NAME" '.runs[] | select(.name == $run_name) | .id' | head -n1
 }
 
 create_run() {
   local case_ids_json
+  local payload
   case_ids_json=$(printf '%s\n' "${results[@]}" | jq -s '.[].case_id' | jq -s .)
+  payload=$(jq -n \
+    --arg name "$RUN_NAME" \
+    --argjson case_ids "$case_ids_json" \
+    '{name: $name, include_all: false, case_ids: $case_ids}')
+
 
   curl -s -u "$TESTRAIL_USER:$TESTRAIL_PASS" \
     -H "Content-Type: application/json" \
-    -d "{\"name\": \"$RUN_NAME\", \"include_all\": false, \"case_ids\": $case_ids_json}" \
+    -d "$payload" \
     "$TESTRAIL_URL/index.php?/api/v2/add_run/$PROJECT_ID" | jq .id
 }
 

--- a/otdfctl/e2e/testrail-integration/upload-bats-test-results-to-testrail.sh
+++ b/otdfctl/e2e/testrail-integration/upload-bats-test-results-to-testrail.sh
@@ -150,7 +150,6 @@ parse_tap() {
 find_existing_run() {
   curl -s -u "$TESTRAIL_USER:$TESTRAIL_PASS" \
     "$TESTRAIL_URL/index.php?/api/v2/get_runs/$PROJECT_ID" |
-#    jq ".runs[] | select(.name==\"$RUN_NAME\") | .id" | head -n1
     jq --arg run_name "$RUN_NAME" '.runs[] | select(.name == $run_name) | .id' | head -n1
 }
 

--- a/otdfctl/e2e/testrail-integration/upload-bats-test-results-to-testrail.sh
+++ b/otdfctl/e2e/testrail-integration/upload-bats-test-results-to-testrail.sh
@@ -136,12 +136,12 @@ parse_tap() {
       if [[ -n "$mapping" ]]; then
         case_id="${mapping%%|*}"
         section="${mapping##*|}"
-        echo -e "\"$name\" ${GREEN}YES_MAPPING_FOUND${NC} $case_id (Section: $section)"
-        echo "\"$name\" YES_MAPPING_FOUND $case_id" >> "$REPORT_FILE"
-        results+=("{\"case_id\": ${case_id#C}, \"status_id\": $status_id, \"comment\": \"$name\"}")
+        printf "\"%s\" ${GREEN}YES_MAPPING_FOUND${NC} %s (Section: %s)\n" "$name" "$case_id" "$section"
+        printf "\"%s\" YES_MAPPING_FOUND %s\n" "$name" "$case_id" >> "$REPORT_FILE"
+        results+=("$(jq -n -c --arg cid "${case_id#C}" --arg sid "$status_id" --arg comment "$name" '{case_id: ($cid|tonumber), status_id: ($sid|tonumber), comment: $comment}')")
       else
-        echo -e "\"$name\" ${RED}MAPPING_NOT_FOUND${NC}"
-        echo "\"$name\" MAPPING_NOT_FOUND" >> "$REPORT_FILE"
+        printf "\"%s\" ${RED}MAPPING_NOT_FOUND${NC}\n" "$name"
+        printf "\"%s\" MAPPING_NOT_FOUND\n" "$name" >> "$REPORT_FILE"
       fi
     fi
   done < "$TAP_FILE"


### PR DESCRIPTION
## Summary

Number of otdfctl e2e improvements:
- **Manual workflow trigger**: Added `workflow_dispatch` input to `checks.yaml` so the E2E tests can be triggered on demand manually with a custom TestRail run name
- **Single scheduled run**: Added scheduled per day run for `checks.yaml` to run tests in the morning and save CLI test results into TestRail
- **TestRail upload gating**: The TestRail result upload and artifact steps in `action.yaml` now only run on scheduled and manually triggered runs, preventing pollution TestRail with lots of PR and merge-to-main runs.
- **Auto-prefix tolerance in name matching**: `upload-bats-test-results-to-testrail.sh` now strips `[Auto] ` / `(Auto) ` prefixes from mapping file keys before comparison, so TestRail case names can carry those prefixes without breaking the TAP→case-ID lookup.
- **Colored output in upload script**: Mapping results now print `YES_MAPPING_FOUND` (green) / `MAPPING_NOT_FOUND` (red) for easier visual scanning of the report.
- **New test case IDs**: `testname-to-testrail-id.virtru.json` updated with new case IDs for policy namespaces, obligation triggers, SCS namespace filters, and subject mapping namespace variants.

Covers AB-2181, AB-2168 JIRA tasks.

## Test plan

- [x] Trigger the workflow manually via GitHub Actions UI and verify the custom run name appears in TestRail (post-merge)
- [x] Confirm scheduled/push-to-main runs still upload results to TestRail (merge/post-merge)
- [x] Confirm PR runs do **not** upload results to TestRail (e.g. test run [here](https://github.com/opentdf/platform/actions/runs/24772783496))
- [x] Verify test cases with `[Auto]`/`(Auto)` prefixes in the mapping file are correctly matched against plain TAP names.
- [x] Check that mapping logs in stdout shows colored output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional input to set a custom TestRail run name for manual workflow runs.

* **Chores**
  * Workflows now run daily and support manual dispatch.
  * TestRail integration and related artifact uploads now run only for scheduled or manually-triggered runs.
  * Expanded end-to-end test mappings.
  * Improved test result reporting with case-insensitive matching and clearer mapping status indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->