### PR TITLE
fix(core): infer JWT algorithms for JWKS keys without alg

### DIFF
--- a/service/internal/auth/token_verifier.go
+++ b/service/internal/auth/token_verifier.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 
 	"github.com/opentdf/platform/service/logger"
@@ -89,7 +90,7 @@ func (v *TokenVerifier) VerifyAccessToken(ctx context.Context, tokenRaw string) 
 	}
 
 	token, err := jwt.Parse([]byte(tokenRaw),
-		jwt.WithKeySet(v.cachedKeySet),
+		jwt.WithKeySet(v.cachedKeySet, jws.WithInferAlgorithmFromKey(true)),
 		jwt.WithValidate(true),
 		jwt.WithIssuer(v.oidcConfiguration.Issuer),
 		jwt.WithAudience(v.oidcConfiguration.Audience),

--- a/service/internal/auth/token_verifier_test.go
+++ b/service/internal/auth/token_verifier_test.go
@@ -25,10 +25,14 @@ type tokenVerifierFixture struct {
 }
 
 func newTokenVerifierFixture(t *testing.T) *tokenVerifierFixture {
-	return newTokenVerifierFixtureWithOptions(t, true)
+	return newTokenVerifierFixtureWithPublicKeyAlgorithm(t, true)
 }
 
-func newTokenVerifierFixtureWithOptions(t *testing.T, includeAlgorithm bool) *tokenVerifierFixture {
+func newTokenVerifierFixtureWithoutPublicKeyAlgorithm(t *testing.T) *tokenVerifierFixture {
+	return newTokenVerifierFixtureWithPublicKeyAlgorithm(t, false)
+}
+
+func newTokenVerifierFixtureWithPublicKeyAlgorithm(t *testing.T, includeAlgorithm bool) *tokenVerifierFixture {
 	t.Helper()
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -157,7 +161,7 @@ func TestTokenVerifier_VerifyAccessToken(t *testing.T) {
 	})
 
 	t.Run("valid token with JWKS key missing alg", func(t *testing.T) {
-		missingAlgFixture := newTokenVerifierFixtureWithOptions(t, false)
+		missingAlgFixture := newTokenVerifierFixtureWithoutPublicKeyAlgorithm(t)
 
 		missingAlgVerifier, err := NewTokenVerifier(t.Context(), AuthNConfig{
 			Issuer:       missingAlgFixture.server.URL,

--- a/service/internal/auth/token_verifier_test.go
+++ b/service/internal/auth/token_verifier_test.go
@@ -33,6 +33,9 @@ func newTokenVerifierFixture(t *testing.T) *tokenVerifierFixture {
 
 func newTokenVerifierFixtureWithoutPublicKeyAlgorithm(t *testing.T) *tokenVerifierFixture {
 	privateKey, publicKeyJWK := newTokenVerifierKeyPair(t)
+	require.NoError(t, publicKeyJWK.Remove(jwk.AlgorithmKey))
+	_, hasAlgorithm := publicKeyJWK.Get(jwk.AlgorithmKey)
+	require.False(t, hasAlgorithm)
 
 	return newTokenVerifierFixtureWithPublicKey(t, privateKey, publicKeyJWK)
 }

--- a/service/internal/auth/token_verifier_test.go
+++ b/service/internal/auth/token_verifier_test.go
@@ -25,6 +25,10 @@ type tokenVerifierFixture struct {
 }
 
 func newTokenVerifierFixture(t *testing.T) *tokenVerifierFixture {
+	return newTokenVerifierFixtureWithOptions(t, true)
+}
+
+func newTokenVerifierFixtureWithOptions(t *testing.T, includeAlgorithm bool) *tokenVerifierFixture {
 	t.Helper()
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -33,7 +37,9 @@ func newTokenVerifierFixture(t *testing.T) *tokenVerifierFixture {
 	publicKeyJWK, err := jwk.FromRaw(privateKey.PublicKey)
 	require.NoError(t, err)
 	require.NoError(t, publicKeyJWK.Set(jws.KeyIDKey, "test-key"))
-	require.NoError(t, publicKeyJWK.Set(jwk.AlgorithmKey, jwa.RS256))
+	if includeAlgorithm {
+		require.NoError(t, publicKeyJWK.Set(jwk.AlgorithmKey, jwa.RS256))
+	}
 
 	keySet := jwk.NewSet()
 	require.NoError(t, keySet.AddKey(publicKeyJWK))
@@ -148,6 +154,24 @@ func TestTokenVerifier_VerifyAccessToken(t *testing.T) {
 
 		_, err = verifier.VerifyAccessToken(t.Context(), token)
 		require.Error(t, err)
+	})
+
+	t.Run("valid token with JWKS key missing alg", func(t *testing.T) {
+		missingAlgFixture := newTokenVerifierFixtureWithOptions(t, false)
+
+		missingAlgVerifier, err := NewTokenVerifier(t.Context(), AuthNConfig{
+			Issuer:       missingAlgFixture.server.URL,
+			Audience:     "test-audience",
+			CacheRefresh: "15m",
+			TokenSkew:    time.Minute,
+		}, logger.CreateTestLogger())
+		require.NoError(t, err)
+
+		token := missingAlgFixture.signToken(t, missingAlgFixture.server.URL, "test-audience", missingAlgFixture.privateKey)
+
+		verifiedToken, err := missingAlgVerifier.VerifyAccessToken(t.Context(), token)
+		require.NoError(t, err)
+		assert.Equal(t, "user-123", verifiedToken.Subject())
 	})
 }
 

--- a/service/internal/auth/token_verifier_test.go
+++ b/service/internal/auth/token_verifier_test.go
@@ -25,14 +25,19 @@ type tokenVerifierFixture struct {
 }
 
 func newTokenVerifierFixture(t *testing.T) *tokenVerifierFixture {
-	return newTokenVerifierFixtureWithPublicKeyAlgorithm(t, true)
+	privateKey, publicKeyJWK := newTokenVerifierKeyPair(t)
+	require.NoError(t, publicKeyJWK.Set(jwk.AlgorithmKey, jwa.RS256))
+
+	return newTokenVerifierFixtureWithPublicKey(t, privateKey, publicKeyJWK)
 }
 
 func newTokenVerifierFixtureWithoutPublicKeyAlgorithm(t *testing.T) *tokenVerifierFixture {
-	return newTokenVerifierFixtureWithPublicKeyAlgorithm(t, false)
+	privateKey, publicKeyJWK := newTokenVerifierKeyPair(t)
+
+	return newTokenVerifierFixtureWithPublicKey(t, privateKey, publicKeyJWK)
 }
 
-func newTokenVerifierFixtureWithPublicKeyAlgorithm(t *testing.T, includeAlgorithm bool) *tokenVerifierFixture {
+func newTokenVerifierKeyPair(t *testing.T) (*rsa.PrivateKey, jwk.Key) {
 	t.Helper()
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -41,9 +46,12 @@ func newTokenVerifierFixtureWithPublicKeyAlgorithm(t *testing.T, includeAlgorith
 	publicKeyJWK, err := jwk.FromRaw(privateKey.PublicKey)
 	require.NoError(t, err)
 	require.NoError(t, publicKeyJWK.Set(jws.KeyIDKey, "test-key"))
-	if includeAlgorithm {
-		require.NoError(t, publicKeyJWK.Set(jwk.AlgorithmKey, jwa.RS256))
-	}
+
+	return privateKey, publicKeyJWK
+}
+
+func newTokenVerifierFixtureWithPublicKey(t *testing.T, privateKey *rsa.PrivateKey, publicKeyJWK jwk.Key) *tokenVerifierFixture {
+	t.Helper()
 
 	keySet := jwk.NewSet()
 	require.NoError(t, keySet.AddKey(publicKeyJWK))


### PR DESCRIPTION
## Summary
- Fix JWT verification for IdPs whose JWKS keys omit `alg`, such as Microsoft Entra.
- Pass `jws.WithInferAlgorithmFromKey(true)` to `jwt.WithKeySet` while preserving issuer, audience, skew, kid, and signature validation.
- Add regression coverage for a JWKS key with `kid` but no `alg`.

## Jira
- DSPX-3172

## Testing
- `~/go/bin/gofumpt -w service/internal/auth/token_verifier.go service/internal/auth/token_verifier_test.go`
- `cd service && go test ./internal/auth -run 'TestTokenVerifier|TestNewTokenVerifier' -v`
- `cd service && go test ./internal/auth`
- `cd service && golangci-lint run --new ./internal/auth`

## Known Existing Failures
- `cd service && golangci-lint run ./internal/auth` fails on pre-existing unused `//nolint` directives in `authn.go`.
- `make test` fails in `lib/fixtures` on `TestTokenManager_InitialLogin` and `TestTokenManager_CustomTokenBuffer`, unrelated to this auth verifier change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JWT verification now infers the signing algorithm from the verification key, allowing token authentication to succeed when JWKS keys omit an explicit algorithm, improving robustness and interoperability.

* **Tests**
  * Added coverage for tokens validated against JWKS entries that do not include an alg field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->