### PR TITLE
chore(policy): consolidate sort integration helpers, add tiebreaker tests, add test cleanup    

### DIFF
--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -654,6 +654,8 @@ func (s *AttributesSuite) Test_ListAttributes_SortTieBreaker_CreatedAtWithIDFall
 	}
 	defer s.deleteSortTestAttributes(ids)
 
+	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "attribute_definitions", ids))
+
 	sorted := slices.Sorted(slices.Values(ids))
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -510,7 +510,7 @@ func (s *AttributesSuite) Test_ListAttributes_OrdersByCreatedAt_Succeeds() {
 
 func (s *AttributesSuite) Test_ListAttributes_SortByName_ASC() {
 	nsID := s.createSortTestNamespace("sort-name-asc")
-	ids := s.createNamedSortTestAttributes(nsID, []string{"aaa-sort", "bbb-sort", "ccc-sort"})
+	ids := s.createSortTestAttributes(nsID, []string{"aaa-sort", "bbb-sort", "ccc-sort"})
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -527,7 +527,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByName_ASC() {
 
 func (s *AttributesSuite) Test_ListAttributes_SortByName_DESC() {
 	nsID := s.createSortTestNamespace("sort-name-desc")
-	ids := s.createNamedSortTestAttributes(nsID, []string{"aaa-sortdesc", "bbb-sortdesc", "ccc-sortdesc"})
+	ids := s.createSortTestAttributes(nsID, []string{"aaa-sortdesc", "bbb-sortdesc", "ccc-sortdesc"})
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -544,7 +544,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByName_DESC() {
 
 func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_ASC() {
 	nsID := s.createSortTestNamespace("sort-created-asc")
-	ids := s.createSortTestAttributes(nsID, "createdasc-attr", 3)
+	ids := s.createSortTestAttributes(nsID, []string{"createdasc-attr-0", "createdasc-attr-1", "createdasc-attr-2"})
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -561,7 +561,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_ASC() {
 
 func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_DESC() {
 	nsID := s.createSortTestNamespace("sort-created-desc")
-	ids := s.createSortTestAttributes(nsID, "createddesc-attr", 3)
+	ids := s.createSortTestAttributes(nsID, []string{"createddesc-attr-0", "createddesc-attr-1", "createddesc-attr-2"})
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -578,7 +578,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_DESC() {
 
 func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_DESC() {
 	nsID := s.createSortTestNamespace("sort-updated-desc")
-	ids := s.createSortTestAttributes(nsID, "upd-sort-attr", 3)
+	ids := s.createSortTestAttributes(nsID, []string{"upd-sort-attr-0", "upd-sort-attr-1", "upd-sort-attr-2"})
 
 	// Update the first attribute so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -606,7 +606,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_DESC() {
 
 func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_ASC() {
 	nsID := s.createSortTestNamespace("sort-updated-asc")
-	ids := s.createSortTestAttributes(nsID, "upd-sort-asc-attr", 3)
+	ids := s.createSortTestAttributes(nsID, []string{"upd-sort-asc-attr-0", "upd-sort-asc-attr-1", "upd-sort-asc-attr-2"})
 
 	// Update the last attribute so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -634,7 +634,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_ASC() {
 
 func (s *AttributesSuite) Test_ListAttributes_SortByUnspecifiedField_DefaultsToCreatedAt() {
 	nsID := s.createSortTestNamespace("sort-unspecified-field")
-	ids := s.createSortTestAttributes(nsID, "unspecified-field-attr", 3)
+	ids := s.createSortTestAttributes(nsID, []string{"unspecified-field-attr-0", "unspecified-field-attr-1", "unspecified-field-attr-2"})
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -651,7 +651,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUnspecifiedField_DefaultsToC
 
 func (s *AttributesSuite) Test_ListAttributes_SortByUnspecifiedDirection_DefaultsToDESC() {
 	nsID := s.createSortTestNamespace("sort-unspecified-dir")
-	ids := s.createSortTestAttributes(nsID, "unspecified-dir-attr", 3)
+	ids := s.createSortTestAttributes(nsID, []string{"unspecified-dir-attr-0", "unspecified-dir-attr-1", "unspecified-dir-attr-2"})
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -668,7 +668,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUnspecifiedDirection_Default
 
 func (s *AttributesSuite) Test_ListAttributes_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
 	nsID := s.createSortTestNamespace("sort-both-unspecified")
-	ids := s.createSortTestAttributes(nsID, "both-unspecified-attr", 3)
+	ids := s.createSortTestAttributes(nsID, []string{"both-unspecified-attr-0", "both-unspecified-attr-1", "both-unspecified-attr-2"})
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -685,7 +685,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByBothUnspecified_DefaultsToCr
 
 func (s *AttributesSuite) Test_ListAttributes_SortOmitted() {
 	nsID := s.createSortTestNamespace("sort-omitted")
-	ids := s.createSortTestAttributes(nsID, "omitted-sort-attr", 3)
+	ids := s.createSortTestAttributes(nsID, []string{"omitted-sort-attr-0", "omitted-sort-attr-1", "omitted-sort-attr-2"})
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -1849,33 +1849,15 @@ func (s *AttributesSuite) createSortTestNamespace(label string) string {
 	return ns.GetId()
 }
 
-// createSortTestAttributes creates count attributes in the given namespace with 5ms gaps for distinct timestamps.
-// Returns the attribute IDs in creation order.
-func (s *AttributesSuite) createSortTestAttributes(nsID string, label string, count int) []string { //nolint:unparam // count is parameterized for reuse across endpoint test files
-	ids := make([]string, count)
-	for i := range count {
+// createSortTestAttributes creates attributes in the given namespace with the given prefixes,
+// adding 5ms gaps between creations for distinct timestamps. Returns the attribute IDs in creation order.
+func (s *AttributesSuite) createSortTestAttributes(nsID string, prefixes []string) []string {
+	ids := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
 		if i > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}
-		name := fmt.Sprintf("%s-%d-%d", label, i, time.Now().UnixNano())
-		created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
-			Name:        name,
-			NamespaceId: nsID,
-			Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF,
-		})
-		s.Require().NoError(err)
-		ids[i] = created.GetId()
-	}
-	return ids
-}
-
-// createNamedSortTestAttributes creates attributes with specific name prefixes for name-sort testing.
-// Returns the attribute IDs in the same order as the prefixes.
-func (s *AttributesSuite) createNamedSortTestAttributes(nsID string, prefixes []string) []string {
-	suffix := time.Now().UnixNano()
-	ids := make([]string, len(prefixes))
-	for i, prefix := range prefixes {
-		name := fmt.Sprintf("%s-%d", prefix, suffix)
+		name := fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
 		created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
 			Name:        name,
 			NamespaceId: nsID,

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -1910,10 +1910,7 @@ func (s *AttributesSuite) createSortTestAttributes(nsID string, prefixes []strin
 
 // deleteSortTestAttributes deactivates attributes created by sort tests.
 func (s *AttributesSuite) deleteSortTestAttributes(ids []string) {
-	for _, id := range ids {
-		_, err := s.db.PolicyClient.DeactivateAttribute(s.ctx, id)
-		s.Require().NoError(err)
-	}
+	s.Require().NoError(forceDeleteRows(s.ctx, s.db, "attribute_definitions", ids))
 }
 
 func (s *AttributesSuite) getAttributeFixtures() map[string]fixtures.FixtureDataAttribute {

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -691,6 +691,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUnspecifiedField_DefaultsToC
 func (s *AttributesSuite) Test_ListAttributes_SortByUnspecifiedDirection_DefaultsToDESC() {
 	nsID := s.createSortTestNamespace("sort-unspecified-dir")
 	ids := s.createSortTestAttributes(nsID, []string{"unspecified-dir-attr-0", "unspecified-dir-attr-1", "unspecified-dir-attr-2"})
+	defer s.deleteSortTestAttributes(ids)
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -708,6 +709,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUnspecifiedDirection_Default
 func (s *AttributesSuite) Test_ListAttributes_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
 	nsID := s.createSortTestNamespace("sort-both-unspecified")
 	ids := s.createSortTestAttributes(nsID, []string{"both-unspecified-attr-0", "both-unspecified-attr-1", "both-unspecified-attr-2"})
+	defer s.deleteSortTestAttributes(ids)
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -725,6 +727,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByBothUnspecified_DefaultsToCr
 func (s *AttributesSuite) Test_ListAttributes_SortOmitted() {
 	nsID := s.createSortTestNamespace("sort-omitted")
 	ids := s.createSortTestAttributes(nsID, []string{"omitted-sort-attr-0", "omitted-sort-attr-1", "omitted-sort-attr-2"})
+	defer s.deleteSortTestAttributes(ids)
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -638,6 +638,36 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_ASC() {
 	assertIDsInOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, ids[0], ids[1], ids[2])
 }
 
+func (s *AttributesSuite) Test_ListAttributes_SortTieBreaker_CreatedAtWithIDFallback() {
+	nsID := s.createSortTestNamespace("sort-tiebreaker")
+	suffix := time.Now().UnixNano()
+	ids := make([]string, 3)
+	for i := range 3 {
+		name := fmt.Sprintf("tiebreaker-attr-%d-%d", i, suffix)
+		created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+			Name:        name,
+			NamespaceId: nsID,
+			Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF,
+		})
+		s.Require().NoError(err)
+		ids[i] = created.GetId()
+	}
+	defer s.deleteSortTestAttributes(ids)
+
+	sorted := slices.Sorted(slices.Values(ids))
+
+	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
+		Namespace: nsID,
+		Sort: []*attributes.AttributesSort{
+			{Field: attributes.SortAttributesType_SORT_ATTRIBUTES_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(listRsp)
+
+	assertIDsInOrder(s.T(), listRsp.GetAttributes(), func(attr *policy.Attribute) string { return attr.GetId() }, sorted[0], sorted[1], sorted[2])
+}
+
 func (s *AttributesSuite) Test_ListAttributes_SortByUnspecifiedField_DefaultsToCreatedAt() {
 	nsID := s.createSortTestNamespace("sort-unspecified-field")
 	ids := s.createSortTestAttributes(nsID, []string{"unspecified-field-attr-0", "unspecified-field-attr-1", "unspecified-field-attr-2"})

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -511,6 +511,7 @@ func (s *AttributesSuite) Test_ListAttributes_OrdersByCreatedAt_Succeeds() {
 func (s *AttributesSuite) Test_ListAttributes_SortByName_ASC() {
 	nsID := s.createSortTestNamespace("sort-name-asc")
 	ids := s.createSortTestAttributes(nsID, []string{"aaa-sort", "bbb-sort", "ccc-sort"})
+	defer s.deleteSortTestAttributes(ids)
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -528,6 +529,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByName_ASC() {
 func (s *AttributesSuite) Test_ListAttributes_SortByName_DESC() {
 	nsID := s.createSortTestNamespace("sort-name-desc")
 	ids := s.createSortTestAttributes(nsID, []string{"aaa-sortdesc", "bbb-sortdesc", "ccc-sortdesc"})
+	defer s.deleteSortTestAttributes(ids)
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -545,6 +547,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByName_DESC() {
 func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_ASC() {
 	nsID := s.createSortTestNamespace("sort-created-asc")
 	ids := s.createSortTestAttributes(nsID, []string{"createdasc-attr-0", "createdasc-attr-1", "createdasc-attr-2"})
+	defer s.deleteSortTestAttributes(ids)
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -562,6 +565,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_ASC() {
 func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_DESC() {
 	nsID := s.createSortTestNamespace("sort-created-desc")
 	ids := s.createSortTestAttributes(nsID, []string{"createddesc-attr-0", "createddesc-attr-1", "createddesc-attr-2"})
+	defer s.deleteSortTestAttributes(ids)
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -579,6 +583,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByCreatedAt_DESC() {
 func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_DESC() {
 	nsID := s.createSortTestNamespace("sort-updated-desc")
 	ids := s.createSortTestAttributes(nsID, []string{"upd-sort-attr-0", "upd-sort-attr-1", "upd-sort-attr-2"})
+	defer s.deleteSortTestAttributes(ids)
 
 	// Update the first attribute so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -607,6 +612,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_DESC() {
 func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_ASC() {
 	nsID := s.createSortTestNamespace("sort-updated-asc")
 	ids := s.createSortTestAttributes(nsID, []string{"upd-sort-asc-attr-0", "upd-sort-asc-attr-1", "upd-sort-asc-attr-2"})
+	defer s.deleteSortTestAttributes(ids)
 
 	// Update the last attribute so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -635,6 +641,7 @@ func (s *AttributesSuite) Test_ListAttributes_SortByUpdatedAt_ASC() {
 func (s *AttributesSuite) Test_ListAttributes_SortByUnspecifiedField_DefaultsToCreatedAt() {
 	nsID := s.createSortTestNamespace("sort-unspecified-field")
 	ids := s.createSortTestAttributes(nsID, []string{"unspecified-field-attr-0", "unspecified-field-attr-1", "unspecified-field-attr-2"})
+	defer s.deleteSortTestAttributes(ids)
 
 	listRsp, err := s.db.PolicyClient.ListAttributes(s.ctx, &attributes.ListAttributesRequest{
 		Namespace: nsID,
@@ -1867,6 +1874,14 @@ func (s *AttributesSuite) createSortTestAttributes(nsID string, prefixes []strin
 		ids[i] = created.GetId()
 	}
 	return ids
+}
+
+// deleteSortTestAttributes deactivates attributes created by sort tests.
+func (s *AttributesSuite) deleteSortTestAttributes(ids []string) {
+	for _, id := range ids {
+		_, err := s.db.PolicyClient.DeactivateAttribute(s.ctx, id)
+		s.Require().NoError(err)
+	}
 }
 
 func (s *AttributesSuite) getAttributeFixtures() map[string]fixtures.FixtureDataAttribute {

--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -2709,8 +2709,6 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortOmitted() {
 
 // Sort test helpers
 
-// createSortTestKasKeys creates 3 kas keys with 5ms gaps for distinct timestamps.
-// Returns the key IDs (UUIDs) in creation order and the parent KAS ID.
 // createSortTestKasKeys creates kas keys with the given prefixes, adding 5ms gaps
 // between creations for distinct timestamps. Returns the key IDs in creation order and the parent KAS ID.
 func (s *KasRegistryKeySuite) createSortTestKasKeys(prefixes []string) ([]string, string) {

--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -2474,7 +2474,7 @@ func (s *KasRegistryKeySuite) createKeyAndKas() *policy.KasKey {
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SortByKeyId_ASC() {
-	ids, kasID := s.createKeyIDSortTestKasKeys([]string{"aaa-kksort", "bbb-kksort", "ccc-kksort"})
+	ids, kasID := s.createSortTestKasKeys([]string{"aaa-kksort", "bbb-kksort", "ccc-kksort"})
 	defer s.deleteSortTestKasKeys(ids, kasID)
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
@@ -2491,7 +2491,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortByKeyId_ASC() {
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SortByKeyId_DESC() {
-	ids, kasID := s.createKeyIDSortTestKasKeys([]string{"aaa-kksortdesc", "bbb-kksortdesc", "ccc-kksortdesc"})
+	ids, kasID := s.createSortTestKasKeys([]string{"aaa-kksortdesc", "bbb-kksortdesc", "ccc-kksortdesc"})
 	defer s.deleteSortTestKasKeys(ids, kasID)
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
@@ -2508,7 +2508,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortByKeyId_DESC() {
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SortByCreatedAt_ASC() {
-	ids, kasID := s.createSortTestKasKeys("createdasc-kk")
+	ids, kasID := s.createSortTestKasKeys([]string{"createdasc-kk-0", "createdasc-kk-1", "createdasc-kk-2"})
 	defer s.deleteSortTestKasKeys(ids, kasID)
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
@@ -2525,7 +2525,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortByCreatedAt_ASC() {
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SortByCreatedAt_DESC() {
-	ids, kasID := s.createSortTestKasKeys("createddesc-kk")
+	ids, kasID := s.createSortTestKasKeys([]string{"createddesc-kk-0", "createddesc-kk-1", "createddesc-kk-2"})
 	defer s.deleteSortTestKasKeys(ids, kasID)
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
@@ -2542,7 +2542,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortByCreatedAt_DESC() {
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SortByUpdatedAt_DESC() {
-	ids, kasID := s.createSortTestKasKeys("upd-sort-kk")
+	ids, kasID := s.createSortTestKasKeys([]string{"upd-sort-kk-0", "upd-sort-kk-1", "upd-sort-kk-2"})
 	defer s.deleteSortTestKasKeys(ids, kasID)
 
 	// Update the first key so its updated_at is the most recent
@@ -2570,7 +2570,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortByUpdatedAt_DESC() {
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SortByUpdatedAt_ASC() {
-	ids, kasID := s.createSortTestKasKeys("updasc-kk")
+	ids, kasID := s.createSortTestKasKeys([]string{"updasc-kk-0", "updasc-kk-1", "updasc-kk-2"})
 	defer s.deleteSortTestKasKeys(ids, kasID)
 
 	// Update the last key so its updated_at is the most recent
@@ -2598,7 +2598,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortByUpdatedAt_ASC() {
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SortByUnspecifiedField_DefaultsToCreatedAt() {
-	ids, kasID := s.createSortTestKasKeys("unsf-kk")
+	ids, kasID := s.createSortTestKasKeys([]string{"unsf-kk-0", "unsf-kk-1", "unsf-kk-2"})
 	defer s.deleteSortTestKasKeys(ids, kasID)
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
@@ -2615,7 +2615,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortByUnspecifiedField_DefaultsToCre
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SortByUnspecifiedDirection_DefaultsToDESC() {
-	ids, kasID := s.createSortTestKasKeys("unsd-kk")
+	ids, kasID := s.createSortTestKasKeys([]string{"unsd-kk-0", "unsd-kk-1", "unsd-kk-2"})
 	defer s.deleteSortTestKasKeys(ids, kasID)
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
@@ -2632,7 +2632,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortByUnspecifiedDirection_DefaultsT
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
-	ids, kasID := s.createSortTestKasKeys("unsb-kk")
+	ids, kasID := s.createSortTestKasKeys([]string{"unsb-kk-0", "unsb-kk-1", "unsb-kk-2"})
 	defer s.deleteSortTestKasKeys(ids, kasID)
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
@@ -2649,7 +2649,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortByBothUnspecified_DefaultsToCrea
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SortOmitted() {
-	ids, kasID := s.createSortTestKasKeys("omit-kk")
+	ids, kasID := s.createSortTestKasKeys([]string{"omit-kk-0", "omit-kk-1", "omit-kk-2"})
 	defer s.deleteSortTestKasKeys(ids, kasID)
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
@@ -2666,62 +2666,30 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortOmitted() {
 
 // createSortTestKasKeys creates 3 kas keys with 5ms gaps for distinct timestamps.
 // Returns the key IDs (UUIDs) in creation order and the parent KAS ID.
-func (s *KasRegistryKeySuite) createSortTestKasKeys(label string) ([]string, string) {
+// createSortTestKasKeys creates kas keys with the given prefixes, adding 5ms gaps
+// between creations for distinct timestamps. Returns the key IDs in creation order and the parent KAS ID.
+func (s *KasRegistryKeySuite) createSortTestKasKeys(prefixes []string) ([]string, string) {
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
-		Name: label + "-kas-" + uuid.NewString(),
-		Uri:  "https://" + label + "-kas-" + uuid.NewString() + ".opentdf.io",
+		Name: prefixes[0] + "-kas-" + uuid.NewString(),
+		Uri:  "https://" + prefixes[0] + "-kas-" + uuid.NewString() + ".opentdf.io",
 	}
 	kas, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasReq)
 	s.Require().NoError(err)
 	s.NotNil(kas)
 
-	const count = 3
-	ids := make([]string, count)
-	for i := range count {
+	ids := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
 		if i > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}
 		keyReq := kasregistry.CreateKeyRequest{
 			KasId:        kas.GetId(),
-			KeyId:        fmt.Sprintf("%s-%d-%d", label, i, time.Now().UnixNano()),
+			KeyId:        fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano()),
 			KeyAlgorithm: policy.Algorithm_ALGORITHM_RSA_2048,
 			KeyMode:      policy.KeyMode_KEY_MODE_CONFIG_ROOT_KEY,
 			PublicKeyCtx: &policy.PublicKeyCtx{Pem: keyCtx},
 			PrivateKeyCtx: &policy.PrivateKeyCtx{
-				KeyId:      fmt.Sprintf("%s-%d", label, i),
-				WrappedKey: keyCtx,
-			},
-		}
-		resp, err := s.db.PolicyClient.CreateKey(s.ctx, &keyReq)
-		s.Require().NoError(err)
-		s.NotNil(resp)
-		ids[i] = resp.GetKasKey().GetKey().GetId()
-	}
-	return ids, kas.GetId()
-}
-
-// createKeyIDSortTestKasKeys creates kas keys with controlled key_id prefixes for lexicographic sort testing.
-// Returns the key IDs (UUIDs) in the same order as the prefixes and the parent KAS ID.
-func (s *KasRegistryKeySuite) createKeyIDSortTestKasKeys(prefixes []string) ([]string, string) {
-	kasReq := kasregistry.CreateKeyAccessServerRequest{
-		Name: "keyidsort-kas-" + uuid.NewString(),
-		Uri:  "https://keyidsort-kas-" + uuid.NewString() + ".opentdf.io",
-	}
-	kas, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasReq)
-	s.Require().NoError(err)
-	s.NotNil(kas)
-
-	suffix := time.Now().UnixNano()
-	ids := make([]string, len(prefixes))
-	for i, prefix := range prefixes {
-		keyReq := kasregistry.CreateKeyRequest{
-			KasId:        kas.GetId(),
-			KeyId:        fmt.Sprintf("%s-%d", prefix, suffix),
-			KeyAlgorithm: policy.Algorithm_ALGORITHM_RSA_2048,
-			KeyMode:      policy.KeyMode_KEY_MODE_CONFIG_ROOT_KEY,
-			PublicKeyCtx: &policy.PublicKeyCtx{Pem: keyCtx},
-			PrivateKeyCtx: &policy.PrivateKeyCtx{
-				KeyId:      fmt.Sprintf("%s-priv-%d", prefix, suffix),
+				KeyId:      fmt.Sprintf("%s-priv-%d", prefix, time.Now().UnixNano()),
 				WrappedKey: keyCtx,
 			},
 		}

--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -2626,6 +2626,8 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortTieBreaker_CreatedAtWithIDFallba
 	}
 	defer s.deleteSortTestKasKeys(ids, kas.GetId())
 
+	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "key_access_server_keys", ids))
+
 	sorted := slices.Sorted(slices.Values(ids))
 
 	listRsp, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
@@ -2712,9 +2714,14 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortOmitted() {
 // createSortTestKasKeys creates kas keys with the given prefixes, adding 5ms gaps
 // between creations for distinct timestamps. Returns the key IDs in creation order and the parent KAS ID.
 func (s *KasRegistryKeySuite) createSortTestKasKeys(prefixes []string) ([]string, string) {
+	label := "kas"
+	if len(prefixes) > 0 {
+		label = prefixes[0]
+	}
+	kasUUID := uuid.NewString()
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
-		Name: prefixes[0] + "-kas-" + uuid.NewString(),
-		Uri:  "https://" + prefixes[0] + "-kas-" + uuid.NewString() + ".opentdf.io",
+		Name: label + "-kas-" + kasUUID,
+		Uri:  "https://" + label + "-kas-" + kasUUID + ".opentdf.io",
 	}
 	kas, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasReq)
 	s.Require().NoError(err)
@@ -2725,14 +2732,15 @@ func (s *KasRegistryKeySuite) createSortTestKasKeys(prefixes []string) ([]string
 		if i > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}
+		ts := time.Now().UnixNano()
 		keyReq := kasregistry.CreateKeyRequest{
 			KasId:        kas.GetId(),
-			KeyId:        fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano()),
+			KeyId:        fmt.Sprintf("%s-%d", prefix, ts),
 			KeyAlgorithm: policy.Algorithm_ALGORITHM_RSA_2048,
 			KeyMode:      policy.KeyMode_KEY_MODE_CONFIG_ROOT_KEY,
 			PublicKeyCtx: &policy.PublicKeyCtx{Pem: keyCtx},
 			PrivateKeyCtx: &policy.PrivateKeyCtx{
-				KeyId:      fmt.Sprintf("%s-priv-%d", prefix, time.Now().UnixNano()),
+				KeyId:      fmt.Sprintf("%s-priv-%d", prefix, ts),
 				WrappedKey: keyCtx,
 			},
 		}

--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 
@@ -2595,6 +2596,50 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SortByUpdatedAt_ASC() {
 
 	// The updated key (ids[2]) should appear last in ASC order
 	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[0], ids[1], ids[2])
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortTieBreaker_CreatedAtWithIDFallback() {
+	kasReq := kasregistry.CreateKeyAccessServerRequest{
+		Name: "tiebreaker-kk-kas-" + uuid.NewString(),
+		Uri:  "https://tiebreaker-kk-kas-" + uuid.NewString() + ".opentdf.io",
+	}
+	kas, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasReq)
+	s.Require().NoError(err)
+
+	suffix := time.Now().UnixNano()
+	ids := make([]string, 3)
+	for i := range 3 {
+		keyReq := kasregistry.CreateKeyRequest{
+			KasId:        kas.GetId(),
+			KeyId:        fmt.Sprintf("tiebreaker-kk-%d-%d", i, suffix),
+			KeyAlgorithm: policy.Algorithm_ALGORITHM_RSA_2048,
+			KeyMode:      policy.KeyMode_KEY_MODE_CONFIG_ROOT_KEY,
+			PublicKeyCtx: &policy.PublicKeyCtx{Pem: keyCtx},
+			PrivateKeyCtx: &policy.PrivateKeyCtx{
+				KeyId:      fmt.Sprintf("tiebreaker-kk-priv-%d-%d", i, suffix),
+				WrappedKey: keyCtx,
+			},
+		}
+		resp, err := s.db.PolicyClient.CreateKey(s.ctx, &keyReq)
+		s.Require().NoError(err)
+		ids[i] = resp.GetKasKey().GetKey().GetId()
+	}
+	defer s.deleteSortTestKasKeys(ids, kas.GetId())
+
+	sorted := slices.Sorted(slices.Values(ids))
+
+	listRsp, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{
+			KasId: kas.GetId(),
+		},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(listRsp)
+
+	assertIDsInOrder(s.T(), listRsp.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, sorted[0], sorted[1], sorted[2])
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SortByUnspecifiedField_DefaultsToCreatedAt() {

--- a/service/integration/kas_registry_test.go
+++ b/service/integration/kas_registry_test.go
@@ -1032,6 +1032,8 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortTieBreaker_CreatedAtWit
 	}
 	defer s.deleteSortTestKeyAccessServers(ids)
 
+	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "key_access_servers", ids))
+
 	sorted := slices.Sorted(slices.Values(ids))
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{

--- a/service/integration/kas_registry_test.go
+++ b/service/integration/kas_registry_test.go
@@ -878,7 +878,7 @@ func (s *KasRegistrySuite) Test_GetKeyAccessServer_ByIdNameUri_ReturnSameResult(
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_ASC() {
-	ids := s.createSortTestKeyAccessServers("sort-kas-created-asc")
+	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-created-asc-0", "sort-kas-created-asc-1", "sort-kas-created-asc-2"})
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -892,7 +892,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_ASC() {
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_DESC() {
-	ids := s.createSortTestKeyAccessServers("sort-kas-created-desc")
+	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-created-desc-0", "sort-kas-created-desc-1", "sort-kas-created-desc-2"})
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -906,7 +906,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_DESC() {
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_DESC() {
-	ids := s.createSortTestKeyAccessServers("sort-kas-updated-desc")
+	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-updated-desc-0", "sort-kas-updated-desc-1", "sort-kas-updated-desc-2"})
 
 	time.Sleep(5 * time.Millisecond)
 	_, err := s.db.PolicyClient.UpdateKeyAccessServer(s.ctx, ids[0], &kasregistry.UpdateKeyAccessServerRequest{
@@ -930,7 +930,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_DESC() {
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_ASC() {
-	ids := s.createSortTestKeyAccessServers("sort-kas-updated-asc")
+	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-updated-asc-0", "sort-kas-updated-asc-1", "sort-kas-updated-asc-2"})
 
 	time.Sleep(5 * time.Millisecond)
 	_, err := s.db.PolicyClient.UpdateKeyAccessServer(s.ctx, ids[2], &kasregistry.UpdateKeyAccessServerRequest{
@@ -1010,7 +1010,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_DESC() {
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedField_DefaultsToCreatedAt() {
-	ids := s.createSortTestKeyAccessServers("unspecified-field-kas")
+	ids := s.createSortTestKeyAccessServers([]string{"unspecified-field-kas-0", "unspecified-field-kas-1", "unspecified-field-kas-2"})
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1025,7 +1025,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedField_Defa
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedDirection_DefaultsToDESC() {
-	ids := s.createSortTestKeyAccessServers("unspecified-dir-kas")
+	ids := s.createSortTestKeyAccessServers([]string{"unspecified-dir-kas-0", "unspecified-dir-kas-1", "unspecified-dir-kas-2"})
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1040,7 +1040,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedDirection_
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
-	ids := s.createSortTestKeyAccessServers("both-unspecified-kas")
+	ids := s.createSortTestKeyAccessServers([]string{"both-unspecified-kas-0", "both-unspecified-kas-1", "both-unspecified-kas-2"})
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1055,7 +1055,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByBothUnspecified_Defau
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortOmitted() {
-	ids := s.createSortTestKeyAccessServers("sort-omitted-kas")
+	ids := s.createSortTestKeyAccessServers([]string{"sort-omitted-kas-0", "sort-omitted-kas-1", "sort-omitted-kas-2"})
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{})
 	s.Require().NoError(err)

--- a/service/integration/kas_registry_test.go
+++ b/service/integration/kas_registry_test.go
@@ -1065,6 +1065,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedField_Defa
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedDirection_DefaultsToDESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"unspecified-dir-kas-0", "unspecified-dir-kas-1", "unspecified-dir-kas-2"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1080,6 +1081,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedDirection_
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"both-unspecified-kas-0", "both-unspecified-kas-1", "both-unspecified-kas-2"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1095,6 +1097,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByBothUnspecified_Defau
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortOmitted() {
 	ids := s.createSortTestKeyAccessServers([]string{"sort-omitted-kas-0", "sort-omitted-kas-1", "sort-omitted-kas-2"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{})
 	s.Require().NoError(err)

--- a/service/integration/kas_registry_test.go
+++ b/service/integration/kas_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1015,6 +1016,33 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_DESC() {
 	s.NotNil(listRsp)
 
 	assertIDsInOrder(s.T(), listRsp.GetKeyAccessServers(), func(kas *policy.KeyAccessServer) string { return kas.GetId() }, ids[2], ids[1], ids[0])
+}
+
+func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortTieBreaker_CreatedAtWithIDFallback() {
+	suffix := time.Now().UnixNano()
+	ids := make([]string, 3)
+	for i := range 3 {
+		name := fmt.Sprintf("tiebreaker-kas-%d-%d", i, suffix)
+		created, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
+			Uri:  fmt.Sprintf("https://%s.example.com", name),
+			Name: name,
+		})
+		s.Require().NoError(err)
+		ids[i] = created.GetId()
+	}
+	defer s.deleteSortTestKeyAccessServers(ids)
+
+	sorted := slices.Sorted(slices.Values(ids))
+
+	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
+		Sort: []*kasregistry.KeyAccessServersSort{
+			{Field: kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(listRsp)
+
+	assertIDsInOrder(s.T(), listRsp.GetKeyAccessServers(), func(kas *policy.KeyAccessServer) string { return kas.GetId() }, sorted[0], sorted[1], sorted[2])
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedField_DefaultsToCreatedAt() {

--- a/service/integration/kas_registry_test.go
+++ b/service/integration/kas_registry_test.go
@@ -954,7 +954,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_ASC() {
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_ASC() {
-	ids := s.createNamedSortTestKeyAccessServers([]string{"aaa-kas-sort", "bbb-kas-sort", "ccc-kas-sort"})
+	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-sort", "bbb-kas-sort", "ccc-kas-sort"})
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -968,7 +968,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_ASC() {
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_DESC() {
-	ids := s.createNamedSortTestKeyAccessServers([]string{"aaa-kas-sortdesc", "bbb-kas-sortdesc", "ccc-kas-sortdesc"})
+	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-sortdesc", "bbb-kas-sortdesc", "ccc-kas-sortdesc"})
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -982,7 +982,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_DESC() {
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_ASC() {
-	ids := s.createNamedSortTestKeyAccessServers([]string{"aaa-kas-uri", "bbb-kas-uri", "ccc-kas-uri"})
+	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-uri", "bbb-kas-uri", "ccc-kas-uri"})
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -996,7 +996,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_ASC() {
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_DESC() {
-	ids := s.createNamedSortTestKeyAccessServers([]string{"aaa-kas-uridesc", "bbb-kas-uridesc", "ccc-kas-uridesc"})
+	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-uridesc", "bbb-kas-uridesc", "ccc-kas-uridesc"})
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1111,35 +1111,18 @@ func (s *KasRegistrySuite) validateKasRegistryKeys(kasr *policy.KeyAccessServer)
 	s.Len(expectedKasKeys, matchingKeysCount)
 }
 
-// createSortTestKeyAccessServers creates 3 KAS entries with 5ms gaps for distinct timestamps.
-// Returns the KAS IDs in creation order.
-func (s *KasRegistrySuite) createSortTestKeyAccessServers(label string) []string {
-	const count = 3
-	ids := make([]string, count)
-	for i := range count {
+// createSortTestKeyAccessServers creates KAS entries with the given prefixes, adding 5ms gaps
+// between creations for distinct timestamps. Returns the KAS IDs in creation order.
+func (s *KasRegistrySuite) createSortTestKeyAccessServers(prefixes []string) []string {
+	ids := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
 		if i > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}
-		suffix := fmt.Sprintf("%s-%d-%d", label, i, time.Now().UnixNano())
+		suffix := fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
 		created, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
 			Uri:  fmt.Sprintf("https://%s.example.com", suffix),
 			Name: suffix,
-		})
-		s.Require().NoError(err)
-		ids[i] = created.GetId()
-	}
-	return ids
-}
-
-// createNamedSortTestKeyAccessServers creates KAS entries with specific name prefixes for deterministic name/uri sorting.
-// Returns the KAS IDs in prefix order.
-func (s *KasRegistrySuite) createNamedSortTestKeyAccessServers(prefixes []string) []string {
-	suffix := time.Now().UnixNano()
-	ids := make([]string, len(prefixes))
-	for i, prefix := range prefixes {
-		created, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
-			Uri:  fmt.Sprintf("https://%s-%d.example.com", prefix, suffix),
-			Name: fmt.Sprintf("%s-%d", prefix, suffix),
 		})
 		s.Require().NoError(err)
 		ids[i] = created.GetId()

--- a/service/integration/kas_registry_test.go
+++ b/service/integration/kas_registry_test.go
@@ -879,6 +879,7 @@ func (s *KasRegistrySuite) Test_GetKeyAccessServer_ByIdNameUri_ReturnSameResult(
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_ASC() {
 	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-created-asc-0", "sort-kas-created-asc-1", "sort-kas-created-asc-2"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -893,6 +894,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_ASC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_DESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-created-desc-0", "sort-kas-created-desc-1", "sort-kas-created-desc-2"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -907,6 +909,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_DESC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_DESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-updated-desc-0", "sort-kas-updated-desc-1", "sort-kas-updated-desc-2"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	time.Sleep(5 * time.Millisecond)
 	_, err := s.db.PolicyClient.UpdateKeyAccessServer(s.ctx, ids[0], &kasregistry.UpdateKeyAccessServerRequest{
@@ -931,6 +934,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_DESC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_ASC() {
 	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-updated-asc-0", "sort-kas-updated-asc-1", "sort-kas-updated-asc-2"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	time.Sleep(5 * time.Millisecond)
 	_, err := s.db.PolicyClient.UpdateKeyAccessServer(s.ctx, ids[2], &kasregistry.UpdateKeyAccessServerRequest{
@@ -955,6 +959,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_ASC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_ASC() {
 	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-sort", "bbb-kas-sort", "ccc-kas-sort"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -969,6 +974,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_ASC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_DESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-sortdesc", "bbb-kas-sortdesc", "ccc-kas-sortdesc"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -983,6 +989,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_DESC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_ASC() {
 	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-uri", "bbb-kas-uri", "ccc-kas-uri"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -997,6 +1004,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_ASC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_DESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-uridesc", "bbb-kas-uridesc", "ccc-kas-uridesc"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1011,6 +1019,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_DESC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedField_DefaultsToCreatedAt() {
 	ids := s.createSortTestKeyAccessServers([]string{"unspecified-field-kas-0", "unspecified-field-kas-1", "unspecified-field-kas-2"})
+	defer s.deleteSortTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1128,6 +1137,14 @@ func (s *KasRegistrySuite) createSortTestKeyAccessServers(prefixes []string) []s
 		ids[i] = created.GetId()
 	}
 	return ids
+}
+
+// deleteSortTestKeyAccessServers cleans up KAS entries created by sort tests.
+func (s *KasRegistrySuite) deleteSortTestKeyAccessServers(ids []string) {
+	for _, id := range ids {
+		_, err := s.db.PolicyClient.DeleteKeyAccessServer(s.ctx, id)
+		s.Require().NoError(err)
+	}
 }
 
 func TestKasRegistrySuite(t *testing.T) {

--- a/service/integration/namespaces_test.go
+++ b/service/integration/namespaces_test.go
@@ -272,6 +272,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_OrdersByCreatedAt_Succeeds() {
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByName_ASC() {
 	ids := s.createSortTestNamespaces([]string{"aaa-sort", "bbb-sort", "ccc-sort"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -288,6 +289,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByName_ASC() {
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByName_DESC() {
 	ids := s.createSortTestNamespaces([]string{"aaa-sortdesc", "bbb-sortdesc", "ccc-sortdesc"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -304,6 +306,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByName_DESC() {
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_ASC() {
 	ids := s.createSortTestNamespaces([]string{"createdasc-ns-0", "createdasc-ns-1", "createdasc-ns-2"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -320,6 +323,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_ASC() {
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_DESC() {
 	ids := s.createSortTestNamespaces([]string{"createddesc-ns-0", "createddesc-ns-1", "createddesc-ns-2"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -336,6 +340,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_DESC() {
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_ASC() {
 	ids := s.createSortTestNamespaces([]string{"aaa-fqnsort", "bbb-fqnsort", "ccc-fqnsort"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -352,6 +357,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_ASC() {
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_DESC() {
 	ids := s.createSortTestNamespaces([]string{"aaa-fqnsortdesc", "bbb-fqnsortdesc", "ccc-fqnsortdesc"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -368,6 +374,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_DESC() {
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_DESC() {
 	ids := s.createSortTestNamespaces([]string{"upd-sort-ns-0", "upd-sort-ns-1", "upd-sort-ns-2"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	// Update the first namespace so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -395,6 +402,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_DESC() {
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_ASC() {
 	ids := s.createSortTestNamespaces([]string{"upd-sort-asc-ns-0", "upd-sort-asc-ns-1", "upd-sort-asc-ns-2"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	// Update the last namespace so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -422,6 +430,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_ASC() {
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUnspecifiedField_DefaultsToCreatedAt() {
 	ids := s.createSortTestNamespaces([]string{"unspecified-sort-ns-0", "unspecified-sort-ns-1", "unspecified-sort-ns-2"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -1418,6 +1427,14 @@ func (s *NamespacesSuite) createSortTestNamespaces(prefixes []string) []string {
 		ids[i] = created.GetId()
 	}
 	return ids
+}
+
+// deleteSortTestNamespaces deactivates namespaces created by sort tests.
+func (s *NamespacesSuite) deleteSortTestNamespaces(ids []string) {
+	for _, id := range ids {
+		_, err := s.db.PolicyClient.DeactivateNamespace(s.ctx, id)
+		s.Require().NoError(err)
+	}
 }
 
 func (s *NamespacesSuite) getActiveNamespaceFixtures() []fixtures.FixtureDataNamespace {

--- a/service/integration/namespaces_test.go
+++ b/service/integration/namespaces_test.go
@@ -1459,10 +1459,7 @@ func (s *NamespacesSuite) createSortTestNamespaces(prefixes []string) []string {
 
 // deleteSortTestNamespaces deactivates namespaces created by sort tests.
 func (s *NamespacesSuite) deleteSortTestNamespaces(ids []string) {
-	for _, id := range ids {
-		_, err := s.db.PolicyClient.DeactivateNamespace(s.ctx, id)
-		s.Require().NoError(err)
-	}
+	s.Require().NoError(forceDeleteRows(s.ctx, s.db, "attribute_namespaces", ids))
 }
 
 func (s *NamespacesSuite) getActiveNamespaceFixtures() []fixtures.FixtureDataNamespace {

--- a/service/integration/namespaces_test.go
+++ b/service/integration/namespaces_test.go
@@ -440,6 +440,8 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortTieBreaker_CreatedAtWithIDFall
 	}
 	defer s.deleteSortTestNamespaces(ids)
 
+	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "attribute_namespaces", ids))
+
 	sorted := slices.Sorted(slices.Values(ids))
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{

--- a/service/integration/namespaces_test.go
+++ b/service/integration/namespaces_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -426,6 +427,31 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_ASC() {
 
 	// The updated namespace (ids[2]) should appear last in ASC order
 	assertIDsInOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, ids[0], ids[1], ids[2])
+}
+
+func (s *NamespacesSuite) Test_ListNamespaces_SortTieBreaker_CreatedAtWithIDFallback() {
+	suffix := time.Now().UnixNano()
+	ids := make([]string, 3)
+	for i := range 3 {
+		name := fmt.Sprintf("tiebreaker-ns-%d-%d.com", i, suffix)
+		created, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{Name: name})
+		s.Require().NoError(err)
+		ids[i] = created.GetId()
+	}
+	defer s.deleteSortTestNamespaces(ids)
+
+	sorted := slices.Sorted(slices.Values(ids))
+
+	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
+		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
+		Sort: []*namespaces.NamespacesSort{
+			{Field: namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(listRsp)
+
+	assertIDsInOrder(s.T(), listRsp.GetNamespaces(), func(ns *policy.Namespace) string { return ns.GetId() }, sorted[0], sorted[1], sorted[2])
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUnspecifiedField_DefaultsToCreatedAt() {

--- a/service/integration/namespaces_test.go
+++ b/service/integration/namespaces_test.go
@@ -475,6 +475,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUnspecifiedField_DefaultsToC
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUnspecifiedDirection_DefaultsToDESC() {
 	ids := s.createSortTestNamespaces([]string{"unspecified-dir-ns-0", "unspecified-dir-ns-1", "unspecified-dir-ns-2"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -491,6 +492,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUnspecifiedDirection_Default
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
 	ids := s.createSortTestNamespaces([]string{"both-unspecified-ns-0", "both-unspecified-ns-1", "both-unspecified-ns-2"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -507,6 +509,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByBothUnspecified_DefaultsToCr
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortOmitted() {
 	ids := s.createSortTestNamespaces([]string{"sort-omitted-ns-0", "sort-omitted-ns-1", "sort-omitted-ns-2"})
+	defer s.deleteSortTestNamespaces(ids)
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,

--- a/service/integration/namespaces_test.go
+++ b/service/integration/namespaces_test.go
@@ -271,7 +271,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_OrdersByCreatedAt_Succeeds() {
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByName_ASC() {
-	ids := s.createNamedSortTestNamespaces([]string{"aaa-sort", "bbb-sort", "ccc-sort"})
+	ids := s.createSortTestNamespaces([]string{"aaa-sort", "bbb-sort", "ccc-sort"})
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -287,7 +287,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByName_ASC() {
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByName_DESC() {
-	ids := s.createNamedSortTestNamespaces([]string{"aaa-sortdesc", "bbb-sortdesc", "ccc-sortdesc"})
+	ids := s.createSortTestNamespaces([]string{"aaa-sortdesc", "bbb-sortdesc", "ccc-sortdesc"})
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -303,7 +303,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByName_DESC() {
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_ASC() {
-	ids := s.createSortTestNamespaces("createdasc-ns")
+	ids := s.createSortTestNamespaces([]string{"createdasc-ns-0", "createdasc-ns-1", "createdasc-ns-2"})
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -319,7 +319,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_ASC() {
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_DESC() {
-	ids := s.createSortTestNamespaces("createddesc-ns")
+	ids := s.createSortTestNamespaces([]string{"createddesc-ns-0", "createddesc-ns-1", "createddesc-ns-2"})
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -335,7 +335,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByCreatedAt_DESC() {
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_ASC() {
-	ids := s.createNamedSortTestNamespaces([]string{"aaa-fqnsort", "bbb-fqnsort", "ccc-fqnsort"})
+	ids := s.createSortTestNamespaces([]string{"aaa-fqnsort", "bbb-fqnsort", "ccc-fqnsort"})
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -351,7 +351,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_ASC() {
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_DESC() {
-	ids := s.createNamedSortTestNamespaces([]string{"aaa-fqnsortdesc", "bbb-fqnsortdesc", "ccc-fqnsortdesc"})
+	ids := s.createSortTestNamespaces([]string{"aaa-fqnsortdesc", "bbb-fqnsortdesc", "ccc-fqnsortdesc"})
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -367,7 +367,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByFqn_DESC() {
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_DESC() {
-	ids := s.createSortTestNamespaces("upd-sort-ns")
+	ids := s.createSortTestNamespaces([]string{"upd-sort-ns-0", "upd-sort-ns-1", "upd-sort-ns-2"})
 
 	// Update the first namespace so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -394,7 +394,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_DESC() {
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_ASC() {
-	ids := s.createSortTestNamespaces("upd-sort-asc-ns")
+	ids := s.createSortTestNamespaces([]string{"upd-sort-asc-ns-0", "upd-sort-asc-ns-1", "upd-sort-asc-ns-2"})
 
 	// Update the last namespace so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -421,7 +421,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUpdatedAt_ASC() {
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUnspecifiedField_DefaultsToCreatedAt() {
-	ids := s.createSortTestNamespaces("unspecified-field-ns")
+	ids := s.createSortTestNamespaces([]string{"unspecified-sort-ns-0", "unspecified-sort-ns-1", "unspecified-sort-ns-2"})
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -437,7 +437,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUnspecifiedField_DefaultsToC
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByUnspecifiedDirection_DefaultsToDESC() {
-	ids := s.createSortTestNamespaces("unspecified-dir-ns")
+	ids := s.createSortTestNamespaces([]string{"unspecified-dir-ns-0", "unspecified-dir-ns-1", "unspecified-dir-ns-2"})
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -453,7 +453,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByUnspecifiedDirection_Default
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
-	ids := s.createSortTestNamespaces("both-unspecified-ns")
+	ids := s.createSortTestNamespaces([]string{"both-unspecified-ns-0", "both-unspecified-ns-1", "both-unspecified-ns-2"})
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -469,7 +469,7 @@ func (s *NamespacesSuite) Test_ListNamespaces_SortByBothUnspecified_DefaultsToCr
 }
 
 func (s *NamespacesSuite) Test_ListNamespaces_SortOmitted() {
-	ids := s.createSortTestNamespaces("sort-omitted-ns")
+	ids := s.createSortTestNamespaces([]string{"sort-omitted-ns-0", "sort-omitted-ns-1", "sort-omitted-ns-2"})
 
 	listRsp, err := s.db.PolicyClient.ListNamespaces(s.ctx, &namespaces.ListNamespacesRequest{
 		State: common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY,
@@ -1404,30 +1404,15 @@ func (s *NamespacesSuite) Test_GetNamespace_ByIdAndName_ReturnSameResult() {
 	}
 }
 
-// createSortTestNamespaces creates 3 namespaces with 5ms gaps for distinct timestamps.
-// Returns the namespace IDs in creation order.
-func (s *NamespacesSuite) createSortTestNamespaces(label string) []string {
-	const count = 3
-	ids := make([]string, count)
-	for i := range count {
+// createSortTestNamespaces creates namespaces with the given prefixes, adding 5ms gaps
+// between creations for distinct timestamps. Returns the namespace IDs in creation order.
+func (s *NamespacesSuite) createSortTestNamespaces(prefixes []string) []string {
+	ids := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
 		if i > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}
-		name := fmt.Sprintf("%s-%d-%d.com", label, i, time.Now().UnixNano())
-		created, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{Name: name})
-		s.Require().NoError(err)
-		ids[i] = created.GetId()
-	}
-	return ids
-}
-
-// createNamedSortTestNamespaces creates namespaces with specific name prefixes for name/fqn sort testing.
-// Returns the namespace IDs in the same order as the prefixes.
-func (s *NamespacesSuite) createNamedSortTestNamespaces(prefixes []string) []string {
-	suffix := time.Now().UnixNano()
-	ids := make([]string, len(prefixes))
-	for i, prefix := range prefixes {
-		name := fmt.Sprintf("%s-%d.com", prefix, suffix)
+		name := fmt.Sprintf("%s-%d.com", prefix, time.Now().UnixNano())
 		created, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{Name: name})
 		s.Require().NoError(err)
 		ids[i] = created.GetId()

--- a/service/integration/obligations_test.go
+++ b/service/integration/obligations_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -1896,6 +1897,30 @@ func (s *ObligationsSuite) Test_ListObligations_SortByUpdatedAt_ASC() {
 }
 
 // Sort by Unspecified (fallback to default)
+
+func (s *ObligationsSuite) Test_ListObligations_SortTieBreaker_CreatedAtWithIDFallback() {
+	namespaceID, _, _ := s.getNamespaceData(nsExampleCom)
+	suffix := time.Now().UnixNano()
+	ids := make([]string, 3)
+	for i := range 3 {
+		name := fmt.Sprintf("tiebreaker-obl-%d-%d", i, suffix)
+		obl := s.createObligation(namespaceID, name, nil)
+		ids[i] = obl.GetId()
+	}
+	defer s.deleteObligations(ids)
+
+	sorted := slices.Sorted(slices.Values(ids))
+
+	listRsp, _, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		Sort: []*obligations.ObligationsSort{
+			{Field: obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(listRsp)
+
+	assertIDsInOrder(s.T(), listRsp, func(o *policy.Obligation) string { return o.GetId() }, sorted[0], sorted[1], sorted[2])
+}
 
 func (s *ObligationsSuite) Test_ListObligations_SortByUnspecifiedField_DefaultsToCreatedAt() {
 	ids := s.createSortTestObligations([]string{"unspecified-field-obl-0", "unspecified-field-obl-1", "unspecified-field-obl-2"})

--- a/service/integration/obligations_test.go
+++ b/service/integration/obligations_test.go
@@ -1909,6 +1909,8 @@ func (s *ObligationsSuite) Test_ListObligations_SortTieBreaker_CreatedAtWithIDFa
 	}
 	defer s.deleteObligations(ids)
 
+	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "obligation_definitions", ids))
+
 	sorted := slices.Sorted(slices.Values(ids))
 
 	listRsp, _, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{

--- a/service/integration/obligations_test.go
+++ b/service/integration/obligations_test.go
@@ -1946,7 +1946,7 @@ func (s *ObligationsSuite) Test_ListObligations_SortByBothUnspecified_DefaultsTo
 }
 
 func (s *ObligationsSuite) Test_ListObligations_SortOmitted() {
-	ids := s.createSortTestObligations("sort-omitted-obl")
+	ids := s.createSortTestObligations([]string{"sort-omitted-obl-0", "sort-omitted-obl-1", "sort-omitted-obl-2"})
 	defer s.deleteObligations(ids)
 
 	listRsp, _, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{})

--- a/service/integration/obligations_test.go
+++ b/service/integration/obligations_test.go
@@ -1724,7 +1724,7 @@ func (s *ObligationsSuite) Test_GetObligation_ByIdAndFqn_ReturnSameResult() {
 // Sort by Name
 
 func (s *ObligationsSuite) Test_ListObligations_SortByName_ASC() {
-	ids := s.createNamedSortTestObligations([]string{"aaa-sort", "bbb-sort", "ccc-sort"})
+	ids := s.createSortTestObligations([]string{"aaa-sort", "bbb-sort", "ccc-sort"})
 	defer s.deleteObligations(ids)
 
 	listRsp, _, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
@@ -1740,7 +1740,7 @@ func (s *ObligationsSuite) Test_ListObligations_SortByName_ASC() {
 }
 
 func (s *ObligationsSuite) Test_ListObligations_SortByName_DESC() {
-	ids := s.createNamedSortTestObligations([]string{"aaa-sortdesc", "bbb-sortdesc", "ccc-sortdesc"})
+	ids := s.createSortTestObligations([]string{"aaa-sortdesc", "bbb-sortdesc", "ccc-sortdesc"})
 	defer s.deleteObligations(ids)
 
 	listRsp, _, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
@@ -1808,7 +1808,7 @@ func (s *ObligationsSuite) Test_ListObligations_SortByFqn_DESC() {
 // Sort by CreatedAt
 
 func (s *ObligationsSuite) Test_ListObligations_SortByCreatedAt_ASC() {
-	ids := s.createSortTestObligations("createdasc-obl")
+	ids := s.createSortTestObligations([]string{"createdasc-obl-0", "createdasc-obl-1", "createdasc-obl-2"})
 	defer s.deleteObligations(ids)
 
 	listRsp, _, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
@@ -1824,7 +1824,7 @@ func (s *ObligationsSuite) Test_ListObligations_SortByCreatedAt_ASC() {
 }
 
 func (s *ObligationsSuite) Test_ListObligations_SortByCreatedAt_DESC() {
-	ids := s.createSortTestObligations("createddesc-obl")
+	ids := s.createSortTestObligations([]string{"createddesc-obl-0", "createddesc-obl-1", "createddesc-obl-2"})
 	defer s.deleteObligations(ids)
 
 	listRsp, _, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
@@ -1842,7 +1842,7 @@ func (s *ObligationsSuite) Test_ListObligations_SortByCreatedAt_DESC() {
 // Sort by UpdatedAt
 
 func (s *ObligationsSuite) Test_ListObligations_SortByUpdatedAt_DESC() {
-	ids := s.createSortTestObligations("upd-sort-obl")
+	ids := s.createSortTestObligations([]string{"upd-sort-obl-0", "upd-sort-obl-1", "upd-sort-obl-2"})
 	defer s.deleteObligations(ids)
 
 	// Update the first obligation so its updated_at is the most recent
@@ -1869,7 +1869,7 @@ func (s *ObligationsSuite) Test_ListObligations_SortByUpdatedAt_DESC() {
 }
 
 func (s *ObligationsSuite) Test_ListObligations_SortByUpdatedAt_ASC() {
-	ids := s.createSortTestObligations("upd-sort-asc-obl")
+	ids := s.createSortTestObligations([]string{"upd-sort-asc-obl-0", "upd-sort-asc-obl-1", "upd-sort-asc-obl-2"})
 	defer s.deleteObligations(ids)
 
 	// Update the last obligation so its updated_at is the most recent
@@ -1898,7 +1898,7 @@ func (s *ObligationsSuite) Test_ListObligations_SortByUpdatedAt_ASC() {
 // Sort by Unspecified (fallback to default)
 
 func (s *ObligationsSuite) Test_ListObligations_SortByUnspecifiedField_DefaultsToCreatedAt() {
-	ids := s.createSortTestObligations("unspecified-field-obl")
+	ids := s.createSortTestObligations([]string{"unspecified-field-obl-0", "unspecified-field-obl-1", "unspecified-field-obl-2"})
 	defer s.deleteObligations(ids)
 
 	listRsp, _, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
@@ -1914,7 +1914,7 @@ func (s *ObligationsSuite) Test_ListObligations_SortByUnspecifiedField_DefaultsT
 }
 
 func (s *ObligationsSuite) Test_ListObligations_SortByUnspecifiedDirection_DefaultsToDESC() {
-	ids := s.createSortTestObligations("unspecified-dir-obl")
+	ids := s.createSortTestObligations([]string{"unspecified-dir-obl-0", "unspecified-dir-obl-1", "unspecified-dir-obl-2"})
 	defer s.deleteObligations(ids)
 
 	listRsp, _, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
@@ -1930,7 +1930,7 @@ func (s *ObligationsSuite) Test_ListObligations_SortByUnspecifiedDirection_Defau
 }
 
 func (s *ObligationsSuite) Test_ListObligations_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
-	ids := s.createSortTestObligations("both-unspecified-obl")
+	ids := s.createSortTestObligations([]string{"both-unspecified-obl-0", "both-unspecified-obl-1", "both-unspecified-obl-2"})
 	defer s.deleteObligations(ids)
 
 	listRsp, _, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
@@ -2204,31 +2204,16 @@ func (s *ObligationsSuite) assertObligationValuesSpecificTriggers(obl *policy.Ob
 
 // Sort test helpers
 
-// createSortTestObligations creates 3 obligations with 5ms gaps for distinct timestamps.
-// Returns the obligation IDs in creation order.
-func (s *ObligationsSuite) createSortTestObligations(label string) []string {
+// createSortTestObligations creates obligations with the given prefixes, adding 5ms gaps
+// between creations for distinct timestamps. Returns the obligation IDs in creation order.
+func (s *ObligationsSuite) createSortTestObligations(prefixes []string) []string {
 	namespaceID, _, _ := s.getNamespaceData(nsExampleCom)
-	const count = 3
-	ids := make([]string, count)
-	for i := range count {
+	ids := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
 		if i > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}
-		name := fmt.Sprintf("%s-%d-%d", label, i, time.Now().UnixNano())
-		obl := s.createObligation(namespaceID, name, nil)
-		ids[i] = obl.GetId()
-	}
-	return ids
-}
-
-// createNamedSortTestObligations creates obligations with specific name prefixes for name/FQN sort testing.
-// Returns the obligation IDs in the same order as the prefixes.
-func (s *ObligationsSuite) createNamedSortTestObligations(prefixes []string) []string {
-	namespaceID, _, _ := s.getNamespaceData(nsExampleCom)
-	suffix := time.Now().UnixNano()
-	ids := make([]string, len(prefixes))
-	for i, prefix := range prefixes {
-		name := fmt.Sprintf("%s-%d", prefix, suffix)
+		name := fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
 		obl := s.createObligation(namespaceID, name, nil)
 		ids[i] = obl.GetId()
 	}

--- a/service/integration/registered_resources_test.go
+++ b/service/integration/registered_resources_test.go
@@ -2402,33 +2402,15 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortOmitted() {
 
 // Sort test helpers
 
-// createSortTestRegisteredResources creates 3 registered resources with 5ms gaps for distinct timestamps.
-// Returns the resource IDs in creation order.
-func (s *RegisteredResourcesSuite) createSortTestRegisteredResources(label string) []string {
-	const count = 3
-	ids := make([]string, count)
-	for i := range count {
+// createSortTestRegisteredResources creates registered resources with the given prefixes, adding 5ms gaps
+// between creations for distinct timestamps. Returns the resource IDs in creation order.
+func (s *RegisteredResourcesSuite) createSortTestRegisteredResources(prefixes []string) []string {
+	ids := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
 		if i > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}
-		name := fmt.Sprintf("%s-%d-%d", label, i, time.Now().UnixNano())
-		created, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
-			NamespaceId: s.getNamespaceID("example.com"),
-			Name:        name,
-		})
-		s.Require().NoError(err)
-		ids[i] = created.GetId()
-	}
-	return ids
-}
-
-// createNamedSortTestRegisteredResources creates registered resources with specific name prefixes for name sort testing.
-// Returns the resource IDs in the same order as the prefixes.
-func (s *RegisteredResourcesSuite) createNamedSortTestRegisteredResources(prefixes []string) []string {
-	suffix := time.Now().UnixNano()
-	ids := make([]string, len(prefixes))
-	for i, prefix := range prefixes {
-		name := fmt.Sprintf("%s-%d", prefix, suffix)
+		name := fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
 		created, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
 			NamespaceId: s.getNamespaceID("example.com"),
 			Name:        name,

--- a/service/integration/registered_resources_test.go
+++ b/service/integration/registered_resources_test.go
@@ -2223,7 +2223,7 @@ func (s *RegisteredResourcesSuite) Test_GetRegisteredResource_ByName_Ambiguous_R
 // Sort tests
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByName_ASC() {
-	ids := s.createNamedSortTestRegisteredResources([]string{"aaa-rrsort", "bbb-rrsort", "ccc-rrsort"})
+	ids := s.createSortTestRegisteredResources([]string{"aaa-rrsort", "bbb-rrsort", "ccc-rrsort"})
 	defer s.deleteSortTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
@@ -2239,7 +2239,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByName_ASC()
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByName_DESC() {
-	ids := s.createNamedSortTestRegisteredResources([]string{"aaa-rrsortdesc", "bbb-rrsortdesc", "ccc-rrsortdesc"})
+	ids := s.createSortTestRegisteredResources([]string{"aaa-rrsortdesc", "bbb-rrsortdesc", "ccc-rrsortdesc"})
 	defer s.deleteSortTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
@@ -2255,7 +2255,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByName_DESC(
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByCreatedAt_ASC() {
-	ids := s.createSortTestRegisteredResources("createdasc-rr")
+	ids := s.createSortTestRegisteredResources([]string{"createdasc-rr-0", "createdasc-rr-1", "createdasc-rr-2"})
 	defer s.deleteSortTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
@@ -2271,7 +2271,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByCreatedAt_
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByCreatedAt_DESC() {
-	ids := s.createSortTestRegisteredResources("createddesc-rr")
+	ids := s.createSortTestRegisteredResources([]string{"createddesc-rr-0", "createddesc-rr-1", "createddesc-rr-2"})
 	defer s.deleteSortTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
@@ -2287,7 +2287,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByCreatedAt_
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUpdatedAt_DESC() {
-	ids := s.createSortTestRegisteredResources("upd-sort-rr")
+	ids := s.createSortTestRegisteredResources([]string{"upd-sort-rr-0", "upd-sort-rr-1", "upd-sort-rr-2"})
 	defer s.deleteSortTestRegisteredResources(ids)
 
 	// Update the first resource so its updated_at is the most recent
@@ -2314,7 +2314,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUpdatedAt_
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUpdatedAt_ASC() {
-	ids := s.createSortTestRegisteredResources("upd-sort-asc-rr")
+	ids := s.createSortTestRegisteredResources([]string{"upd-sort-asc-rr-0", "upd-sort-asc-rr-1", "upd-sort-asc-rr-2"})
 	defer s.deleteSortTestRegisteredResources(ids)
 
 	// Update the last resource so its updated_at is the most recent
@@ -2341,7 +2341,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUpdatedAt_
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUnspecifiedField_DefaultsToCreatedAt() {
-	ids := s.createSortTestRegisteredResources("unspecified-field-rr")
+	ids := s.createSortTestRegisteredResources([]string{"unspecified-field-rr-0", "unspecified-field-rr-1", "unspecified-field-rr-2"})
 	defer s.deleteSortTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
@@ -2357,7 +2357,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUnspecifie
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUnspecifiedDirection_DefaultsToDESC() {
-	ids := s.createSortTestRegisteredResources("unspecified-dir-rr")
+	ids := s.createSortTestRegisteredResources([]string{"unspecified-dir-rr-0", "unspecified-dir-rr-1", "unspecified-dir-rr-2"})
 	defer s.deleteSortTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
@@ -2373,7 +2373,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUnspecifie
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
-	ids := s.createSortTestRegisteredResources("both-unspecified-rr")
+	ids := s.createSortTestRegisteredResources([]string{"both-unspecified-rr-0", "both-unspecified-rr-1", "both-unspecified-rr-2"})
 	defer s.deleteSortTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
@@ -2389,7 +2389,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByBothUnspec
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortOmitted() {
-	ids := s.createSortTestRegisteredResources("sort-omitted-rr")
+	ids := s.createSortTestRegisteredResources([]string{"sort-omitted-rr-0", "sort-omitted-rr-1", "sort-omitted-rr-2"})
 	defer s.deleteSortTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{})

--- a/service/integration/registered_resources_test.go
+++ b/service/integration/registered_resources_test.go
@@ -2355,6 +2355,8 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortTieBreaker_C
 	}
 	defer s.deleteSortTestRegisteredResources(ids)
 
+	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "registered_resources", ids))
+
 	sorted := slices.Sorted(slices.Values(ids))
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{

--- a/service/integration/registered_resources_test.go
+++ b/service/integration/registered_resources_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2338,6 +2339,33 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUpdatedAt_
 
 	// The updated resource (ids[2]) should appear last in ASC order
 	assertIDsInOrder(s.T(), list.GetResources(), func(r *policy.RegisteredResource) string { return r.GetId() }, ids[0], ids[1], ids[2])
+}
+
+func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortTieBreaker_CreatedAtWithIDFallback() {
+	suffix := time.Now().UnixNano()
+	ids := make([]string, 3)
+	for i := range 3 {
+		name := fmt.Sprintf("tiebreaker-rr-%d-%d", i, suffix)
+		created, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
+			NamespaceId: s.getNamespaceID("example.com"),
+			Name:        name,
+		})
+		s.Require().NoError(err)
+		ids[i] = created.GetId()
+	}
+	defer s.deleteSortTestRegisteredResources(ids)
+
+	sorted := slices.Sorted(slices.Values(ids))
+
+	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
+		Sort: []*registeredresources.RegisteredResourcesSort{
+			{Field: registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(list)
+
+	assertIDsInOrder(s.T(), list.GetResources(), func(r *policy.RegisteredResource) string { return r.GetId() }, sorted[0], sorted[1], sorted[2])
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUnspecifiedField_DefaultsToCreatedAt() {

--- a/service/integration/subject_mappings_test.go
+++ b/service/integration/subject_mappings_test.go
@@ -600,7 +600,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_OrdersByCreatedAt_Succee
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_ASC() {
-	ids := s.createSortTestSubjectMappings("sort-created-asc")
+	ids := s.createSortTestSubjectMappings([]string{"sort-created-asc-0", "sort-created-asc-1", "sort-created-asc-2"})
 	defer s.deleteSortTestSubjectMappings(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
@@ -616,7 +616,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_ASC() {
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_DESC() {
-	ids := s.createSortTestSubjectMappings("sort-created-desc")
+	ids := s.createSortTestSubjectMappings([]string{"sort-created-desc-0", "sort-created-desc-1", "sort-created-desc-2"})
 	defer s.deleteSortTestSubjectMappings(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
@@ -632,7 +632,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_DESC() {
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_DESC() {
-	ids := s.createSortTestSubjectMappings("sort-updated-desc")
+	ids := s.createSortTestSubjectMappings([]string{"sort-updated-desc-0", "sort-updated-desc-1", "sort-updated-desc-2"})
 	defer s.deleteSortTestSubjectMappings(ids)
 
 	// Update the first mapping so its updated_at is the most recent
@@ -659,7 +659,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_DESC() {
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_ASC() {
-	ids := s.createSortTestSubjectMappings("sort-updated-asc")
+	ids := s.createSortTestSubjectMappings([]string{"sort-updated-asc-0", "sort-updated-asc-1", "sort-updated-asc-2"})
 	defer s.deleteSortTestSubjectMappings(ids)
 
 	// Update the last mapping so its updated_at is the most recent
@@ -737,7 +737,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortTieBreaker_CreatedAt
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUnspecifiedField_DefaultsToCreatedAt() {
-	ids := s.createSortTestSubjectMappings("unspecified-field-sm")
+	ids := s.createSortTestSubjectMappings([]string{"unspecified-field-sm-0", "unspecified-field-sm-1", "unspecified-field-sm-2"})
 	defer s.deleteSortTestSubjectMappings(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
@@ -753,7 +753,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUnspecifiedField_D
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUnspecifiedDirection_DefaultsToDESC() {
-	ids := s.createSortTestSubjectMappings("unspecified-dir-sm")
+	ids := s.createSortTestSubjectMappings([]string{"unspecified-dir-sm-0", "unspecified-dir-sm-1", "unspecified-dir-sm-2"})
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
 		Sort: []*subjectmapping.SubjectMappingsSort{
@@ -768,7 +768,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUnspecifiedDirecti
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
-	ids := s.createSortTestSubjectMappings("both-unspecified-sm")
+	ids := s.createSortTestSubjectMappings([]string{"both-unspecified-sm-0", "both-unspecified-sm-1", "both-unspecified-sm-2"})
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
 		Sort: []*subjectmapping.SubjectMappingsSort{
@@ -783,7 +783,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByBothUnspecified_De
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortOmitted() {
-	ids := s.createSortTestSubjectMappings("sort-omitted-sm")
+	ids := s.createSortTestSubjectMappings([]string{"sort-omitted-sm-0", "sort-omitted-sm-1", "sort-omitted-sm-2"})
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{})
 	s.Require().NoError(err)
@@ -1480,7 +1480,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_NoNamespaceFilter_R
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_ASC() {
-	ids := s.createSortTestSubjectConditionSets("sort-scs-created-asc")
+	ids := s.createSortTestSubjectConditionSets([]string{"sort-scs-created-asc-0", "sort-scs-created-asc-1", "sort-scs-created-asc-2"})
 	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
@@ -1496,7 +1496,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_ASC
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_DESC() {
-	ids := s.createSortTestSubjectConditionSets("sort-scs-created-desc")
+	ids := s.createSortTestSubjectConditionSets([]string{"sort-scs-created-desc-0", "sort-scs-created-desc-1", "sort-scs-created-desc-2"})
 	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
@@ -1512,7 +1512,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_DES
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_DESC() {
-	ids := s.createSortTestSubjectConditionSets("sort-scs-updated-desc")
+	ids := s.createSortTestSubjectConditionSets([]string{"sort-scs-updated-desc-0", "sort-scs-updated-desc-1", "sort-scs-updated-desc-2"})
 	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	// Update the first SCS so its updated_at is the most recent
@@ -1539,7 +1539,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_DES
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_ASC() {
-	ids := s.createSortTestSubjectConditionSets("sort-scs-updated-asc")
+	ids := s.createSortTestSubjectConditionSets([]string{"sort-scs-updated-asc-0", "sort-scs-updated-asc-1", "sort-scs-updated-asc-2"})
 	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	// Update the last SCS so its updated_at is the most recent
@@ -1609,7 +1609,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortTieBreaker_Crea
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedField_DefaultsToCreatedAt() {
-	ids := s.createSortTestSubjectConditionSets("unspecified-field-scs")
+	ids := s.createSortTestSubjectConditionSets([]string{"unspecified-field-scs-0", "unspecified-field-scs-1", "unspecified-field-scs-2"})
 	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
@@ -1625,7 +1625,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedFi
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedDirection_DefaultsToDESC() {
-	ids := s.createSortTestSubjectConditionSets("unspecified-dir-scs")
+	ids := s.createSortTestSubjectConditionSets([]string{"unspecified-dir-scs-0", "unspecified-dir-scs-1", "unspecified-dir-scs-2"})
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -1640,7 +1640,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedDi
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
-	ids := s.createSortTestSubjectConditionSets("both-unspecified-scs")
+	ids := s.createSortTestSubjectConditionSets([]string{"both-unspecified-scs-0", "both-unspecified-scs-1", "both-unspecified-scs-2"})
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -1655,7 +1655,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByBothUnspecifi
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortOmitted() {
-	ids := s.createSortTestSubjectConditionSets("sort-omitted-scs")
+	ids := s.createSortTestSubjectConditionSets([]string{"sort-omitted-scs-0", "sort-omitted-scs-1", "sort-omitted-scs-2"})
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{})
 	s.Require().NoError(err)
@@ -2853,19 +2853,16 @@ func (s *SubjectMappingsSuite) newSCSInNamespace(nsID string) *policy.SubjectCon
 	return scs
 }
 
-// createSortTestSubjectMappings creates 3 subject mappings with 5ms gaps for distinct timestamps.
-// Returns the subject mapping IDs in creation order.
-func (s *SubjectMappingsSuite) createSortTestSubjectMappings(label string) []string {
+func (s *SubjectMappingsSuite) createSortTestSubjectMappings(prefixes []string) []string {
 	fixtureAttrValID := s.f.GetAttributeValueKey("example.net/attr/attr1/value/value2").ID
 	actionRead := s.f.GetStandardAction(policydb.ActionRead.String())
 
-	const count = 3
-	ids := make([]string, count)
-	for i := range count {
+	ids := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
 		if i > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}
-		email := fmt.Sprintf("%s-%d-%d@example.com", label, i, time.Now().UnixNano())
+		email := fmt.Sprintf("%s-%d@example.com", prefix, time.Now().UnixNano())
 		scs := &subjectmapping.SubjectConditionSetCreate{
 			SubjectSets: []*policy.SubjectSet{
 				{
@@ -2895,16 +2892,13 @@ func (s *SubjectMappingsSuite) createSortTestSubjectMappings(label string) []str
 	return ids
 }
 
-// createSortTestSubjectConditionSets creates 3 subject condition sets with 5ms gaps for distinct timestamps.
-// Returns the SCS IDs in creation order.
-func (s *SubjectMappingsSuite) createSortTestSubjectConditionSets(label string) []string {
-	const count = 3
-	ids := make([]string, count)
-	for i := range count {
+func (s *SubjectMappingsSuite) createSortTestSubjectConditionSets(prefixes []string) []string {
+	ids := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
 		if i > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}
-		val := fmt.Sprintf("%s-%d-%d", label, i, time.Now().UnixNano())
+		val := fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
 		created, err := s.db.PolicyClient.CreateSubjectConditionSet(s.ctx, &subjectmapping.SubjectConditionSetCreate{
 			SubjectSets: []*policy.SubjectSet{
 				{

--- a/service/integration/subject_mappings_test.go
+++ b/service/integration/subject_mappings_test.go
@@ -754,6 +754,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUnspecifiedField_D
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUnspecifiedDirection_DefaultsToDESC() {
 	ids := s.createSortTestSubjectMappings([]string{"unspecified-dir-sm-0", "unspecified-dir-sm-1", "unspecified-dir-sm-2"})
+	defer s.deleteSortTestSubjectMappings(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
 		Sort: []*subjectmapping.SubjectMappingsSort{
@@ -769,6 +770,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUnspecifiedDirecti
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
 	ids := s.createSortTestSubjectMappings([]string{"both-unspecified-sm-0", "both-unspecified-sm-1", "both-unspecified-sm-2"})
+	defer s.deleteSortTestSubjectMappings(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
 		Sort: []*subjectmapping.SubjectMappingsSort{
@@ -784,6 +786,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByBothUnspecified_De
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortOmitted() {
 	ids := s.createSortTestSubjectMappings([]string{"sort-omitted-sm-0", "sort-omitted-sm-1", "sort-omitted-sm-2"})
+	defer s.deleteSortTestSubjectMappings(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{})
 	s.Require().NoError(err)
@@ -1626,6 +1629,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedFi
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedDirection_DefaultsToDESC() {
 	ids := s.createSortTestSubjectConditionSets([]string{"unspecified-dir-scs-0", "unspecified-dir-scs-1", "unspecified-dir-scs-2"})
+	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -1641,6 +1645,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedDi
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
 	ids := s.createSortTestSubjectConditionSets([]string{"both-unspecified-scs-0", "both-unspecified-scs-1", "both-unspecified-scs-2"})
+	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -1656,6 +1661,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByBothUnspecifi
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortOmitted() {
 	ids := s.createSortTestSubjectConditionSets([]string{"sort-omitted-scs-0", "sort-omitted-scs-1", "sort-omitted-scs-2"})
+	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{})
 	s.Require().NoError(err)

--- a/service/integration/subject_mappings_test.go
+++ b/service/integration/subject_mappings_test.go
@@ -721,6 +721,8 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortTieBreaker_CreatedAt
 	}
 	defer s.deleteSortTestSubjectMappings(ids)
 
+	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "subject_mappings", ids))
+
 	sorted := slices.Sorted(slices.Values(ids))
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
@@ -1590,6 +1592,8 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortTieBreaker_Crea
 		ids[i] = created.GetId()
 	}
 	defer s.deleteSortTestSubjectConditionSets(ids)
+
+	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "subject_condition_set", ids))
 
 	sorted := slices.Sorted(slices.Values(ids))
 

--- a/service/integration/subject_mappings_test.go
+++ b/service/integration/subject_mappings_test.go
@@ -600,6 +600,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_OrdersByCreatedAt_Succee
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_ASC() {
 	ids := s.createSortTestSubjectMappings("sort-created-asc")
+	defer s.deleteSortTestSubjectMappings(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
 		Sort: []*subjectmapping.SubjectMappingsSort{
@@ -615,6 +616,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_ASC() {
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_DESC() {
 	ids := s.createSortTestSubjectMappings("sort-created-desc")
+	defer s.deleteSortTestSubjectMappings(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
 		Sort: []*subjectmapping.SubjectMappingsSort{
@@ -630,6 +632,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByCreatedAt_DESC() {
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_DESC() {
 	ids := s.createSortTestSubjectMappings("sort-updated-desc")
+	defer s.deleteSortTestSubjectMappings(ids)
 
 	// Update the first mapping so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -656,6 +659,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_DESC() {
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_ASC() {
 	ids := s.createSortTestSubjectMappings("sort-updated-asc")
+	defer s.deleteSortTestSubjectMappings(ids)
 
 	// Update the last mapping so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -682,6 +686,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_ASC() {
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUnspecifiedField_DefaultsToCreatedAt() {
 	ids := s.createSortTestSubjectMappings("unspecified-field-sm")
+	defer s.deleteSortTestSubjectMappings(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
 		Sort: []*subjectmapping.SubjectMappingsSort{
@@ -1424,6 +1429,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_NoNamespaceFilter_R
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_ASC() {
 	ids := s.createSortTestSubjectConditionSets("sort-scs-created-asc")
+	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -1439,6 +1445,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_ASC
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_DESC() {
 	ids := s.createSortTestSubjectConditionSets("sort-scs-created-desc")
+	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -1454,6 +1461,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_DES
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_DESC() {
 	ids := s.createSortTestSubjectConditionSets("sort-scs-updated-desc")
+	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	// Update the first SCS so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -1480,6 +1488,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_DES
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_ASC() {
 	ids := s.createSortTestSubjectConditionSets("sort-scs-updated-asc")
+	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	// Update the last SCS so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -1506,6 +1515,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_ASC
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedField_DefaultsToCreatedAt() {
 	ids := s.createSortTestSubjectConditionSets("unspecified-field-scs")
+	defer s.deleteSortTestSubjectConditionSets(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -2822,4 +2832,20 @@ func (s *SubjectMappingsSuite) createSortTestSubjectConditionSets(label string) 
 		ids[i] = created.GetId()
 	}
 	return ids
+}
+
+// deleteSortTestSubjectMappings cleans up subject mappings created by sort tests.
+func (s *SubjectMappingsSuite) deleteSortTestSubjectMappings(ids []string) {
+	for _, id := range ids {
+		_, err := s.db.PolicyClient.DeleteSubjectMapping(s.ctx, id)
+		s.Require().NoError(err)
+	}
+}
+
+// deleteSortTestSubjectConditionSets cleans up subject condition sets created by sort tests.
+func (s *SubjectMappingsSuite) deleteSortTestSubjectConditionSets(ids []string) {
+	for _, id := range ids {
+		_, err := s.db.PolicyClient.DeleteSubjectConditionSet(s.ctx, id)
+		s.Require().NoError(err)
+	}
 }

--- a/service/integration/subject_mappings_test.go
+++ b/service/integration/subject_mappings_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -682,6 +683,55 @@ func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUpdatedAt_ASC() {
 
 	// The updated mapping (ids[2]) should appear last in ASC order
 	assertIDsInOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, ids[0], ids[1], ids[2])
+}
+
+func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortTieBreaker_CreatedAtWithIDFallback() {
+	fixtureAttrValID := s.f.GetAttributeValueKey("example.net/attr/attr1/value/value2").ID
+	actionRead := s.f.GetStandardAction(policydb.ActionRead.String())
+
+	suffix := time.Now().UnixNano()
+	ids := make([]string, 3)
+	for i := range 3 {
+		email := fmt.Sprintf("tiebreaker-sm-%d-%d@example.com", i, suffix)
+		scs := &subjectmapping.SubjectConditionSetCreate{
+			SubjectSets: []*policy.SubjectSet{
+				{
+					ConditionGroups: []*policy.ConditionGroup{
+						{
+							BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+							Conditions: []*policy.Condition{
+								{
+									SubjectExternalSelectorValue: ".email",
+									Operator:                     policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+									SubjectExternalValues:        []string{email},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		created, err := s.db.PolicyClient.CreateSubjectMapping(s.ctx, &subjectmapping.CreateSubjectMappingRequest{
+			AttributeValueId:       fixtureAttrValID,
+			NewSubjectConditionSet: scs,
+			Actions:                []*policy.Action{actionRead},
+		})
+		s.Require().NoError(err)
+		ids[i] = created.GetId()
+	}
+	defer s.deleteSortTestSubjectMappings(ids)
+
+	sorted := slices.Sorted(slices.Values(ids))
+
+	listRsp, err := s.db.PolicyClient.ListSubjectMappings(s.ctx, &subjectmapping.ListSubjectMappingsRequest{
+		Sort: []*subjectmapping.SubjectMappingsSort{
+			{Field: subjectmapping.SortSubjectMappingsType_SORT_SUBJECT_MAPPINGS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(listRsp)
+
+	assertIDsInOrder(s.T(), listRsp.GetSubjectMappings(), func(sm *policy.SubjectMapping) string { return sm.GetId() }, sorted[0], sorted[1], sorted[2])
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectMappings_SortByUnspecifiedField_DefaultsToCreatedAt() {
@@ -1511,6 +1561,47 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_ASC
 
 	// The updated SCS (ids[2]) should appear last in ASC order
 	assertIDsInOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, ids[0], ids[1], ids[2])
+}
+
+func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortTieBreaker_CreatedAtWithIDFallback() {
+	suffix := time.Now().UnixNano()
+	ids := make([]string, 3)
+	for i := range 3 {
+		val := fmt.Sprintf("tiebreaker-scs-%d-%d", i, suffix)
+		created, err := s.db.PolicyClient.CreateSubjectConditionSet(s.ctx, &subjectmapping.SubjectConditionSetCreate{
+			SubjectSets: []*policy.SubjectSet{
+				{
+					ConditionGroups: []*policy.ConditionGroup{
+						{
+							BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+							Conditions: []*policy.Condition{
+								{
+									SubjectExternalSelectorValue: ".sort_test",
+									Operator:                     policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+									SubjectExternalValues:        []string{val},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, "", "")
+		s.Require().NoError(err)
+		ids[i] = created.GetId()
+	}
+	defer s.deleteSortTestSubjectConditionSets(ids)
+
+	sorted := slices.Sorted(slices.Values(ids))
+
+	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
+		Sort: []*subjectmapping.SubjectConditionSetsSort{
+			{Field: subjectmapping.SortSubjectConditionSetsType_SORT_SUBJECT_CONDITION_SETS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(listRsp)
+
+	assertIDsInOrder(s.T(), listRsp.GetSubjectConditionSets(), func(scs *policy.SubjectConditionSet) string { return scs.GetId() }, sorted[0], sorted[1], sorted[2])
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedField_DefaultsToCreatedAt() {

--- a/service/integration/utils.go
+++ b/service/integration/utils.go
@@ -1,8 +1,11 @@
 package integration
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/opentdf/platform/service/internal/fixtures"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,4 +29,15 @@ func assertIDsInOrder[T any](tb testing.TB, items []T, getID func(T) string, ids
 	for i := 0; i < len(ids)-1; i++ {
 		require.Less(tb, positions[ids[i]], positions[ids[i+1]])
 	}
+}
+
+// forceCreatedAtTie sets created_at to a fixed timestamp for the given IDs,
+// guaranteeing that the ORDER BY tiebreaker (id ASC) determines sort order.
+func forceCreatedAtTie(ctx context.Context, db fixtures.DBInterface, table string, ids []string) error {
+	sql := fmt.Sprintf(
+		`UPDATE %s SET created_at = '2000-01-01T00:00:00Z' WHERE id = ANY($1::uuid[])`,
+		db.TableName(table),
+	)
+	_, err := db.Client.Pgx.Exec(ctx, sql, ids)
+	return err
 }

--- a/service/integration/utils.go
+++ b/service/integration/utils.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// assertIDsInOrder verifies that the given IDs appear in the expected relative
+// order within items, tolerating extra rows that don't match any target ID.
 func assertIDsInOrder[T any](tb testing.TB, items []T, getID func(T) string, ids ...string) {
 	tb.Helper()
 
@@ -29,6 +31,17 @@ func assertIDsInOrder[T any](tb testing.TB, items []T, getID func(T) string, ids
 	for i := 0; i < len(ids)-1; i++ {
 		require.Less(tb, positions[ids[i]], positions[ids[i+1]])
 	}
+}
+
+// forceDeleteRows hard-deletes rows by ID via raw SQL, bypassing the API's
+// soft-delete/deactivate limitation for resources like namespaces and attributes.
+func forceDeleteRows(ctx context.Context, db fixtures.DBInterface, table string, ids []string) error {
+	sql := fmt.Sprintf(
+		`DELETE FROM %s WHERE id = ANY($1::uuid[])`,
+		db.TableName(table),
+	)
+	_, err := db.Client.Pgx.Exec(ctx, sql, ids)
+	return err
 }
 
 // forceCreatedAtTie sets created_at to a fixed timestamp for the given IDs,


### PR DESCRIPTION
## Proposed Changes

Consolidates integration test helpers across all policy sort test suites, adds proper test cleanup, and adds tiebreaker-specific integration tests that verify the `id ASC` fallback produces deterministic ordering.

## Changes

### Integration Test Helpers -- service/integration/utils.go

- `forceDeleteRows`: hard-deletes rows by ID via raw SQL, bypassing the API's soft-delete/deactivate limitation for test cleanup
- `forceCreatedAtTie`: sets `created_at` to a fixed timestamp for given IDs, guaranteeing that the `ORDER BY` tiebreaker (`id ASC`) determines sort order

### Integration Test Consolidation -- service/integration/*_test.go

- Refactored `createSortTest*` helpers from `(label string)` to `(prefixes []string)` across all RPCs, giving each test explicit control over resource names
- Added `defer` cleanup calls to all sort integration tests via `deleteSortTest*` helpers
- Added `Test_List*_SortTieBreaker_CreatedAtWithIDFallback` for all 8 RPCs: Namespaces, Attributes, KeyAccessServers, KasKeys, Obligations, RegisteredResources, SubjectMappings, SubjectConditionSets

### Tiebreaker Test Strategy

Each tiebreaker test:
1. Creates 3 resources
2. Forces identical `created_at` timestamps via `forceCreatedAtTie`
3. Sorts the UUIDs lexicographically to get expected order
4. Lists with `created_at ASC` and asserts rows match the UUID-sorted order

This proves the `id ASC` tiebreaker added in #3402 produces deterministic results when the primary sort column ties.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Standardized sort test helpers across integration tests to ensure consistent attribute, key, namespace, obligation, and resource creation with deterministic timestamps.
  * Added tie-breaker tests to validate deterministic ordering behavior when creation timestamps are equal.
  * Enhanced test utilities for database cleanup and timestamp management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->