### PR TITLE
fix(policy): include action_attribute_values in GetRegisteredResource response

### DIFF
--- a/service/integration/registered_resources_test.go
+++ b/service/integration/registered_resources_test.go
@@ -382,6 +382,93 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_RegResValuesCont
 	s.True(foundVal2, "Value 2 not found in registered resource values")
 }
 
+func (s *RegisteredResourcesSuite) Test_GetRegisteredResource_RegResValuesContainActionAttributeValues() {
+	// Create a registered resource with values that have action attribute values
+	newRegRes, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
+		NamespaceId: s.getNamespaceID("example.com"),
+		Name:        "test_get_reg_res_with_action_attr_values",
+	})
+	s.Require().NoError(err)
+	s.NotNil(newRegRes)
+	regResID := newRegRes.GetId()
+
+	val1, err := s.db.PolicyClient.CreateRegisteredResourceValue(s.ctx, &registeredresources.CreateRegisteredResourceValueRequest{
+		ResourceId: regResID,
+		Value:      "test_value_1",
+		ActionAttributeValues: []*registeredresources.ActionAttributeValue{
+			{
+				ActionIdentifier: &registeredresources.ActionAttributeValue_ActionName{
+					ActionName: actions.ActionNameCreate,
+				},
+				AttributeValueIdentifier: &registeredresources.ActionAttributeValue_AttributeValueFqn{
+					AttributeValueFqn: "https://example.com/attr/attr1/value/value1",
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(val1)
+
+	val2, err := s.db.PolicyClient.CreateRegisteredResourceValue(s.ctx, &registeredresources.CreateRegisteredResourceValueRequest{
+		ResourceId: regResID,
+		Value:      "test_value_2",
+		ActionAttributeValues: []*registeredresources.ActionAttributeValue{
+			{
+				ActionIdentifier: &registeredresources.ActionAttributeValue_ActionName{
+					ActionName: actions.ActionNameUpdate,
+				},
+				AttributeValueIdentifier: &registeredresources.ActionAttributeValue_AttributeValueFqn{
+					AttributeValueFqn: "https://example.com/attr/attr2/value/value2",
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(val2)
+
+	// Get the registered resource and check if values contain action attribute values
+	got, err := s.db.PolicyClient.GetRegisteredResource(s.ctx, &registeredresources.GetRegisteredResourceRequest{
+		Identifier: &registeredresources.GetRegisteredResourceRequest_Id{
+			Id: regResID,
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(got)
+	s.Equal("test_get_reg_res_with_action_attr_values", got.GetName())
+
+	values := got.GetValues()
+	s.Require().Len(values, 2)
+
+	foundVal1 := false
+	foundVal2 := false
+	for _, v := range values {
+		if v.GetId() == val1.GetId() {
+			foundVal1 = true
+			actionAttrValues := v.GetActionAttributeValues()
+			s.Require().NotEmpty(actionAttrValues)
+			for _, aav := range actionAttrValues {
+				s.NotNil(aav.GetAction())
+				s.NotNil(aav.GetAttributeValue())
+				s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
+				s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
+			}
+		}
+		if v.GetId() == val2.GetId() {
+			foundVal2 = true
+			actionAttrValues := v.GetActionAttributeValues()
+			s.Require().NotEmpty(actionAttrValues)
+			for _, aav := range actionAttrValues {
+				s.NotNil(aav.GetAction())
+				s.NotNil(aav.GetAttributeValue())
+				s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
+				s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
+			}
+		}
+	}
+	s.True(foundVal1, "Value 1 not found in registered resource values")
+	s.True(foundVal2, "Value 2 not found in registered resource values")
+}
+
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_Limit_Succeeds() {
 	var limit int32 = 1
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{

--- a/service/integration/registered_resources_test.go
+++ b/service/integration/registered_resources_test.go
@@ -352,22 +352,26 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_RegResValuesCont
 		foundRegRes = true
 
 		for _, v := range values {
+			actionAttrValues := v.GetActionAttributeValues()
+			s.Require().Len(actionAttrValues, 1)
+			aav := actionAttrValues[0]
+			s.Require().NotNil(aav.GetAction())
+			s.Require().NotNil(aav.GetAttributeValue())
+			s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
+			s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
+			s.Equal("https://example.com", aav.GetAction().GetNamespace().GetFqn())
+
 			switch v.GetId() {
 			case val1.GetId():
 				foundVal1 = true
+				s.Equal(actions.ActionNameCreate, aav.GetAction().GetName())
+				s.Equal("https://example.com/attr/attr1/value/value1", aav.GetAttributeValue().GetFqn())
 			case val2.GetId():
 				foundVal2 = true
+				s.Equal(actions.ActionNameUpdate, aav.GetAction().GetName())
+				s.Equal("https://example.com/attr/attr2/value/value2", aav.GetAttributeValue().GetFqn())
 			default:
 				s.FailNow("unexpected value found", "value id: %s", v.GetId())
-			}
-
-			actionAttrValues := v.GetActionAttributeValues()
-			s.Require().NotEmpty(actionAttrValues)
-			for _, aav := range actionAttrValues {
-				s.NotNil(aav.GetAction())
-				s.NotNil(aav.GetAttributeValue())
-				s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
-				s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
 			}
 		}
 	}
@@ -435,22 +439,26 @@ func (s *RegisteredResourcesSuite) Test_GetRegisteredResource_RegResValuesContai
 
 	var foundVal1, foundVal2 bool
 	for _, v := range values {
+		actionAttrValues := v.GetActionAttributeValues()
+		s.Require().Len(actionAttrValues, 1)
+		aav := actionAttrValues[0]
+		s.Require().NotNil(aav.GetAction())
+		s.Require().NotNil(aav.GetAttributeValue())
+		s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
+		s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
+		s.Equal("https://example.com", aav.GetAction().GetNamespace().GetFqn())
+
 		switch v.GetId() {
 		case val1.GetId():
 			foundVal1 = true
+			s.Equal(actions.ActionNameCreate, aav.GetAction().GetName())
+			s.Equal("https://example.com/attr/attr1/value/value1", aav.GetAttributeValue().GetFqn())
 		case val2.GetId():
 			foundVal2 = true
+			s.Equal(actions.ActionNameUpdate, aav.GetAction().GetName())
+			s.Equal("https://example.com/attr/attr2/value/value2", aav.GetAttributeValue().GetFqn())
 		default:
 			s.FailNow("unexpected value found", "value id: %s", v.GetId())
-		}
-
-		actionAttrValues := v.GetActionAttributeValues()
-		s.Require().NotEmpty(actionAttrValues)
-		for _, aav := range actionAttrValues {
-			s.NotNil(aav.GetAction())
-			s.NotNil(aav.GetAttributeValue())
-			s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
-			s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
 		}
 	}
 	s.True(foundVal1, "Value 1 not found in registered resource values")

--- a/service/integration/registered_resources_test.go
+++ b/service/integration/registered_resources_test.go
@@ -341,39 +341,33 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_RegResValuesCont
 	s.NotNil(list)
 
 	foundRegRes := false
-	foundVal1 := false
-	foundVal2 := false
+	var foundVal1, foundVal2 bool
 	for _, r := range list.GetResources() {
-		if r.GetId() == regResID {
-			s.Equal("test_list_reg_res_with_action_attr_values", r.GetName())
-			values := r.GetValues()
-			s.Require().Len(values, 2)
-			foundRegRes = true
+		if r.GetId() != regResID {
+			continue
+		}
+		s.Equal("test_list_reg_res_with_action_attr_values", r.GetName())
+		values := r.GetValues()
+		s.Require().Len(values, 2)
+		foundRegRes = true
 
-			// Check if action attribute values are present in the values
-			for _, v := range values {
-				if v.GetId() == val1.GetId() {
-					foundVal1 = true
-					actionAttrValues := v.GetActionAttributeValues()
-					s.Require().NotEmpty(actionAttrValues)
-					for _, aav := range actionAttrValues {
-						s.NotNil(aav.GetAction())
-						s.NotNil(aav.GetAttributeValue())
-						s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
-						s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
-					}
-				}
-				if v.GetId() == val2.GetId() {
-					foundVal2 = true
-					actionAttrValues := v.GetActionAttributeValues()
-					s.Require().NotEmpty(actionAttrValues)
-					for _, aav := range actionAttrValues {
-						s.NotNil(aav.GetAction())
-						s.NotNil(aav.GetAttributeValue())
-						s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
-						s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
-					}
-				}
+		for _, v := range values {
+			switch v.GetId() {
+			case val1.GetId():
+				foundVal1 = true
+			case val2.GetId():
+				foundVal2 = true
+			default:
+				s.FailNow("unexpected value found", "value id: %s", v.GetId())
+			}
+
+			actionAttrValues := v.GetActionAttributeValues()
+			s.Require().NotEmpty(actionAttrValues)
+			for _, aav := range actionAttrValues {
+				s.NotNil(aav.GetAction())
+				s.NotNil(aav.GetAttributeValue())
+				s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
+				s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
 			}
 		}
 	}
@@ -439,30 +433,24 @@ func (s *RegisteredResourcesSuite) Test_GetRegisteredResource_RegResValuesContai
 	values := got.GetValues()
 	s.Require().Len(values, 2)
 
-	foundVal1 := false
-	foundVal2 := false
+	var foundVal1, foundVal2 bool
 	for _, v := range values {
-		if v.GetId() == val1.GetId() {
+		switch v.GetId() {
+		case val1.GetId():
 			foundVal1 = true
-			actionAttrValues := v.GetActionAttributeValues()
-			s.Require().NotEmpty(actionAttrValues)
-			for _, aav := range actionAttrValues {
-				s.NotNil(aav.GetAction())
-				s.NotNil(aav.GetAttributeValue())
-				s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
-				s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
-			}
-		}
-		if v.GetId() == val2.GetId() {
+		case val2.GetId():
 			foundVal2 = true
-			actionAttrValues := v.GetActionAttributeValues()
-			s.Require().NotEmpty(actionAttrValues)
-			for _, aav := range actionAttrValues {
-				s.NotNil(aav.GetAction())
-				s.NotNil(aav.GetAttributeValue())
-				s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
-				s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
-			}
+		default:
+			s.FailNow("unexpected value found", "value id: %s", v.GetId())
+		}
+
+		actionAttrValues := v.GetActionAttributeValues()
+		s.Require().NotEmpty(actionAttrValues)
+		for _, aav := range actionAttrValues {
+			s.NotNil(aav.GetAction())
+			s.NotNil(aav.GetAttributeValue())
+			s.NotNil(aav.GetAction().GetNamespace(), "action namespace should be populated for namespaced RR")
+			s.Equal("example.com", aav.GetAction().GetNamespace().GetName())
 		}
 	}
 	s.True(foundVal1, "Value 1 not found in registered resource values")

--- a/service/policy/db/queries/registered_resources.sql
+++ b/service/policy/db/queries/registered_resources.sql
@@ -68,7 +68,9 @@ LEFT JOIN LATERAL (
                 'id', a.id,
                 'name', a.name,
                 'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
-                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                    -- Namespace FQN is deterministic from the name, so build it inline
+                    -- instead of joining attribute_fqns for it.
+                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', CONCAT('https://', ans.name))
                 END
             ),
             'attribute_value', JSON_BUILD_OBJECT(
@@ -82,7 +84,6 @@ LEFT JOIN LATERAL (
     FROM registered_resource_action_attribute_values rav
     LEFT JOIN actions a on rav.action_id = a.id
     LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
-    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
     LEFT JOIN attribute_values av on rav.attribute_value_id = av.id
     LEFT JOIN attribute_fqns fqns on av.id = fqns.value_id
     -- Correlate to the outer query's resource value
@@ -149,7 +150,9 @@ LEFT JOIN LATERAL (
                 'id', a.id,
                 'name', a.name,
                 'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
-                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                    -- Namespace FQN is deterministic from the name, so build it inline
+                    -- instead of joining attribute_fqns for it.
+                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', CONCAT('https://', ans.name))
                 END
             ),
             'attribute_value', JSON_BUILD_OBJECT(
@@ -163,7 +166,6 @@ LEFT JOIN LATERAL (
     FROM registered_resource_action_attribute_values rav
     LEFT JOIN actions a on rav.action_id = a.id
     LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
-    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
     LEFT JOIN attribute_values av on rav.attribute_value_id = av.id
     LEFT JOIN attribute_fqns fqns on av.id = fqns.value_id
     -- Correlate to the outer query's resource value

--- a/service/policy/db/queries/registered_resources.sql
+++ b/service/policy/db/queries/registered_resources.sql
@@ -60,7 +60,9 @@ LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attr
 LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
 -- Build a JSON array of action/attribute pairs for each resource value
 LEFT JOIN LATERAL (
-    SELECT JSON_AGG(
+    -- COALESCE so a value with no mappings yields '[]' rather than SQL NULL,
+    -- giving consumers a consistent JSON array shape for action_attribute_values.
+    SELECT COALESCE(JSON_AGG(
         JSON_BUILD_OBJECT(
             'action', JSON_BUILD_OBJECT(
                 'id', a.id,
@@ -75,7 +77,7 @@ LEFT JOIN LATERAL (
                 'fqn', fqns.fqn
             )
         )
-    ) AS values
+    ), '[]'::json) AS values
     -- Join to get all action-attribute relationships for this resource value
     FROM registered_resource_action_attribute_values rav
     LEFT JOIN actions a on rav.action_id = a.id
@@ -139,7 +141,9 @@ CROSS JOIN params p
 LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
 -- Build a JSON array of action/attribute pairs for each resource value
 LEFT JOIN LATERAL (
-    SELECT JSON_AGG(
+    -- COALESCE so a value with no mappings yields '[]' rather than SQL NULL,
+    -- giving consumers a consistent JSON array shape for action_attribute_values.
+    SELECT COALESCE(JSON_AGG(
         JSON_BUILD_OBJECT(
             'action', JSON_BUILD_OBJECT(
                 'id', a.id,
@@ -154,7 +158,7 @@ LEFT JOIN LATERAL (
                 'fqn', fqns.fqn
             )
         )
-    ) AS values
+    ), '[]'::json) AS values
     -- Join to get all action-attribute relationships for this resource value
     FROM registered_resource_action_attribute_values rav
     LEFT JOIN actions a on rav.action_id = a.id

--- a/service/policy/db/queries/registered_resources.sql
+++ b/service/policy/db/queries/registered_resources.sql
@@ -50,13 +50,42 @@ SELECT
     JSON_AGG(
         JSON_BUILD_OBJECT(
             'id', v.id,
-            'value', v.value
+            'value', v.value,
+            'action_attribute_values', action_attrs.values
         )
     ) FILTER (WHERE v.id IS NOT NULL) as values
 FROM registered_resources r
 LEFT JOIN attribute_namespaces n ON r.namespace_id = n.id
 LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
 LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
+-- Build a JSON array of action/attribute pairs for each resource value
+LEFT JOIN LATERAL (
+    SELECT JSON_AGG(
+        JSON_BUILD_OBJECT(
+            'action', JSON_BUILD_OBJECT(
+                'id', a.id,
+                'name', a.name,
+                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                END
+            ),
+            'attribute_value', JSON_BUILD_OBJECT(
+                'id', av.id,
+                'value', av.value,
+                'fqn', fqns.fqn
+            )
+        )
+    ) AS values
+    -- Join to get all action-attribute relationships for this resource value
+    FROM registered_resource_action_attribute_values rav
+    LEFT JOIN actions a on rav.action_id = a.id
+    LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
+    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
+    LEFT JOIN attribute_values av on rav.attribute_value_id = av.id
+    LEFT JOIN attribute_fqns fqns on av.id = fqns.value_id
+    -- Correlate to the outer query's resource value
+    WHERE rav.registered_resource_value_id = v.id
+) action_attrs ON true  -- required syntax for LATERAL joins
 WHERE
     (sqlc.narg('id')::uuid IS NULL OR r.id = sqlc.narg('id')::uuid) AND
     (sqlc.narg('name')::text IS NULL OR r.name = sqlc.narg('name')::text) AND

--- a/service/policy/db/registered_resources.sql.go
+++ b/service/policy/db/registered_resources.sql.go
@@ -224,7 +224,9 @@ LEFT JOIN LATERAL (
                 'id', a.id,
                 'name', a.name,
                 'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
-                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                    -- Namespace FQN is deterministic from the name, so build it inline
+                    -- instead of joining attribute_fqns for it.
+                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', CONCAT('https://', ans.name))
                 END
             ),
             'attribute_value', JSON_BUILD_OBJECT(
@@ -238,7 +240,6 @@ LEFT JOIN LATERAL (
     FROM registered_resource_action_attribute_values rav
     LEFT JOIN actions a on rav.action_id = a.id
     LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
-    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
     LEFT JOIN attribute_values av on rav.attribute_value_id = av.id
     LEFT JOIN attribute_fqns fqns on av.id = fqns.value_id
     -- Correlate to the outer query's resource value
@@ -303,7 +304,9 @@ type getRegisteredResourceRow struct {
 //	                'id', a.id,
 //	                'name', a.name,
 //	                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
-//	                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+//	                    -- Namespace FQN is deterministic from the name, so build it inline
+//	                    -- instead of joining attribute_fqns for it.
+//	                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', CONCAT('https://', ans.name))
 //	                END
 //	            ),
 //	            'attribute_value', JSON_BUILD_OBJECT(
@@ -317,7 +320,6 @@ type getRegisteredResourceRow struct {
 //	    FROM registered_resource_action_attribute_values rav
 //	    LEFT JOIN actions a on rav.action_id = a.id
 //	    LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
-//	    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
 //	    LEFT JOIN attribute_values av on rav.attribute_value_id = av.id
 //	    LEFT JOIN attribute_fqns fqns on av.id = fqns.value_id
 //	    -- Correlate to the outer query's resource value
@@ -689,7 +691,9 @@ LEFT JOIN LATERAL (
                 'id', a.id,
                 'name', a.name,
                 'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
-                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                    -- Namespace FQN is deterministic from the name, so build it inline
+                    -- instead of joining attribute_fqns for it.
+                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', CONCAT('https://', ans.name))
                 END
             ),
             'attribute_value', JSON_BUILD_OBJECT(
@@ -703,7 +707,6 @@ LEFT JOIN LATERAL (
     FROM registered_resource_action_attribute_values rav
     LEFT JOIN actions a on rav.action_id = a.id
     LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
-    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
     LEFT JOIN attribute_values av on rav.attribute_value_id = av.id
     LEFT JOIN attribute_fqns fqns on av.id = fqns.value_id
     -- Correlate to the outer query's resource value
@@ -794,7 +797,9 @@ type listRegisteredResourcesRow struct {
 //	                'id', a.id,
 //	                'name', a.name,
 //	                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
-//	                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+//	                    -- Namespace FQN is deterministic from the name, so build it inline
+//	                    -- instead of joining attribute_fqns for it.
+//	                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', CONCAT('https://', ans.name))
 //	                END
 //	            ),
 //	            'attribute_value', JSON_BUILD_OBJECT(
@@ -808,7 +813,6 @@ type listRegisteredResourcesRow struct {
 //	    FROM registered_resource_action_attribute_values rav
 //	    LEFT JOIN actions a on rav.action_id = a.id
 //	    LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
-//	    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
 //	    LEFT JOIN attribute_values av on rav.attribute_value_id = av.id
 //	    LEFT JOIN attribute_fqns fqns on av.id = fqns.value_id
 //	    -- Correlate to the outer query's resource value

--- a/service/policy/db/registered_resources.sql.go
+++ b/service/policy/db/registered_resources.sql.go
@@ -216,7 +216,9 @@ LEFT JOIN attribute_namespaces n ON r.namespace_id = n.id
 LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
 LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
 LEFT JOIN LATERAL (
-    SELECT JSON_AGG(
+    -- COALESCE so a value with no mappings yields '[]' rather than SQL NULL,
+    -- giving consumers a consistent JSON array shape for action_attribute_values.
+    SELECT COALESCE(JSON_AGG(
         JSON_BUILD_OBJECT(
             'action', JSON_BUILD_OBJECT(
                 'id', a.id,
@@ -231,7 +233,7 @@ LEFT JOIN LATERAL (
                 'fqn', fqns.fqn
             )
         )
-    ) AS values
+    ), '[]'::json) AS values
     -- Join to get all action-attribute relationships for this resource value
     FROM registered_resource_action_attribute_values rav
     LEFT JOIN actions a on rav.action_id = a.id
@@ -293,7 +295,9 @@ type getRegisteredResourceRow struct {
 //	LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
 //	LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
 //	LEFT JOIN LATERAL (
-//	    SELECT JSON_AGG(
+//	    -- COALESCE so a value with no mappings yields '[]' rather than SQL NULL,
+//	    -- giving consumers a consistent JSON array shape for action_attribute_values.
+//	    SELECT COALESCE(JSON_AGG(
 //	        JSON_BUILD_OBJECT(
 //	            'action', JSON_BUILD_OBJECT(
 //	                'id', a.id,
@@ -308,7 +312,7 @@ type getRegisteredResourceRow struct {
 //	                'fqn', fqns.fqn
 //	            )
 //	        )
-//	    ) AS values
+//	    ), '[]'::json) AS values
 //	    -- Join to get all action-attribute relationships for this resource value
 //	    FROM registered_resource_action_attribute_values rav
 //	    LEFT JOIN actions a on rav.action_id = a.id
@@ -677,7 +681,9 @@ CROSS JOIN counted
 CROSS JOIN params p
 LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
 LEFT JOIN LATERAL (
-    SELECT JSON_AGG(
+    -- COALESCE so a value with no mappings yields '[]' rather than SQL NULL,
+    -- giving consumers a consistent JSON array shape for action_attribute_values.
+    SELECT COALESCE(JSON_AGG(
         JSON_BUILD_OBJECT(
             'action', JSON_BUILD_OBJECT(
                 'id', a.id,
@@ -692,7 +698,7 @@ LEFT JOIN LATERAL (
                 'fqn', fqns.fqn
             )
         )
-    ) AS values
+    ), '[]'::json) AS values
     -- Join to get all action-attribute relationships for this resource value
     FROM registered_resource_action_attribute_values rav
     LEFT JOIN actions a on rav.action_id = a.id
@@ -780,7 +786,9 @@ type listRegisteredResourcesRow struct {
 //	CROSS JOIN params p
 //	LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
 //	LEFT JOIN LATERAL (
-//	    SELECT JSON_AGG(
+//	    -- COALESCE so a value with no mappings yields '[]' rather than SQL NULL,
+//	    -- giving consumers a consistent JSON array shape for action_attribute_values.
+//	    SELECT COALESCE(JSON_AGG(
 //	        JSON_BUILD_OBJECT(
 //	            'action', JSON_BUILD_OBJECT(
 //	                'id', a.id,
@@ -795,7 +803,7 @@ type listRegisteredResourcesRow struct {
 //	                'fqn', fqns.fqn
 //	            )
 //	        )
-//	    ) AS values
+//	    ), '[]'::json) AS values
 //	    -- Join to get all action-attribute relationships for this resource value
 //	    FROM registered_resource_action_attribute_values rav
 //	    LEFT JOIN actions a on rav.action_id = a.id

--- a/service/policy/db/registered_resources.sql.go
+++ b/service/policy/db/registered_resources.sql.go
@@ -207,13 +207,41 @@ SELECT
     JSON_AGG(
         JSON_BUILD_OBJECT(
             'id', v.id,
-            'value', v.value
+            'value', v.value,
+            'action_attribute_values', action_attrs.values
         )
     ) FILTER (WHERE v.id IS NOT NULL) as values
 FROM registered_resources r
 LEFT JOIN attribute_namespaces n ON r.namespace_id = n.id
 LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
 LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
+LEFT JOIN LATERAL (
+    SELECT JSON_AGG(
+        JSON_BUILD_OBJECT(
+            'action', JSON_BUILD_OBJECT(
+                'id', a.id,
+                'name', a.name,
+                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                END
+            ),
+            'attribute_value', JSON_BUILD_OBJECT(
+                'id', av.id,
+                'value', av.value,
+                'fqn', fqns.fqn
+            )
+        )
+    ) AS values
+    -- Join to get all action-attribute relationships for this resource value
+    FROM registered_resource_action_attribute_values rav
+    LEFT JOIN actions a on rav.action_id = a.id
+    LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
+    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
+    LEFT JOIN attribute_values av on rav.attribute_value_id = av.id
+    LEFT JOIN attribute_fqns fqns on av.id = fqns.value_id
+    -- Correlate to the outer query's resource value
+    WHERE rav.registered_resource_value_id = v.id
+) action_attrs ON true  -- required syntax for LATERAL joins
 WHERE
     ($1::uuid IS NULL OR r.id = $1::uuid) AND
     ($2::text IS NULL OR r.name = $2::text) AND
@@ -239,6 +267,7 @@ type getRegisteredResourceRow struct {
 	Values    []byte      `json:"values"`
 }
 
+// Build a JSON array of action/attribute pairs for each resource value
 // prefer non-namespaced over namespaced results (to support legacy behavior)
 //
 //	SELECT
@@ -255,13 +284,41 @@ type getRegisteredResourceRow struct {
 //	    JSON_AGG(
 //	        JSON_BUILD_OBJECT(
 //	            'id', v.id,
-//	            'value', v.value
+//	            'value', v.value,
+//	            'action_attribute_values', action_attrs.values
 //	        )
 //	    ) FILTER (WHERE v.id IS NOT NULL) as values
 //	FROM registered_resources r
 //	LEFT JOIN attribute_namespaces n ON r.namespace_id = n.id
 //	LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
 //	LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
+//	LEFT JOIN LATERAL (
+//	    SELECT JSON_AGG(
+//	        JSON_BUILD_OBJECT(
+//	            'action', JSON_BUILD_OBJECT(
+//	                'id', a.id,
+//	                'name', a.name,
+//	                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+//	                    ELSE JSON_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+//	                END
+//	            ),
+//	            'attribute_value', JSON_BUILD_OBJECT(
+//	                'id', av.id,
+//	                'value', av.value,
+//	                'fqn', fqns.fqn
+//	            )
+//	        )
+//	    ) AS values
+//	    -- Join to get all action-attribute relationships for this resource value
+//	    FROM registered_resource_action_attribute_values rav
+//	    LEFT JOIN actions a on rav.action_id = a.id
+//	    LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
+//	    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
+//	    LEFT JOIN attribute_values av on rav.attribute_value_id = av.id
+//	    LEFT JOIN attribute_fqns fqns on av.id = fqns.value_id
+//	    -- Correlate to the outer query's resource value
+//	    WHERE rav.registered_resource_value_id = v.id
+//	) action_attrs ON true  -- required syntax for LATERAL joins
 //	WHERE
 //	    ($1::uuid IS NULL OR r.id = $1::uuid) AND
 //	    ($2::text IS NULL OR r.name = $2::text) AND


### PR DESCRIPTION
## Summary

`GetRegisteredResource` returned each value with only `id`, `value`, and `fqn` populated — the `action_attribute_values` field was always empty even when mappings existed. Callers that authorize on `(resource, action) → attributes` via this RPC were silently denied; `GetRegisteredResourceValue` returned the same value with mappings populated, exposing the divergence.

Root cause: the `getRegisteredResource` SQL in `service/policy/db/queries/registered_resources.sql` built each value's JSON object with only `id` and `value`. `listRegisteredResources` already used the correct `LEFT JOIN LATERAL` pattern; this PR mirrors it into the single-resource query and regenerates the sqlc binding. The follow-up commit also wraps the inner `JSON_AGG` in both queries with `COALESCE(..., '[]'::json)` so a value with no mappings produces an empty array rather than SQL NULL.

Fixes #3471

## Why this is different from #3398

PR #3398 (also a "hydrate a nested field that some queries populate and others don't" change, on `ListAttributes`) was closed with the explanation that `ListAttributes` is on a lot of hot paths and the team would rather pursue selectors/expanders than expand the default response payload. That concern is real for paginated list RPCs but does not apply to this change:

- **Bug fix, not feature expansion.** `GetRegisteredResource` is the only sibling that fails to populate `action_attribute_values`. `ListRegisteredResources` and `GetRegisteredResourceValue` both already hydrate it. The proto field `RegisteredResourceValue.action_attribute_values` is declared and documented; leaving it empty here is divergence, not an opt-in payload addition.
- **Silent authorization failures in production.** Downstream callers that read `value.GetActionAttributeValues()` off the `GetRegisteredResource` response see an empty slice and deny the request with `"no attribute mappings found for resource"`, even though the mappings exist in the database and are returned by every sibling RPC. This is the bug described in #3471 — not a payload-completeness preference.
- **Not a hot-path list endpoint.** `GetRegisteredResource` is a single-item lookup by id or name. The cardinality argument that motivated closing #3398 (thousands of attribute values × N mappings each, on a frequently-called paginated endpoint) does not transfer.
- **No proto change, no new field, no new opt-in toggle.** The shape this PR returns is already what `listRegisteredResources` returns today.

If the team would prefer to address this through a `GetRegisteredResourceWithMappings` selector or an `expand=action_attribute_values` parameter instead of fixing the divergence inline, happy to redirect — but the silent-denial bug is real and the rest of the policy DB queries already treat populating this field as the default.

## Test plan

- [x] Wrote failing integration test first; confirmed it fails against unfixed SQL with `Should NOT be empty, but was []` (red-green verified).
- [x] Confirmed it passes after the SQL fix.
- [x] Full `TestRegisteredResourcesSuite` integration suite passes (testcontainers/postgres) — both the new test and the existing fixture-based tests against values with no AAVs.
- [x] `go test ./service/policy/...` unit tests pass.
- [x] `golangci-lint run` on changed files: 0 new issues.
- [x] `gofumpt` clean on changed Go files.
- [ ] Reviewer: re-verify with `cd service && go test ./integration/ -run TestRegisteredResourcesSuite -count=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for retrieving registered resources with action attribute values.
  * Enhanced existing test with stricter validation of namespaced action information and attribute identifiers.

* **Bug Fixes**
  * Registered resources now properly return action attribute values with complete namespace details when fetched.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentdf/platform/pull/3472)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->