### PR TITLE
feat(cli): add sensitive flag annotation to DocFlag

### DIFF
--- a/otdfctl/cmd/policy/kasKeys.go
+++ b/otdfctl/cmd/policy/kasKeys.go
@@ -876,6 +876,7 @@ func initKASKeysCommands() {
 		createDoc.GetDocFlag("private-key-pem").Default,
 		createDoc.GetDocFlag("private-key-pem").Description,
 	)
+	createDoc.MarkSensitiveFlags()
 	injectLabelFlags(&createDoc.Command, false)
 
 	// Get Kas Key
@@ -994,6 +995,7 @@ func initKASKeysCommands() {
 		rotateDoc.GetDocFlag("private-key-pem").Default,
 		rotateDoc.GetDocFlag("private-key-pem").Description,
 	)
+	rotateDoc.MarkSensitiveFlags()
 	injectLabelFlags(&rotateDoc.Command, true)
 
 	// Import Kas Key
@@ -1048,6 +1050,7 @@ func initKASKeysCommands() {
 		importDoc.GetDocFlag("legacy").Default,
 		importDoc.GetDocFlag("legacy").Description,
 	)
+	importDoc.MarkSensitiveFlags()
 	injectLabelFlags(&importDoc.Command, false)
 
 	mappingsDoc := man.Docs.GetCommand("policy/kas-registry/key/list-mappings",

--- a/otdfctl/cmd/policy/kasKeys.go
+++ b/otdfctl/cmd/policy/kasKeys.go
@@ -876,8 +876,8 @@ func initKASKeysCommands() {
 		createDoc.GetDocFlag("private-key-pem").Default,
 		createDoc.GetDocFlag("private-key-pem").Description,
 	)
-	createDoc.MarkSensitiveFlags()
 	injectLabelFlags(&createDoc.Command, false)
+	createDoc.MarkSensitiveFlags()
 
 	// Get Kas Key
 	getDoc := man.Docs.GetCommand("policy/kas-registry/key/get",
@@ -995,8 +995,8 @@ func initKASKeysCommands() {
 		rotateDoc.GetDocFlag("private-key-pem").Default,
 		rotateDoc.GetDocFlag("private-key-pem").Description,
 	)
-	rotateDoc.MarkSensitiveFlags()
 	injectLabelFlags(&rotateDoc.Command, true)
+	rotateDoc.MarkSensitiveFlags()
 
 	// Import Kas Key
 	importDoc := man.Docs.GetCommand("policy/kas-registry/key/import",
@@ -1050,8 +1050,8 @@ func initKASKeysCommands() {
 		importDoc.GetDocFlag("legacy").Default,
 		importDoc.GetDocFlag("legacy").Description,
 	)
-	importDoc.MarkSensitiveFlags()
 	injectLabelFlags(&importDoc.Command, false)
+	importDoc.MarkSensitiveFlags()
 
 	mappingsDoc := man.Docs.GetCommand("policy/kas-registry/key/list-mappings",
 		man.WithRun(policyListKeyMappings),

--- a/otdfctl/docs/man/policy/kas-registry/key/create.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/create.md
@@ -23,8 +23,10 @@ command:
       description: Identifier related to the wrapping key. Its meaning depends on the `mode`. For `local` mode, it's a descriptive ID for the `wrappingKey` you provide. For `provider` or `remote` mode, it's the ID of the key within the external provider/system used for wrapping.
     - name: wrapping-key
       shorthand: w
+      sensitive: true
       description: The symmetric key material (AES cipher, hex encoded) used to wrap the generated private key. Primarily used when `mode` is `local`.
     - name: private-key-pem
+      sensitive: true
       description: The private key PEM (encrypted by an AES 32-byte key, then base64 encoded). Used when importing an existing key pair, typically with `provider` mode.
     - name: provider-config-id
       shorthand: p

--- a/otdfctl/docs/man/policy/kas-registry/key/import.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/import.md
@@ -20,9 +20,11 @@ command:
       required: true
     - name: wrapping-key
       shorthand: w
+      sensitive: true
       description: The symmetric key material (AES cipher, hex encoded) used to wrap the imported private key.
       required: true
     - name: private-key-pem
+      sensitive: true
       description: The base64 encoded private key PEM to import
       required: true
     - name: public-key-pem

--- a/otdfctl/docs/man/policy/kas-registry/key/rotate.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/rotate.md
@@ -30,8 +30,10 @@ command:
       description: Identifier related to the wrapping key. Its meaning depends on the `mode`. For `local` mode, it's a descriptive ID for the `wrappingKey` you provide. For `provider` or `remote` mode, it's the ID of the key within the external provider/system used for wrapping.
     - name: wrapping-key
       shorthand: w
+      sensitive: true
       description: The symmetric key material (AES cipher, base64 encoded) used to wrap the generated private key. Primarily used when `mode` is `local`.
     - name: private-key-pem
+      sensitive: true
       description: The private key PEM (encrypted by an AES 32-byte key, then base64 encoded). Used when importing an existing key pair, typically with `provider` mode.
     - name: provider-config-id
       shorthand: p

--- a/otdfctl/docs/man/policy/kas-registry/key/rotate.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/rotate.md
@@ -31,7 +31,7 @@ command:
     - name: wrapping-key
       shorthand: w
       sensitive: true
-      description: The symmetric key material (AES cipher, base64 encoded) used to wrap the generated private key. Primarily used when `mode` is `local`.
+      description: The symmetric key material (AES cipher, hex encoded) used to wrap the generated private key. Primarily used when `mode` is `local`.
     - name: private-key-pem
       sensitive: true
       description: The private key PEM (encrypted by an AES 32-byte key, then base64 encoded). Used when importing an existing key pair, typically with `provider` mode.

--- a/otdfctl/docs/man/policy/kas-registry/key/rotate.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/rotate.md
@@ -56,7 +56,7 @@ This command replaces an existing key with a new one while maintaining reference
 Rotate an existing key to a new key in local mode, where the KAS generates the key pair and the private key is wrapped by the provided `wrappingKey`:
 
 ```shell
-otdfctl policy kas-registry key rotate --key "old-key-id" --kas "https://kas.example.com/kas" --key-id "new-key-v2" --algorithm "rsa:2048" --mode "local" --wrapping-key-id "virtru-stored-key" --wrapping-key "YWVzIGtleQ=="
+otdfctl policy kas-registry key rotate --key "old-key-id" --kas "https://kas.example.com/kas" --key-id "new-key-v2" --algorithm "rsa:2048" --mode "local" --wrapping-key-id "virtru-stored-key" --wrapping-key "a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1"
 ```
 
 ### Rotate a key in `provider` mode

--- a/otdfctl/pkg/man/docflags.go
+++ b/otdfctl/pkg/man/docflags.go
@@ -6,12 +6,18 @@ import (
 	"github.com/opentdf/platform/otdfctl/pkg/cli"
 )
 
+// SensitiveAnnotationKey is the pflag annotation key used to mark flags whose
+// values contain secrets (cryptographic keys, tokens, etc.) and must not appear
+// in logs or process listings.
+const SensitiveAnnotationKey = "sensitive"
+
 type DocFlag struct {
 	Name        string   `yaml:"name"`
 	Description string   `yaml:"description"`
 	Shorthand   string   `yaml:"shorthand"`
 	Default     string   `yaml:"default"`
 	Enum        []string `yaml:"enum"`
+	Sensitive   bool     `yaml:"sensitive"`
 }
 
 func (d *Doc) GetDocFlag(name string) DocFlag {
@@ -28,4 +34,15 @@ func (d *Doc) GetDocFlag(name string) DocFlag {
 
 func (f DocFlag) DefaultAsBool() bool {
 	return f.Default == "true"
+}
+
+// MarkSensitiveFlags sets pflag annotations on all flags in the command's
+// FlagSet that are marked sensitive in the doc metadata. Call after all
+// flags have been registered.
+func (d *Doc) MarkSensitiveFlags() {
+	for _, df := range d.DocFlags {
+		if df.Sensitive {
+			_ = d.Flags().SetAnnotation(df.Name, SensitiveAnnotationKey, []string{"true"})
+		}
+	}
 }

--- a/otdfctl/pkg/man/docflags.go
+++ b/otdfctl/pkg/man/docflags.go
@@ -42,7 +42,9 @@ func (f DocFlag) DefaultAsBool() bool {
 func (d *Doc) MarkSensitiveFlags() {
 	for _, df := range d.DocFlags {
 		if df.Sensitive {
-			_ = d.Flags().SetAnnotation(df.Name, SensitiveAnnotationKey, []string{"true"})
+			if err := d.Flags().SetAnnotation(df.Name, SensitiveAnnotationKey, []string{"true"}); err != nil {
+				panic(fmt.Sprintf("failed to mark flag %q as sensitive for command %q: %v", df.Name, d.Use, err))
+			}
 		}
 	}
 }

--- a/otdfctl/pkg/man/docflags_test.go
+++ b/otdfctl/pkg/man/docflags_test.go
@@ -1,0 +1,79 @@
+package man
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDocFlagSensitiveParsing(t *testing.T) {
+	doc, err := ProcessDoc(`---
+title: Test Command
+command:
+  name: test
+  flags:
+    - name: wrapping-key
+      sensitive: true
+      description: A sensitive flag
+    - name: algorithm
+      description: A non-sensitive flag
+---
+
+Test doc body.
+`)
+	require.NoError(t, err)
+	require.Len(t, doc.DocFlags, 2)
+
+	wk := doc.GetDocFlag("wrapping-key")
+	assert.True(t, wk.Sensitive)
+
+	alg := doc.GetDocFlag("algorithm")
+	assert.False(t, alg.Sensitive)
+}
+
+func TestMarkSensitiveFlags(t *testing.T) {
+	doc, err := ProcessDoc(`---
+title: Test Command
+command:
+  name: test
+  flags:
+    - name: wrapping-key
+      sensitive: true
+      description: Sensitive
+    - name: name
+      description: Not sensitive
+---
+
+Body.
+`)
+	require.NoError(t, err)
+
+	doc.Flags().String("wrapping-key", "", "Sensitive")
+	doc.Flags().String("name", "", "Not sensitive")
+
+	doc.MarkSensitiveFlags()
+
+	wkFlag := doc.Flags().Lookup("wrapping-key")
+	require.NotNil(t, wkFlag)
+	assert.Equal(t, []string{"true"}, wkFlag.Annotations[SensitiveAnnotationKey])
+
+	nameFlag := doc.Flags().Lookup("name")
+	require.NotNil(t, nameFlag)
+	assert.Nil(t, nameFlag.Annotations)
+}
+
+func TestMarkSensitiveFlagsSkipsUnregistered(t *testing.T) {
+	doc := &Doc{
+		Command: cobra.Command{Use: "test"},
+		DocFlags: []DocFlag{
+			{Name: "missing-flag", Sensitive: true},
+		},
+	}
+
+	// Should not panic even though the flag is not registered
+	assert.NotPanics(t, func() {
+		doc.MarkSensitiveFlags()
+	})
+}

--- a/otdfctl/pkg/man/docflags_test.go
+++ b/otdfctl/pkg/man/docflags_test.go
@@ -64,7 +64,7 @@ Body.
 	assert.Nil(t, nameFlag.Annotations)
 }
 
-func TestMarkSensitiveFlagsSkipsUnregistered(t *testing.T) {
+func TestMarkSensitiveFlagsPanicsOnUnregistered(t *testing.T) {
 	doc := &Doc{
 		Command: cobra.Command{Use: "test"},
 		DocFlags: []DocFlag{
@@ -72,8 +72,7 @@ func TestMarkSensitiveFlagsSkipsUnregistered(t *testing.T) {
 		},
 	}
 
-	// Should not panic even though the flag is not registered
-	assert.NotPanics(t, func() {
+	assert.Panics(t, func() {
 		doc.MarkSensitiveFlags()
 	})
 }


### PR DESCRIPTION
### Proposed Changes

* Add `Sensitive bool` field to `DocFlag` struct with YAML support
* Add `MarkSensitiveFlags()` method that propagates sensitive annotations to pflag via `SetAnnotation`
* Mark `wrapping-key` and `private-key-pem` as sensitive in KAS key create/import/rotate man docs
* Call `MarkSensitiveFlags()` in KAS key command setup

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation

### Testing Instructions

Run `go test ./otdfctl/pkg/man/... -race -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KAS key management commands (create, rotate, import) now properly mark `--wrapping-key` and `--private-key-pem` flags as sensitive inputs, ensuring the CLI framework handles secret material appropriately.

* **Documentation**
  * Updated KAS key rotate command documentation to clarify wrapping-key and private-key-pem flag specifications for sensitive inputs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentdf/platform/pull/3457)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->