### PR TITLE
fix(sdk): DSPX-3464 Adds subject_token_type to RFC 8693 token exchanges

### DIFF
--- a/sdk/auth/oauth/oauth.go
+++ b/sdk/auth/oauth/oauth.go
@@ -34,8 +34,11 @@ type ClientCredentials struct {
 }
 
 type TokenExchangeInfo struct {
-	SubjectToken string
-	Audience     []string
+	SubjectToken     string
+	// SubjectTokenType declares the type of SubjectToken per RFC 8693 §2.1.
+	// Defaults to urn:ietf:params:oauth:token-type:access_token when empty.
+	SubjectTokenType string
+	Audience         []string
 }
 
 type Token struct {
@@ -279,9 +282,14 @@ func DoTokenExchange(ctx context.Context, client *http.Client, tokenEndpoint str
 }
 
 func getTokenExchangeRequest(ctx context.Context, tokenEndpoint, dpopNonce string, scopes []string, clientCredentials ClientCredentials, tokenExchange TokenExchangeInfo, privateJWK *jwk.Key) (*http.Request, error) {
+	subjectTokenType := tokenExchange.SubjectTokenType
+	if subjectTokenType == "" {
+		subjectTokenType = "urn:ietf:params:oauth:token-type:access_token"
+	}
 	data := url.Values{
 		"grant_type":           {"urn:ietf:params:oauth:grant-type:token-exchange"},
 		"subject_token":        {tokenExchange.SubjectToken},
+		"subject_token_type":   {subjectTokenType},
 		"requested_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
 	}
 

--- a/sdk/auth/oauth/oauth.go
+++ b/sdk/auth/oauth/oauth.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -20,9 +21,10 @@ import (
 )
 
 const (
-	tokenExpirationBuffer    = 10 * time.Second
-	defaultSubjectTokenType  = "urn:ietf:params:oauth:token-type:access_token"
+	tokenExpirationBuffer = 10 * time.Second
 )
+
+const defaultSubjectTokenType = "urn:ietf:params:oauth:token-type:access_token" //nolint:gosec // OAuth token type URN, not a credential
 
 type CertExchangeInfo struct {
 	HTTPClient *http.Client
@@ -284,7 +286,7 @@ func DoTokenExchange(ctx context.Context, client *http.Client, tokenEndpoint str
 
 func getTokenExchangeRequest(ctx context.Context, tokenEndpoint, dpopNonce string, scopes []string, clientCredentials ClientCredentials, tokenExchange TokenExchangeInfo, privateJWK *jwk.Key) (*http.Request, error) {
 	if tokenExchange.SubjectToken == "" {
-		return nil, fmt.Errorf("subject_token is required for token exchange")
+		return nil, errors.New("subject_token is required for token exchange")
 	}
 	subjectTokenType := tokenExchange.SubjectTokenType
 	if subjectTokenType == "" {
@@ -294,7 +296,7 @@ func getTokenExchangeRequest(ctx context.Context, tokenEndpoint, dpopNonce strin
 		"grant_type":           {"urn:ietf:params:oauth:grant-type:token-exchange"},
 		"subject_token":        {tokenExchange.SubjectToken},
 		"subject_token_type":   {subjectTokenType},
-		"requested_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
+		"requested_token_type": {defaultSubjectTokenType},
 	}
 
 	for _, a := range tokenExchange.Audience {

--- a/sdk/auth/oauth/oauth.go
+++ b/sdk/auth/oauth/oauth.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	tokenExpirationBuffer = 10 * time.Second
+	tokenExpirationBuffer    = 10 * time.Second
+	defaultSubjectTokenType  = "urn:ietf:params:oauth:token-type:access_token"
 )
 
 type CertExchangeInfo struct {
@@ -34,7 +35,7 @@ type ClientCredentials struct {
 }
 
 type TokenExchangeInfo struct {
-	SubjectToken     string
+	SubjectToken string
 	// SubjectTokenType declares the type of SubjectToken per RFC 8693 §2.1.
 	// Defaults to urn:ietf:params:oauth:token-type:access_token when empty.
 	SubjectTokenType string
@@ -284,7 +285,7 @@ func DoTokenExchange(ctx context.Context, client *http.Client, tokenEndpoint str
 func getTokenExchangeRequest(ctx context.Context, tokenEndpoint, dpopNonce string, scopes []string, clientCredentials ClientCredentials, tokenExchange TokenExchangeInfo, privateJWK *jwk.Key) (*http.Request, error) {
 	subjectTokenType := tokenExchange.SubjectTokenType
 	if subjectTokenType == "" {
-		subjectTokenType = "urn:ietf:params:oauth:token-type:access_token"
+		subjectTokenType = defaultSubjectTokenType
 	}
 	data := url.Values{
 		"grant_type":           {"urn:ietf:params:oauth:grant-type:token-exchange"},

--- a/sdk/auth/oauth/oauth.go
+++ b/sdk/auth/oauth/oauth.go
@@ -283,6 +283,9 @@ func DoTokenExchange(ctx context.Context, client *http.Client, tokenEndpoint str
 }
 
 func getTokenExchangeRequest(ctx context.Context, tokenEndpoint, dpopNonce string, scopes []string, clientCredentials ClientCredentials, tokenExchange TokenExchangeInfo, privateJWK *jwk.Key) (*http.Request, error) {
+	if tokenExchange.SubjectToken == "" {
+		return nil, fmt.Errorf("subject_token is required for token exchange")
+	}
 	subjectTokenType := tokenExchange.SubjectTokenType
 	if subjectTokenType == "" {
 		subjectTokenType = defaultSubjectTokenType

--- a/sdk/auth/oauth/oauth_test.go
+++ b/sdk/auth/oauth/oauth_test.go
@@ -92,13 +92,12 @@ func TestGetTokenExchangeRequest_SubjectTokenType(t *testing.T) {
 		return form
 	}
 
-	const accessTokenURN = "urn:ietf:params:oauth:token-type:access_token"
 	const idTokenURN = "urn:ietf:params:oauth:token-type:id_token"
 
 	t.Run("defaults to access_token when SubjectTokenType is empty", func(t *testing.T) {
 		form := parseForm(t, TokenExchangeInfo{SubjectToken: "tok"})
-		if got := form.Get("subject_token_type"); got != accessTokenURN {
-			t.Errorf("subject_token_type = %q, want %q", got, accessTokenURN)
+		if got := form.Get("subject_token_type"); got != defaultSubjectTokenType {
+			t.Errorf("subject_token_type = %q, want %q", got, defaultSubjectTokenType)
 		}
 	})
 

--- a/sdk/auth/oauth/oauth_test.go
+++ b/sdk/auth/oauth/oauth_test.go
@@ -1,9 +1,26 @@
 package oauth
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"io"
+	"net/url"
 	"testing"
 	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
 )
+
+func mustGenerateRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	return k
+}
 
 func TestTokenExpiration_RespectsLeeway(t *testing.T) {
 	expiredToken := Token{
@@ -31,4 +48,77 @@ func TestTokenExpiration_RespectsLeeway(t *testing.T) {
 	if !justOverBorderToken.Expired() {
 		t.Fatalf("token should not be expired")
 	}
+}
+
+// TestGetTokenExchangeRequest_SubjectTokenType verifies that the RFC 8693 required
+// field subject_token_type is present in the token exchange POST body and defaults
+// to access_token when not explicitly set.
+func TestGetTokenExchangeRequest_SubjectTokenType(t *testing.T) {
+	makeKey := func(t *testing.T) jwk.Key {
+		t.Helper()
+		raw, err := jwk.FromRaw(mustGenerateRSAKey(t))
+		if err != nil {
+			t.Fatalf("jwk.FromRaw: %v", err)
+		}
+		if err := raw.Set(jwk.AlgorithmKey, jwa.RS256); err != nil {
+			t.Fatalf("set algorithm: %v", err)
+		}
+		return raw
+	}
+
+	parseForm := func(t *testing.T, info TokenExchangeInfo) url.Values {
+		t.Helper()
+		key := makeKey(t)
+		req, err := getTokenExchangeRequest(
+			context.Background(),
+			"https://idp.example.com/token",
+			"",
+			[]string{"openid"},
+			ClientCredentials{ClientID: "test-client", ClientAuth: "test-secret"},
+			info,
+			&key,
+		)
+		if err != nil {
+			t.Fatalf("getTokenExchangeRequest: %v", err)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		form, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		return form
+	}
+
+	const accessTokenURN = "urn:ietf:params:oauth:token-type:access_token"
+	const idTokenURN = "urn:ietf:params:oauth:token-type:id_token"
+
+	t.Run("defaults to access_token when SubjectTokenType is empty", func(t *testing.T) {
+		form := parseForm(t, TokenExchangeInfo{SubjectToken: "tok"})
+		if got := form.Get("subject_token_type"); got != accessTokenURN {
+			t.Errorf("subject_token_type = %q, want %q", got, accessTokenURN)
+		}
+	})
+
+	t.Run("uses caller-supplied SubjectTokenType", func(t *testing.T) {
+		form := parseForm(t, TokenExchangeInfo{SubjectToken: "tok", SubjectTokenType: idTokenURN})
+		if got := form.Get("subject_token_type"); got != idTokenURN {
+			t.Errorf("subject_token_type = %q, want %q", got, idTokenURN)
+		}
+	})
+
+	t.Run("required RFC 8693 fields are present", func(t *testing.T) {
+		form := parseForm(t, TokenExchangeInfo{SubjectToken: "my-subject-token"})
+		if got := form.Get("grant_type"); got != "urn:ietf:params:oauth:grant-type:token-exchange" {
+			t.Errorf("grant_type = %q, want token-exchange URN", got)
+		}
+		if got := form.Get("subject_token"); got != "my-subject-token" {
+			t.Errorf("subject_token = %q, want %q", got, "my-subject-token")
+		}
+		if got := form.Get("subject_token_type"); got == "" {
+			t.Error("subject_token_type must not be empty")
+		}
+	})
 }


### PR DESCRIPTION
### Proposed Changes

The `getTokenExchangeRequest` function in `sdk/auth/oauth/oauth.go` was missing the
`subject_token_type` parameter from the token exchange POST body.

[RFC 8693 §2.1](https://www.rfc-editor.org/rfc/rfc8693.html#name-request) defines `subject_token_type`
as a **required** parameter when `grant_type` is `urn:ietf:params:oauth:grant-type:token-exchange`.
Authorization servers, including Keycloak, reject the request with a 400 when the type is absent on token exchanges.

- Adds `subject_token_type` to the form values in `getTokenExchangeRequest`,
  defaulting to `urn:ietf:params:oauth:token-type:access_token`
- Adds `SubjectTokenType string` field to `TokenExchangeInfo` so callers can
  declare a different token type (e.g. `id_token`, `jwt`) when needed; empty
  string preserves the default behaviour
- Adds unit tests covering the default, an explicit override, and presence of
  all required RFC 8693 fields

## References

- [RFC 8693 §2.1 — Request](https://www.rfc-editor.org/rfc/rfc8693#section-2.1)

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth token exchange requests now support optional subject token type as per RFC 8693 standard
  * Automatically defaults to access token URN when not specified

* **Tests**
  * Added comprehensive test coverage for subject token type behavior in OAuth token exchange

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentdf/platform/pull/3465)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->