### PR TITLE
fix(cli): support json profile output

### DIFF
--- a/otdfctl/cmd/profile.go
+++ b/otdfctl/cmd/profile.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 
@@ -25,6 +26,25 @@ const (
 		" delete the specific profile from either the filesystem or keyring and run the migration again." +
 		" If that still doesn't work, you can remove all profiles from the filesystem via the `delete-all` command."
 )
+
+type profileListOutput struct {
+	Store    string           `json:"store"`
+	Profiles []profileSummary `json:"profiles"`
+}
+
+type profileSummary struct {
+	Name      string `json:"name"`
+	IsDefault bool   `json:"is_default"`
+}
+
+type profileGetOutput struct {
+	Profile      string `json:"profile"`
+	Endpoint     string `json:"endpoint"`
+	IsDefault    bool   `json:"is_default"`
+	OutputFormat string `json:"output_format"`
+	AuthType     string `json:"auth_type,omitempty"`
+	ClientID     string `json:"client_id,omitempty"`
+}
 
 func newProfilerFromCLI(c *cli.Cli) *osprofiles.Profiler {
 	driverType := getDriverTypeFromUser(c)
@@ -104,7 +124,13 @@ var profileListCmd = &cobra.Command{
 		var sb strings.Builder
 		fmt.Fprintf(&sb, "Listing profiles from %s\n", driverType)
 
+		out := profileListOutput{Store: string(driverType)}
 		for _, p := range osprofiles.ListProfiles(profiler) {
+			isDefault := p == defaultProfile
+			out.Profiles = append(out.Profiles, profileSummary{
+				Name:      p,
+				IsDefault: isDefault,
+			})
 			if p == defaultProfile {
 				fmt.Fprintf(&sb, "* %s\n", p)
 				continue
@@ -112,7 +138,7 @@ var profileListCmd = &cobra.Command{
 			fmt.Fprintf(&sb, "  %s\n", p)
 		}
 
-		c.ExitWithMessage(sb.String(), cli.ExitCodeSuccess)
+		c.ExitWith(sb.String(), out, cli.ExitCodeSuccess, os.Stdout)
 	},
 }
 
@@ -130,27 +156,39 @@ var profileGetCmd = &cobra.Command{
 			cli.ExitWithError("Error loading profile store for profile "+profileName, err)
 		}
 
-		isDefault := "false"
+		isDefault := profileStore.IsDefault()
+		isDefaultString := "false"
 		if profileStore.IsDefault() {
-			isDefault = "true"
+			isDefaultString = "true"
 		}
 
 		var auth string
+		authType := ""
+		clientID := ""
 		ac := profileStore.GetAuthCredentials()
 		if ac.AuthType == profiles.AuthTypeClientCredentials {
 			maskedSecret := "********"
 			auth = "client-credentials (" + ac.ClientID + ", " + maskedSecret + ")"
+			authType = ac.AuthType
+			clientID = ac.ClientID
 		}
 
 		t := cli.NewTabular(
 			[]string{"Profile", profileStore.Name()},
 			[]string{"Endpoint", profileStore.GetEndpoint()},
-			[]string{"Is default", isDefault},
+			[]string{"Is default", isDefaultString},
 			[]string{"Output format", profileStore.GetOutputFormat()},
 			[]string{"Auth type", auth},
 		)
 
-		c.ExitWithMessage(t.View(), cli.ExitCodeSuccess)
+		c.ExitWith(t.View(), profileGetOutput{
+			Profile:      profileStore.Name(),
+			Endpoint:     profileStore.GetEndpoint(),
+			IsDefault:    isDefault,
+			OutputFormat: profileStore.GetOutputFormat(),
+			AuthType:     authType,
+			ClientID:     clientID,
+		}, cli.ExitCodeSuccess, os.Stdout)
 	},
 }
 

