### PR TITLE
feat(sdk): IsHealthy(ctx) public reachability probe

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -6,6 +6,7 @@ toolchain go1.25.9
 
 require (
 	connectrpc.com/connect v1.19.1
+	connectrpc.com/grpchealth v1.4.0
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/google/uuid v1.6.0
 	github.com/gowebpki/jcs v1.0.1

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -2,6 +2,8 @@ buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-2025060316535
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250603165357-b52ab10f4468.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
 connectrpc.com/connect v1.19.1 h1:R5M57z05+90EfEvCY1b7hBxDVOUl45PrtXtAV2fOC14=
 connectrpc.com/connect v1.19.1/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
+connectrpc.com/grpchealth v1.4.0 h1:MJC96JLelARPgZTiRF9KRfY/2N9OcoQvF2EWX07v2IE=
+connectrpc.com/grpchealth v1.4.0/go.mod h1:WhW6m1EzTmq3Ky1FE8EfkIpSDc6TfUx2M2KqZO3ts/Q=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -175,7 +175,10 @@ func WithPlatformConfiguration(platformConfiguration PlatformConfiguration) Opti
 	}
 }
 
-// WithConnectionValidation will validate connection to a healthy, running platform
+// WithConnectionValidation will validate connection to a healthy, running platform at
+// SDK construction time. For runtime readiness probes (e.g. Kubernetes liveness/readiness
+// endpoints), use SDK.HealthCheck(ctx, service) instead — it honors ctx for deadlines
+// and tracing and does not fail-fast at construction.
 func WithConnectionValidation() Option {
 	return func(c *config) {
 		c.shouldValidatePlatformConnectivity = true

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -177,8 +177,8 @@ func WithPlatformConfiguration(platformConfiguration PlatformConfiguration) Opti
 
 // WithConnectionValidation will validate connection to a healthy, running platform at
 // SDK construction time. For runtime readiness probes (e.g. Kubernetes liveness/readiness
-// endpoints), use SDK.HealthCheck(ctx, service) instead — it honors ctx for deadlines
-// and tracing and does not fail-fast at construction.
+// endpoints), use SDK.IsHealthy(ctx) instead — it honors ctx for deadlines and tracing
+// and does not fail-fast at construction.
 func WithConnectionValidation() Option {
 	return func(c *config) {
 		c.shouldValidatePlatformConnectivity = true

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -443,21 +443,40 @@ func isValidManifest(manifest string, intensity SchemaValidationIntensity) (bool
 	return true, nil
 }
 
-// Test connectability to the platform and validate a healthy status
-func validateHealthyPlatformConnection(platformEndpoint string, httpClient *http.Client, options []connect.ClientOption) error {
+// checkPlatformHealth issues a single gRPC Health v1 Check against the platform health endpoint.
+// ctx controls deadline, cancellation, and trace-context propagation. service selects scope:
+// "" = reachability, "all" = every registered readiness probe, otherwise a specific service name.
+func checkPlatformHealth(
+	ctx context.Context,
+	endpoint, service string,
+	httpClient *http.Client,
+	options []connect.ClientOption,
+) (healthpb.HealthCheckResponse_ServingStatus, error) {
 	healthClient := connect.NewClient[healthpb.HealthCheckRequest, healthpb.HealthCheckResponse](
 		httpClient,
-		platformEndpoint+"/grpc.health.v1.Health/Check",
+		endpoint+"/grpc.health.v1.Health/Check",
 		options...,
 	)
-	res, err := healthClient.CallUnary(
-		context.Background(),
-		connect.NewRequest(&healthpb.HealthCheckRequest{}),
-	)
-	if err != nil || res.Msg.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+	res, err := healthClient.CallUnary(ctx, connect.NewRequest(&healthpb.HealthCheckRequest{Service: service}))
+	if err != nil {
+		return healthpb.HealthCheckResponse_UNKNOWN, err
+	}
+	return res.Msg.GetStatus(), nil
+}
+
+// validateHealthyPlatformConnection is the construction-time reachability gate used by New when
+// WithConnectionValidation is set. It uses context.Background() to preserve today's behavior.
+// Callers pass cfg.extraClientOptions (pre-auth) because the auth and audit interceptors are
+// assembled after this gate fires; the runtime SDK.HealthCheck method uses the post-interceptor
+// s.conn.Options instead.
+func validateHealthyPlatformConnection(platformEndpoint string, httpClient *http.Client, options []connect.ClientOption) error {
+	status, err := checkPlatformHealth(context.Background(), platformEndpoint, "", httpClient, options)
+	if err != nil {
 		return errors.Join(ErrPlatformUnreachable, err)
 	}
-
+	if status != healthpb.HealthCheckResponse_SERVING {
+		return errors.Join(ErrPlatformUnreachable, fmt.Errorf("platform health status %q", status))
+	}
 	return nil
 }
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -503,9 +503,13 @@ func checkPlatformHealth(
 	httpClient *http.Client,
 	options []connect.ClientOption,
 ) (healthpb.HealthCheckResponse_ServingStatus, error) {
+	checkURL, err := url.JoinPath(endpoint, "grpc.health.v1.Health", "Check")
+	if err != nil {
+		return healthpb.HealthCheckResponse_UNKNOWN, err
+	}
 	healthClient := connect.NewClient[healthpb.HealthCheckRequest, healthpb.HealthCheckResponse](
 		httpClient,
-		endpoint+"/grpc.health.v1.Health/Check",
+		checkURL,
 		options...,
 	)
 	res, err := healthClient.CallUnary(ctx, connect.NewRequest(&healthpb.HealthCheckRequest{Service: service}))

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -35,7 +35,7 @@ const (
 	ErrGrpcDialFailed      = Error("failed to dial grpc endpoint")
 	ErrShutdownFailed      = Error("failed to shutdown sdk")
 	ErrPlatformUnreachable = Error("platform unreachable or not responding")
-	// ErrHealthCheckUnsupported is returned by SDK.HealthCheck when the SDK is configured
+	// ErrHealthCheckUnsupported is returned by SDK.IsHealthy when the SDK is configured
 	// in IPC mode, which does not support the gRPC Health protocol.
 	ErrHealthCheckUnsupported        = Error("health check not supported in IPC mode")
 	ErrPlatformConfigFailed          = Error("failed to retrieve platform configuration")
@@ -59,33 +59,6 @@ type Error string
 
 func (c Error) Error() string {
 	return string(c)
-}
-
-// HealthStatus is the serving status reported by the platform's gRPC Health v1 endpoint.
-// It mirrors google.golang.org/grpc/health/grpc_health_v1.HealthCheckResponse_ServingStatus
-// so callers do not need to import the grpc health protobuf to branch on results.
-type HealthStatus int
-
-const (
-	// HealthStatusUnknown means the platform could not determine status, or the requested
-	// service is not registered on this deployment.
-	HealthStatusUnknown HealthStatus = iota
-	// HealthStatusServing means the requested scope reports SERVING.
-	HealthStatusServing
-	// HealthStatusNotServing means the requested scope was reached but reports NOT_SERVING.
-	HealthStatusNotServing
-)
-
-// String returns the uppercase name of the status. Unknown or out-of-range values render as "UNKNOWN".
-func (s HealthStatus) String() string {
-	switch s { //nolint:exhaustive // default intentionally covers HealthStatusUnknown and any future out-of-range values
-	case HealthStatusServing:
-		return "SERVING"
-	case HealthStatusNotServing:
-		return "NOT_SERVING"
-	default:
-		return "UNKNOWN"
-	}
 }
 
 // getLogger returns the package-level logger, defaulting to slog.Default() if not set to
@@ -340,55 +313,24 @@ func (s SDK) Conn() *ConnectRPCConnection {
 	return s.conn
 }
 
-// HealthCheck queries the platform's gRPC Health v1 endpoint (grpc.health.v1.Health/Check)
-// and returns the reported serving status.
+// IsHealthy reports whether the platform's gRPC Health v1 endpoint is reachable and SERVING.
+// The check honors ctx for deadline and cancellation; OTEL tracing works automatically when
+// otelconnect.NewInterceptor is registered via WithExtraClientOptions at SDK construction.
 //
-// The service argument selects the check scope:
-//
-//   - ""     — reachability check. Returns SERVING if the health handler responds. Does
-//     not exercise any registered readiness probe.
-//   - "all"  — runs every readiness check the platform has registered. Returns
-//     NOT_SERVING if any registered service reports an error.
-//   - other  — runs only the named service's readiness check (e.g. "kas", "authorization").
-//     Returns HealthStatusUnknown if the service is not registered on this deployment.
-//
-// The call honors ctx for deadline, cancellation, and trace-context propagation. Callers are
-// expected to manage timeouts via context.WithTimeout and to drive probe cadence / retry themselves.
-//
-// OTEL tracing works automatically when the caller has registered otelconnect.NewInterceptor()
-// via sdk.WithExtraClientOptions at SDK construction time. The SDK does not emit spans of its own.
-//
-// Returns (HealthStatusServing, nil) on SERVING; (HealthStatusNotServing, nil) on NOT_SERVING;
-// (HealthStatusUnknown, nil) on UNKNOWN / SERVICE_UNKNOWN; (HealthStatusUnknown, err wrapping
-// ErrPlatformUnreachable) on any transport failure including ctx errors; and
-// (HealthStatusUnknown, ErrHealthCheckUnsupported) when the SDK is in IPC mode.
-func (s SDK) HealthCheck(ctx context.Context, service string) (HealthStatus, error) {
+// Returns:
+//   - (true, nil) when the platform reports SERVING.
+//   - (false, nil) when the platform is reachable but reports NOT_SERVING or UNKNOWN.
+//   - (false, ErrHealthCheckUnsupported) when the SDK is configured in IPC mode.
+//   - (false, error) wrapping ErrPlatformUnreachable on transport failure or ctx errors.
+func (s SDK) IsHealthy(ctx context.Context) (bool, error) {
 	if s.ipc || s.conn == nil {
-		return HealthStatusUnknown, ErrHealthCheckUnsupported
+		return false, ErrHealthCheckUnsupported
 	}
-	status, err := checkPlatformHealth(ctx, s.conn.Endpoint, service, s.conn.Client, s.conn.Options)
+	healthy, err := checkPlatformHealth(ctx, s.conn.Endpoint, s.conn.Client, s.conn.Options)
 	if err != nil {
-		// Unregistered services can surface in two ways depending on the server
-		// implementation. The OpenTDF platform's handler reports them via proto
-		// HealthCheckResponse_UNKNOWN, which falls through to the switch default
-		// below. Generic grpchealth servers (e.g. grpchealth.NewStaticChecker,
-		// which the SDK tests use) surface them as a Connect not_found error.
-		// Both paths map to HealthStatusUnknown with no transport-error wrapper.
-		var connErr *connect.Error
-		if errors.As(err, &connErr) && connErr.Code() == connect.CodeNotFound {
-			return HealthStatusUnknown, nil
-		}
-		return HealthStatusUnknown, errors.Join(ErrPlatformUnreachable, err)
+		return false, errors.Join(ErrPlatformUnreachable, err)
 	}
-	switch status { //nolint:exhaustive // default intentionally covers UNKNOWN and SERVICE_UNKNOWN
-	case healthpb.HealthCheckResponse_SERVING:
-		return HealthStatusServing, nil
-	case healthpb.HealthCheckResponse_NOT_SERVING:
-		return HealthStatusNotServing, nil
-	default:
-		// UNKNOWN and SERVICE_UNKNOWN both map to HealthStatusUnknown.
-		return HealthStatusUnknown, nil
-	}
+	return healthy, nil
 }
 
 type TdfType string
@@ -494,43 +436,41 @@ func isValidManifest(manifest string, intensity SchemaValidationIntensity) (bool
 	return true, nil
 }
 
-// checkPlatformHealth issues a single gRPC Health v1 Check against the platform health endpoint.
-// ctx controls deadline, cancellation, and trace-context propagation. service selects scope:
-// "" = reachability, "all" = every registered readiness probe, otherwise a specific service name.
+// checkPlatformHealth issues a single gRPC Health v1 Check against the platform endpoint and
+// reports whether the response is SERVING. ctx controls deadline, cancellation, and trace-context.
 func checkPlatformHealth(
 	ctx context.Context,
-	endpoint, service string,
+	endpoint string,
 	httpClient *http.Client,
 	options []connect.ClientOption,
-) (healthpb.HealthCheckResponse_ServingStatus, error) {
+) (bool, error) {
 	checkURL, err := url.JoinPath(endpoint, "grpc.health.v1.Health", "Check")
 	if err != nil {
-		return healthpb.HealthCheckResponse_UNKNOWN, err
+		return false, err
 	}
 	healthClient := connect.NewClient[healthpb.HealthCheckRequest, healthpb.HealthCheckResponse](
 		httpClient,
 		checkURL,
 		options...,
 	)
-	res, err := healthClient.CallUnary(ctx, connect.NewRequest(&healthpb.HealthCheckRequest{Service: service}))
+	res, err := healthClient.CallUnary(ctx, connect.NewRequest(&healthpb.HealthCheckRequest{}))
 	if err != nil {
-		return healthpb.HealthCheckResponse_UNKNOWN, err
+		return false, err
 	}
-	return res.Msg.GetStatus(), nil
+	return res.Msg.GetStatus() == healthpb.HealthCheckResponse_SERVING, nil
 }
 
 // validateHealthyPlatformConnection is the construction-time reachability gate used by New when
-// WithConnectionValidation is set. It uses context.Background() to preserve today's behavior.
-// Callers pass cfg.extraClientOptions (pre-auth) because the auth and audit interceptors are
-// assembled after this gate fires; the runtime SDK.HealthCheck method uses the post-interceptor
-// s.conn.Options instead.
+// WithConnectionValidation is set. Callers pass cfg.extraClientOptions (pre-auth) because the
+// auth and audit interceptors are assembled after this gate fires; the runtime SDK.IsHealthy
+// method uses the post-interceptor s.conn.Options instead.
 func validateHealthyPlatformConnection(platformEndpoint string, httpClient *http.Client, options []connect.ClientOption) error {
-	status, err := checkPlatformHealth(context.Background(), platformEndpoint, "", httpClient, options)
+	healthy, err := checkPlatformHealth(context.Background(), platformEndpoint, httpClient, options)
 	if err != nil {
 		return errors.Join(ErrPlatformUnreachable, err)
 	}
-	if status != healthpb.HealthCheckResponse_SERVING {
-		return errors.Join(ErrPlatformUnreachable, fmt.Errorf("platform health status %q", status))
+	if !healthy {
+		return ErrPlatformUnreachable
 	}
 	return nil
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -32,9 +32,12 @@ import (
 const (
 	// Failure while connecting to a service.
 	// Check your configuration and/or retry.
-	ErrGrpcDialFailed                = Error("failed to dial grpc endpoint")
-	ErrShutdownFailed                = Error("failed to shutdown sdk")
-	ErrPlatformUnreachable           = Error("platform unreachable or not responding")
+	ErrGrpcDialFailed      = Error("failed to dial grpc endpoint")
+	ErrShutdownFailed      = Error("failed to shutdown sdk")
+	ErrPlatformUnreachable = Error("platform unreachable or not responding")
+	// ErrHealthCheckUnsupported is returned by SDK.HealthCheck when the SDK is configured
+	// in IPC mode, which does not support the gRPC Health protocol.
+	ErrHealthCheckUnsupported        = Error("health check not supported in IPC mode")
 	ErrPlatformConfigFailed          = Error("failed to retrieve platform configuration")
 	ErrPlatformEndpointMalformed     = Error("platform endpoint is malformed")
 	ErrPlatformIssuerNotFound        = Error("issuer not found in well-known idp configuration")
@@ -56,6 +59,33 @@ type Error string
 
 func (c Error) Error() string {
 	return string(c)
+}
+
+// HealthStatus is the serving status reported by the platform's gRPC Health v1 endpoint.
+// It mirrors google.golang.org/grpc/health/grpc_health_v1.HealthCheckResponse_ServingStatus
+// so callers do not need to import the grpc health protobuf to branch on results.
+type HealthStatus int
+
+const (
+	// HealthStatusUnknown means the platform could not determine status, or the requested
+	// service is not registered on this deployment.
+	HealthStatusUnknown HealthStatus = iota
+	// HealthStatusServing means the requested scope reports SERVING.
+	HealthStatusServing
+	// HealthStatusNotServing means the requested scope was reached but reports NOT_SERVING.
+	HealthStatusNotServing
+)
+
+// String returns the uppercase name of the status. Unknown or out-of-range values render as "UNKNOWN".
+func (s HealthStatus) String() string {
+	switch s { //nolint:exhaustive // default intentionally covers HealthStatusUnknown and any future out-of-range values
+	case HealthStatusServing:
+		return "SERVING"
+	case HealthStatusNotServing:
+		return "NOT_SERVING"
+	default:
+		return "UNKNOWN"
+	}
 }
 
 // getLogger returns the package-level logger, defaulting to slog.Default() if not set to

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -340,6 +340,57 @@ func (s SDK) Conn() *ConnectRPCConnection {
 	return s.conn
 }
 
+// HealthCheck queries the platform's gRPC Health v1 endpoint (grpc.health.v1.Health/Check)
+// and returns the reported serving status.
+//
+// The service argument selects the check scope:
+//
+//   - ""     — reachability check. Returns SERVING if the health handler responds. Does
+//     not exercise any registered readiness probe.
+//   - "all"  — runs every readiness check the platform has registered. Returns
+//     NOT_SERVING if any registered service reports an error.
+//   - other  — runs only the named service's readiness check (e.g. "kas", "authorization").
+//     Returns HealthStatusUnknown if the service is not registered on this deployment.
+//
+// The call honors ctx for deadline, cancellation, and trace-context propagation. Callers are
+// expected to manage timeouts via context.WithTimeout and to drive probe cadence / retry themselves.
+//
+// OTEL tracing works automatically when the caller has registered otelconnect.NewInterceptor()
+// via sdk.WithExtraClientOptions at SDK construction time. The SDK does not emit spans of its own.
+//
+// Returns (HealthStatusServing, nil) on SERVING; (HealthStatusNotServing, nil) on NOT_SERVING;
+// (HealthStatusUnknown, nil) on UNKNOWN / SERVICE_UNKNOWN; (HealthStatusUnknown, err wrapping
+// ErrPlatformUnreachable) on any transport failure including ctx errors; and
+// (HealthStatusUnknown, ErrHealthCheckUnsupported) when the SDK is in IPC mode.
+func (s SDK) HealthCheck(ctx context.Context, service string) (HealthStatus, error) {
+	if s.ipc || s.conn == nil {
+		return HealthStatusUnknown, ErrHealthCheckUnsupported
+	}
+	status, err := checkPlatformHealth(ctx, s.conn.Endpoint, service, s.conn.Client, s.conn.Options)
+	if err != nil {
+		// Unregistered services can surface in two ways depending on the server
+		// implementation. The OpenTDF platform's handler reports them via proto
+		// HealthCheckResponse_UNKNOWN, which falls through to the switch default
+		// below. Generic grpchealth servers (e.g. grpchealth.NewStaticChecker,
+		// which the SDK tests use) surface them as a Connect not_found error.
+		// Both paths map to HealthStatusUnknown with no transport-error wrapper.
+		var connErr *connect.Error
+		if errors.As(err, &connErr) && connErr.Code() == connect.CodeNotFound {
+			return HealthStatusUnknown, nil
+		}
+		return HealthStatusUnknown, errors.Join(ErrPlatformUnreachable, err)
+	}
+	switch status { //nolint:exhaustive // default intentionally covers UNKNOWN and SERVICE_UNKNOWN
+	case healthpb.HealthCheckResponse_SERVING:
+		return HealthStatusServing, nil
+	case healthpb.HealthCheckResponse_NOT_SERVING:
+		return HealthStatusNotServing, nil
+	default:
+		// UNKNOWN and SERVICE_UNKNOWN both map to HealthStatusUnknown.
+		return HealthStatusUnknown, nil
+	}
+}
+
 type TdfType string
 
 const (

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -483,3 +483,30 @@ func TestSDK_HealthCheck_Serving_HappyPath(t *testing.T) {
 		assert.Equal(t, sdk.HealthStatusUnknown, status)
 	})
 }
+
+// TestSDK_HealthCheck_TrailingSlashEndpoint verifies that a platform endpoint
+// with a trailing slash does not produce a double-slash in the request URL,
+// which strict HTTP routers can reject.
+func TestSDK_HealthCheck_TrailingSlashEndpoint(t *testing.T) {
+	ts := newHealthTestServer(t, []string{"kas"}, nil)
+	defer ts.Close()
+
+	s, err := sdk.New(ts.URL+"/",
+		sdk.WithPlatformConfiguration(sdk.PlatformConfiguration{
+			"idp": map[string]interface{}{
+				"issuer":                 "https://example.org",
+				"authorization_endpoint": "https://example.org/auth",
+				"token_endpoint":         "https://example.org/token",
+			},
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	status, err := s.HealthCheck(ctx, "kas")
+	require.NoError(t, err)
+	assert.Equal(t, sdk.HealthStatusServing, status)
+}

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -319,42 +319,18 @@ func Test_GetType_Invalid2Bytes(t *testing.T) {
 	assert.Equal(t, sdk.Invalid, tdfType)
 }
 
-func TestHealthStatus_String(t *testing.T) {
-	tests := []struct {
-		name   string
-		status sdk.HealthStatus
-		want   string
-	}{
-		{"unknown", sdk.HealthStatusUnknown, "UNKNOWN"},
-		{"serving", sdk.HealthStatusServing, "SERVING"},
-		{"not_serving", sdk.HealthStatusNotServing, "NOT_SERVING"},
-		{"out_of_range", sdk.HealthStatus(99), "UNKNOWN"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.status.String())
-		})
-	}
-}
-
 func TestErrHealthCheckUnsupported_Distinct(t *testing.T) {
 	assert.NotEqual(t, sdk.ErrHealthCheckUnsupported, sdk.ErrPlatformUnreachable)
 	assert.Equal(t, "health check not supported in IPC mode", sdk.ErrHealthCheckUnsupported.Error())
 }
 
-// newHealthTestServer starts an httptest.Server serving grpc.health.v1.Health.
-// serving is the set of service names that should report SERVING; notServing is the set
-// that should report NOT_SERVING. Any service name not in either set causes
-// grpchealth.StaticChecker to return a Connect not_found error, which SDK.HealthCheck
-// maps to HealthStatusUnknown.
-// The empty service name ("") reports SERVING regardless (StaticChecker default).
-func newHealthTestServer(t *testing.T, serving, notServing []string) *httptest.Server {
+// newHealthTestServer starts an httptest.Server serving grpc.health.v1.Health with the
+// configured serving status for the empty service name (the SDK's reachability probe).
+func newHealthTestServer(t *testing.T, serving bool) *httptest.Server {
 	t.Helper()
-	all := append([]string{}, serving...)
-	all = append(all, notServing...)
-	checker := grpchealth.NewStaticChecker(all...)
-	for _, svc := range notServing {
-		checker.SetStatus(svc, grpchealth.StatusNotServing)
+	checker := grpchealth.NewStaticChecker()
+	if !serving {
+		checker.SetStatus("", grpchealth.StatusNotServing)
 	}
 	mux := http.NewServeMux()
 	path, handler := grpchealth.NewHandler(checker)
@@ -362,7 +338,7 @@ func newHealthTestServer(t *testing.T, serving, notServing []string) *httptest.S
 	return httptest.NewServer(mux)
 }
 
-func TestSDK_HealthCheck_IPCMode_ReturnsErrHealthCheckUnsupported(t *testing.T) {
+func TestSDK_IsHealthy_IPCMode_ReturnsErrHealthCheckUnsupported(t *testing.T) {
 	// IPC mode requires a coreConn; provide a dummy one to satisfy sdk.New.
 	dummyConn := &sdk.ConnectRPCConnection{
 		Endpoint: "http://localhost:0",
@@ -382,13 +358,12 @@ func TestSDK_HealthCheck_IPCMode_ReturnsErrHealthCheckUnsupported(t *testing.T) 
 	require.NoError(t, err)
 	require.NotNil(t, s)
 
-	ctx := context.Background()
-	status, err := s.HealthCheck(ctx, "")
-	assert.Equal(t, sdk.HealthStatusUnknown, status)
+	healthy, err := s.IsHealthy(context.Background())
+	assert.False(t, healthy)
 	require.ErrorIs(t, err, sdk.ErrHealthCheckUnsupported)
 }
 
-func TestSDK_HealthCheck_Unreachable_ReturnsErrPlatformUnreachable(t *testing.T) {
+func TestSDK_IsHealthy_Unreachable_ReturnsErrPlatformUnreachable(t *testing.T) {
 	s, err := sdk.New(badPlatformEndpoint,
 		sdk.WithPlatformConfiguration(sdk.PlatformConfiguration{
 			"idp": map[string]interface{}{
@@ -405,15 +380,15 @@ func TestSDK_HealthCheck_Unreachable_ReturnsErrPlatformUnreachable(t *testing.T)
 	defer cancel()
 
 	start := time.Now()
-	status, err := s.HealthCheck(ctx, "")
+	healthy, err := s.IsHealthy(ctx)
 	elapsed := time.Since(start)
 
-	assert.Equal(t, sdk.HealthStatusUnknown, status)
+	assert.False(t, healthy)
 	require.ErrorIs(t, err, sdk.ErrPlatformUnreachable)
 	assert.Less(t, elapsed, 2*time.Second, "health check should return promptly against a closed port, not wait for the ctx deadline")
 }
 
-func TestSDK_HealthCheck_ContextCanceled_ReturnsQuickly(t *testing.T) {
+func TestSDK_IsHealthy_ContextCanceled_ReturnsQuickly(t *testing.T) {
 	s, err := sdk.New(badPlatformEndpoint,
 		sdk.WithPlatformConfiguration(sdk.PlatformConfiguration{
 			"idp": map[string]interface{}{
@@ -430,18 +405,18 @@ func TestSDK_HealthCheck_ContextCanceled_ReturnsQuickly(t *testing.T) {
 	cancel() // canceled before the call
 
 	start := time.Now()
-	status, err := s.HealthCheck(ctx, "")
+	healthy, err := s.IsHealthy(ctx)
 	elapsed := time.Since(start)
 
-	assert.Equal(t, sdk.HealthStatusUnknown, status)
+	assert.False(t, healthy)
 	require.Error(t, err)
 	require.ErrorIs(t, err, sdk.ErrPlatformUnreachable)
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Less(t, elapsed, 500*time.Millisecond, "pre-canceled ctx should short-circuit")
 }
 
-func TestSDK_HealthCheck_Serving_HappyPath(t *testing.T) {
-	ts := newHealthTestServer(t, []string{"kas"}, []string{"broken"})
+func TestSDK_IsHealthy_Serving(t *testing.T) {
+	ts := newHealthTestServer(t, true)
 	defer ts.Close()
 
 	s, err := sdk.New(ts.URL,
@@ -459,36 +434,40 @@ func TestSDK_HealthCheck_Serving_HappyPath(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	t.Run("empty service returns SERVING", func(t *testing.T) {
-		status, err := s.HealthCheck(ctx, "")
-		require.NoError(t, err)
-		assert.Equal(t, sdk.HealthStatusServing, status)
-	})
-
-	t.Run("named serving service returns SERVING", func(t *testing.T) {
-		status, err := s.HealthCheck(ctx, "kas")
-		require.NoError(t, err)
-		assert.Equal(t, sdk.HealthStatusServing, status)
-	})
-
-	t.Run("named not-serving service returns NOT_SERVING", func(t *testing.T) {
-		status, err := s.HealthCheck(ctx, "broken")
-		require.NoError(t, err)
-		assert.Equal(t, sdk.HealthStatusNotServing, status)
-	})
-
-	t.Run("unknown service returns UNKNOWN", func(t *testing.T) {
-		status, err := s.HealthCheck(ctx, "does-not-exist")
-		require.NoError(t, err)
-		assert.Equal(t, sdk.HealthStatusUnknown, status)
-	})
+	healthy, err := s.IsHealthy(ctx)
+	require.NoError(t, err)
+	assert.True(t, healthy)
 }
 
-// TestSDK_HealthCheck_TrailingSlashEndpoint verifies that a platform endpoint
+func TestSDK_IsHealthy_NotServing(t *testing.T) {
+	ts := newHealthTestServer(t, false)
+	defer ts.Close()
+
+	s, err := sdk.New(ts.URL,
+		sdk.WithPlatformConfiguration(sdk.PlatformConfiguration{
+			"idp": map[string]interface{}{
+				"issuer":                 "https://example.org",
+				"authorization_endpoint": "https://example.org/auth",
+				"token_endpoint":         "https://example.org/token",
+			},
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	healthy, err := s.IsHealthy(ctx)
+	require.NoError(t, err)
+	assert.False(t, healthy)
+}
+
+// TestSDK_IsHealthy_TrailingSlashEndpoint verifies that a platform endpoint
 // with a trailing slash does not produce a double-slash in the request URL,
 // which strict HTTP routers can reject.
-func TestSDK_HealthCheck_TrailingSlashEndpoint(t *testing.T) {
-	ts := newHealthTestServer(t, []string{"kas"}, nil)
+func TestSDK_IsHealthy_TrailingSlashEndpoint(t *testing.T) {
+	ts := newHealthTestServer(t, true)
 	defer ts.Close()
 
 	s, err := sdk.New(ts.URL+"/",
@@ -506,7 +485,7 @@ func TestSDK_HealthCheck_TrailingSlashEndpoint(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	status, err := s.HealthCheck(ctx, "kas")
+	healthy, err := s.IsHealthy(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, sdk.HealthStatusServing, status)
+	assert.True(t, healthy)
 }

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -325,13 +325,11 @@ func TestErrHealthCheckUnsupported_Distinct(t *testing.T) {
 }
 
 // newHealthTestServer starts an httptest.Server serving grpc.health.v1.Health with the
-// configured serving status for the empty service name (the SDK's reachability probe).
-func newHealthTestServer(t *testing.T, serving bool) *httptest.Server {
+// configured status for the empty service name (the SDK's reachability probe).
+func newHealthTestServer(t *testing.T, status grpchealth.Status) *httptest.Server {
 	t.Helper()
 	checker := grpchealth.NewStaticChecker()
-	if !serving {
-		checker.SetStatus("", grpchealth.StatusNotServing)
-	}
+	checker.SetStatus("", status)
 	mux := http.NewServeMux()
 	path, handler := grpchealth.NewHandler(checker)
 	mux.Handle(path, handler)
@@ -416,7 +414,7 @@ func TestSDK_IsHealthy_ContextCanceled_ReturnsQuickly(t *testing.T) {
 }
 
 func TestSDK_IsHealthy_Serving(t *testing.T) {
-	ts := newHealthTestServer(t, true)
+	ts := newHealthTestServer(t, grpchealth.StatusServing)
 	defer ts.Close()
 
 	s, err := sdk.New(ts.URL,
@@ -440,7 +438,33 @@ func TestSDK_IsHealthy_Serving(t *testing.T) {
 }
 
 func TestSDK_IsHealthy_NotServing(t *testing.T) {
-	ts := newHealthTestServer(t, false)
+	ts := newHealthTestServer(t, grpchealth.StatusNotServing)
+	defer ts.Close()
+
+	s, err := sdk.New(ts.URL,
+		sdk.WithPlatformConfiguration(sdk.PlatformConfiguration{
+			"idp": map[string]interface{}{
+				"issuer":                 "https://example.org",
+				"authorization_endpoint": "https://example.org/auth",
+				"token_endpoint":         "https://example.org/token",
+			},
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	healthy, err := s.IsHealthy(ctx)
+	require.NoError(t, err)
+	assert.False(t, healthy)
+}
+
+// TestSDK_IsHealthy_Unknown locks the contract that an UNKNOWN status from a reachable
+// platform returns (false, nil) — distinct from transport errors which wrap ErrPlatformUnreachable.
+func TestSDK_IsHealthy_Unknown(t *testing.T) {
+	ts := newHealthTestServer(t, grpchealth.StatusUnknown)
 	defer ts.Close()
 
 	s, err := sdk.New(ts.URL,
@@ -467,7 +491,7 @@ func TestSDK_IsHealthy_NotServing(t *testing.T) {
 // with a trailing slash does not produce a double-slash in the request URL,
 // which strict HTTP routers can reject.
 func TestSDK_IsHealthy_TrailingSlashEndpoint(t *testing.T) {
-	ts := newHealthTestServer(t, true)
+	ts := newHealthTestServer(t, grpchealth.StatusServing)
 	defer ts.Close()
 
 	s, err := sdk.New(ts.URL+"/",

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -2,10 +2,15 @@ package sdk_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
+	"connectrpc.com/grpchealth"
 	"github.com/opentdf/platform/protocol/go/policy/attributes/attributesconnect"
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry/kasregistryconnect"
 	"github.com/opentdf/platform/protocol/go/policy/resourcemapping/resourcemappingconnect"
@@ -335,4 +340,146 @@ func TestHealthStatus_String(t *testing.T) {
 func TestErrHealthCheckUnsupported_Distinct(t *testing.T) {
 	assert.NotEqual(t, sdk.ErrHealthCheckUnsupported, sdk.ErrPlatformUnreachable)
 	assert.Equal(t, "health check not supported in IPC mode", sdk.ErrHealthCheckUnsupported.Error())
+}
+
+// newHealthTestServer starts an httptest.Server serving grpc.health.v1.Health.
+// serving is the set of service names that should report SERVING; notServing is the set
+// that should report NOT_SERVING. Any service name not in either set causes
+// grpchealth.StaticChecker to return a Connect not_found error, which SDK.HealthCheck
+// maps to HealthStatusUnknown.
+// The empty service name ("") reports SERVING regardless (StaticChecker default).
+func newHealthTestServer(t *testing.T, serving, notServing []string) *httptest.Server {
+	t.Helper()
+	all := append([]string{}, serving...)
+	all = append(all, notServing...)
+	checker := grpchealth.NewStaticChecker(all...)
+	for _, svc := range notServing {
+		checker.SetStatus(svc, grpchealth.StatusNotServing)
+	}
+	mux := http.NewServeMux()
+	path, handler := grpchealth.NewHandler(checker)
+	mux.Handle(path, handler)
+	return httptest.NewServer(mux)
+}
+
+func TestSDK_HealthCheck_IPCMode_ReturnsErrHealthCheckUnsupported(t *testing.T) {
+	// IPC mode requires a coreConn; provide a dummy one to satisfy sdk.New.
+	dummyConn := &sdk.ConnectRPCConnection{
+		Endpoint: "http://localhost:0",
+		Client:   http.DefaultClient,
+	}
+	s, err := sdk.New("",
+		sdk.WithIPC(),
+		sdk.WithCustomCoreConnection(dummyConn),
+		sdk.WithPlatformConfiguration(sdk.PlatformConfiguration{
+			"idp": map[string]interface{}{
+				"issuer":                 "https://example.org",
+				"authorization_endpoint": "https://example.org/auth",
+				"token_endpoint":         "https://example.org/token",
+			},
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	ctx := context.Background()
+	status, err := s.HealthCheck(ctx, "")
+	assert.Equal(t, sdk.HealthStatusUnknown, status)
+	require.ErrorIs(t, err, sdk.ErrHealthCheckUnsupported)
+}
+
+func TestSDK_HealthCheck_Unreachable_ReturnsErrPlatformUnreachable(t *testing.T) {
+	s, err := sdk.New(badPlatformEndpoint,
+		sdk.WithPlatformConfiguration(sdk.PlatformConfiguration{
+			"idp": map[string]interface{}{
+				"issuer":                 "https://example.org",
+				"authorization_endpoint": "https://example.org/auth",
+				"token_endpoint":         "https://example.org/token",
+			},
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	status, err := s.HealthCheck(ctx, "")
+	elapsed := time.Since(start)
+
+	assert.Equal(t, sdk.HealthStatusUnknown, status)
+	require.ErrorIs(t, err, sdk.ErrPlatformUnreachable)
+	assert.Less(t, elapsed, 2*time.Second, "health check should return promptly against a closed port, not wait for the ctx deadline")
+}
+
+func TestSDK_HealthCheck_ContextCanceled_ReturnsQuickly(t *testing.T) {
+	s, err := sdk.New(badPlatformEndpoint,
+		sdk.WithPlatformConfiguration(sdk.PlatformConfiguration{
+			"idp": map[string]interface{}{
+				"issuer":                 "https://example.org",
+				"authorization_endpoint": "https://example.org/auth",
+				"token_endpoint":         "https://example.org/token",
+			},
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled before the call
+
+	start := time.Now()
+	status, err := s.HealthCheck(ctx, "")
+	elapsed := time.Since(start)
+
+	assert.Equal(t, sdk.HealthStatusUnknown, status)
+	require.Error(t, err)
+	require.ErrorIs(t, err, sdk.ErrPlatformUnreachable)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, 500*time.Millisecond, "pre-canceled ctx should short-circuit")
+}
+
+func TestSDK_HealthCheck_Serving_HappyPath(t *testing.T) {
+	ts := newHealthTestServer(t, []string{"kas"}, []string{"broken"})
+	defer ts.Close()
+
+	s, err := sdk.New(ts.URL,
+		sdk.WithPlatformConfiguration(sdk.PlatformConfiguration{
+			"idp": map[string]interface{}{
+				"issuer":                 "https://example.org",
+				"authorization_endpoint": "https://example.org/auth",
+				"token_endpoint":         "https://example.org/token",
+			},
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	t.Run("empty service returns SERVING", func(t *testing.T) {
+		status, err := s.HealthCheck(ctx, "")
+		require.NoError(t, err)
+		assert.Equal(t, sdk.HealthStatusServing, status)
+	})
+
+	t.Run("named serving service returns SERVING", func(t *testing.T) {
+		status, err := s.HealthCheck(ctx, "kas")
+		require.NoError(t, err)
+		assert.Equal(t, sdk.HealthStatusServing, status)
+	})
+
+	t.Run("named not-serving service returns NOT_SERVING", func(t *testing.T) {
+		status, err := s.HealthCheck(ctx, "broken")
+		require.NoError(t, err)
+		assert.Equal(t, sdk.HealthStatusNotServing, status)
+	})
+
+	t.Run("unknown service returns UNKNOWN", func(t *testing.T) {
+		status, err := s.HealthCheck(ctx, "does-not-exist")
+		require.NoError(t, err)
+		assert.Equal(t, sdk.HealthStatusUnknown, status)
+	})
 }

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -313,3 +313,26 @@ func Test_GetType_Invalid2Bytes(t *testing.T) {
 
 	assert.Equal(t, sdk.Invalid, tdfType)
 }
+
+func TestHealthStatus_String(t *testing.T) {
+	tests := []struct {
+		name   string
+		status sdk.HealthStatus
+		want   string
+	}{
+		{"unknown", sdk.HealthStatusUnknown, "UNKNOWN"},
+		{"serving", sdk.HealthStatusServing, "SERVING"},
+		{"not_serving", sdk.HealthStatusNotServing, "NOT_SERVING"},
+		{"out_of_range", sdk.HealthStatus(99), "UNKNOWN"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.status.String())
+		})
+	}
+}
+
+func TestErrHealthCheckUnsupported_Distinct(t *testing.T) {
+	assert.NotEqual(t, sdk.ErrHealthCheckUnsupported, sdk.ErrPlatformUnreachable)
+	assert.Equal(t, "health check not supported in IPC mode", sdk.ErrHealthCheckUnsupported.Error())
+}


### PR DESCRIPTION
## Summary

Adds a public `SDK.IsHealthy(ctx) (bool, error)` method so downstream services (data-harbor and others) can run readiness probes through the SDK instead of open-coding `http.Client.Get(healthzEndpoint)` — which has no context propagation, bleeds timeout configuration into unrelated RPCs, and bypasses OTEL/auth/audit interceptors.

## Background

Takeover of #3379 by @pflynn-virtru. Paul's original 5 commits are preserved on this branch (`feat(sdk): add HealthStatus type` → `refactor(sdk): use url.JoinPath`); a final `refactor(sdk): simplify HealthCheck to IsHealthy(ctx) per review` commit collapses the API per @strantalis' [review feedback](https://github.com/opentdf/platform/pull/3379#discussion_r3149087433).

### What changed from #3379

| Before (#3379) | After (this PR) |
|---|---|
| `HealthCheck(ctx, service string) (HealthStatus, error)` | `IsHealthy(ctx) (bool, error)` |
| 3 exported `HealthStatus*` constants + `String()` method | (removed — idiomatic `(bool, error)` predicate) |
| `service` arg with `""` / `"all"` / per-service semantics | (removed — always uses `""` reachability probe) |

Retained:
- `ErrHealthCheckUnsupported` for IPC mode (distinct from `ErrPlatformUnreachable`)
- The `url.JoinPath` fix (gemini-code-assist suggestion, applied in #3379)
- All ctx / OTEL / interceptor behavior

### Behavior

- `(true, nil)` — platform reports SERVING
- `(false, nil)` — reachable but NOT_SERVING / UNKNOWN
- `(false, ErrHealthCheckUnsupported)` — SDK is in IPC mode
- `(false, err)` wrapping `ErrPlatformUnreachable` — transport / ctx errors

Honors `ctx` for deadline, cancellation, and OTEL trace-context propagation. OTEL works automatically when `otelconnect.NewInterceptor` is registered via `WithExtraClientOptions` at SDK construction.

## Test plan

- [x] `go test ./sdk/...` — all pass
- [x] `golangci-lint run` — clean on changed files (`sdk/sdk.go`, `sdk/sdk_test.go`, `sdk/options.go`)
- [x] `go test -run TestREADMECodeBlocks` — pass
- [x] All commits DCO + SSH signed

Tests cover: IPC mode, unreachable platform, pre-canceled ctx, SERVING happy path, NOT_SERVING, trailing-slash endpoint regression.

## Replaces

Replaces #3379. Will close that PR once this one is approved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to check platform reachability at runtime, with support for context deadlines and cancellation to enable flexible health verification.

* **Documentation**
  * Updated connection validation documentation to clarify construction-time validation and direct users to the new runtime health check capability for ongoing reachability monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->