### PR TITLE
fix(ci): DSPX-3086 Updates checks.yaml xtest to prefer in-repo otdfctl

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -492,6 +492,7 @@ jobs:
     uses: opentdf/tests/.github/workflows/xtest.yml@main
     with:
       focus-sdk: go
+      otdfctl-source: platform
       # use commit instead of ref so we can "go get" specific sdk version
       platform-ref: ${{ github.event.pull_request.head.sha || github.sha }} lts
 


### PR DESCRIPTION

### Proposed Changes

* Add 'otdfctl-source' input to xtest workflow.
* This will update future calls to use otdfctl within this repo by default

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->