### PR TITLE
chore(cli): modernize BATS library loading in e2e tests

### DIFF
--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -65,7 +65,7 @@ https://github.com/opentdf/platform/blob/main/service/go.mod#L3
 You can now access platform services at http://localhost:8080/ , and Keycloak at http://localhost:8888/auth/ .
 
 ##  Next steps
-* Try out our CLI (`otdfctl`): https://github.com/opentdf/otdfctl
+* Try out our CLI (`otdfctl`): https://github.com/opentdf/platform/otdfctl
    ```sh
    otdfctl auth client-credentials --host http://localhost:8080 --client-id opentdf --client-secret secret
    ```

--- a/otdfctl/e2e/actions.bats
+++ b/otdfctl/e2e/actions.bats
@@ -12,8 +12,8 @@ setup_file() {
 }
 
 setup() {
-    load "${BATS_LIB_PATH}/bats-support/load.bash"
-    load "${BATS_LIB_PATH}/bats-assert/load.bash"
+    bats_load_library bats-support
+    bats_load_library bats-assert
 
     # invoke binary with credentials
     run_otdfctl_action () {

--- a/otdfctl/e2e/attributes.bats
+++ b/otdfctl/e2e/attributes.bats
@@ -1,12 +1,11 @@
 #!/usr/bin/env bats
 
-load "${BATS_LIB_PATH}/bats-support/load.bash"
-load "${BATS_LIB_PATH}/bats-assert/load.bash"
-load "otdfctl-utils.sh"
-
 # Tests for attributes
 
 setup_file() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  load "otdfctl-utils.sh"
   export WITH_CREDS='--with-client-creds-file ./creds.json'
   export HOST='--host http://localhost:8080'
 
@@ -26,6 +25,8 @@ setup_file() {
 
 # always create a randomly named attribute
 setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
   # invoke binary with credentials
   run_otdfctl_attr() {
     run sh -c "./otdfctl $HOST $WITH_CREDS policy attributes $*"

--- a/otdfctl/e2e/auth.bats
+++ b/otdfctl/e2e/auth.bats
@@ -8,8 +8,8 @@ setup_file() {
 }
 
 setup() {
-    load "${BATS_LIB_PATH}/bats-support/load.bash"
-    load "${BATS_LIB_PATH}/bats-assert/load.bash"
+    bats_load_library bats-support
+    bats_load_library bats-assert
 
     # invoke binary with credentials
     run_otdfctl () {

--- a/otdfctl/e2e/encrypt-decrypt.bats
+++ b/otdfctl/e2e/encrypt-decrypt.bats
@@ -69,8 +69,8 @@ setup_file() {
 }
 
 setup() {
-    load "${BATS_LIB_PATH}/bats-support/load.bash"
-    load "${BATS_LIB_PATH}/bats-assert/load.bash"
+    bats_load_library bats-support
+    bats_load_library bats-assert
 }
 
 teardown() {

--- a/otdfctl/e2e/kas-grants.bats
+++ b/otdfctl/e2e/kas-grants.bats
@@ -17,8 +17,8 @@ setup_file() {
 }
 
 setup() {
-  load "${BATS_LIB_PATH}/bats-support/load.bash"
-  load "${BATS_LIB_PATH}/bats-assert/load.bash"
+  bats_load_library bats-support
+  bats_load_library bats-assert
 
   # invoke binary with credentials
   run_otdfctl_kasg() {

--- a/otdfctl/e2e/kas-keys-mappings.bats
+++ b/otdfctl/e2e/kas-keys-mappings.bats
@@ -2,10 +2,6 @@
 
 # Tests listing key mappings
 
-load "${BATS_LIB_PATH}/bats-support/load.bash"
-load "${BATS_LIB_PATH}/bats-assert/load.bash"
-load "otdfctl-utils.sh"
-
 # Helper functions for otdfctl commands
 run_otdfctl_key() {
   run sh -c "./otdfctl policy kas-registry key $HOST $WITH_CREDS $*"
@@ -64,6 +60,9 @@ run_otdfctl_namespace_delete() {
 }
 
 setup_file() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  load "otdfctl-utils.sh"
   export WITH_CREDS='--with-client-creds-file ./creds.json'
   export HOST='--host http://localhost:8080'
   export KAS_URI="https://test-kas-for-mappings.com"
@@ -133,8 +132,8 @@ setup_file() {
 }
 
 setup() {
-  # No setup specific to individual tests needed here currently
-  : # No-op
+  bats_load_library bats-support
+  bats_load_library bats-assert
 }
 
 teardown_file() {

--- a/otdfctl/e2e/kas-keys-mappings.bats
+++ b/otdfctl/e2e/kas-keys-mappings.bats
@@ -134,6 +134,7 @@ setup_file() {
 setup() {
   bats_load_library bats-support
   bats_load_library bats-assert
+  load "otdfctl-utils.sh"
 }
 
 teardown_file() {

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -38,6 +38,7 @@ setup_file() {
 setup() {
   bats_load_library bats-support
   bats_load_library bats-assert
+  load "otdfctl-utils.sh"
 }
 
 

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -1,9 +1,5 @@
 #!/usr/bin/env bats
 
-load "${BATS_LIB_PATH}/bats-support/load.bash"
-load "${BATS_LIB_PATH}/bats-assert/load.bash"
-load "otdfctl-utils.sh"
-
 run_otdfctl_kas_registry_create() {
   run sh -c "./otdfctl policy kas-registry create $HOST $WITH_CREDS $*"
 }
@@ -13,6 +9,9 @@ run_otdfctl_provider_create() {
 }
 
 setup_file() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  load "otdfctl-utils.sh"
   export WITH_CREDS='--with-client-creds-file ./creds.json'
   export HOST='--host http://localhost:8080'
   # This command is not a 'kas-registry key' subcommand, so it won't use run_otdfctl_key
@@ -37,8 +36,8 @@ setup_file() {
 }
 
 setup() {
-  # No setup specific to individual tests needed here currently
-  : # No-op
+  bats_load_library bats-support
+  bats_load_library bats-assert
 }
 
 

--- a/otdfctl/e2e/kas-registry.bats
+++ b/otdfctl/e2e/kas-registry.bats
@@ -11,8 +11,8 @@ setup_file() {
 }
 
 setup() {
-    load "${BATS_LIB_PATH}/bats-support/load.bash"
-    load "${BATS_LIB_PATH}/bats-assert/load.bash"
+    bats_load_library bats-support
+    bats_load_library bats-assert
 
     # invoke binary with credentials
     run_otdfctl_kasr() {

--- a/otdfctl/e2e/key-base.bats
+++ b/otdfctl/e2e/key-base.bats
@@ -1,11 +1,11 @@
 #!/usr/bin/env bats
 
 # NEEDS TO RUN AFTER encrypt-decrypt.bats
-load "${BATS_LIB_PATH}/bats-support/load.bash"
-load "${BATS_LIB_PATH}/bats-assert/load.bash"
-load "otdfctl-utils.sh"
 
 setup_file() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  load "otdfctl-utils.sh"
   export WITH_CREDS='--with-client-creds-file ./creds.json'
   export HOST='--host http://localhost:8080'
 
@@ -22,6 +22,8 @@ setup_file() {
 }
 
 setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
   # invoke binary with credentials for base key commands
   run_otdfctl_base_key() {
     run sh -c "./otdfctl policy kas-registry key base $HOST $WITH_CREDS $*"

--- a/otdfctl/e2e/logging.bats
+++ b/otdfctl/e2e/logging.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "${BATS_LIB_PATH}/bats-support/load.bash"
-    load "${BATS_LIB_PATH}/bats-assert/load.bash"
+    bats_load_library bats-support
+    bats_load_library bats-assert
 }
 
 @test "version is logged to stderr when debug logging enabled" {

--- a/otdfctl/e2e/migrate-namespaced-policy.bats
+++ b/otdfctl/e2e/migrate-namespaced-policy.bats
@@ -1182,6 +1182,8 @@ setup() {
 }
 
 setup_file() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
   export WITH_CREDS='--with-client-creds-file ./creds.json'
   export HOST='--host http://localhost:8080'
 

--- a/otdfctl/e2e/migrate-namespaced-policy.bats
+++ b/otdfctl/e2e/migrate-namespaced-policy.bats
@@ -10,9 +10,6 @@
 # CI should run this tag in a separate invocation, then run the remaining suite
 # with this tag filtered out.
 
-load "${BATS_LIB_PATH}/bats-support/load.bash"
-load "${BATS_LIB_PATH}/bats-assert/load.bash"
-
 run_otdfctl_migrate() {
   run ./otdfctl --host http://localhost:8080 --with-client-creds-file ./creds.json migrate "$@"
 }
@@ -1064,6 +1061,8 @@ run_namespaced_policy_commit() {
 }
 
 setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
   export TEST_PREFIX="${MIGRATION_TEST_PREFIX}-t${BATS_TEST_NUMBER}"
   export TRACKED_ACTION_IDS=""
   export TRACKED_REGISTERED_RESOURCE_IDS=""

--- a/otdfctl/e2e/namespaces.bats
+++ b/otdfctl/e2e/namespaces.bats
@@ -1,11 +1,11 @@
 #!/usr/bin/env bats
 
 # Tests for namespaces
-load "${BATS_LIB_PATH}/bats-support/load.bash"
-load "${BATS_LIB_PATH}/bats-assert/load.bash"
-load "otdfctl-utils.sh"
 
 setup_file() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  load "otdfctl-utils.sh"
   export WITH_CREDS='--with-client-creds-file ./creds.json'
   export HOST='--host http://localhost:8080'
 
@@ -26,6 +26,8 @@ setup_file() {
 }
 
 setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
   # invoke binary with credentials under 'policy attributes namespaces'
   run_otdfctl_ns() {
     run sh -c "./otdfctl $HOST $WITH_CREDS policy attributes namespaces $*"

--- a/otdfctl/e2e/obligations.bats
+++ b/otdfctl/e2e/obligations.bats
@@ -72,8 +72,8 @@ setup_file() {
 }
 
 setup() {
-    load "${BATS_LIB_PATH}/bats-support/load.bash"
-    load "${BATS_LIB_PATH}/bats-assert/load.bash"
+    bats_load_library bats-support
+    bats_load_library bats-assert
 
     # invoke binary with credentials
     run_otdfctl_obl () {

--- a/otdfctl/e2e/profile.bats
+++ b/otdfctl/e2e/profile.bats
@@ -7,8 +7,8 @@ setup_file() {
 }
 
 setup() {
-  load "${BATS_LIB_PATH}/bats-support/load.bash"
-  load "${BATS_LIB_PATH}/bats-assert/load.bash"
+  bats_load_library bats-support
+  bats_load_library bats-assert
 
   run_otdfctl() {
     run bash -c "./otdfctl profile $*"

--- a/otdfctl/e2e/provider-config.bats
+++ b/otdfctl/e2e/provider-config.bats
@@ -14,8 +14,8 @@ setup() {
     if [ "$RUN_EXPERIMENTAL_TESTS" != "true" ]; then
         skip "Skipping experimental test"
     fi
-    load "${BATS_LIB_PATH}/bats-support/load.bash"
-    load "${BATS_LIB_PATH}/bats-assert/load.bash"
+    bats_load_library bats-support
+    bats_load_library bats-assert
 
     # invoke binary with credentials
     run_otdfctl_key_pc () {

--- a/otdfctl/e2e/registered-resources.bats
+++ b/otdfctl/e2e/registered-resources.bats
@@ -40,8 +40,8 @@ setup_file() {
 }
 
 setup() {
-    load "${BATS_LIB_PATH}/bats-support/load.bash"
-    load "${BATS_LIB_PATH}/bats-assert/load.bash"
+    bats_load_library bats-support
+    bats_load_library bats-assert
 
     # invoke binary with credentials
     run_otdfctl_reg_res () {

--- a/otdfctl/e2e/resource-mapping-groups.bats
+++ b/otdfctl/e2e/resource-mapping-groups.bats
@@ -27,8 +27,8 @@ setup_file() {
 }
 
 setup() {
-    load "${BATS_LIB_PATH}/bats-support/load.bash"
-    load "${BATS_LIB_PATH}/bats-assert/load.bash"
+    bats_load_library bats-support
+    bats_load_library bats-assert
 
     # invoke binary with credentials
     run_otdfctl_rmg () {

--- a/otdfctl/e2e/resource-mapping.bats
+++ b/otdfctl/e2e/resource-mapping.bats
@@ -24,8 +24,8 @@ setup_file() {
 }
 
 setup() {
-    load "${BATS_LIB_PATH}/bats-support/load.bash"
-    load "${BATS_LIB_PATH}/bats-assert/load.bash"
+    bats_load_library bats-support
+    bats_load_library bats-assert
 
     # invoke binary with credentials
     run_otdfctl_rm () {

--- a/otdfctl/e2e/subject-condition-sets.bats
+++ b/otdfctl/e2e/subject-condition-sets.bats
@@ -16,8 +16,8 @@ setup_file() {
 }
 
 setup() {
-  load "${BATS_LIB_PATH}/bats-support/load.bash"
-  load "${BATS_LIB_PATH}/bats-assert/load.bash"
+  bats_load_library bats-support
+  bats_load_library bats-assert
 
   # invoke binary with credentials
   run_otdfctl_scs () {

--- a/otdfctl/e2e/subject-mapping.bats
+++ b/otdfctl/e2e/subject-mapping.bats
@@ -25,8 +25,8 @@ setup_file() {
 }
 
 setup() {
-    load "${BATS_LIB_PATH}/bats-support/load.bash"
-    load "${BATS_LIB_PATH}/bats-assert/load.bash"
+    bats_load_library bats-support
+    bats_load_library bats-assert
 
     # invoke binary with credentials
     run_otdfctl_sm () {


### PR DESCRIPTION
### Proposed Changes

* Replace manual `load "${BATS_LIB_PATH}/..."` with the modern `bats_load_library` API across all 20 otdfctl e2e test files, consolidating BATS infrastructure to match the pattern in `test/rego/` (part of DSPX-2662).

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

CI `otdfctl-test` job runs the full BATS e2e suite and will validate these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized end-to-end test initialization by moving helper library loading into per-file/per-test setup and consolidating the loading approach across suites. No test logic, commands, or assertions were changed. Improves maintainability and consistency of the test infrastructure without affecting test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->