### PR TITLE
feat(cli): Add E2E tests for namespaced policy.

### DIFF
--- a/otdfctl/e2e/migrate-namespaced-policy.bats
+++ b/otdfctl/e2e/migrate-namespaced-policy.bats
@@ -342,26 +342,25 @@ namespace_state_json() {
   local registered_resources_total
   local obligation_triggers_total
 
-  actions_total=$(
-    ./otdfctl $HOST $WITH_CREDS policy actions list --namespace "$namespace_filter" --limit 1 --offset 0 --json \
-      | jq -r '.pagination.total // 0'
-  )
-  subject_mappings_total=$(
-    ./otdfctl $HOST $WITH_CREDS policy subject-mappings list --namespace "$namespace_filter" --limit 1 --offset 0 --json \
-      | jq -r '.pagination.total // 0'
-  )
-  scs_total=$(
-    ./otdfctl $HOST $WITH_CREDS policy scs list --namespace "$namespace_filter" --limit 1 --offset 0 --json \
-      | jq -r '.pagination.total // 0'
-  )
-  registered_resources_total=$(
-    ./otdfctl $HOST $WITH_CREDS policy registered-resources list --namespace "$namespace_filter" --limit 1 --offset 0 --json \
-      | jq -r '.pagination.total // 0'
-  )
-  obligation_triggers_total=$(
-    ./otdfctl $HOST $WITH_CREDS policy obligations triggers list --namespace "$namespace_filter" --limit 1 --offset 0 --json \
-      | jq -r '.pagination.total // 0'
-  )
+  run ./otdfctl $HOST $WITH_CREDS policy actions list --namespace "$namespace_filter" --limit 1 --offset 0 --json
+  assert_success
+  actions_total=$(echo "$output" | jq -r '.pagination.total // 0')
+
+  run ./otdfctl $HOST $WITH_CREDS policy subject-mappings list --namespace "$namespace_filter" --limit 1 --offset 0 --json
+  assert_success
+  subject_mappings_total=$(echo "$output" | jq -r '.pagination.total // 0')
+
+  run ./otdfctl $HOST $WITH_CREDS policy scs list --namespace "$namespace_filter" --limit 1 --offset 0 --json
+  assert_success
+  scs_total=$(echo "$output" | jq -r '.pagination.total // 0')
+
+  run ./otdfctl $HOST $WITH_CREDS policy registered-resources list --namespace "$namespace_filter" --limit 1 --offset 0 --json
+  assert_success
+  registered_resources_total=$(echo "$output" | jq -r '.pagination.total // 0')
+
+  run ./otdfctl $HOST $WITH_CREDS policy obligations triggers list --namespace "$namespace_filter" --limit 1 --offset 0 --json
+  assert_success
+  obligation_triggers_total=$(echo "$output" | jq -r '.pagination.total // 0')
 
   jq -cn \
     --argjson actions "$actions_total" \
@@ -427,15 +426,15 @@ subject_mapping_json_by_migrated_from() {
   ./otdfctl $HOST $WITH_CREDS policy subject-mappings list --namespace "$namespace_filter" --limit 100 --offset 0 --json \
     | jq -cer --arg source_mapping_id "$source_mapping_id" '
       [
-        .subject_mappings[]
+        (.subject_mappings // [])[]
         | select((.metadata.labels.migrated_from // "") == $source_mapping_id)
       ] | if length == 1 then .[0] else empty end
     '
 }
 
 subject_mapping_id_by_migrated_from() {
-  local source_mapping_id="$1"
-  local namespace_filter="$2"
+  local namespace_filter="$1"
+  local source_mapping_id="$2"
 
   subject_mapping_json_by_migrated_from "$namespace_filter" "$source_mapping_id" | jq -r '.id // empty'
 }
@@ -468,7 +467,7 @@ assert_subject_mapping_created_in_namespace() {
   assert_not_equal "$expected_action_target_id" ""
 
   local expected_scs_target_id
-  expected_scs_target_id=$(scs_id_by_migrated_from "$source_scs_id" "$namespace_id")
+  expected_scs_target_id=$(scs_id_by_migrated_from "$namespace_id" "$source_scs_id")
   assert_not_equal "$expected_scs_target_id" ""
 
   local source_mapping_json
@@ -537,7 +536,8 @@ obligation_trigger_json_by_id() {
   local trigger_id="$1"
   local namespace_filter="$2"
 
-  ./otdfctl $HOST $WITH_CREDS policy obligations triggers list --namespace "$namespace_filter" --limit 100 --offset 0 --json | jq -cer --arg trigger_id "$trigger_id" '.triggers[] | select(.id == $trigger_id)'
+  ./otdfctl $HOST $WITH_CREDS policy obligations triggers list --namespace "$namespace_filter" --limit 100 --offset 0 --json \
+    | jq -cer --arg trigger_id "$trigger_id" '(.triggers // [])[] | select(.id == $trigger_id)'
 }
 
 obligation_trigger_json_by_migrated_from() {
@@ -547,15 +547,15 @@ obligation_trigger_json_by_migrated_from() {
   ./otdfctl $HOST $WITH_CREDS policy obligations triggers list --namespace "$namespace_filter" --limit 100 --offset 0 --json \
     | jq -cer --arg source_trigger_id "$source_trigger_id" '
       [
-        .triggers[]
+        (.triggers // [])[]
         | select((.metadata.labels.migrated_from // "") == $source_trigger_id)
       ] | if length == 1 then .[0] else empty end
     '
 }
 
 obligation_trigger_id_by_migrated_from() {
-  local source_trigger_id="$1"
-  local namespace_filter="$2"
+  local namespace_filter="$1"
+  local source_trigger_id="$2"
 
   obligation_trigger_json_by_migrated_from "$namespace_filter" "$source_trigger_id" | jq -r '.id // empty'
 }
@@ -595,15 +595,15 @@ scs_json_by_migrated_from() {
   ./otdfctl $HOST $WITH_CREDS policy scs list --namespace "$namespace_filter" --limit 100 --offset 0 --json \
     | jq -cer --arg source_scs_id "$source_scs_id" '
       [
-        .subject_condition_sets[]
+        (.subject_condition_sets // [])[]
         | select((.metadata.labels.migrated_from // "") == $source_scs_id)
       ] | if length == 1 then .[0] else empty end
     '
 }
 
 scs_id_by_migrated_from() {
-  local source_scs_id="$1"
-  local namespace_filter="$2"
+  local namespace_filter="$1"
+  local source_scs_id="$2"
 
   scs_json_by_migrated_from "$namespace_filter" "$source_scs_id" | jq -r '.id // empty'
 }
@@ -615,15 +615,15 @@ registered_resource_json_by_migrated_from() {
   ./otdfctl $HOST $WITH_CREDS policy registered-resources list --namespace "$namespace_filter" --limit 100 --offset 0 --json \
     | jq -cer --arg source_resource_id "$source_resource_id" '
       [
-        .resources[]
+        (.resources // [])[]
         | select((.metadata.labels.migrated_from // "") == $source_resource_id)
       ] | if length == 1 then .[0] else empty end
     '
 }
 
 registered_resource_id_by_migrated_from() {
-  local source_resource_id="$1"
-  local namespace_filter="$2"
+  local namespace_filter="$1"
+  local source_resource_id="$2"
 
   registered_resource_json_by_migrated_from "$namespace_filter" "$source_resource_id" | jq -r '.id // empty'
 }
@@ -635,7 +635,7 @@ registered_resource_value_json_by_migrated_from() {
   ./otdfctl $HOST $WITH_CREDS policy registered-resources values list --resource "$resource_id" --limit 100 --offset 0 --json \
     | jq -cer --arg source_value_id "$source_value_id" '
       [
-        .values[]
+        (.values // [])[]
         | select((.metadata.labels.migrated_from // "") == $source_value_id)
       ] | if length == 1 then .[0] else empty end
     '
@@ -662,7 +662,25 @@ assert_scs_absent_in_namespace() {
 
   run sh -c "./otdfctl $HOST $WITH_CREDS policy scs list --namespace \"$namespace_filter\" --limit 100 --offset 0 --json"
   assert_success
-  assert_equal "$(echo "$output" | jq -r --arg source_scs_id "$source_scs_id" '[.subject_condition_sets[] | select((.metadata.labels.migrated_from // "") == $source_scs_id)] | length')" "0"
+  assert_equal "$(echo "$output" | jq -r --arg source_scs_id "$source_scs_id" '[(.subject_condition_sets // [])[] | select((.metadata.labels.migrated_from // "") == $source_scs_id)] | length')" "0"
+}
+
+registered_resource_values_signature() {
+  local resource_json="$1"
+
+  echo "$resource_json" | jq -c '
+    def normalized_bindings:
+      (.action_attribute_values // [])
+      | map("\(.action.name | ascii_downcase)|\(.attribute_value.fqn)")
+      | sort;
+
+    (.values // [])
+    | map({
+        value: (.value | ascii_downcase),
+        bindings: normalized_bindings
+      })
+    | sort_by([.value, (.bindings | join(","))])
+  '
 }
 
 assert_standard_action_resolved_in_namespace() {
@@ -834,31 +852,7 @@ assert_registered_resource_already_migrated_in_namespace() {
   assert_equal "$(echo "$existing_resource_json" | jq -r '.id // empty')" "$existing_resource_id"
   assert_equal "$(echo "$existing_resource_json" | jq -r '.namespace.id')" "$namespace_id"
   assert_equal "$(echo "$existing_resource_json" | jq -r '.name')" "$(echo "$source_resource_json" | jq -r '.name')"
-  assert_equal \
-    "$(echo "$existing_resource_json" | jq -c '
-      (.values // [])
-      | map({
-          value: (.value | ascii_downcase),
-          action_attribute_values: (
-            (.action_attribute_values // [])
-            | map("\(.action.name | ascii_downcase)|\(.attribute_value.fqn)")
-            | sort
-          )
-        })
-      | sort_by(.value, (.action_attribute_values | join(",")))
-    ')" \
-    "$(echo "$source_resource_json" | jq -c '
-      (.values // [])
-      | map({
-          value: (.value | ascii_downcase),
-          action_attribute_values: (
-            (.action_attribute_values // [])
-            | map("\(.action.name | ascii_downcase)|\(.attribute_value.fqn)")
-            | sort
-          )
-        })
-      | sort_by(.value, (.action_attribute_values | join(",")))
-    ')"
+  assert_equal "$(registered_resource_values_signature "$existing_resource_json")" "$(registered_resource_values_signature "$source_resource_json")"
 }
 
 assert_registered_resource_value_uses_action() {
@@ -1302,8 +1296,8 @@ teardown_file() {
   # canonical target should continue to resolve as already_migrated.
   local fanout_ns_a_target_id
   local single_namespace_target_id
-  fanout_ns_a_target_id=$(scs_id_by_migrated_from "$fanout_scs_id" "$NS_A_ID")
-  single_namespace_target_id=$(scs_id_by_migrated_from "$single_namespace_scs_id" "$NS_A_ID")
+  fanout_ns_a_target_id=$(scs_id_by_migrated_from "$NS_A_ID" "$fanout_scs_id")
+  single_namespace_target_id=$(scs_id_by_migrated_from "$NS_A_ID" "$single_namespace_scs_id")
   assert_not_equal "$fanout_ns_a_target_id" ""
   assert_not_equal "$single_namespace_target_id" ""
 
@@ -1381,10 +1375,10 @@ teardown_file() {
   local mapping_a_target_id
   local mapping_b_target_id
   custom_action_target_id=$(action_id_by_name_in_namespace "$custom_action_name" "$NS_A_ID")
-  sm_a_scs_target_id=$(scs_id_by_migrated_from "$sm_a_scs_id" "$NS_A_ID")
-  sm_b_scs_target_id=$(scs_id_by_migrated_from "$sm_b_scs_id" "$NS_B_ID")
-  mapping_a_target_id=$(subject_mapping_id_by_migrated_from "$mapping_a_id" "$NS_A_ID")
-  mapping_b_target_id=$(subject_mapping_id_by_migrated_from "$mapping_b_id" "$NS_B_ID")
+  sm_a_scs_target_id=$(scs_id_by_migrated_from "$NS_A_ID" "$sm_a_scs_id")
+  sm_b_scs_target_id=$(scs_id_by_migrated_from "$NS_B_ID" "$sm_b_scs_id")
+  mapping_a_target_id=$(subject_mapping_id_by_migrated_from "$NS_A_ID" "$mapping_a_id")
+  mapping_b_target_id=$(subject_mapping_id_by_migrated_from "$NS_B_ID" "$mapping_b_id")
 
   ns_a_state_before="$ns_a_state_after"
   ns_b_state_before="$ns_b_state_after"
@@ -1480,7 +1474,7 @@ teardown_file() {
   local custom_action_target_id
   local rr_a_target_id
   custom_action_target_id=$(action_id_by_name_in_namespace "$custom_action_name" "$NS_A_ID")
-  rr_a_target_id=$(registered_resource_id_by_migrated_from "$rr_a_id" "$NS_A_ID")
+  rr_a_target_id=$(registered_resource_id_by_migrated_from "$NS_A_ID" "$rr_a_id")
 
   ns_a_state_before="$ns_a_state_after"
   ns_b_state_before="$ns_b_state_after"
@@ -1571,7 +1565,7 @@ teardown_file() {
   local custom_action_target_id
   local trigger_a_target_id
   custom_action_target_id=$(action_id_by_name_in_namespace "$custom_action_name" "$NS_A_ID")
-  trigger_a_target_id=$(obligation_trigger_id_by_migrated_from "$trigger_a_id" "$NS_A_ID")
+  trigger_a_target_id=$(obligation_trigger_id_by_migrated_from "$NS_A_ID" "$trigger_a_id")
 
   ns_a_state_before="$ns_a_state_after"
   ns_b_state_before="$ns_b_state_after"
@@ -1661,10 +1655,10 @@ teardown_file() {
   local rr_target_id
   local trigger_target_id
   custom_action_target_id=$(action_id_by_name_in_namespace "$custom_action_name" "$NS_A_ID")
-  scs_target_id=$(scs_id_by_migrated_from "$scs_id" "$NS_A_ID")
-  mapping_target_id=$(subject_mapping_id_by_migrated_from "$mapping_id" "$NS_A_ID")
-  rr_target_id=$(registered_resource_id_by_migrated_from "$rr_id" "$NS_A_ID")
-  trigger_target_id=$(obligation_trigger_id_by_migrated_from "$trigger_id" "$NS_A_ID")
+  scs_target_id=$(scs_id_by_migrated_from "$NS_A_ID" "$scs_id")
+  mapping_target_id=$(subject_mapping_id_by_migrated_from "$NS_A_ID" "$mapping_id")
+  rr_target_id=$(registered_resource_id_by_migrated_from "$NS_A_ID" "$rr_id")
+  trigger_target_id=$(obligation_trigger_id_by_migrated_from "$NS_A_ID" "$trigger_id")
 
   ns_a_state_before="$ns_a_state_after"
   ns_b_state_before="$ns_b_state_after"

--- a/otdfctl/e2e/migrate-namespaced-policy.bats
+++ b/otdfctl/e2e/migrate-namespaced-policy.bats
@@ -334,116 +334,155 @@ lookup_namespaced_action_id() {
   printf -v "$result_var" '%s' "$looked_up_action_id"
 }
 
-subject_mapping_plan_target_count() {
-  local output_file="$1"
-  local source_mapping_id="$2"
-  jq -er --arg source_mapping_id "$source_mapping_id" '
-    [
-      .subject_mappings[]
-      | select(.source.id == $source_mapping_id)
-      | .target
-      | select(. != null)
-    ] | length
-  ' "$output_file"
+namespace_state_json() {
+  local namespace_filter="$1"
+  local actions_total
+  local subject_mappings_total
+  local scs_total
+  local registered_resources_total
+  local obligation_triggers_total
+
+  actions_total=$(
+    ./otdfctl $HOST $WITH_CREDS policy actions list --namespace "$namespace_filter" --limit 1 --offset 0 --json \
+      | jq -r '.pagination.total // 0'
+  )
+  subject_mappings_total=$(
+    ./otdfctl $HOST $WITH_CREDS policy subject-mappings list --namespace "$namespace_filter" --limit 1 --offset 0 --json \
+      | jq -r '.pagination.total // 0'
+  )
+  scs_total=$(
+    ./otdfctl $HOST $WITH_CREDS policy scs list --namespace "$namespace_filter" --limit 1 --offset 0 --json \
+      | jq -r '.pagination.total // 0'
+  )
+  registered_resources_total=$(
+    ./otdfctl $HOST $WITH_CREDS policy registered-resources list --namespace "$namespace_filter" --limit 1 --offset 0 --json \
+      | jq -r '.pagination.total // 0'
+  )
+  obligation_triggers_total=$(
+    ./otdfctl $HOST $WITH_CREDS policy obligations triggers list --namespace "$namespace_filter" --limit 1 --offset 0 --json \
+      | jq -r '.pagination.total // 0'
+  )
+
+  jq -cn \
+    --argjson actions "$actions_total" \
+    --argjson subject_mappings "$subject_mappings_total" \
+    --argjson scs "$scs_total" \
+    --argjson registered_resources "$registered_resources_total" \
+    --argjson obligation_triggers "$obligation_triggers_total" \
+    '{
+      actions: $actions,
+      subject_mappings: $subject_mappings,
+      scs: $scs,
+      registered_resources: $registered_resources,
+      obligation_triggers: $obligation_triggers
+    }'
 }
 
-subject_mapping_plan_target_status() {
-  local output_file="$1"
-  local source_mapping_id="$2"
-  local namespace_fqn="$3"
-  jq -er --arg source_mapping_id "$source_mapping_id" --arg namespace_fqn "$namespace_fqn" '
-    .subject_mappings[]
-    | select(.source.id == $source_mapping_id)
-    | .target
-    | select(.namespace.fqn == $namespace_fqn)
-    | .status
-  ' "$output_file"
+assert_namespace_state_delta() {
+  local before_state="$1"
+  local after_state="$2"
+  local expected_actions_delta="$3"
+  local expected_subject_mappings_delta="$4"
+  local expected_scs_delta="$5"
+  local expected_registered_resources_delta="$6"
+  local expected_obligation_triggers_delta="$7"
+  local actual_delta_json
+  local expected_delta_json
+
+  actual_delta_json=$(
+    jq -cn \
+      --argjson before "$before_state" \
+      --argjson after "$after_state" \
+      '{
+        actions: ($after.actions - $before.actions),
+        subject_mappings: ($after.subject_mappings - $before.subject_mappings),
+        scs: ($after.scs - $before.scs),
+        registered_resources: ($after.registered_resources - $before.registered_resources),
+        obligation_triggers: ($after.obligation_triggers - $before.obligation_triggers)
+      }'
+  )
+  expected_delta_json=$(
+    jq -cn \
+      --argjson actions "$expected_actions_delta" \
+      --argjson subject_mappings "$expected_subject_mappings_delta" \
+      --argjson scs "$expected_scs_delta" \
+      --argjson registered_resources "$expected_registered_resources_delta" \
+      --argjson obligation_triggers "$expected_obligation_triggers_delta" \
+      '{
+        actions: $actions,
+        subject_mappings: $subject_mappings,
+        scs: $scs,
+        registered_resources: $registered_resources,
+        obligation_triggers: $obligation_triggers
+      }'
+  )
+
+  assert_equal "$actual_delta_json" "$expected_delta_json"
 }
 
-subject_mapping_plan_target_effective_id() {
-  local output_file="$1"
+subject_mapping_json_by_migrated_from() {
+  local namespace_filter="$1"
   local source_mapping_id="$2"
-  local namespace_fqn="$3"
-  jq -er --arg source_mapping_id "$source_mapping_id" --arg namespace_fqn "$namespace_fqn" '
-    .subject_mappings[]
-    | select(.source.id == $source_mapping_id)
-    | .target
-    | select(.namespace.fqn == $namespace_fqn)
-    | (.execution.created_target_id // .existing_id // empty)
-  ' "$output_file"
+
+  ./otdfctl $HOST $WITH_CREDS policy subject-mappings list --namespace "$namespace_filter" --limit 100 --offset 0 --json \
+    | jq -cer --arg source_mapping_id "$source_mapping_id" '
+      [
+        .subject_mappings[]
+        | select((.metadata.labels.migrated_from // "") == $source_mapping_id)
+      ] | if length == 1 then .[0] else empty end
+    '
 }
 
-assert_subject_mapping_target_count() {
-  local output_file="$1"
-  local source_mapping_id="$2"
-  local expected_count="$3"
+subject_mapping_id_by_migrated_from() {
+  local source_mapping_id="$1"
+  local namespace_filter="$2"
 
-  run subject_mapping_plan_target_count "$output_file" "$source_mapping_id"
-  assert_success
-  assert_equal "$output" "$expected_count"
+  subject_mapping_json_by_migrated_from "$namespace_filter" "$source_mapping_id" | jq -r '.id // empty'
 }
 
 assert_subject_mapping_created_in_namespace() {
-  local output_file="$1"
-  local source_mapping_id="$2"
-  local namespace_id="$3"
-  local namespace_fqn="$4"
-  local attribute_value_id="$5"
-  local action_name="$6"
-  local source_action_id="$7"
-  local expected_action_status="$8"
-  local expected_action_count="$9"
-  local source_scs_id="${10}"
-  local expected_scs_count="${11}"
+  local source_mapping_id="$1"
+  local namespace_id="$2"
+  local attribute_value_id="$3"
+  local action_name="$4"
+  local source_action_id="$5"
+  local expected_action_status="$6"
+  local source_scs_id="$7"
 
-  run subject_mapping_plan_target_status "$output_file" "$source_mapping_id" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "create"
-
-  assert_action_target_count "$output_file" "$action_name" "$expected_action_count"
   case "$expected_action_status" in
     create)
-      assert_custom_action_created_in_namespace "$output_file" "$action_name" "$source_action_id" "$namespace_id" "$namespace_fqn"
+      assert_custom_action_created_in_namespace "$action_name" "$source_action_id" "$namespace_id"
       ;;
     existing_standard)
-      assert_standard_action_resolved_in_namespace "$output_file" "$action_name" "$namespace_id" "$namespace_fqn"
+      assert_standard_action_resolved_in_namespace "$action_name" "$namespace_id"
       ;;
     *)
       false
       ;;
   esac
 
-  run action_plan_target_status "$output_file" "$action_name" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "$expected_action_status"
+  assert_scs_created_in_namespace "$source_scs_id" "$namespace_id"
 
   local expected_action_target_id
-  expected_action_target_id=$(action_plan_target_effective_id "$output_file" "$action_name" "$namespace_fqn")
+  expected_action_target_id=$(action_id_by_name_in_namespace "$action_name" "$namespace_id")
   assert_not_equal "$expected_action_target_id" ""
 
-  assert_scs_target_count "$output_file" "$source_scs_id" "$expected_scs_count"
-  assert_scs_created_in_namespace "$output_file" "$source_scs_id" "$namespace_id" "$namespace_fqn"
-
-  run scs_plan_target_status "$output_file" "$source_scs_id" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "create"
-
   local expected_scs_target_id
-  expected_scs_target_id=$(scs_plan_target_effective_id "$output_file" "$source_scs_id" "$namespace_fqn")
+  expected_scs_target_id=$(scs_id_by_migrated_from "$source_scs_id" "$namespace_id")
   assert_not_equal "$expected_scs_target_id" ""
-
-  local created_target_id
-  created_target_id=$(subject_mapping_plan_target_effective_id "$output_file" "$source_mapping_id" "$namespace_fqn")
-  assert_not_equal "$created_target_id" ""
-  assert_not_equal "$created_target_id" "$source_mapping_id"
 
   local source_mapping_json
   source_mapping_json=$(./otdfctl $HOST $WITH_CREDS policy subject-mappings get --id "$source_mapping_id" --json)
 
   local created_mapping_json
-  created_mapping_json=$(./otdfctl $HOST $WITH_CREDS policy subject-mappings get --id "$created_target_id" --json)
+  created_mapping_json=$(subject_mapping_json_by_migrated_from "$namespace_id" "$source_mapping_id")
+  assert_not_equal "$created_mapping_json" ""
 
-  assert_equal "$(echo "$created_mapping_json" | jq -r '.id')" "$created_target_id"
+  local created_target_id
+  created_target_id=$(echo "$created_mapping_json" | jq -r '.id // empty')
+  assert_not_equal "$created_target_id" ""
+  assert_not_equal "$created_target_id" "$source_mapping_id"
+
   assert_equal "$(echo "$created_mapping_json" | jq -r '.namespace.id')" "$namespace_id"
   assert_equal "$(echo "$created_mapping_json" | jq -r '.attribute_value.id')" "$attribute_value_id"
   assert_equal "$(echo "$created_mapping_json" | jq -r '.actions[0].id')" "$expected_action_target_id"
@@ -454,28 +493,21 @@ assert_subject_mapping_created_in_namespace() {
 }
 
 assert_subject_mapping_already_migrated_in_namespace() {
-  local output_file="$1"
-  local source_mapping_id="$2"
-  local namespace_id="$3"
-  local namespace_fqn="$4"
-  local existing_mapping_id="$5"
+  local source_mapping_id="$1"
+  local namespace_id="$2"
+  local existing_mapping_id="$3"
 
   assert_not_equal "$existing_mapping_id" ""
 
-  run subject_mapping_plan_target_status "$output_file" "$source_mapping_id" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "already_migrated"
-
-  local effective_target_id
-  effective_target_id=$(subject_mapping_plan_target_effective_id "$output_file" "$source_mapping_id" "$namespace_fqn")
-  assert_not_equal "$effective_target_id" ""
-  assert_equal "$effective_target_id" "$existing_mapping_id"
+  local source_mapping_json
+  source_mapping_json=$(./otdfctl $HOST $WITH_CREDS policy subject-mappings get --id "$source_mapping_id" --json)
 
   local existing_mapping_json
   existing_mapping_json=$(./otdfctl $HOST $WITH_CREDS policy subject-mappings get --id "$existing_mapping_id" --json)
 
   assert_equal "$(echo "$existing_mapping_json" | jq -r '.id // empty')" "$existing_mapping_id"
   assert_equal "$(echo "$existing_mapping_json" | jq -r '.namespace.id')" "$namespace_id"
+  assert_equal "$(echo "$existing_mapping_json" | jq -r '.attribute_value.id')" "$(echo "$source_mapping_json" | jq -r '.attribute_value.id')"
 }
 
 assert_legacy_subject_mapping_still_exists() {
@@ -495,134 +527,10 @@ assert_legacy_subject_mapping_still_exists() {
 
 assert_no_subject_mappings_in_namespace() {
   local namespace_id="$1"
+  local namespace_state
 
-  run sh -c "./otdfctl $HOST $WITH_CREDS policy subject-mappings list --namespace \"$namespace_id\" --json"
-  assert_success
-  assert_equal "$(echo "$output" | jq -r '.subject_mappings | length')" "0"
-}
-
-registered_resource_plan_target_count() {
-  local output_file="$1"
-  local source_resource_id="$2"
-  jq -er --arg source_resource_id "$source_resource_id" '
-    [
-      .registered_resources[]
-      | select(.source.id == $source_resource_id)
-      | .targets[]
-    ] | length
-  ' "$output_file"
-}
-
-registered_resource_plan_target_status() {
-  local output_file="$1"
-  local source_resource_id="$2"
-  local namespace_fqn="$3"
-  jq -er --arg source_resource_id "$source_resource_id" --arg namespace_fqn "$namespace_fqn" '
-    .registered_resources[]
-    | select(.source.id == $source_resource_id)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-    | .status
-  ' "$output_file"
-}
-
-registered_resource_plan_target_effective_id() {
-  local output_file="$1"
-  local source_resource_id="$2"
-  local namespace_fqn="$3"
-  jq -er --arg source_resource_id "$source_resource_id" --arg namespace_fqn "$namespace_fqn" '
-    .registered_resources[]
-    | select(.source.id == $source_resource_id)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-    | (.execution.created_target_id // .existing.id // empty)
-  ' "$output_file"
-}
-
-registered_resource_value_plan_effective_id() {
-  local output_file="$1"
-  local source_resource_id="$2"
-  local namespace_fqn="$3"
-  local source_value_id="$4"
-  jq -er --arg source_resource_id "$source_resource_id" --arg namespace_fqn "$namespace_fqn" --arg source_value_id "$source_value_id" '
-    .registered_resources[]
-    | select(.source.id == $source_resource_id)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-    | .values[]
-    | select(.source.id == $source_value_id)
-    | (.execution.created_target_id // empty)
-  ' "$output_file"
-}
-
-registered_resource_plan_action_status() {
-  local output_file="$1"
-  local source_resource_id="$2"
-  local namespace_fqn="$3"
-  local source_value_id="$4"
-  local source_action_id="$5"
-  jq -er --arg source_resource_id "$source_resource_id" --arg namespace_fqn "$namespace_fqn" --arg source_value_id "$source_value_id" --arg source_action_id "$source_action_id" '
-    .registered_resources[]
-    | select(.source.id == $source_resource_id)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-    | .values[]
-    | select(.source.id == $source_value_id)
-    | .action_bindings[]
-    | select(.source_action_id == $source_action_id)
-    | .action_target.status
-  ' "$output_file"
-}
-
-obligation_trigger_plan_target_count() {
-  local output_file="$1"
-  local source_trigger_id="$2"
-  jq -er --arg source_trigger_id "$source_trigger_id" '
-    [
-      .obligation_triggers[]
-      | select(.source.id == $source_trigger_id)
-      | .targets[]
-    ] | length
-  ' "$output_file"
-}
-
-obligation_trigger_plan_target_status() {
-  local output_file="$1"
-  local source_trigger_id="$2"
-  local namespace_fqn="$3"
-  jq -er --arg source_trigger_id "$source_trigger_id" --arg namespace_fqn "$namespace_fqn" '
-    .obligation_triggers[]
-    | select(.source.id == $source_trigger_id)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-    | .status
-  ' "$output_file"
-}
-
-obligation_trigger_plan_target_effective_id() {
-  local output_file="$1"
-  local source_trigger_id="$2"
-  local namespace_fqn="$3"
-  jq -er --arg source_trigger_id "$source_trigger_id" --arg namespace_fqn "$namespace_fqn" '
-    .obligation_triggers[]
-    | select(.source.id == $source_trigger_id)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-    | (.execution.created_target_id // .existing.id // empty)
-  ' "$output_file"
-}
-
-obligation_trigger_plan_action_status() {
-  local output_file="$1"
-  local source_trigger_id="$2"
-  local namespace_fqn="$3"
-  jq -er --arg source_trigger_id "$source_trigger_id" --arg namespace_fqn "$namespace_fqn" '
-    .obligation_triggers[]
-    | select(.source.id == $source_trigger_id)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-    | .action.status
-  ' "$output_file"
+  namespace_state=$(namespace_state_json "$namespace_id")
+  assert_equal "$(echo "$namespace_state" | jq -r '.subject_mappings')" "0"
 }
 
 obligation_trigger_json_by_id() {
@@ -630,6 +538,26 @@ obligation_trigger_json_by_id() {
   local namespace_filter="$2"
 
   ./otdfctl $HOST $WITH_CREDS policy obligations triggers list --namespace "$namespace_filter" --limit 100 --offset 0 --json | jq -cer --arg trigger_id "$trigger_id" '.triggers[] | select(.id == $trigger_id)'
+}
+
+obligation_trigger_json_by_migrated_from() {
+  local namespace_filter="$1"
+  local source_trigger_id="$2"
+
+  ./otdfctl $HOST $WITH_CREDS policy obligations triggers list --namespace "$namespace_filter" --limit 100 --offset 0 --json \
+    | jq -cer --arg source_trigger_id "$source_trigger_id" '
+      [
+        .triggers[]
+        | select((.metadata.labels.migrated_from // "") == $source_trigger_id)
+      ] | if length == 1 then .[0] else empty end
+    '
+}
+
+obligation_trigger_id_by_migrated_from() {
+  local source_trigger_id="$1"
+  local namespace_filter="$2"
+
+  obligation_trigger_json_by_migrated_from "$namespace_filter" "$source_trigger_id" | jq -r '.id // empty'
 }
 
 assert_metadata_labels_preserved() {
@@ -646,178 +574,114 @@ assert_metadata_labels_preserved() {
   assert_equal "$target_labels" "$source_labels"
 }
 
-action_plan_source_id() {
-  local output_file="$1"
-  local action_name="$2"
-  jq -er --arg action_name "$action_name" '
-    .actions[]
-    | select(.source.name == $action_name)
-    | .source.id
-  ' "$output_file"
+action_json_by_name_in_namespace() {
+  local action_name="$1"
+  local namespace_filter="$2"
+
+  ./otdfctl $HOST $WITH_CREDS policy actions get --name "$action_name" --namespace "$namespace_filter" --json
 }
 
-action_plan_target_count() {
-  local output_file="$1"
-  local action_name="$2"
-  jq -er --arg action_name "$action_name" '
-    [
-      .actions[]
-      | select(.source.name == $action_name)
-      | .targets[]
-    ] | length
-  ' "$output_file"
+action_id_by_name_in_namespace() {
+  local action_name="$1"
+  local namespace_filter="$2"
+
+  action_json_by_name_in_namespace "$action_name" "$namespace_filter" | jq -r '.id // empty'
 }
 
-action_plan_target_status() {
-  local output_file="$1"
-  local action_name="$2"
-  local namespace_fqn="$3"
-  jq -er --arg action_name "$action_name" --arg namespace_fqn "$namespace_fqn" '
-    .actions[]
-    | select(.source.name == $action_name)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-    | .status
-  ' "$output_file"
-}
-
-action_plan_target_effective_id() {
-  local output_file="$1"
-  local action_name="$2"
-  local namespace_fqn="$3"
-  jq -er --arg action_name "$action_name" --arg namespace_fqn "$namespace_fqn" '
-    .actions[]
-    | select(.source.name == $action_name)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-    | (.execution.created_target_id // .existing_id // empty)
-  ' "$output_file"
-}
-
-scs_plan_target_count() {
-  local output_file="$1"
+scs_json_by_migrated_from() {
+  local namespace_filter="$1"
   local source_scs_id="$2"
-  jq -er --arg source_scs_id "$source_scs_id" '
-    [
-      .subject_condition_sets[]
-      | select(.source.id == $source_scs_id)
-      | .targets[]
-    ] | length
-  ' "$output_file"
+
+  ./otdfctl $HOST $WITH_CREDS policy scs list --namespace "$namespace_filter" --limit 100 --offset 0 --json \
+    | jq -cer --arg source_scs_id "$source_scs_id" '
+      [
+        .subject_condition_sets[]
+        | select((.metadata.labels.migrated_from // "") == $source_scs_id)
+      ] | if length == 1 then .[0] else empty end
+    '
 }
 
-scs_plan_target_status() {
-  local output_file="$1"
-  local source_scs_id="$2"
-  local namespace_fqn="$3"
-  jq -er --arg source_scs_id "$source_scs_id" --arg namespace_fqn "$namespace_fqn" '
-    .subject_condition_sets[]
-    | select(.source.id == $source_scs_id)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-    | .status
-  ' "$output_file"
+scs_id_by_migrated_from() {
+  local source_scs_id="$1"
+  local namespace_filter="$2"
+
+  scs_json_by_migrated_from "$namespace_filter" "$source_scs_id" | jq -r '.id // empty'
 }
 
-scs_plan_target_effective_id() {
-  local output_file="$1"
-  local source_scs_id="$2"
-  local namespace_fqn="$3"
-  jq -er --arg source_scs_id "$source_scs_id" --arg namespace_fqn "$namespace_fqn" '
-    .subject_condition_sets[]
-    | select(.source.id == $source_scs_id)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-    | (.execution.created_target_id // .existing_id // empty)
-  ' "$output_file"
+registered_resource_json_by_migrated_from() {
+  local namespace_filter="$1"
+  local source_resource_id="$2"
+
+  ./otdfctl $HOST $WITH_CREDS policy registered-resources list --namespace "$namespace_filter" --limit 100 --offset 0 --json \
+    | jq -cer --arg source_resource_id "$source_resource_id" '
+      [
+        .resources[]
+        | select((.metadata.labels.migrated_from // "") == $source_resource_id)
+      ] | if length == 1 then .[0] else empty end
+    '
 }
 
-assert_action_target_count() {
-  local output_file="$1"
-  local action_name="$2"
-  local expected_count="$3"
+registered_resource_id_by_migrated_from() {
+  local source_resource_id="$1"
+  local namespace_filter="$2"
 
-  run action_plan_target_count "$output_file" "$action_name"
-  assert_success
-  assert_equal "$output" "$expected_count"
+  registered_resource_json_by_migrated_from "$namespace_filter" "$source_resource_id" | jq -r '.id // empty'
 }
 
-assert_scs_target_count() {
-  local output_file="$1"
-  local source_scs_id="$2"
-  local expected_count="$3"
+registered_resource_value_json_by_migrated_from() {
+  local resource_id="$1"
+  local source_value_id="$2"
 
-  run scs_plan_target_count "$output_file" "$source_scs_id"
-  assert_success
-  assert_equal "$output" "$expected_count"
+  ./otdfctl $HOST $WITH_CREDS policy registered-resources values list --resource "$resource_id" --limit 100 --offset 0 --json \
+    | jq -cer --arg source_value_id "$source_value_id" '
+      [
+        .values[]
+        | select((.metadata.labels.migrated_from // "") == $source_value_id)
+      ] | if length == 1 then .[0] else empty end
+    '
 }
 
-assert_action_target_absent() {
-  local output_file="$1"
-  local action_name="$2"
-  local namespace_fqn="$3"
+registered_resource_value_id_by_migrated_from() {
+  local resource_id="$1"
+  local source_value_id="$2"
 
-  run jq -e --arg action_name "$action_name" --arg namespace_fqn "$namespace_fqn" '
-    .actions[]
-    | select(.source.name == $action_name)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-  ' "$output_file"
+  registered_resource_value_json_by_migrated_from "$resource_id" "$source_value_id" | jq -r '.id // empty'
+}
+
+assert_action_absent_in_namespace() {
+  local action_name="$1"
+  local namespace_filter="$2"
+
+  run sh -c "./otdfctl $HOST $WITH_CREDS policy actions get --name \"$action_name\" --namespace \"$namespace_filter\" --json"
   assert_failure
 }
 
-assert_scs_target_absent() {
-  local output_file="$1"
-  local source_scs_id="$2"
-  local namespace_fqn="$3"
+assert_scs_absent_in_namespace() {
+  local source_scs_id="$1"
+  local namespace_filter="$2"
 
-  run jq -e --arg source_scs_id "$source_scs_id" --arg namespace_fqn "$namespace_fqn" '
-    .subject_condition_sets[]
-    | select(.source.id == $source_scs_id)
-    | .targets[]
-    | select(.namespace.fqn == $namespace_fqn)
-  ' "$output_file"
-  assert_failure
+  run sh -c "./otdfctl $HOST $WITH_CREDS policy scs list --namespace \"$namespace_filter\" --limit 100 --offset 0 --json"
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg source_scs_id "$source_scs_id" '[.subject_condition_sets[] | select((.metadata.labels.migrated_from // "") == $source_scs_id)] | length')" "0"
 }
 
 assert_standard_action_resolved_in_namespace() {
-  local output_file="$1"
-  local action_name="$2"
-  local namespace_id="$3"
-  local namespace_fqn="$4"
+  local action_name="$1"
+  local namespace_id="$2"
 
-  run action_plan_target_status "$output_file" "$action_name" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "existing_standard"
-
-  local planned_target_id
-  planned_target_id=$(action_plan_target_effective_id "$output_file" "$action_name" "$namespace_fqn")
-  assert_not_equal "$planned_target_id" ""
-
-  local live_target_id
-  live_target_id=$(./otdfctl $HOST $WITH_CREDS policy actions get --name "$action_name" --namespace "$namespace_id" --json | jq -r '.id // empty')
-  assert_not_equal "$live_target_id" ""
-
-  assert_equal "$planned_target_id" "$live_target_id"
+  local live_action_json
+  live_action_json=$(action_json_by_name_in_namespace "$action_name" "$namespace_id")
+  assert_not_equal "$live_action_json" ""
+  assert_not_equal "$(echo "$live_action_json" | jq -r '.id // empty')" ""
+  assert_equal "$(echo "$live_action_json" | jq -r '.namespace.id')" "$namespace_id"
 }
 
 assert_action_already_migrated_in_namespace() {
-  local output_file="$1"
-  local action_name="$2"
-  local namespace_id="$3"
-  local namespace_fqn="$4"
-  local existing_action_id="$5"
+  local action_name="$1"
+  local namespace_id="$2"
+  local existing_action_id="$3"
 
   assert_not_equal "$existing_action_id" ""
-
-  run action_plan_target_status "$output_file" "$action_name" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "already_migrated"
-
-  local effective_target_id
-  effective_target_id=$(action_plan_target_effective_id "$output_file" "$action_name" "$namespace_fqn")
-  assert_not_equal "$effective_target_id" ""
-  assert_equal "$effective_target_id" "$existing_action_id"
 
   local existing_action_json
   existing_action_json=$(./otdfctl $HOST $WITH_CREDS policy actions get --id "$existing_action_id" --json)
@@ -827,28 +691,22 @@ assert_action_already_migrated_in_namespace() {
 }
 
 assert_custom_action_created_in_namespace() {
-  local output_file="$1"
-  local action_name="$2"
-  local source_action_id="$3"
-  local namespace_id="$4"
-  local namespace_fqn="$5"
-
-  run action_plan_target_status "$output_file" "$action_name" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "create"
-
-  local created_target_id
-  created_target_id=$(action_plan_target_effective_id "$output_file" "$action_name" "$namespace_fqn")
-  assert_not_equal "$created_target_id" ""
-  assert_not_equal "$created_target_id" "$source_action_id"
+  local action_name="$1"
+  local source_action_id="$2"
+  local namespace_id="$3"
 
   local source_action_json
   source_action_json=$(./otdfctl $HOST $WITH_CREDS policy actions get --id "$source_action_id" --json)
 
   local created_action_json
-  created_action_json=$(./otdfctl $HOST $WITH_CREDS policy actions get --id "$created_target_id" --json)
+  created_action_json=$(action_json_by_name_in_namespace "$action_name" "$namespace_id")
+  assert_not_equal "$created_action_json" ""
 
-  assert_equal "$(echo "$created_action_json" | jq -r '.id')" "$created_target_id"
+  local created_target_id
+  created_target_id=$(echo "$created_action_json" | jq -r '.id // empty')
+  assert_not_equal "$created_target_id" ""
+  assert_not_equal "$created_target_id" "$source_action_id"
+
   assert_equal "$(echo "$created_action_json" | jq -r '.name')" "$action_name"
   assert_equal "$(echo "$created_action_json" | jq -r '.namespace.id')" "$namespace_id"
   assert_metadata_labels_preserved "$source_action_json" "$created_action_json"
@@ -872,27 +730,21 @@ assert_legacy_custom_action_still_exists() {
 }
 
 assert_scs_created_in_namespace() {
-  local output_file="$1"
-  local source_scs_id="$2"
-  local namespace_id="$3"
-  local namespace_fqn="$4"
-
-  run scs_plan_target_status "$output_file" "$source_scs_id" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "create"
-
-  local created_target_id
-  created_target_id=$(scs_plan_target_effective_id "$output_file" "$source_scs_id" "$namespace_fqn")
-  assert_not_equal "$created_target_id" ""
-  assert_not_equal "$created_target_id" "$source_scs_id"
+  local source_scs_id="$1"
+  local namespace_id="$2"
 
   local source_scs_json
   source_scs_json=$(./otdfctl $HOST $WITH_CREDS policy scs get --id "$source_scs_id" --json)
 
   local created_scs_json
-  created_scs_json=$(./otdfctl $HOST $WITH_CREDS policy scs get --id "$created_target_id" --json)
+  created_scs_json=$(scs_json_by_migrated_from "$namespace_id" "$source_scs_id")
+  assert_not_equal "$created_scs_json" ""
 
-  assert_equal "$(echo "$created_scs_json" | jq -r '.id')" "$created_target_id"
+  local created_target_id
+  created_target_id=$(echo "$created_scs_json" | jq -r '.id // empty')
+  assert_not_equal "$created_target_id" ""
+  assert_not_equal "$created_target_id" "$source_scs_id"
+
   assert_equal "$(echo "$created_scs_json" | jq -r '.namespace.id')" "$namespace_id"
   assert_equal "$(echo "$created_scs_json" | jq -c '.subject_sets')" "$(echo "$source_scs_json" | jq -c '.subject_sets')"
   assert_metadata_labels_preserved "$source_scs_json" "$created_scs_json"
@@ -900,85 +752,63 @@ assert_scs_created_in_namespace() {
   assert_not_equal "$(echo "$created_scs_json" | jq -r '.metadata.labels.migration_run // empty')" ""
 }
 
-assert_registered_resource_target_count() {
-  local output_file="$1"
-  local source_resource_id="$2"
-  local expected_count="$3"
-
-  run registered_resource_plan_target_count "$output_file" "$source_resource_id"
-  assert_success
-  assert_equal "$output" "$expected_count"
-}
-
 assert_registered_resource_created_in_namespace() {
-  local output_file="$1"
-  local source_resource_id="$2"
-  local source_value_id="$3"
-  local namespace_id="$4"
-  local namespace_fqn="$5"
-  local resource_name="$6"
-  local resource_value="$7"
-  local action_name="$8"
-  local source_action_id="$9"
-  local expected_action_status="${10}"
-  local expected_action_count="${11}"
-  local attribute_value_id="${12}"
+  local source_resource_id="$1"
+  local source_value_id="$2"
+  local namespace_id="$3"
+  local resource_name="$4"
+  local resource_value="$5"
+  local action_name="$6"
+  local source_action_id="$7"
+  local expected_action_status="$8"
+  local attribute_value_id="$9"
 
-  run registered_resource_plan_target_status "$output_file" "$source_resource_id" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "create"
-
-  assert_action_target_count "$output_file" "$action_name" "$expected_action_count"
   case "$expected_action_status" in
     create)
-      assert_custom_action_created_in_namespace "$output_file" "$action_name" "$source_action_id" "$namespace_id" "$namespace_fqn"
+      assert_custom_action_created_in_namespace "$action_name" "$source_action_id" "$namespace_id"
       ;;
     existing_standard)
-      assert_standard_action_resolved_in_namespace "$output_file" "$action_name" "$namespace_id" "$namespace_fqn"
+      assert_standard_action_resolved_in_namespace "$action_name" "$namespace_id"
       ;;
     *)
       false
       ;;
   esac
 
-  run registered_resource_plan_action_status "$output_file" "$source_resource_id" "$namespace_fqn" "$source_value_id" "$source_action_id"
-  assert_success
-  assert_equal "$output" "$expected_action_status"
-
   local expected_action_target_id
-  expected_action_target_id=$(action_plan_target_effective_id "$output_file" "$action_name" "$namespace_fqn")
+  expected_action_target_id=$(action_id_by_name_in_namespace "$action_name" "$namespace_id")
   assert_not_equal "$expected_action_target_id" ""
-
-  local created_resource_id
-  created_resource_id=$(registered_resource_plan_target_effective_id "$output_file" "$source_resource_id" "$namespace_fqn")
-  assert_not_equal "$created_resource_id" ""
-  assert_not_equal "$created_resource_id" "$source_resource_id"
 
   local source_resource_json
   source_resource_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources get --id "$source_resource_id" --json)
 
   local created_resource_json
-  created_resource_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources get --id "$created_resource_id" --json)
+  created_resource_json=$(registered_resource_json_by_migrated_from "$namespace_id" "$source_resource_id")
+  assert_not_equal "$created_resource_json" ""
 
-  assert_equal "$(echo "$created_resource_json" | jq -r '.id')" "$created_resource_id"
+  local created_resource_id
+  created_resource_id=$(echo "$created_resource_json" | jq -r '.id // empty')
+  assert_not_equal "$created_resource_id" ""
+  assert_not_equal "$created_resource_id" "$source_resource_id"
+
   assert_equal "$(echo "$created_resource_json" | jq -r '.name')" "$resource_name"
   assert_equal "$(echo "$created_resource_json" | jq -r '.namespace.id')" "$namespace_id"
   assert_metadata_labels_preserved "$source_resource_json" "$created_resource_json"
   assert_equal "$(echo "$created_resource_json" | jq -r '.metadata.labels.migrated_from')" "$source_resource_id"
   assert_not_equal "$(echo "$created_resource_json" | jq -r '.metadata.labels.migration_run // empty')" ""
 
-  local created_resource_value_id
-  created_resource_value_id=$(registered_resource_value_plan_effective_id "$output_file" "$source_resource_id" "$namespace_fqn" "$source_value_id")
-  assert_not_equal "$created_resource_value_id" ""
-  assert_not_equal "$created_resource_value_id" "$source_value_id"
-
   local source_resource_value_json
   source_resource_value_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources values get --id "$source_value_id" --json)
 
   local created_resource_value_json
-  created_resource_value_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources values get --id "$created_resource_value_id" --json)
+  created_resource_value_json=$(registered_resource_value_json_by_migrated_from "$created_resource_id" "$source_value_id")
+  assert_not_equal "$created_resource_value_json" ""
 
-  assert_equal "$(echo "$created_resource_value_json" | jq -r '.id')" "$created_resource_value_id"
+  local created_resource_value_id
+  created_resource_value_id=$(echo "$created_resource_value_json" | jq -r '.id // empty')
+  assert_not_equal "$created_resource_value_id" ""
+  assert_not_equal "$created_resource_value_id" "$source_value_id"
+
   assert_equal "$(echo "$created_resource_value_json" | jq -r '.value')" "$resource_value"
   assert_equal "$(echo "$created_resource_value_json" | jq -r '.action_attribute_values | length')" "1"
   assert_equal "$(echo "$created_resource_value_json" | jq -r '.action_attribute_values[0].action.id')" "$expected_action_target_id"
@@ -989,28 +819,59 @@ assert_registered_resource_created_in_namespace() {
 }
 
 assert_registered_resource_already_migrated_in_namespace() {
-  local output_file="$1"
-  local source_resource_id="$2"
-  local namespace_id="$3"
-  local namespace_fqn="$4"
-  local existing_resource_id="$5"
+  local source_resource_id="$1"
+  local namespace_id="$2"
+  local existing_resource_id="$3"
 
   assert_not_equal "$existing_resource_id" ""
 
-  run registered_resource_plan_target_status "$output_file" "$source_resource_id" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "already_migrated"
-
-  local effective_target_id
-  effective_target_id=$(registered_resource_plan_target_effective_id "$output_file" "$source_resource_id" "$namespace_fqn")
-  assert_not_equal "$effective_target_id" ""
-  assert_equal "$effective_target_id" "$existing_resource_id"
+  local source_resource_json
+  source_resource_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources get --id "$source_resource_id" --json)
 
   local existing_resource_json
   existing_resource_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources get --id "$existing_resource_id" --json)
 
   assert_equal "$(echo "$existing_resource_json" | jq -r '.id // empty')" "$existing_resource_id"
   assert_equal "$(echo "$existing_resource_json" | jq -r '.namespace.id')" "$namespace_id"
+  assert_equal "$(echo "$existing_resource_json" | jq -r '.name')" "$(echo "$source_resource_json" | jq -r '.name')"
+  assert_equal \
+    "$(echo "$existing_resource_json" | jq -c '
+      (.values // [])
+      | map({
+          value: (.value | ascii_downcase),
+          action_attribute_values: (
+            (.action_attribute_values // [])
+            | map("\(.action.name | ascii_downcase)|\(.attribute_value.fqn)")
+            | sort
+          )
+        })
+      | sort_by(.value, (.action_attribute_values | join(",")))
+    ')" \
+    "$(echo "$source_resource_json" | jq -c '
+      (.values // [])
+      | map({
+          value: (.value | ascii_downcase),
+          action_attribute_values: (
+            (.action_attribute_values // [])
+            | map("\(.action.name | ascii_downcase)|\(.attribute_value.fqn)")
+            | sort
+          )
+        })
+      | sort_by(.value, (.action_attribute_values | join(",")))
+    ')"
+}
+
+assert_registered_resource_value_uses_action() {
+  local value_id="$1"
+  local expected_action_id="$2"
+  local attribute_value_id="$3"
+
+  local value_json
+  value_json=$(./otdfctl $HOST $WITH_CREDS policy registered-resources values get --id "$value_id" --json)
+
+  assert_equal "$(echo "$value_json" | jq -r '.action_attribute_values | length')" "1"
+  assert_equal "$(echo "$value_json" | jq -r '.action_attribute_values[0].action.id')" "$expected_action_id"
+  assert_equal "$(echo "$value_json" | jq -r '.action_attribute_values[0].attribute_value.id')" "$attribute_value_id"
 }
 
 assert_legacy_registered_resource_still_exists() {
@@ -1036,66 +897,44 @@ assert_legacy_registered_resource_still_exists() {
   assert_equal "$(echo "$legacy_resource_value_json" | jq -r '.value')" "$resource_value"
 }
 
-assert_obligation_trigger_target_count() {
-  local output_file="$1"
-  local source_trigger_id="$2"
-  local expected_count="$3"
-
-  run obligation_trigger_plan_target_count "$output_file" "$source_trigger_id"
-  assert_success
-  assert_equal "$output" "$expected_count"
-}
-
 assert_obligation_trigger_created_in_namespace() {
-  local output_file="$1"
-  local source_trigger_id="$2"
-  local namespace_id="$3"
-  local namespace_fqn="$4"
-  local attribute_value_id="$5"
-  local obligation_value_id="$6"
-  local action_name="$7"
-  local source_action_id="$8"
-  local expected_action_status="$9"
-  local expected_action_count="${10}"
-  local client_id="${11}"
+  local source_trigger_id="$1"
+  local namespace_id="$2"
+  local attribute_value_id="$3"
+  local obligation_value_id="$4"
+  local action_name="$5"
+  local source_action_id="$6"
+  local expected_action_status="$7"
+  local client_id="$8"
 
-  run obligation_trigger_plan_target_status "$output_file" "$source_trigger_id" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "create"
-
-  assert_action_target_count "$output_file" "$action_name" "$expected_action_count"
   case "$expected_action_status" in
     create)
-      assert_custom_action_created_in_namespace "$output_file" "$action_name" "$source_action_id" "$namespace_id" "$namespace_fqn"
+      assert_custom_action_created_in_namespace "$action_name" "$source_action_id" "$namespace_id"
       ;;
     existing_standard)
-      assert_standard_action_resolved_in_namespace "$output_file" "$action_name" "$namespace_id" "$namespace_fqn"
+      assert_standard_action_resolved_in_namespace "$action_name" "$namespace_id"
       ;;
     *)
       false
       ;;
   esac
 
-  run obligation_trigger_plan_action_status "$output_file" "$source_trigger_id" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "$expected_action_status"
-
   local expected_action_target_id
-  expected_action_target_id=$(action_plan_target_effective_id "$output_file" "$action_name" "$namespace_fqn")
+  expected_action_target_id=$(action_id_by_name_in_namespace "$action_name" "$namespace_id")
   assert_not_equal "$expected_action_target_id" ""
-
-  local created_trigger_id
-  created_trigger_id=$(obligation_trigger_plan_target_effective_id "$output_file" "$source_trigger_id" "$namespace_fqn")
-  assert_not_equal "$created_trigger_id" ""
-  assert_not_equal "$created_trigger_id" "$source_trigger_id"
 
   local source_trigger_json
   source_trigger_json=$(obligation_trigger_json_by_id "$source_trigger_id" "$namespace_id")
 
   local created_trigger_json
-  created_trigger_json=$(obligation_trigger_json_by_id "$created_trigger_id" "$namespace_id")
+  created_trigger_json=$(obligation_trigger_json_by_migrated_from "$namespace_id" "$source_trigger_id")
+  assert_not_equal "$created_trigger_json" ""
 
-  assert_equal "$(echo "$created_trigger_json" | jq -r '.id')" "$created_trigger_id"
+  local created_trigger_id
+  created_trigger_id=$(echo "$created_trigger_json" | jq -r '.id // empty')
+  assert_not_equal "$created_trigger_id" ""
+  assert_not_equal "$created_trigger_id" "$source_trigger_id"
+
   assert_equal "$(echo "$created_trigger_json" | jq -r '.attribute_value.id')" "$attribute_value_id"
   assert_equal "$(echo "$created_trigger_json" | jq -r '.action.id')" "$expected_action_target_id"
   assert_equal "$(echo "$created_trigger_json" | jq -r '.obligation_value.id')" "$obligation_value_id"
@@ -1107,27 +946,25 @@ assert_obligation_trigger_created_in_namespace() {
 }
 
 assert_obligation_trigger_already_migrated_in_namespace() {
-  local output_file="$1"
-  local source_trigger_id="$2"
-  local namespace_id="$3"
-  local namespace_fqn="$4"
-  local existing_trigger_id="$5"
+  local source_trigger_id="$1"
+  local namespace_id="$2"
+  local existing_trigger_id="$3"
 
   assert_not_equal "$existing_trigger_id" ""
 
-  run obligation_trigger_plan_target_status "$output_file" "$source_trigger_id" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "already_migrated"
-
-  local effective_target_id
-  effective_target_id=$(obligation_trigger_plan_target_effective_id "$output_file" "$source_trigger_id" "$namespace_fqn")
-  assert_not_equal "$effective_target_id" ""
-  assert_equal "$effective_target_id" "$existing_trigger_id"
+  local source_trigger_json
+  source_trigger_json=$(obligation_trigger_json_by_id "$source_trigger_id" "$namespace_id")
 
   local existing_trigger_json
   existing_trigger_json=$(obligation_trigger_json_by_id "$existing_trigger_id" "$namespace_id")
 
   assert_equal "$(echo "$existing_trigger_json" | jq -r '.id // empty')" "$existing_trigger_id"
+  assert_equal "$(echo "$existing_trigger_json" | jq -r '.attribute_value.id')" "$(echo "$source_trigger_json" | jq -r '.attribute_value.id')"
+  assert_equal "$(echo "$existing_trigger_json" | jq -r '.obligation_value.id')" "$(echo "$source_trigger_json" | jq -r '.obligation_value.id')"
+  assert_equal \
+    "$(echo "$existing_trigger_json" | jq -c '(.context // []) | map(.pep.client_id // "") | sort')" \
+    "$(echo "$source_trigger_json" | jq -c '(.context // []) | map(.pep.client_id // "") | sort')"
+
   local existing_action_id
   existing_action_id=$(echo "$existing_trigger_json" | jq -r '.action.id // empty')
   assert_not_equal "$existing_action_id" ""
@@ -1161,22 +998,11 @@ assert_legacy_obligation_trigger_still_exists() {
 }
 
 assert_scs_already_migrated_in_namespace() {
-  local output_file="$1"
-  local source_scs_id="$2"
-  local namespace_id="$3"
-  local namespace_fqn="$4"
-  local existing_scs_id="$5"
+  local source_scs_id="$1"
+  local namespace_id="$2"
+  local existing_scs_id="$3"
 
   assert_not_equal "$existing_scs_id" ""
-
-  run scs_plan_target_status "$output_file" "$source_scs_id" "$namespace_fqn"
-  assert_success
-  assert_equal "$output" "already_migrated"
-
-  local effective_target_id
-  effective_target_id=$(scs_plan_target_effective_id "$output_file" "$source_scs_id" "$namespace_fqn")
-  assert_not_equal "$effective_target_id" ""
-  assert_equal "$effective_target_id" "$existing_scs_id"
 
   local source_scs_json
   source_scs_json=$(./otdfctl $HOST $WITH_CREDS policy scs get --id "$source_scs_id" --json)
@@ -1203,14 +1029,11 @@ assert_legacy_scs_still_exists() {
 
 run_namespaced_policy_commit() {
   local scope="$1"
-  local output_file="$2"
 
-  run_otdfctl_migrate --commit namespaced-policy --scope "$scope" --output "$output_file"
+  run_otdfctl_migrate --commit namespaced-policy --scope "$scope"
 }
 
 setup() {
-  skip "migrate-namespaced-policy.bats temporarily disabled"
-
   export TEST_PREFIX="${MIGRATION_TEST_PREFIX}-t${BATS_TEST_NUMBER}"
   export TRACKED_ACTION_IDS=""
   export TRACKED_REGISTERED_RESOURCE_IDS=""
@@ -1225,9 +1048,6 @@ setup_file() {
   export HOST='--host http://localhost:8080'
 
   export MIGRATION_TEST_PREFIX="np-migrate-$(date +%s)"
-  export MIGRATION_OUTPUT_DIR="/tmp/${MIGRATION_TEST_PREFIX}"
-  mkdir -p "$MIGRATION_OUTPUT_DIR"
-
   export NS_A_NAME="${MIGRATION_TEST_PREFIX}-a.test"
   export NS_B_NAME="${MIGRATION_TEST_PREFIX}-b.test"
   export NS_A_FQN="https://${NS_A_NAME}"
@@ -1355,9 +1175,7 @@ teardown_file() {
   ./otdfctl $HOST $WITH_CREDS policy attributes namespaces unsafe delete --id "$NS_A_ID" --force
   ./otdfctl $HOST $WITH_CREDS policy attributes namespaces unsafe delete --id "$NS_B_ID" --force
 
-  rm -rf "$MIGRATION_OUTPUT_DIR"
-
-  unset HOST WITH_CREDS MIGRATION_TEST_PREFIX MIGRATION_OUTPUT_DIR TEST_PREFIX
+  unset HOST WITH_CREDS MIGRATION_TEST_PREFIX TEST_PREFIX
   unset NS_A_NAME NS_B_NAME NS_A_FQN NS_B_FQN NS_A_ID NS_B_ID
   unset ATTR_A_ID ATTR_A_VAL_1_ID ATTR_A_VAL_2_ID ATTR_B_ID ATTR_B_VAL_1_ID
   unset GLOBAL_READ_ID
@@ -1365,16 +1183,19 @@ teardown_file() {
   unset TRACKED_SCS_IDS TRACKED_SUBJECT_MAPPING_IDS TRACKED_OBLIGATION_TRIGGER_IDS
 }
 
-# Asserts action-scope migration resolves shared standard actions in-place,
-# creates only the required custom action target, preserves metadata, does not
-# create namespaced subject mappings as a side effect, and is idempotent on
-# rerun.
-@test "migrate namespaced-policy actions resolves standard actions and creates custom actions" {
+# Asserts action-scope migration only creates the required custom action
+# target, does not create unrelated namespaced objects as a side effect, and is
+# idempotent on rerun.
+@test "migrate namespaced-policy actions creates only required custom actions" {
   local custom_action_name="${TEST_PREFIX}-download"
   local shared_scs='[{"condition_groups":[{"conditions":[{"operator":1,"subject_external_values":["'"${TEST_PREFIX}"'-engineering"],"subject_external_selector_value":".org.name"}],"boolean_operator":1}]}]'
   local custom_action_labels=(--label "test_case=actions" --label "fixture=${TEST_PREFIX}-custom-action")
   local custom_action_id
   local shared_scs_id
+  local ns_a_state_before
+  local ns_b_state_before
+  local ns_a_state_after
+  local ns_b_state_after
 
   create_global_action custom_action_id "$custom_action_name" "${custom_action_labels[@]}"
   create_global_scs shared_scs_id "$shared_scs"
@@ -1390,49 +1211,48 @@ teardown_file() {
   create_legacy_subject_mapping ignored_mapping_id "$ATTR_A_VAL_2_ID" "$custom_action_id" "$shared_scs_id"
   create_legacy_subject_mapping ignored_mapping_id "$ATTR_B_VAL_1_ID" "$GLOBAL_READ_ID" "$shared_scs_id"
 
-  local output_file="${MIGRATION_OUTPUT_DIR}/actions-plan.json"
+  ns_a_state_before=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_before=$(namespace_state_json "$NS_B_ID")
 
-  run_namespaced_policy_commit "actions" "$output_file"
+  run_namespaced_policy_commit "actions"
   assert_success
 
-  assert_action_target_count "$output_file" "read" 2
-  assert_standard_action_resolved_in_namespace "$output_file" "read" "$NS_A_ID" "$NS_A_FQN"
-  assert_standard_action_resolved_in_namespace "$output_file" "read" "$NS_B_ID" "$NS_B_FQN"
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
 
-  assert_action_target_count "$output_file" "$custom_action_name" 1
-  source_action_id=$(action_plan_source_id "$output_file" "$custom_action_name")
-  assert_equal "$source_action_id" "$custom_action_id"
-  assert_custom_action_created_in_namespace "$output_file" "$custom_action_name" "$custom_action_id" "$NS_A_ID" "$NS_A_FQN"
-  assert_action_target_absent "$output_file" "$custom_action_name" "$NS_B_FQN"
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 1 0 0 0 0
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 0 0 0 0
+
+  assert_custom_action_created_in_namespace "$custom_action_name" "$custom_action_id" "$NS_A_ID"
+  assert_action_absent_in_namespace "$custom_action_name" "$NS_B_ID"
 
   assert_legacy_custom_action_still_exists "$custom_action_id" "$custom_action_name"
-  assert_no_subject_mappings_in_namespace "$NS_A_ID"
-  assert_no_subject_mappings_in_namespace "$NS_B_ID"
 
-  # Re-running the same migration should be idempotent. Custom action targets
-  # should now be marked already_migrated, while standard actions still resolve
-  # as existing_standard.
-  local rerun_output_file="${MIGRATION_OUTPUT_DIR}/actions-rerun-plan.json"
+  # Re-running the same migration should be idempotent. No namespace-scoped
+  # counts should change on the second pass.
   local custom_action_target_id
-  # Get the created ids of the objects from the initial run's output file.
-  custom_action_target_id=$(action_plan_target_effective_id "$output_file" "$custom_action_name" "$NS_A_FQN")
+  custom_action_target_id=$(action_id_by_name_in_namespace "$custom_action_name" "$NS_A_ID")
+  assert_not_equal "$custom_action_target_id" ""
 
-  run_namespaced_policy_commit "actions" "$rerun_output_file"
+  ns_a_state_before="$ns_a_state_after"
+  ns_b_state_before="$ns_b_state_after"
+
+  run_namespaced_policy_commit "actions"
   assert_success
 
-  assert_action_target_count "$rerun_output_file" "read" 2
-  assert_standard_action_resolved_in_namespace "$rerun_output_file" "read" "$NS_A_ID" "$NS_A_FQN"
-  assert_standard_action_resolved_in_namespace "$rerun_output_file" "read" "$NS_B_ID" "$NS_B_FQN"
-  assert_action_target_count "$rerun_output_file" "$custom_action_name" 1
-  assert_action_already_migrated_in_namespace "$rerun_output_file" "$custom_action_name" "$NS_A_ID" "$NS_A_FQN" "$custom_action_target_id"
-  assert_action_target_absent "$rerun_output_file" "$custom_action_name" "$NS_B_FQN"
-  assert_no_subject_mappings_in_namespace "$NS_A_ID"
-  assert_no_subject_mappings_in_namespace "$NS_B_ID"
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
+
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 0 0 0 0 0
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 0 0 0 0
+
+  assert_action_already_migrated_in_namespace "$custom_action_name" "$NS_A_ID" "$custom_action_target_id"
+  assert_action_absent_in_namespace "$custom_action_name" "$NS_B_ID"
 }
 
 # Asserts SCS-scope migration creates missing namespaced SCS targets, reuses an
 # already-migrated canonical target when present, preserves subject_sets and
-# metadata, does not create namespaced subject mappings as a side effect, and
+# metadata, does not create unrelated namespaced objects as a side effect, and
 # is idempotent on rerun.
 @test "migrate namespaced-policy subject-condition-sets creates single-namespace targets and reuses existing fanout targets" {
   local fanout_scs='[{"condition_groups":[{"conditions":[{"operator":1,"subject_external_values":["'"${TEST_PREFIX}"'-shared"],"subject_external_selector_value":".org.name"}],"boolean_operator":1}]}]'
@@ -1442,6 +1262,10 @@ teardown_file() {
   local fanout_scs_id
   local single_namespace_scs_id
   local existing_fanout_ns_b_scs_id
+  local ns_a_state_before
+  local ns_b_state_before
+  local ns_a_state_after
+  local ns_b_state_after
 
   create_global_scs fanout_scs_id "$fanout_scs" "${fanout_scs_labels[@]}"
   create_global_scs single_namespace_scs_id "$single_namespace_scs" "${single_namespace_scs_labels[@]}"
@@ -1452,45 +1276,53 @@ teardown_file() {
   create_legacy_subject_mapping ignored_mapping_id "$ATTR_B_VAL_1_ID" "$GLOBAL_READ_ID" "$fanout_scs_id"
   create_legacy_subject_mapping ignored_mapping_id "$ATTR_A_VAL_2_ID" "$GLOBAL_READ_ID" "$single_namespace_scs_id"
 
-  local output_file="${MIGRATION_OUTPUT_DIR}/subject-condition-sets-plan.json"
+  ns_a_state_before=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_before=$(namespace_state_json "$NS_B_ID")
 
-  run_namespaced_policy_commit "subject-condition-sets" "$output_file"
+  run_namespaced_policy_commit "subject-condition-sets"
   assert_success
 
-  assert_scs_target_count "$output_file" "$fanout_scs_id" 2
-  assert_scs_created_in_namespace "$output_file" "$fanout_scs_id" "$NS_A_ID" "$NS_A_FQN"
-  assert_scs_already_migrated_in_namespace "$output_file" "$fanout_scs_id" "$NS_B_ID" "$NS_B_FQN" "$existing_fanout_ns_b_scs_id"
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
 
-  assert_scs_target_count "$output_file" "$single_namespace_scs_id" 1
-  assert_scs_created_in_namespace "$output_file" "$single_namespace_scs_id" "$NS_A_ID" "$NS_A_FQN"
-  assert_scs_target_absent "$output_file" "$single_namespace_scs_id" "$NS_B_FQN"
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 0 0 2 0 0
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 0 0 0 0
+
+  assert_scs_created_in_namespace "$fanout_scs_id" "$NS_A_ID"
+  assert_scs_already_migrated_in_namespace "$fanout_scs_id" "$NS_B_ID" "$existing_fanout_ns_b_scs_id"
+
+  assert_scs_created_in_namespace "$single_namespace_scs_id" "$NS_A_ID"
+  assert_scs_absent_in_namespace "$single_namespace_scs_id" "$NS_B_ID"
 
   assert_legacy_scs_still_exists "$fanout_scs_id"
   assert_legacy_scs_still_exists "$single_namespace_scs_id"
-  assert_no_subject_mappings_in_namespace "$NS_A_ID"
-  assert_no_subject_mappings_in_namespace "$NS_B_ID"
 
   # Re-running the same migration should be idempotent. The previously created
   # SCS targets should now be marked already_migrated, and the pre-existing
   # canonical target should continue to resolve as already_migrated.
-  local rerun_output_file="${MIGRATION_OUTPUT_DIR}/subject-condition-sets-rerun-plan.json"
   local fanout_ns_a_target_id
   local single_namespace_target_id
-  # Get the created ids of the objects from the initial run's output file.
-  fanout_ns_a_target_id=$(scs_plan_target_effective_id "$output_file" "$fanout_scs_id" "$NS_A_FQN")
-  single_namespace_target_id=$(scs_plan_target_effective_id "$output_file" "$single_namespace_scs_id" "$NS_A_FQN")
+  fanout_ns_a_target_id=$(scs_id_by_migrated_from "$fanout_scs_id" "$NS_A_ID")
+  single_namespace_target_id=$(scs_id_by_migrated_from "$single_namespace_scs_id" "$NS_A_ID")
+  assert_not_equal "$fanout_ns_a_target_id" ""
+  assert_not_equal "$single_namespace_target_id" ""
 
-  run_namespaced_policy_commit "subject-condition-sets" "$rerun_output_file"
+  ns_a_state_before="$ns_a_state_after"
+  ns_b_state_before="$ns_b_state_after"
+
+  run_namespaced_policy_commit "subject-condition-sets"
   assert_success
 
-  assert_scs_target_count "$rerun_output_file" "$fanout_scs_id" 2
-  assert_scs_already_migrated_in_namespace "$rerun_output_file" "$fanout_scs_id" "$NS_A_ID" "$NS_A_FQN" "$fanout_ns_a_target_id"
-  assert_scs_already_migrated_in_namespace "$rerun_output_file" "$fanout_scs_id" "$NS_B_ID" "$NS_B_FQN" "$existing_fanout_ns_b_scs_id"
-  assert_scs_target_count "$rerun_output_file" "$single_namespace_scs_id" 1
-  assert_scs_already_migrated_in_namespace "$rerun_output_file" "$single_namespace_scs_id" "$NS_A_ID" "$NS_A_FQN" "$single_namespace_target_id"
-  assert_scs_target_absent "$rerun_output_file" "$single_namespace_scs_id" "$NS_B_FQN"
-  assert_no_subject_mappings_in_namespace "$NS_A_ID"
-  assert_no_subject_mappings_in_namespace "$NS_B_ID"
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
+
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 0 0 0 0 0
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 0 0 0 0
+
+  assert_scs_already_migrated_in_namespace "$fanout_scs_id" "$NS_A_ID" "$fanout_ns_a_target_id"
+  assert_scs_already_migrated_in_namespace "$fanout_scs_id" "$NS_B_ID" "$existing_fanout_ns_b_scs_id"
+  assert_scs_already_migrated_in_namespace "$single_namespace_scs_id" "$NS_A_ID" "$single_namespace_target_id"
+  assert_scs_absent_in_namespace "$single_namespace_scs_id" "$NS_B_ID"
 }
 
 # Asserts subject-mapping migration creates namespaced mappings, rewrites action
@@ -1510,6 +1342,10 @@ teardown_file() {
   local sm_b_scs_id
   local mapping_a_id
   local mapping_b_id
+  local ns_a_state_before
+  local ns_b_state_before
+  local ns_a_state_after
+  local ns_b_state_after
 
   create_global_action custom_action_id "$custom_action_name" "${custom_action_labels[@]}"
   create_global_scs sm_a_scs_id "$sm_a_scs" "${sm_a_scs_labels[@]}"
@@ -1518,16 +1354,20 @@ teardown_file() {
   create_legacy_subject_mapping mapping_a_id "$ATTR_A_VAL_1_ID" "$custom_action_id" "$sm_a_scs_id" "${mapping_a_labels[@]}"
   create_legacy_subject_mapping mapping_b_id "$ATTR_B_VAL_1_ID" "$GLOBAL_READ_ID" "$sm_b_scs_id" "${mapping_b_labels[@]}"
 
-  local output_file="${MIGRATION_OUTPUT_DIR}/subject-mappings-plan.json"
+  ns_a_state_before=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_before=$(namespace_state_json "$NS_B_ID")
 
-  run_namespaced_policy_commit "subject-mappings" "$output_file"
+  run_namespaced_policy_commit "subject-mappings"
   assert_success
 
-  assert_subject_mapping_target_count "$output_file" "$mapping_a_id" 1
-  assert_subject_mapping_created_in_namespace "$output_file" "$mapping_a_id" "$NS_A_ID" "$NS_A_FQN" "$ATTR_A_VAL_1_ID" "$custom_action_name" "$custom_action_id" "create" 1 "$sm_a_scs_id" 1
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
 
-  assert_subject_mapping_target_count "$output_file" "$mapping_b_id" 1
-  assert_subject_mapping_created_in_namespace "$output_file" "$mapping_b_id" "$NS_B_ID" "$NS_B_FQN" "$ATTR_B_VAL_1_ID" "read" "$GLOBAL_READ_ID" "existing_standard" 1 "$sm_b_scs_id" 1
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 1 1 1 0 0
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 1 1 0 0
+
+  assert_subject_mapping_created_in_namespace "$mapping_a_id" "$NS_A_ID" "$ATTR_A_VAL_1_ID" "$custom_action_name" "$custom_action_id" "create" "$sm_a_scs_id"
+  assert_subject_mapping_created_in_namespace "$mapping_b_id" "$NS_B_ID" "$ATTR_B_VAL_1_ID" "read" "$GLOBAL_READ_ID" "existing_standard" "$sm_b_scs_id"
 
   assert_legacy_subject_mapping_still_exists "$ATTR_A_VAL_1_ID" "$mapping_a_id"
   assert_legacy_subject_mapping_still_exists "$ATTR_B_VAL_1_ID" "$mapping_b_id"
@@ -1535,40 +1375,42 @@ teardown_file() {
   # Re-running the same migration should be idempotent. The custom action,
   # migrated SCS targets, and migrated subject mappings should all resolve as
   # already_migrated on the second pass. Standard read remains existing_standard.
-  local rerun_output_file="${MIGRATION_OUTPUT_DIR}/subject-mappings-rerun-plan.json"
   local custom_action_target_id
   local sm_a_scs_target_id
   local sm_b_scs_target_id
   local mapping_a_target_id
   local mapping_b_target_id
-  # Get the created ids of the objects from the initial run's output file.
-  custom_action_target_id=$(action_plan_target_effective_id "$output_file" "$custom_action_name" "$NS_A_FQN")
-  sm_a_scs_target_id=$(scs_plan_target_effective_id "$output_file" "$sm_a_scs_id" "$NS_A_FQN")
-  sm_b_scs_target_id=$(scs_plan_target_effective_id "$output_file" "$sm_b_scs_id" "$NS_B_FQN")
-  mapping_a_target_id=$(subject_mapping_plan_target_effective_id "$output_file" "$mapping_a_id" "$NS_A_FQN")
-  mapping_b_target_id=$(subject_mapping_plan_target_effective_id "$output_file" "$mapping_b_id" "$NS_B_FQN")
+  custom_action_target_id=$(action_id_by_name_in_namespace "$custom_action_name" "$NS_A_ID")
+  sm_a_scs_target_id=$(scs_id_by_migrated_from "$sm_a_scs_id" "$NS_A_ID")
+  sm_b_scs_target_id=$(scs_id_by_migrated_from "$sm_b_scs_id" "$NS_B_ID")
+  mapping_a_target_id=$(subject_mapping_id_by_migrated_from "$mapping_a_id" "$NS_A_ID")
+  mapping_b_target_id=$(subject_mapping_id_by_migrated_from "$mapping_b_id" "$NS_B_ID")
 
-  run_namespaced_policy_commit "subject-mappings" "$rerun_output_file"
+  ns_a_state_before="$ns_a_state_after"
+  ns_b_state_before="$ns_b_state_after"
+
+  run_namespaced_policy_commit "subject-mappings"
   assert_success
 
-  assert_action_target_count "$rerun_output_file" "$custom_action_name" 1
-  assert_action_already_migrated_in_namespace "$rerun_output_file" "$custom_action_name" "$NS_A_ID" "$NS_A_FQN" "$custom_action_target_id"
-  assert_action_target_count "$rerun_output_file" "read" 1
-  assert_standard_action_resolved_in_namespace "$rerun_output_file" "read" "$NS_B_ID" "$NS_B_FQN"
-  assert_scs_target_count "$rerun_output_file" "$sm_a_scs_id" 1
-  assert_scs_already_migrated_in_namespace "$rerun_output_file" "$sm_a_scs_id" "$NS_A_ID" "$NS_A_FQN" "$sm_a_scs_target_id"
-  assert_scs_target_count "$rerun_output_file" "$sm_b_scs_id" 1
-  assert_scs_already_migrated_in_namespace "$rerun_output_file" "$sm_b_scs_id" "$NS_B_ID" "$NS_B_FQN" "$sm_b_scs_target_id"
-  assert_subject_mapping_target_count "$rerun_output_file" "$mapping_a_id" 1
-  assert_subject_mapping_already_migrated_in_namespace "$rerun_output_file" "$mapping_a_id" "$NS_A_ID" "$NS_A_FQN" "$mapping_a_target_id"
-  assert_subject_mapping_target_count "$rerun_output_file" "$mapping_b_id" 1
-  assert_subject_mapping_already_migrated_in_namespace "$rerun_output_file" "$mapping_b_id" "$NS_B_ID" "$NS_B_FQN" "$mapping_b_target_id"
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
+
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 0 0 0 0 0
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 0 0 0 0
+
+  assert_action_already_migrated_in_namespace "$custom_action_name" "$NS_A_ID" "$custom_action_target_id"
+  assert_standard_action_resolved_in_namespace "read" "$NS_B_ID"
+  assert_scs_already_migrated_in_namespace "$sm_a_scs_id" "$NS_A_ID" "$sm_a_scs_target_id"
+  assert_scs_already_migrated_in_namespace "$sm_b_scs_id" "$NS_B_ID" "$sm_b_scs_target_id"
+  assert_subject_mapping_already_migrated_in_namespace "$mapping_a_id" "$NS_A_ID" "$mapping_a_target_id"
+  assert_subject_mapping_already_migrated_in_namespace "$mapping_b_id" "$NS_B_ID" "$mapping_b_target_id"
 }
 
 # Asserts registered-resource migration creates missing namespaced targets,
 # rewrites action-attribute-value bindings to migrated action IDs, reuses an
 # already-migrated canonical RR target when present, preserves metadata on both
-# the parent RR and value, and is idempotent on rerun.
+# the parent RR and value, does not create unrelated namespaced objects as a
+# side effect, and is idempotent on rerun.
 @test "migrate namespaced-policy registered-resources rewrites action bindings and reuses canonical targets" {
   local custom_action_name="${TEST_PREFIX}-download"
   local rr_a_name="${TEST_PREFIX}-repo-a"
@@ -1588,6 +1430,10 @@ teardown_file() {
   local ns_b_read_action_id
   local existing_rr_b_id
   local existing_rr_b_value_id
+  local ns_a_state_before
+  local ns_b_state_before
+  local ns_a_state_after
+  local ns_b_state_after
 
   create_global_action custom_action_id "$custom_action_name" "${custom_action_labels[@]}"
   create_global_registered_resource rr_a_id "$rr_a_name" "${rr_a_labels[@]}"
@@ -1607,21 +1453,23 @@ teardown_file() {
   existing_rr_b_value_id=$(echo "$output" | jq -r '.id // empty')
   assert_not_equal "$existing_rr_b_value_id" ""
 
-  local output_file="${MIGRATION_OUTPUT_DIR}/registered-resources-plan.json"
+  ns_a_state_before=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_before=$(namespace_state_json "$NS_B_ID")
 
-  run_namespaced_policy_commit "registered-resources" "$output_file"
+  run_namespaced_policy_commit "registered-resources"
   assert_success
 
-  assert_registered_resource_target_count "$output_file" "$rr_a_id" 1
-  assert_registered_resource_created_in_namespace "$output_file" "$rr_a_id" "$rr_a_value_id" "$NS_A_ID" "$NS_A_FQN" "$rr_a_name" "$rr_a_value" "$custom_action_name" "$custom_action_id" "create" 1 "$ATTR_A_VAL_1_ID"
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
 
-  assert_registered_resource_target_count "$output_file" "$rr_b_id" 1
-  assert_registered_resource_already_migrated_in_namespace "$output_file" "$rr_b_id" "$NS_B_ID" "$NS_B_FQN" "$existing_rr_b_id"
-  assert_action_target_count "$output_file" "read" 1
-  assert_standard_action_resolved_in_namespace "$output_file" "read" "$NS_B_ID" "$NS_B_FQN"
-  run registered_resource_plan_action_status "$output_file" "$rr_b_id" "$NS_B_FQN" "$rr_b_value_id" "$GLOBAL_READ_ID"
-  assert_success
-  assert_equal "$output" "existing_standard"
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 1 0 0 1 0
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 0 0 0 0
+
+  assert_registered_resource_created_in_namespace "$rr_a_id" "$rr_a_value_id" "$NS_A_ID" "$rr_a_name" "$rr_a_value" "$custom_action_name" "$custom_action_id" "create" "$ATTR_A_VAL_1_ID"
+
+  assert_registered_resource_already_migrated_in_namespace "$rr_b_id" "$NS_B_ID" "$existing_rr_b_id"
+  assert_standard_action_resolved_in_namespace "read" "$NS_B_ID"
+  assert_registered_resource_value_uses_action "$existing_rr_b_value_id" "$ns_b_read_action_id" "$ATTR_B_VAL_1_ID"
 
   assert_legacy_registered_resource_still_exists "$rr_a_id" "$rr_a_value_id" "$rr_a_name" "$rr_a_value"
   assert_legacy_registered_resource_still_exists "$rr_b_id" "$rr_b_value_id" "$rr_b_name" "$rr_b_value"
@@ -1629,29 +1477,34 @@ teardown_file() {
   # Re-running the same migration should be idempotent. The previously created
   # RR target should now resolve as already_migrated, while the existing
   # canonical RR target continues to resolve as already_migrated.
-  local rerun_output_file="${MIGRATION_OUTPUT_DIR}/registered-resources-rerun-plan.json"
   local custom_action_target_id
   local rr_a_target_id
-  custom_action_target_id=$(action_plan_target_effective_id "$output_file" "$custom_action_name" "$NS_A_FQN")
-  rr_a_target_id=$(registered_resource_plan_target_effective_id "$output_file" "$rr_a_id" "$NS_A_FQN")
+  custom_action_target_id=$(action_id_by_name_in_namespace "$custom_action_name" "$NS_A_ID")
+  rr_a_target_id=$(registered_resource_id_by_migrated_from "$rr_a_id" "$NS_A_ID")
 
-  run_namespaced_policy_commit "registered-resources" "$rerun_output_file"
+  ns_a_state_before="$ns_a_state_after"
+  ns_b_state_before="$ns_b_state_after"
+
+  run_namespaced_policy_commit "registered-resources"
   assert_success
 
-  assert_action_target_count "$rerun_output_file" "$custom_action_name" 1
-  assert_action_already_migrated_in_namespace "$rerun_output_file" "$custom_action_name" "$NS_A_ID" "$NS_A_FQN" "$custom_action_target_id"
-  assert_action_target_count "$rerun_output_file" "read" 1
-  assert_standard_action_resolved_in_namespace "$rerun_output_file" "read" "$NS_B_ID" "$NS_B_FQN"
-  assert_registered_resource_target_count "$rerun_output_file" "$rr_a_id" 1
-  assert_registered_resource_already_migrated_in_namespace "$rerun_output_file" "$rr_a_id" "$NS_A_ID" "$NS_A_FQN" "$rr_a_target_id"
-  assert_registered_resource_target_count "$rerun_output_file" "$rr_b_id" 1
-  assert_registered_resource_already_migrated_in_namespace "$rerun_output_file" "$rr_b_id" "$NS_B_ID" "$NS_B_FQN" "$existing_rr_b_id"
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
+
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 0 0 0 0 0
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 0 0 0 0
+
+  assert_action_already_migrated_in_namespace "$custom_action_name" "$NS_A_ID" "$custom_action_target_id"
+  assert_standard_action_resolved_in_namespace "read" "$NS_B_ID"
+  assert_registered_resource_already_migrated_in_namespace "$rr_a_id" "$NS_A_ID" "$rr_a_target_id"
+  assert_registered_resource_already_migrated_in_namespace "$rr_b_id" "$NS_B_ID" "$existing_rr_b_id"
 }
 
 # Asserts obligation-trigger migration creates missing namespaced trigger
 # targets, rewrites the referenced action to the migrated action target,
 # reuses an already-migrated canonical trigger when present, preserves source
-# metadata, and is idempotent on rerun.
+# metadata, does not create unrelated namespaced objects as a side effect, and
+# is idempotent on rerun.
 @test "migrate namespaced-policy obligation-triggers rewrites action dependencies and reuses canonical targets" {
   local custom_action_name="${TEST_PREFIX}-download"
   local obligation_a_name="${TEST_PREFIX}-notify-a"
@@ -1671,6 +1524,10 @@ teardown_file() {
   local trigger_b_id
   local ns_b_read_action_id
   local existing_trigger_b_id
+  local ns_a_state_before
+  local ns_b_state_before
+  local ns_a_state_after
+  local ns_b_state_after
 
   create_global_action custom_action_id "$custom_action_name" "${custom_action_labels[@]}"
   create_namespaced_obligation obligation_a_id "$NS_A_ID" "$obligation_a_name" --label "test_case=obligation-triggers" --label "fixture=${TEST_PREFIX}-obligation-a"
@@ -1688,21 +1545,22 @@ teardown_file() {
   existing_trigger_b_id=$(echo "$output" | jq -r '.id // empty')
   assert_not_equal "$existing_trigger_b_id" ""
 
-  local output_file="${MIGRATION_OUTPUT_DIR}/obligation-triggers-plan.json"
+  ns_a_state_before=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_before=$(namespace_state_json "$NS_B_ID")
 
-  run_namespaced_policy_commit "obligation-triggers" "$output_file"
+  run_namespaced_policy_commit "obligation-triggers"
   assert_success
 
-  assert_obligation_trigger_target_count "$output_file" "$trigger_a_id" 1
-  assert_obligation_trigger_created_in_namespace "$output_file" "$trigger_a_id" "$NS_A_ID" "$NS_A_FQN" "$ATTR_A_VAL_1_ID" "$obligation_a_value_id" "$custom_action_name" "$custom_action_id" "create" 1 "$trigger_a_client_id"
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
 
-  assert_obligation_trigger_target_count "$output_file" "$trigger_b_id" 1
-  assert_obligation_trigger_already_migrated_in_namespace "$output_file" "$trigger_b_id" "$NS_B_ID" "$NS_B_FQN" "$existing_trigger_b_id"
-  assert_action_target_count "$output_file" "read" 1
-  assert_standard_action_resolved_in_namespace "$output_file" "read" "$NS_B_ID" "$NS_B_FQN"
-  run obligation_trigger_plan_action_status "$output_file" "$trigger_b_id" "$NS_B_FQN"
-  assert_success
-  assert_equal "$output" "existing_standard"
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 1 0 0 0 1
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 0 0 0 0
+
+  assert_obligation_trigger_created_in_namespace "$trigger_a_id" "$NS_A_ID" "$ATTR_A_VAL_1_ID" "$obligation_a_value_id" "$custom_action_name" "$custom_action_id" "create" "$trigger_a_client_id"
+
+  assert_obligation_trigger_already_migrated_in_namespace "$trigger_b_id" "$NS_B_ID" "$existing_trigger_b_id"
+  assert_standard_action_resolved_in_namespace "read" "$NS_B_ID"
 
   assert_legacy_obligation_trigger_still_exists "$trigger_a_id" "$NS_A_ID" "$ATTR_A_VAL_1_ID" "$custom_action_id" "$obligation_a_value_id" "$trigger_a_client_id"
   assert_legacy_obligation_trigger_still_exists "$trigger_b_id" "$NS_B_ID" "$ATTR_B_VAL_1_ID" "$GLOBAL_READ_ID" "$obligation_b_value_id" "$trigger_b_client_id"
@@ -1710,27 +1568,32 @@ teardown_file() {
   # Re-running the same migration should be idempotent. The previously created
   # custom action target and trigger target should resolve as already_migrated,
   # while the pre-existing canonical trigger remains already_migrated.
-  local rerun_output_file="${MIGRATION_OUTPUT_DIR}/obligation-triggers-rerun-plan.json"
   local custom_action_target_id
   local trigger_a_target_id
-  custom_action_target_id=$(action_plan_target_effective_id "$output_file" "$custom_action_name" "$NS_A_FQN")
-  trigger_a_target_id=$(obligation_trigger_plan_target_effective_id "$output_file" "$trigger_a_id" "$NS_A_FQN")
+  custom_action_target_id=$(action_id_by_name_in_namespace "$custom_action_name" "$NS_A_ID")
+  trigger_a_target_id=$(obligation_trigger_id_by_migrated_from "$trigger_a_id" "$NS_A_ID")
 
-  run_namespaced_policy_commit "obligation-triggers" "$rerun_output_file"
+  ns_a_state_before="$ns_a_state_after"
+  ns_b_state_before="$ns_b_state_after"
+
+  run_namespaced_policy_commit "obligation-triggers"
   assert_success
 
-  assert_action_target_count "$rerun_output_file" "$custom_action_name" 1
-  assert_action_already_migrated_in_namespace "$rerun_output_file" "$custom_action_name" "$NS_A_ID" "$NS_A_FQN" "$custom_action_target_id"
-  assert_action_target_count "$rerun_output_file" "read" 1
-  assert_standard_action_resolved_in_namespace "$rerun_output_file" "read" "$NS_B_ID" "$NS_B_FQN"
-  assert_obligation_trigger_target_count "$rerun_output_file" "$trigger_a_id" 1
-  assert_obligation_trigger_already_migrated_in_namespace "$rerun_output_file" "$trigger_a_id" "$NS_A_ID" "$NS_A_FQN" "$trigger_a_target_id"
-  assert_obligation_trigger_target_count "$rerun_output_file" "$trigger_b_id" 1
-  assert_obligation_trigger_already_migrated_in_namespace "$rerun_output_file" "$trigger_b_id" "$NS_B_ID" "$NS_B_FQN" "$existing_trigger_b_id"
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
+
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 0 0 0 0 0
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 0 0 0 0
+
+  assert_action_already_migrated_in_namespace "$custom_action_name" "$NS_A_ID" "$custom_action_target_id"
+  assert_standard_action_resolved_in_namespace "read" "$NS_B_ID"
+  assert_obligation_trigger_already_migrated_in_namespace "$trigger_a_id" "$NS_A_ID" "$trigger_a_target_id"
+  assert_obligation_trigger_already_migrated_in_namespace "$trigger_b_id" "$NS_B_ID" "$existing_trigger_b_id"
 }
 
 # Asserts selecting every migration scope together creates one namespaced
-# target for each supported object type in a simple single-namespace graph.
+# target for each supported object type in a simple single-namespace graph and
+# is idempotent on rerun.
 @test "migrate namespaced-policy all scopes creates one target for each object type" {
   local custom_action_name="${TEST_PREFIX}-download"
   local all_scopes_scs='[{"condition_groups":[{"conditions":[{"operator":1,"subject_external_values":["'"${TEST_PREFIX}"'-all-scopes"],"subject_external_selector_value":".org.name"}],"boolean_operator":1}]}]'
@@ -1747,6 +1610,10 @@ teardown_file() {
   local obligation_id
   local obligation_value_id
   local trigger_id
+  local ns_a_state_before
+  local ns_b_state_before
+  local ns_a_state_after
+  local ns_b_state_after
 
   create_global_action custom_action_id "$custom_action_name" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-custom-action"
   create_global_scs scs_id "$all_scopes_scs" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-scs"
@@ -1757,29 +1624,63 @@ teardown_file() {
   create_obligation_value obligation_value_id "$obligation_id" "$obligation_value" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-obligation-value"
   create_legacy_obligation_trigger trigger_id "$ATTR_A_VAL_1_ID" "$custom_action_id" "$obligation_value_id" --client-id "$trigger_client_id" --label "test_case=all-scopes" --label "fixture=${TEST_PREFIX}-trigger"
 
-  local output_file="${MIGRATION_OUTPUT_DIR}/all-scopes-plan.json"
+  ns_a_state_before=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_before=$(namespace_state_json "$NS_B_ID")
 
-  run_namespaced_policy_commit "actions,subject-condition-sets,subject-mappings,registered-resources,obligation-triggers" "$output_file"
+  run_namespaced_policy_commit "actions,subject-condition-sets,subject-mappings,registered-resources,obligation-triggers"
   assert_success
 
-  assert_action_target_count "$output_file" "$custom_action_name" 1
-  assert_custom_action_created_in_namespace "$output_file" "$custom_action_name" "$custom_action_id" "$NS_A_ID" "$NS_A_FQN"
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
 
-  assert_scs_target_count "$output_file" "$scs_id" 1
-  assert_scs_created_in_namespace "$output_file" "$scs_id" "$NS_A_ID" "$NS_A_FQN"
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 1 1 1 1 1
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 0 0 0 0
 
-  assert_subject_mapping_target_count "$output_file" "$mapping_id" 1
-  assert_subject_mapping_created_in_namespace "$output_file" "$mapping_id" "$NS_A_ID" "$NS_A_FQN" "$ATTR_A_VAL_1_ID" "$custom_action_name" "$custom_action_id" "create" 1 "$scs_id" 1
+  assert_custom_action_created_in_namespace "$custom_action_name" "$custom_action_id" "$NS_A_ID"
 
-  assert_registered_resource_target_count "$output_file" "$rr_id" 1
-  assert_registered_resource_created_in_namespace "$output_file" "$rr_id" "$rr_value_id" "$NS_A_ID" "$NS_A_FQN" "$rr_name" "$rr_value" "$custom_action_name" "$custom_action_id" "create" 1 "$ATTR_A_VAL_2_ID"
+  assert_scs_created_in_namespace "$scs_id" "$NS_A_ID"
 
-  assert_obligation_trigger_target_count "$output_file" "$trigger_id" 1
-  assert_obligation_trigger_created_in_namespace "$output_file" "$trigger_id" "$NS_A_ID" "$NS_A_FQN" "$ATTR_A_VAL_1_ID" "$obligation_value_id" "$custom_action_name" "$custom_action_id" "create" 1 "$trigger_client_id"
+  assert_subject_mapping_created_in_namespace "$mapping_id" "$NS_A_ID" "$ATTR_A_VAL_1_ID" "$custom_action_name" "$custom_action_id" "create" "$scs_id"
+
+  assert_registered_resource_created_in_namespace "$rr_id" "$rr_value_id" "$NS_A_ID" "$rr_name" "$rr_value" "$custom_action_name" "$custom_action_id" "create" "$ATTR_A_VAL_2_ID"
+
+  assert_obligation_trigger_created_in_namespace "$trigger_id" "$NS_A_ID" "$ATTR_A_VAL_1_ID" "$obligation_value_id" "$custom_action_name" "$custom_action_id" "create" "$trigger_client_id"
 
   assert_legacy_custom_action_still_exists "$custom_action_id" "$custom_action_name"
   assert_legacy_scs_still_exists "$scs_id"
   assert_legacy_subject_mapping_still_exists "$ATTR_A_VAL_1_ID" "$mapping_id"
   assert_legacy_registered_resource_still_exists "$rr_id" "$rr_value_id" "$rr_name" "$rr_value"
   assert_legacy_obligation_trigger_still_exists "$trigger_id" "$NS_A_ID" "$ATTR_A_VAL_1_ID" "$custom_action_id" "$obligation_value_id" "$trigger_client_id"
+
+  # Re-running the combined migration should be idempotent. Every target created
+  # above should now resolve as already_migrated, and no namespace counts
+  # should change on the second pass.
+  local custom_action_target_id
+  local scs_target_id
+  local mapping_target_id
+  local rr_target_id
+  local trigger_target_id
+  custom_action_target_id=$(action_id_by_name_in_namespace "$custom_action_name" "$NS_A_ID")
+  scs_target_id=$(scs_id_by_migrated_from "$scs_id" "$NS_A_ID")
+  mapping_target_id=$(subject_mapping_id_by_migrated_from "$mapping_id" "$NS_A_ID")
+  rr_target_id=$(registered_resource_id_by_migrated_from "$rr_id" "$NS_A_ID")
+  trigger_target_id=$(obligation_trigger_id_by_migrated_from "$trigger_id" "$NS_A_ID")
+
+  ns_a_state_before="$ns_a_state_after"
+  ns_b_state_before="$ns_b_state_after"
+
+  run_namespaced_policy_commit "actions,subject-condition-sets,subject-mappings,registered-resources,obligation-triggers"
+  assert_success
+
+  ns_a_state_after=$(namespace_state_json "$NS_A_ID")
+  ns_b_state_after=$(namespace_state_json "$NS_B_ID")
+
+  assert_namespace_state_delta "$ns_a_state_before" "$ns_a_state_after" 0 0 0 0 0
+  assert_namespace_state_delta "$ns_b_state_before" "$ns_b_state_after" 0 0 0 0 0
+
+  assert_action_already_migrated_in_namespace "$custom_action_name" "$NS_A_ID" "$custom_action_target_id"
+  assert_scs_already_migrated_in_namespace "$scs_id" "$NS_A_ID" "$scs_target_id"
+  assert_subject_mapping_already_migrated_in_namespace "$mapping_id" "$NS_A_ID" "$mapping_target_id"
+  assert_registered_resource_already_migrated_in_namespace "$rr_id" "$NS_A_ID" "$rr_target_id"
+  assert_obligation_trigger_already_migrated_in_namespace "$trigger_id" "$NS_A_ID" "$trigger_target_id"
 }

--- a/otdfctl/e2e/migrate-namespaced-policy.bats
+++ b/otdfctl/e2e/migrate-namespaced-policy.bats
@@ -683,6 +683,42 @@ registered_resource_values_signature() {
   '
 }
 
+subject_sets_signature() {
+  local scs_json="$1"
+
+  echo "$scs_json" | jq -c '
+    def normalized_condition:
+      {
+        selector: (.subject_external_selector_value // ""),
+        operator: (.operator // 0),
+        values: ((.subject_external_values // []) | sort)
+      };
+
+    def normalized_group:
+      {
+        conditions: (
+          (.conditions // [])
+          | map(select(. != null) | normalized_condition)
+          | sort_by([.selector, .operator, (.values | join(","))])
+        ),
+        boolean_operator: (.boolean_operator // 0)
+      };
+
+    (.subject_sets // [])
+    | map(
+        select(. != null)
+        | {
+            condition_groups: (
+              (.condition_groups // [])
+              | map(select(. != null) | normalized_group)
+              | sort_by(tojson)
+            )
+          }
+      )
+    | sort_by(tojson)
+  '
+}
+
 assert_standard_action_resolved_in_namespace() {
   local action_name="$1"
   local namespace_id="$2"
@@ -764,7 +800,7 @@ assert_scs_created_in_namespace() {
   assert_not_equal "$created_target_id" "$source_scs_id"
 
   assert_equal "$(echo "$created_scs_json" | jq -r '.namespace.id')" "$namespace_id"
-  assert_equal "$(echo "$created_scs_json" | jq -c '.subject_sets')" "$(echo "$source_scs_json" | jq -c '.subject_sets')"
+  assert_equal "$(subject_sets_signature "$created_scs_json")" "$(subject_sets_signature "$source_scs_json")"
   assert_metadata_labels_preserved "$source_scs_json" "$created_scs_json"
   assert_equal "$(echo "$created_scs_json" | jq -r '.metadata.labels.migrated_from')" "$source_scs_id"
   assert_not_equal "$(echo "$created_scs_json" | jq -r '.metadata.labels.migration_run // empty')" ""
@@ -1006,7 +1042,7 @@ assert_scs_already_migrated_in_namespace() {
 
   assert_equal "$(echo "$existing_scs_json" | jq -r '.id // empty')" "$existing_scs_id"
   assert_equal "$(echo "$existing_scs_json" | jq -r '.namespace.id')" "$namespace_id"
-  assert_equal "$(echo "$existing_scs_json" | jq -c '.subject_sets')" "$(echo "$source_scs_json" | jq -c '.subject_sets')"
+  assert_equal "$(subject_sets_signature "$existing_scs_json")" "$(subject_sets_signature "$source_scs_json")"
 }
 
 assert_legacy_scs_still_exists() {


### PR DESCRIPTION
### Proposed Changes

1.) Fix E2E tests to not rely on output anymore, but instead just take snapshots of the state of the policy objects in each namespace before and after commits. We validate that state just on the count, not the uniqueness of the objects within. Checking if an object has been created or already migrated is done within other checks.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored end-to-end migration tests to verify live cluster state instead of relying on plan output files.
  * Added namespace-wide state helpers and label-based lookups to identify migrated objects.
  * Updated assertions to re-resolve targets from live objects, validate “already migrated” via live data, ensure zero namespace deltas on reruns, and remove creation of plan artifact outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->