### PR TITLE
chore(ci): document why protocol/go is excluded from partial go.work

### DIFF
--- a/.github/scripts/work-init.sh
+++ b/.github/scripts/work-init.sh
@@ -45,12 +45,14 @@ sdk)
   rm -f go.work go.work.sum &&
     go work init &&
     go work use ./sdk &&
+    go work use ./protocol/go &&
     go work use ./service &&
     go work use ./examples
   ;;
 service)
   rm -f go.work go.work.sum &&
     go work init &&
+    go work use ./protocol/go &&
     go work use ./service &&
     go work use ./examples
   ;;
@@ -63,6 +65,7 @@ otdfctl)
   rm -f go.work go.work.sum &&
     go work init &&
     go work use ./otdfctl &&
+    go work use ./protocol/go &&
     # service and examples are needed for release branch checks
     go work use ./service &&
     go work use ./examples

--- a/.github/scripts/work-init.sh
+++ b/.github/scripts/work-init.sh
@@ -42,17 +42,20 @@ lib/ocrypto | lib/fixtures | lib/flattening | lib/identifier | protocol/go)
   echo "[INFO] skipping for leaf package"
   ;;
 sdk)
+  # NOTE: protocol/go is intentionally excluded. Upstream deps like protocol/go
+  # must be released and tagged before sdk can be released. Using local source
+  # here would mask unreleased protocol/go changes and allow tagging sdk against
+  # a version of protocol/go that hasn't been published yet.
   rm -f go.work go.work.sum &&
     go work init &&
     go work use ./sdk &&
-    go work use ./protocol/go &&
     go work use ./service &&
     go work use ./examples
   ;;
 service)
+  # NOTE: protocol/go is intentionally excluded (see sdk case comment above).
   rm -f go.work go.work.sum &&
     go work init &&
-    go work use ./protocol/go &&
     go work use ./service &&
     go work use ./examples
   ;;
@@ -65,7 +68,7 @@ otdfctl)
   rm -f go.work go.work.sum &&
     go work init &&
     go work use ./otdfctl &&
-    go work use ./protocol/go &&
+    # NOTE: protocol/go is intentionally excluded (see sdk case comment above).
     # service and examples are needed for release branch checks
     go work use ./service &&
     go work use ./examples


### PR DESCRIPTION
## Summary

- Adds comments to the `sdk`, `service`, and `otdfctl` cases in `.github/scripts/work-init.sh` explaining why `protocol/go` is intentionally excluded from the partial workspace

## Context

The partial `go.work` generated by `work-init.sh` deliberately omits upstream deps like `protocol/go`. This ensures they must be released and tagged before downstream components (sdk, service, otdfctl) can be released — using local source would mask unreleased `protocol/go` changes and allow tagging a component against an unpublished version.

This wasn't documented in the script, which led to confusion (including the original version of this PR, which tried to add `protocol/go` to the workspace). Adding comments so future contributors and AI tools don't repeat the mistake.

## Test plan

- [x] `shellcheck .github/scripts/work-init.sh` passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added clarifying documentation to internal initialization scripts regarding dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->