### PR TITLE
chore(ci): DSPX- 2960 - bump Go toolchain to 1.25.9 to fix govulncheck reported vulnerabilities

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,6 @@ on:
     branches:
       - main
       - release/**
-      - dspx-2960-bump-go-toolchain-1.25.9
   merge_group:
     branches:
       - main

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,6 +13,7 @@ on:
     branches:
       - main
       - release/**
+      - dspx-2960-bump-go-toolchain-1.25.9
   merge_group:
     branches:
       - main
@@ -84,7 +85,7 @@ jobs:
         continue-on-error: true
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: "1.25.7"
+          go-version-input: "1.25.9"
           work-dir: ${{ matrix.directory }}
       - if: steps.govulncheck.outcome == 'failure'
         run: echo "$MODULE_DIR" > "/tmp/govulncheck-failure-${JOB_INDEX}.txt"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,7 +26,7 @@ jobs:
       - name: "Setup Go"
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.9"
           check-latest: false
           cache-dependency-path: |
             service/go.sum

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/examples
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.25.5
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 use (
 	./examples

--- a/lib/fixtures/go.mod
+++ b/lib/fixtures/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/lib/fixtures
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require github.com/Nerzal/gocloak/v13 v13.9.0
 

--- a/lib/flattening/go.mod
+++ b/lib/flattening/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/lib/flattening
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require github.com/stretchr/testify v1.11.1
 

--- a/lib/identifier/go.mod
+++ b/lib/identifier/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/lib/identifier
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require github.com/stretchr/testify v1.11.1
 

--- a/lib/ocrypto/go.mod
+++ b/lib/ocrypto/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/lib/ocrypto
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/otdfctl/go.mod
+++ b/otdfctl/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/otdfctl
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/adrg/frontmatter v0.2.0

--- a/protocol/go/go.mod
+++ b/protocol/go/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/protocol/go
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/sdk
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/service/go.mod
+++ b/service/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/service
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	buf.build/go/protovalidate v1.0.0

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/test/integration
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 replace (
 	github.com/opentdf/platform/lib/fixtures => ../../lib/fixtures

--- a/tests-bdd/go.mod
+++ b/tests-bdd/go.mod
@@ -2,7 +2,7 @@ module github.com/opentdf/platform/tests-bdd
 
 go 1.25.5
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/cucumber/godog v0.15.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from `go1.25.8` to `go1.25.9` to resolve 4 standard library vulnerabilities flagged by `govulncheck`:

| CVE | Package | Description |
|-----|---------|-------------|
| GO-2026-4947 | `crypto/x509` | Unexpected work during chain building |
| GO-2026-4946 | `crypto/x509` | Inefficient policy validation |
| GO-2026-4870 | `crypto/tls` | Unauthenticated TLS 1.3 KeyUpdate causes DoS |
| GO-2026-4865 | `html/template` | XSS via JsBraceDepth context tracking |

No code changes required — this is a patch release with no breaking changes.

Vulns were initially reported in opentdf/otdfctl and PR submitted as https://github.com/opentdf/otdfctl/pull/796

## Test plan

- [x] target vulnerabilities are solved, `govulncheck` step passes in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to version 1.25.9 across all project modules and CI/CD infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->