### PR TITLE
feat(policy): hydrate resource_mappings on ListAttributes values

### DIFF
--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy/attributes"
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
 	"github.com/opentdf/platform/protocol/go/policy/namespaces"
+	"github.com/opentdf/platform/protocol/go/policy/resourcemapping"
 	"github.com/opentdf/platform/protocol/go/policy/unsafe"
 	"github.com/opentdf/platform/service/internal/fixtures"
 	"github.com/opentdf/platform/service/pkg/db"
@@ -765,6 +766,92 @@ func (s *AttributesSuite) Test_ListAttributes_FqnsIncluded() {
 			s.Equal(fmt.Sprintf("https://%s/attr/%s/value/%s", a.GetNamespace().GetName(), a.GetName(), v.GetValue()), v.GetFqn())
 		}
 	}
+}
+
+func (s *AttributesSuite) Test_ListAttributes_HydratesResourceMappings() {
+	createdAttr, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+		Name:        "test__list_attributes_hydrates_resource_mappings",
+		NamespaceId: fixtureNamespaceID,
+		Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+		Values:      []string{"mapped", "unmapped"},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(createdAttr)
+	s.Require().Len(createdAttr.GetValues(), 2)
+
+	mappedValueID := createdAttr.GetValues()[0].GetId()
+	unmappedValueID := createdAttr.GetValues()[1].GetId()
+
+	rmGrp, err := s.db.PolicyClient.CreateResourceMappingGroup(s.ctx, &resourcemapping.CreateResourceMappingGroupRequest{
+		NamespaceId: fixtureNamespaceID,
+		Name:        "list_attrs_rm_group",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(rmGrp)
+
+	grouped, err := s.db.PolicyClient.CreateResourceMapping(s.ctx, &resourcemapping.CreateResourceMappingRequest{
+		GroupId:          rmGrp.GetId(),
+		AttributeValueId: mappedValueID,
+		Terms:            []string{"alpha", "beta"},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(grouped)
+
+	ungrouped, err := s.db.PolicyClient.CreateResourceMapping(s.ctx, &resourcemapping.CreateResourceMappingRequest{
+		AttributeValueId: mappedValueID,
+		Terms:            []string{"gamma"},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(ungrouped)
+
+	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
+		Namespace: fixtureNamespaceID,
+		State:     common.ActiveStateEnum_ACTIVE_STATE_ENUM_ACTIVE,
+		Pagination: &policy.PageRequest{
+			Limit: s.db.LimitMax,
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(listRsp)
+
+	var found *policy.Attribute
+	for _, a := range listRsp.GetAttributes() {
+		if a.GetId() == createdAttr.GetId() {
+			found = a
+			break
+		}
+	}
+	s.Require().NotNil(found, "created attribute missing from list response")
+	s.Require().Len(found.GetValues(), 2)
+
+	valuesByID := map[string]*policy.Value{}
+	for _, v := range found.GetValues() {
+		valuesByID[v.GetId()] = v
+	}
+
+	mappedValue, ok := valuesByID[mappedValueID]
+	s.Require().True(ok)
+	rms := mappedValue.GetResourceMappings()
+	s.Require().Len(rms, 2)
+
+	byID := map[string]*policy.ResourceMapping{}
+	for _, rm := range rms {
+		byID[rm.GetId()] = rm
+	}
+	gotGrouped, ok := byID[grouped.GetId()]
+	s.Require().True(ok)
+	s.ElementsMatch([]string{"alpha", "beta"}, gotGrouped.GetTerms())
+	s.Require().NotNil(gotGrouped.GetGroup())
+	s.Equal(rmGrp.GetId(), gotGrouped.GetGroup().GetId())
+
+	gotUngrouped, ok := byID[ungrouped.GetId()]
+	s.Require().True(ok)
+	s.ElementsMatch([]string{"gamma"}, gotUngrouped.GetTerms())
+	s.Nil(gotUngrouped.GetGroup())
+
+	unmappedValue, ok := valuesByID[unmappedValueID]
+	s.Require().True(ok)
+	s.Empty(unmappedValue.GetResourceMappings())
 }
 
 func (s *AttributesSuite) Test_ListAttributes_IncludesAllowTraversal() {

--- a/service/policy/db/attributes.sql.go
+++ b/service/policy/db/attributes.sql.go
@@ -758,6 +758,27 @@ func (q *Queries) listAttributesByDefOrValueFqns(ctx context.Context, arg listAt
 
 const listAttributesDetail = `-- name: listAttributesDetail :many
 
+WITH value_resource_mappings AS (
+    SELECT
+        rm.attribute_value_id AS id,
+        JSON_AGG(
+            JSON_BUILD_OBJECT(
+                'id', rm.id,
+                'terms', rm.terms,
+                'group', CASE
+                            WHEN rm.group_id IS NULL THEN NULL
+                            ELSE JSON_BUILD_OBJECT(
+                                'id', rmg.id,
+                                'name', rmg.name,
+                                'namespace_id', rmg.namespace_id
+                            )
+                         END
+            )
+        ) AS res_maps
+    FROM resource_mappings rm
+    LEFT JOIN resource_mapping_groups rmg ON rm.group_id = rmg.id
+    GROUP BY rm.attribute_value_id
+)
 SELECT
     ad.id,
     ad.name as attribute_name,
@@ -772,7 +793,8 @@ SELECT
             'id', avt.id,
             'value', avt.value,
             'active', avt.active,
-            'fqn', CONCAT(fqns.fqn, '/value/', avt.value)
+            'fqn', CONCAT(fqns.fqn, '/value/', avt.value),
+            'resource_mappings', avrm.res_maps
         ) ORDER BY ARRAY_POSITION(ad.values_order, avt.id)
     ) FILTER (WHERE avt.id IS NOT NULL) AS values,
     fqns.fqn,
@@ -788,6 +810,7 @@ LEFT JOIN (
   FROM attribute_values av
   GROUP BY av.id
 ) avt ON avt.attribute_definition_id = ad.id
+LEFT JOIN value_resource_mappings avrm ON avt.id = avrm.id
 LEFT JOIN attribute_fqns fqns ON fqns.attribute_id = ad.id AND fqns.value_id IS NULL
 WHERE
     ($1::BOOLEAN IS NULL OR ad.active = $1) AND
@@ -835,6 +858,27 @@ type listAttributesDetailRow struct {
 // ATTRIBUTES
 // --------------------------------------------------------------
 //
+//	WITH value_resource_mappings AS (
+//	    SELECT
+//	        rm.attribute_value_id AS id,
+//	        JSON_AGG(
+//	            JSON_BUILD_OBJECT(
+//	                'id', rm.id,
+//	                'terms', rm.terms,
+//	                'group', CASE
+//	                            WHEN rm.group_id IS NULL THEN NULL
+//	                            ELSE JSON_BUILD_OBJECT(
+//	                                'id', rmg.id,
+//	                                'name', rmg.name,
+//	                                'namespace_id', rmg.namespace_id
+//	                            )
+//	                         END
+//	            )
+//	        ) AS res_maps
+//	    FROM resource_mappings rm
+//	    LEFT JOIN resource_mapping_groups rmg ON rm.group_id = rmg.id
+//	    GROUP BY rm.attribute_value_id
+//	)
 //	SELECT
 //	    ad.id,
 //	    ad.name as attribute_name,
@@ -849,7 +893,8 @@ type listAttributesDetailRow struct {
 //	            'id', avt.id,
 //	            'value', avt.value,
 //	            'active', avt.active,
-//	            'fqn', CONCAT(fqns.fqn, '/value/', avt.value)
+//	            'fqn', CONCAT(fqns.fqn, '/value/', avt.value),
+//	            'resource_mappings', avrm.res_maps
 //	        ) ORDER BY ARRAY_POSITION(ad.values_order, avt.id)
 //	    ) FILTER (WHERE avt.id IS NOT NULL) AS values,
 //	    fqns.fqn,
@@ -865,6 +910,7 @@ type listAttributesDetailRow struct {
 //	  FROM attribute_values av
 //	  GROUP BY av.id
 //	) avt ON avt.attribute_definition_id = ad.id
+//	LEFT JOIN value_resource_mappings avrm ON avt.id = avrm.id
 //	LEFT JOIN attribute_fqns fqns ON fqns.attribute_id = ad.id AND fqns.value_id IS NULL
 //	WHERE
 //	    ($1::BOOLEAN IS NULL OR ad.active = $1) AND

--- a/service/policy/db/attributes.sql.go
+++ b/service/policy/db/attributes.sql.go
@@ -776,7 +776,14 @@ WITH value_resource_mappings AS (
             )
         ) AS res_maps
     FROM resource_mappings rm
+    INNER JOIN attribute_values av ON av.id = rm.attribute_value_id
+    INNER JOIN attribute_definitions ad ON ad.id = av.attribute_definition_id
+    LEFT JOIN attribute_namespaces n ON n.id = ad.namespace_id
     LEFT JOIN resource_mapping_groups rmg ON rm.group_id = rmg.id
+    WHERE
+        ($1::BOOLEAN IS NULL OR ad.active = $1) AND
+        ($2::uuid IS NULL OR ad.namespace_id = $2::uuid) AND
+        ($3::text IS NULL OR n.name = $3::text)
     GROUP BY rm.attribute_value_id
 )
 SELECT
@@ -876,7 +883,14 @@ type listAttributesDetailRow struct {
 //	            )
 //	        ) AS res_maps
 //	    FROM resource_mappings rm
+//	    INNER JOIN attribute_values av ON av.id = rm.attribute_value_id
+//	    INNER JOIN attribute_definitions ad ON ad.id = av.attribute_definition_id
+//	    LEFT JOIN attribute_namespaces n ON n.id = ad.namespace_id
 //	    LEFT JOIN resource_mapping_groups rmg ON rm.group_id = rmg.id
+//	    WHERE
+//	        ($1::BOOLEAN IS NULL OR ad.active = $1) AND
+//	        ($2::uuid IS NULL OR ad.namespace_id = $2::uuid) AND
+//	        ($3::text IS NULL OR n.name = $3::text)
 //	    GROUP BY rm.attribute_value_id
 //	)
 //	SELECT

--- a/service/policy/db/queries/attributes.sql
+++ b/service/policy/db/queries/attributes.sql
@@ -21,7 +21,14 @@ WITH value_resource_mappings AS (
             )
         ) AS res_maps
     FROM resource_mappings rm
+    INNER JOIN attribute_values av ON av.id = rm.attribute_value_id
+    INNER JOIN attribute_definitions ad ON ad.id = av.attribute_definition_id
+    LEFT JOIN attribute_namespaces n ON n.id = ad.namespace_id
     LEFT JOIN resource_mapping_groups rmg ON rm.group_id = rmg.id
+    WHERE
+        (sqlc.narg('active')::BOOLEAN IS NULL OR ad.active = sqlc.narg('active')) AND
+        (sqlc.narg('namespace_id')::uuid IS NULL OR ad.namespace_id = sqlc.narg('namespace_id')::uuid) AND
+        (sqlc.narg('namespace_name')::text IS NULL OR n.name = sqlc.narg('namespace_name')::text)
     GROUP BY rm.attribute_value_id
 )
 SELECT

--- a/service/policy/db/queries/attributes.sql
+++ b/service/policy/db/queries/attributes.sql
@@ -3,6 +3,27 @@
 ----------------------------------------------------------------
 
 -- name: listAttributesDetail :many
+WITH value_resource_mappings AS (
+    SELECT
+        rm.attribute_value_id AS id,
+        JSON_AGG(
+            JSON_BUILD_OBJECT(
+                'id', rm.id,
+                'terms', rm.terms,
+                'group', CASE
+                            WHEN rm.group_id IS NULL THEN NULL
+                            ELSE JSON_BUILD_OBJECT(
+                                'id', rmg.id,
+                                'name', rmg.name,
+                                'namespace_id', rmg.namespace_id
+                            )
+                         END
+            )
+        ) AS res_maps
+    FROM resource_mappings rm
+    LEFT JOIN resource_mapping_groups rmg ON rm.group_id = rmg.id
+    GROUP BY rm.attribute_value_id
+)
 SELECT
     ad.id,
     ad.name as attribute_name,
@@ -17,7 +38,8 @@ SELECT
             'id', avt.id,
             'value', avt.value,
             'active', avt.active,
-            'fqn', CONCAT(fqns.fqn, '/value/', avt.value)
+            'fqn', CONCAT(fqns.fqn, '/value/', avt.value),
+            'resource_mappings', avrm.res_maps
         ) ORDER BY ARRAY_POSITION(ad.values_order, avt.id)
     ) FILTER (WHERE avt.id IS NOT NULL) AS values,
     fqns.fqn,
@@ -33,6 +55,7 @@ LEFT JOIN (
   FROM attribute_values av
   GROUP BY av.id
 ) avt ON avt.attribute_definition_id = ad.id
+LEFT JOIN value_resource_mappings avrm ON avt.id = avrm.id
 LEFT JOIN attribute_fqns fqns ON fqns.attribute_id = ad.id AND fqns.value_id IS NULL
 WHERE
     (sqlc.narg('active')::BOOLEAN IS NULL OR ad.active = sqlc.narg('active')) AND


### PR DESCRIPTION
## Summary

- `policy.attributes.AttributesService/ListAttributes` now returns `resource_mappings` on every `Value`, matching the shape already produced by `GetAttributeValuesByFqns` and already advertised in the generated OpenAPI spec.
- The SQL change extends `listAttributesDetail` with a pre-aggregated `value_resource_mappings` CTE (same pattern used by `listAttributesByDefOrValueFqns`), so mappings are hydrated without introducing row-explosion through the main `GROUP BY`.
- No proto change. No new request toggle. No behavior change for callers that ignore the new field.

### Before / after

Before (trimmed):

```json
{
  "id": "…",
  "value": "topsecret",
  "fqn": "https://demo.com/attr/classification/value/topsecret",
  "active": true
}
```

After:

```json
{
  "id": "…",
  "value": "topsecret",
  "fqn": "https://demo.com/attr/classification/value/topsecret",
  "active": true,
  "resourceMappings": [
    { "id": "…", "terms": ["ts", "top-secret", "top_secret"] }
  ]
}
```

Reproduction:

```bash
grpcurl -plaintext -d '{"pagination":{"limit":500}}' \
  localhost:8080 policy.attributes.AttributesService/ListAttributes
```

### Why

Clients that need label/term data (UI pickers, classifiers, policy editors) currently have to enumerate FQNs via `ListAttributes` and then batch‑hydrate them through `GetAttributeValuesByFqns` (250 FQN cap per call). The OpenAPI spec already documents `resourceMappings` on `ListAttributes`, so the current server response is inconsistent with the schema clients read. Hydrating directly collapses the two round trips into one.

### Implementation notes

- `listAttributesDetail` gets a new CTE (`value_resource_mappings`) keyed by `attribute_value_id`, producing a `JSON_AGG` of `{id, terms, group}` per value — exactly the shape `listAttributesByDefOrValueFqns` emits.
- The CTE is joined once against the flattened `avt` subquery by `av.id`. Row count per attribute definition is unchanged (one row per value), so `JSON_AGG … FILTER (WHERE avt.id IS NOT NULL)` and the `GROUP BY ad.id, n.name, fqns.fqn` + `COUNT(*) OVER()` pagination continue to behave the same.
- `Value` already declares `repeated ResourceMapping resource_mappings = 10;`, so the Go DAO (`attributesValuesProtojson` → `protojson.Unmarshal`) picks up the new field automatically. No scanning code changed.
- `GetAttribute` is intentionally out of scope — it uses the separate `getAttribute` query and was left unchanged.

### Out of scope

- `subject_mappings` / `kas_keys` / `grants` / `obligations` / value-level `metadata` hydration on `ListAttributes`. Each is its own JOIN and its own tradeoff, tracked as follow-ups.

## Test plan

- [x] `go build ./service/...`
- [x] `go vet ./service/policy/... ./service/integration/...`
- [x] `golangci-lint run -c .golangci.yaml ./policy/db/...` — 0 issues
- [x] `go test ./service/policy/...` — 761 passed
- [x] `go test -run '^TestAttributesSuite$' ./service/integration/...` — 92 passed (includes new `Test_ListAttributes_HydratesResourceMappings`)
- [x] `go test -run '^TestAttributeFqnSuite$' ./service/integration/...` — 38 passed
- [x] `go test -run '^TestResourceMappingsSuite$|^TestAttributeValuesSuite$|^TestNamespacesSuite$' ./service/integration/...` — 161 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attribute listings now include resource mapping information for each attribute value.

* **Tests**
  * Added integration test verifying resource mappings are properly populated for attribute values, including both grouped and ungrouped mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->