--- a/otdfctl/cmd/profile.go
+++ b/otdfctl/cmd/profile.go
@@ -124,7 +124,10 @@ var profileListCmd = &cobra.Command{
 		var sb strings.Builder
 		fmt.Fprintf(&sb, "Listing profiles from %s\n", driverType)
 
-		out := profileListOutput{Store: string(driverType)}
+		out := profileListOutput{
+			Store:    string(driverType),
+			Profiles: []profileSummary{},
+		}
 		for _, p := range osprofiles.ListProfiles(profiler) {
 			isDefault := p == defaultProfile
 			out.Profiles = append(out.Profiles, profileSummary{

--- a/otdfctl/cmd/profile.go
+++ b/otdfctl/cmd/profile.go
@@ -134,7 +134,7 @@ var profileListCmd = &cobra.Command{
 				Name:      p,
 				IsDefault: isDefault,
 			})
-			if p == defaultProfile {
+			if isDefault {
 				fmt.Fprintf(&sb, "* %s\n", p)
 				continue
 			}
@@ -161,7 +161,7 @@ var profileGetCmd = &cobra.Command{
 
 		isDefault := profileStore.IsDefault()
 		isDefaultString := "false"
-		if profileStore.IsDefault() {
+		if isDefault {
 			isDefaultString = "true"
 		}
 

--- a/otdfctl/cmd/profile.go
+++ b/otdfctl/cmd/profile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 
 	osprofiles "github.com/jrschumacher/go-osprofiles"
@@ -160,10 +161,6 @@ var profileGetCmd = &cobra.Command{
 		}
 
 		isDefault := profileStore.IsDefault()
-		isDefaultString := "false"
-		if isDefault {
-			isDefaultString = "true"
-		}
 
 		var auth string
 		authType := ""
@@ -179,7 +176,7 @@ var profileGetCmd = &cobra.Command{
 		t := cli.NewTabular(
 			[]string{"Profile", profileStore.Name()},
 			[]string{"Endpoint", profileStore.GetEndpoint()},
-			[]string{"Is default", isDefaultString},
+			[]string{"Is default", strconv.FormatBool(isDefault)},
 			[]string{"Output format", profileStore.GetOutputFormat()},
 			[]string{"Auth type", auth},
 		)

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -572,7 +572,8 @@ format_kas_name_as_uri() {
 @test "kas-keys: update key (missing id)" {
   run_otdfctl_key update --json
   assert_failure
-  assert_output --partial "ERROR    Flag '--id' is required"
+  assert_equal "$(echo "$output" | jq -r .status)" "ERROR"
+  assert_equal "$(echo "$output" | jq -r .message)" "Flag '--id' is required"
 }
 
 # LIST Tests

--- a/otdfctl/e2e/profile.bats
+++ b/otdfctl/e2e/profile.bats
@@ -139,6 +139,37 @@ teardown() {
   refute_output --partial "$target_profile_keyring"
 }
 
+@test "profile list supports json output" {
+  profile1="${PROFILE_TEST_PREFIX}-list-json-1"
+  profile2="${PROFILE_TEST_PREFIX}-list-json-2"
+
+  run_otdfctl create "$profile1" http://localhost:8080
+  assert_success
+
+  run_otdfctl create "$profile2" http://localhost:8080 --set-default
+  assert_success
+
+  run bash -c "set -o pipefail; ./otdfctl profile list --json | jq -e --arg profile1 '$profile1' --arg profile2 '$profile2' '.store == \"filesystem\" and any(.profiles[]; .name == \$profile1 and .is_default == false) and any(.profiles[]; .name == \$profile2 and .is_default == true)'"
+  assert_success
+}
+
+@test "profile get supports json output" {
+  profile="${PROFILE_TEST_PREFIX}-get-json"
+
+  run_otdfctl create "$profile" http://localhost:8080 --set-default --output-format json
+  assert_success
+
+  run bash -c "set -o pipefail; ./otdfctl profile get '$profile' --json | jq -e --arg profile '$profile' '.profile == \$profile and .endpoint == \"http://localhost:8080\" and .is_default == true and .output_format == \"json\"'"
+  assert_success
+}
+
+@test "profile errors support json output" {
+  profile="${PROFILE_TEST_PREFIX}-missing-json"
+
+  run bash -c "output=\$(./otdfctl profile get '$profile' --json 2>&1 >/dev/null); status=\$?; test \$status -ne 0 && jq -e --arg profile '$profile' '.status == \"ERROR\" and (.message | contains(\$profile))' <<< \"\$output\""
+  assert_success
+}
+
 @test "profile set-default updates default profile" {
   base="${PROFILE_TEST_PREFIX}-set-default"
   profile1="${base}-1"

--- a/otdfctl/e2e/profile.bats
+++ b/otdfctl/e2e/profile.bats
@@ -149,8 +149,11 @@ teardown() {
   run_otdfctl create "$profile2" http://localhost:8080 --set-default
   assert_success
 
-  run bash -c "set -o pipefail; ./otdfctl profile list --json | jq -e --arg profile1 '$profile1' --arg profile2 '$profile2' '.store == \"filesystem\" and any(.profiles[]; .name == \$profile1 and .is_default == false) and any(.profiles[]; .name == \$profile2 and .is_default == true)'"
+  run_otdfctl list --json
   assert_success
+  assert_equal "$(echo "$output" | jq -r .store)" "filesystem"
+  echo "$output" | jq -e --arg profile1 "$profile1" --arg profile2 "$profile2" \
+    'any(.profiles[]; .name == $profile1 and .is_default == false) and any(.profiles[]; .name == $profile2 and .is_default == true)'
 }
 
 @test "profile get supports json output" {
@@ -159,15 +162,21 @@ teardown() {
   run_otdfctl create "$profile" http://localhost:8080 --set-default --output-format json
   assert_success
 
-  run bash -c "set -o pipefail; ./otdfctl profile get '$profile' --json | jq -e --arg profile '$profile' '.profile == \$profile and .endpoint == \"http://localhost:8080\" and .is_default == true and .output_format == \"json\"'"
+  run_otdfctl get "$profile" --json
   assert_success
+  assert_equal "$(echo "$output" | jq -r .profile)" "$profile"
+  assert_equal "$(echo "$output" | jq -r .endpoint)" "http://localhost:8080"
+  assert_equal "$(echo "$output" | jq -r .is_default)" "true"
+  assert_equal "$(echo "$output" | jq -r .output_format)" "json"
 }
 
 @test "profile errors support json output" {
   profile="${PROFILE_TEST_PREFIX}-missing-json"
 
-  run bash -c "output=\$(./otdfctl profile get '$profile' --json 2>&1 >/dev/null); status=\$?; test \$status -ne 0 && jq -e --arg profile '$profile' '.status == \"ERROR\" and (.message | contains(\$profile))' <<< \"\$output\""
-  assert_success
+  run_otdfctl get "$profile" --json
+  assert_failure
+  assert_equal "$(echo "$output" | jq -r .status)" "ERROR"
+  echo "$output" | jq -e --arg profile "$profile" '.message | contains($profile)'
 }
 
 @test "profile set-default updates default profile" {

--- a/otdfctl/pkg/cli/cli.go
+++ b/otdfctl/pkg/cli/cli.go
@@ -38,10 +38,7 @@ func New(cmd *cobra.Command, args []string, options ...cliVariadicOption) *Cli {
 	// Temp wrapper for FlagHelper until we can remove it
 	cli.FlagHelper = cli.Flags
 
-	cli.printer = newPrinter(cli)
-	if opts.printerJSON {
-		cli.printer.setJSON(true)
-	}
+	cli.printer = newPrinter(opts.printerJSON || cli.Flags.GetOptionalBool("json"))
 
 	return cli
 }

--- a/otdfctl/pkg/cli/errors.go
+++ b/otdfctl/pkg/cli/errors.go
@@ -58,10 +58,14 @@ func (c *Cli) ExitWithSuccess(msg string) {
 }
 
 func (c *Cli) ExitWithMessage(msg string, code int) {
+	w := os.Stdout
+	if code != ExitCodeSuccess {
+		w = os.Stderr
+	}
 	if c.printer.json {
-		c.printJSON(MessageJSON(statusForExitCode(code), strings.TrimSpace(msg)), os.Stdout)
+		c.printJSON(MessageJSON(statusForExitCode(code), strings.TrimSpace(msg)), w)
 	} else {
-		c.println(os.Stdout, msg)
+		c.println(w, msg)
 	}
 	os.Exit(code)
 }

--- a/otdfctl/pkg/cli/errors.go
+++ b/otdfctl/pkg/cli/errors.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"io"
 	"os"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -15,17 +16,17 @@ const (
 
 func ExitWithError(errMsg string, err error) {
 	// This is temporary until we can refactor the code to use the Cli struct
-	(&Cli{printer: &Printer{enabled: true}}).ExitWithError(errMsg, err)
+	(&Cli{printer: defaultPrinter()}).ExitWithError(errMsg, err)
 }
 
 func ExitWithNotFoundError(errMsg string, err error) {
 	// This is temporary until we can refactor the code to use the Cli struct
-	(&Cli{printer: &Printer{enabled: true}}).ExitWithNotFoundError(errMsg, err)
+	(&Cli{printer: defaultPrinter()}).ExitWithNotFoundError(errMsg, err)
 }
 
 func ExitWithWarning(warnMsg string) {
 	// This is temporary until we can refactor the code to use the Cli struct
-	(&Cli{printer: &Printer{enabled: true}}).ExitWithWarning(warnMsg)
+	(&Cli{printer: defaultPrinter()}).ExitWithWarning(warnMsg)
 }
 
 // ExitWithError prints an error message and exits with a non-zero status code.
@@ -57,10 +58,12 @@ func (c *Cli) ExitWithSuccess(msg string) {
 }
 
 func (c *Cli) ExitWithMessage(msg string, code int) {
-	if c.printer.enabled {
+	if c.printer.json {
+		c.printJSON(MessageJSON(statusForExitCode(code), strings.TrimSpace(msg)), os.Stdout)
+	} else {
 		c.println(os.Stdout, msg)
-		os.Exit(code)
 	}
+	os.Exit(code)
 }
 
 func (c *Cli) ExitWithJSON(v interface{}, code int) {
@@ -79,4 +82,11 @@ func (c *Cli) ExitWith(styledMsg string, jsonMsg interface{}, code int, w io.Wri
 		c.println(w, styledMsg)
 	}
 	os.Exit(code)
+}
+
+func statusForExitCode(code int) string {
+	if code == ExitCodeSuccess {
+		return "SUCCESS"
+	}
+	return "ERROR"
 }

--- a/otdfctl/pkg/cli/printer.go
+++ b/otdfctl/pkg/cli/printer.go
@@ -5,9 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 )
 
 var ErrPrinterExpectsCommand = errors.New("printer expects a command")
+
+var defaultJSONOutput atomic.Bool
 
 type Printer struct {
 	enabled bool
@@ -32,6 +35,7 @@ func newPrinter(cli *Cli) *Printer {
 func (p *Printer) setJSON(json bool) {
 	p.json = json
 	p.enabled = !json
+	defaultJSONOutput.Store(json)
 }
 
 // PrintJSON prints the given value as json
@@ -56,4 +60,12 @@ func (c *Cli) SetJSONOutput(enabled bool) {
 		return
 	}
 	c.printer.setJSON(enabled)
+}
+
+func defaultPrinter() *Printer {
+	json := defaultJSONOutput.Load()
+	return &Printer{
+		enabled: !json,
+		json:    json,
+	}
 }

--- a/otdfctl/pkg/cli/printer.go
+++ b/otdfctl/pkg/cli/printer.go
@@ -18,7 +18,7 @@ type Printer struct {
 	debug   bool
 }
 
-func newPrinter(cli *Cli) *Printer {
+func newPrinter(json bool) *Printer {
 	p := &Printer{
 		enabled: true,
 		json:    false,
@@ -26,8 +26,8 @@ func newPrinter(cli *Cli) *Printer {
 	}
 
 	// if json output is enabled, disable the printer
-	printJSON := cli.Flags.GetOptionalBool("json")
-	p.setJSON(printJSON)
+	defaultJSONOutput.Store(json)
+	p.setJSON(json)
 
 	return p
 }
@@ -35,7 +35,6 @@ func newPrinter(cli *Cli) *Printer {
 func (p *Printer) setJSON(json bool) {
 	p.json = json
 	p.enabled = !json
-	defaultJSONOutput.Store(json)
 }
 
 // PrintJSON prints the given value as json


### PR DESCRIPTION
## Summary
- add structured JSON output for profile list/get
- make generic message exits emit JSON when --json is active
- preserve JSON mode for legacy package-level CLI error helpers

Inspired by: https://trevinsays.com/p/10-principles-for-agent-native-clis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON output support for `profile list` and `profile get` commands via `--json` flag
  * Profile commands now return structured data including store location, endpoint, default status, and authentication details

* **Tests**
  * Added end-to-end test coverage for JSON output functionality across profile commands, including error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->