### PR TITLE
fix(ci): resolve otdfctl binary vs source directory collision

### DIFF
--- a/.github/scripts/connectivity-test.sh
+++ b/.github/scripts/connectivity-test.sh
@@ -22,8 +22,8 @@ while true; do
         # Introduce random delay before each execution (between 1 and 4 seconds)
         sleep $((RANDOM % 4 + 1))
         
-        echo "Running randomly selected command './otdfctl policy $random_subcommand list...'"
-        result=$(./otdfctl policy $random_subcommand list --with-client-creds '{"clientId":"opentdf","clientSecret":"secret"}' --host http://localhost:8080 | grep -i "success")
+        echo "Running randomly selected command './bin/otdfctl policy $random_subcommand list...'"
+        result=$(./bin/otdfctl policy $random_subcommand list --with-client-creds '{"clientId":"opentdf","clientSecret":"secret"}' --host http://localhost:8080 | grep -i "success")
         echo $result
         if [ -z "$result" ]; then
         echo "Failure: 'success' not found in output; CLI failed."

--- a/.github/workflows/nightly-checks.yaml
+++ b/.github/workflows/nightly-checks.yaml
@@ -62,9 +62,7 @@ jobs:
           working-directory: platform
 
       ######## BUILD 'otdfctl' (now part of platform monorepo) #############
-      - run: go build -o otdfctl .
-        working-directory: platform/otdfctl
-      - run: cp otdfctl ../
+      - run: go build -o ../bin/otdfctl .
         working-directory: platform/otdfctl
 
       ######## RUN TESTS #############


### PR DESCRIPTION
### Proposed Changes

* The nightly `db-flakiness-recovery` job builds `otdfctl` and then invokes `./otdfctl` from the repo root. Since commit 5339c997 added `./otdfctl` to `go.work`, that path is now a source **directory**, so `cp otdfctl ../` and the subsequent `./otdfctl` invocation both collide with the directory and the job fails.
* Build the binary into `platform/bin/otdfctl` via `go build -o ../bin/otdfctl .` and drop the now-unneeded `cp` step in `.github/workflows/nightly-checks.yaml`.
* Update `.github/scripts/connectivity-test.sh` to invoke `./bin/otdfctl` (and echo the matching path).

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

1. Trigger the `Nightly Checks` workflow via `workflow_dispatch` on this branch and confirm the `db-flakiness-recovery` job passes.
2. Locally reproduce the relevant steps:
   ```bash
   (cd otdfctl && go build -o ../bin/otdfctl .)
   ls -l bin/otdfctl        # executable file, not a directory
   ./bin/otdfctl --help
   ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal build artifact organization and CI/CD workflow paths for improved deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->