### PR TITLE
feat(core): Add explicit external and IPC ConnectRPC registration

### DIFF
--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -231,6 +231,7 @@ type OpenTDFServer struct {
 	ConnectRPCInProcess *inProcessServer
 	ConnectRPC          *ConnectRPC
 	CacheManager        *cache.Manager
+	connectRPCGateway   *inProcessServer
 
 	// To Deprecate: Use the TrustKeyIndex and TrustKeyManager instead
 	CryptoProvider *security.StandardCrypto
@@ -339,6 +340,13 @@ func NewOpenTDFServer(config Config, logger *logger.Logger, cacheManager *cache.
 			maxCallRecvMsgSize: config.GRPC.MaxCallRecvMsgSizeBytes,
 			maxCallSendMsgSize: config.GRPC.MaxCallSendMsgSizeBytes,
 			ConnectRPC:         connectRPCIpc,
+		},
+		connectRPCGateway: &inProcessServer{
+			logger:             logger.With("gateway_server", "true"),
+			srv:                memhttp.New(connectRPC.Mux),
+			maxCallRecvMsgSize: config.GRPC.MaxCallRecvMsgSizeBytes,
+			maxCallSendMsgSize: config.GRPC.MaxCallSendMsgSizeBytes,
+			ConnectRPC:         connectRPC,
 		},
 		logger:         logger,
 		PublicHostname: config.PublicHostname,
@@ -597,8 +605,16 @@ func (s OpenTDFServer) Stop() {
 		s.logger.Error("failed to shutdown in process connect-rpc server", slog.String("error", err.Error()))
 		return
 	}
+	if err := s.connectRPCGateway.srv.Shutdown(ctx); err != nil {
+		s.logger.Error("failed to shutdown grpc gateway connect-rpc server", slog.String("error", err.Error()))
+		return
+	}
 
 	s.logger.Info("shutdown complete")
+}
+
+func (s OpenTDFServer) GRPCGatewayConn() *grpc.ClientConn {
+	return s.connectRPCGateway.GrpcConn()
 }
 
 func (s inProcessServer) Conn() *sdk.ConnectRPCConnection {

--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -236,12 +236,12 @@ func startServices(ctx context.Context, params startServicesParams) (func(), err
 
 			// Register Connect RPC Services
 			if err := registerExternalConnectRPCServiceHandler(ctx, svc, otdf.ConnectRPC); err != nil {
-				logger.Info("service did not register a connect-rpc handler", slog.String("namespace", ns))
+				logger.Info("service did not register an external connect-rpc handler", slog.String("namespace", ns))
 			}
 
 			// Register In Process Connect RPC Services
 			if err := registerIPCConnectRPCServiceHandler(ctx, svc, otdf.ConnectRPCInProcess.ConnectRPC); err != nil {
-				logger.Info("service did not register a connect-rpc handler", slog.String("namespace", ns))
+				logger.Info("service did not register an IPC connect-rpc handler", slog.String("namespace", ns))
 			}
 
 			// Register GRPC Gateway Handler using the external connect rpc

--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -235,12 +235,12 @@ func startServices(ctx context.Context, params startServicesParams) (func(), err
 			}
 
 			// Register Connect RPC Services
-			if err := svc.RegisterConnectRPCServiceHandler(ctx, otdf.ConnectRPC); err != nil {
+			if err := registerExternalConnectRPCServiceHandler(ctx, svc, otdf.ConnectRPC); err != nil {
 				logger.Info("service did not register a connect-rpc handler", slog.String("namespace", ns))
 			}
 
 			// Register In Process Connect RPC Services
-			if err := svc.RegisterConnectRPCServiceHandler(ctx, otdf.ConnectRPCInProcess.ConnectRPC); err != nil {
+			if err := registerIPCConnectRPCServiceHandler(ctx, svc, otdf.ConnectRPCInProcess.ConnectRPC); err != nil {
 				logger.Info("service did not register a connect-rpc handler", slog.String("namespace", ns))
 			}
 
@@ -280,6 +280,28 @@ func startServices(ctx context.Context, params startServicesParams) (func(), err
 		gatewayCleanup = func() {}
 	}
 	return gatewayCleanup, nil
+}
+
+func registerExternalConnectRPCServiceHandler(
+	ctx context.Context,
+	svc serviceregistry.IService,
+	connectRPC *server.ConnectRPC,
+) error {
+	if externalSvc, ok := svc.(serviceregistry.ExternalConnectRPCService); ok {
+		return externalSvc.RegisterExternalConnectRPCServiceHandler(ctx, connectRPC)
+	}
+	return svc.RegisterConnectRPCServiceHandler(ctx, connectRPC)
+}
+
+func registerIPCConnectRPCServiceHandler(
+	ctx context.Context,
+	svc serviceregistry.IService,
+	connectRPC *server.ConnectRPC,
+) error {
+	if ipcSvc, ok := svc.(serviceregistry.IPCConnectRPCService); ok {
+		return ipcSvc.RegisterIPCConnectRPCServiceHandler(ctx, connectRPC)
+	}
+	return svc.RegisterConnectRPCServiceHandler(ctx, connectRPC)
 }
 
 func extractServiceLoggerConfig(cfg config.ServiceConfig) (string, error) {

--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -244,9 +244,9 @@ func startServices(ctx context.Context, params startServicesParams) (func(), err
 				logger.Info("service did not register a connect-rpc handler", slog.String("namespace", ns))
 			}
 
-			// Register GRPC Gateway Handler using the in-process connect rpc
-			grpcConn := otdf.ConnectRPCInProcess.GrpcConn()
-			err := svc.RegisterGRPCGatewayHandler(ctx, otdf.GRPCGatewayMux, otdf.ConnectRPCInProcess.GrpcConn())
+			// Register GRPC Gateway Handler using the external connect rpc
+			grpcConn := otdf.GRPCGatewayConn()
+			err := svc.RegisterGRPCGatewayHandler(ctx, otdf.GRPCGatewayMux, grpcConn)
 			if err != nil {
 				logger.Info("service did not register a grpc gateway handler", slog.String("namespace", ns))
 			} else if gatewayCleanup == nil {

--- a/service/pkg/server/services_test.go
+++ b/service/pkg/server/services_test.go
@@ -607,6 +607,14 @@ func (m *mockOrderTrackingService) RegisterConnectRPCServiceHandler(context.Cont
 	return nil
 }
 
+func (m *mockOrderTrackingService) RegisterExternalConnectRPCServiceHandler(context.Context, *server.ConnectRPC) error {
+	return nil
+}
+
+func (m *mockOrderTrackingService) RegisterIPCConnectRPCServiceHandler(context.Context, *server.ConnectRPC) error {
+	return nil
+}
+
 func (m *mockOrderTrackingService) RegisterGRPCGatewayHandler(context.Context, *runtime.ServeMux, *grpc.ClientConn) error {
 	return nil
 }

--- a/service/pkg/server/services_test.go
+++ b/service/pkg/server/services_test.go
@@ -3,16 +3,20 @@ package server
 import (
 	"context"
 	"embed"
+	"errors"
 	"net/http"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/opentdf/platform/service/internal/server"
 	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/pkg/cache"
 	"github.com/opentdf/platform/service/pkg/config"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type spyTestService struct {
@@ -686,6 +690,83 @@ func (suite *ServiceTestSuite) TestStartServices_StartsInRegistrationOrder() {
 
 	// call close function
 	registry.Shutdown()
+}
+
+func (suite *ServiceTestSuite) TestStartServices_GRPCGatewayUsesExternalConnectRPCHandler() {
+	ctx := context.Background()
+	registry := serviceregistry.NewServiceRegistry()
+	gatewayUsedExternalHandler := false
+	var gatewayErr error
+
+	const procedure = "/test.Gateway/Call"
+	externalHandler := func(struct{}, ...connect.HandlerOption) (string, http.Handler) {
+		return procedure, connect.NewUnaryHandler(
+			procedure,
+			func(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+				return connect.NewResponse(&emptypb.Empty{}), nil
+			},
+		)
+	}
+	ipcHandler := func(struct{}, ...connect.HandlerOption) (string, http.Handler) {
+		return procedure, connect.NewUnaryHandler(
+			procedure,
+			func(context.Context, *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+				return nil, connect.NewError(connect.CodePermissionDenied, errors.New("ipc handler reached"))
+			},
+		)
+	}
+
+	svc := &serviceregistry.Service[struct{}]{
+		ServiceOptions: serviceregistry.ServiceOptions[struct{}]{
+			Namespace: "gateway-test",
+			ServiceDesc: &grpc.ServiceDesc{
+				ServiceName: "test.Gateway",
+			},
+			RegisterFunc: func(serviceregistry.RegistrationParams) (struct{}, serviceregistry.HandlerServer) {
+				return struct{}{}, nil
+			},
+			ExternalConnectRPCFunc: externalHandler,
+			IPCConnectRPCFunc:      ipcHandler,
+			GRPCGatewayFunc: func(ctx context.Context, _ *runtime.ServeMux, conn *grpc.ClientConn) error {
+				err := conn.Invoke(ctx, procedure, &emptypb.Empty{}, &emptypb.Empty{})
+				gatewayErr = err
+				gatewayUsedExternalHandler = err == nil
+				return err
+			},
+		},
+	}
+	suite.Require().NoError(registry.RegisterService(svc, "test"))
+
+	otdf, err := server.NewOpenTDFServer(server.Config{
+		GRPC: server.GRPCConfig{
+			MaxCallRecvMsgSizeBytes: 4194304,
+			MaxCallSendMsgSizeBytes: 4194304,
+		},
+		WellKnownConfigRegister: func(string, any) error {
+			return nil
+		},
+	}, logger.CreateTestLogger(), &cache.Manager{})
+	suite.Require().NoError(err)
+	defer otdf.Stop()
+
+	newLogger, err := logger.NewLogger(logger.Config{Output: "stdout", Level: "info", Type: "json"})
+	suite.Require().NoError(err)
+	cleanup, err := startServices(ctx, startServicesParams{
+		cfg: &config.Config{
+			Mode: []string{"test"},
+			Services: map[string]config.ServiceConfig{
+				"gateway-test": {},
+			},
+		},
+		otdf:   otdf,
+		logger: newLogger,
+		reg:    registry,
+	})
+	suite.Require().NoError(err)
+	defer cleanup()
+
+	suite.Require().NoError(gatewayErr)
+	suite.Require().True(gatewayUsedExternalHandler, "gRPC gateway should call the external ConnectRPC handler")
 }
 
 // Test_Extra_Services_With_Mode_Negation validates that extra services (both extra core services

--- a/service/pkg/serviceregistry/connectrpc_test.go
+++ b/service/pkg/serviceregistry/connectrpc_test.go
@@ -36,10 +36,7 @@ func TestConnectRPCSplitUsesExplicitExternalAndIPCHandlers(t *testing.T) {
 
 	var calls []string
 	service := newConnectRPCTestService(
-		func(string, ...connect.HandlerOption) (string, http.Handler) {
-			calls = append(calls, "default")
-			return "/test.Default/Call", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
-		},
+		nil,
 		func(impl string, _ ...connect.HandlerOption) (string, http.Handler) {
 			calls = append(calls, "external:"+impl)
 			return "/test.External/Call", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
@@ -55,6 +52,42 @@ func TestConnectRPCSplitUsesExplicitExternalAndIPCHandlers(t *testing.T) {
 	require.NoError(t, service.RegisterIPCConnectRPCServiceHandler(context.Background(), newTestConnectRPC()))
 
 	require.Equal(t, []string{"external:impl", "ipc:impl"}, calls)
+}
+
+func TestConnectRPCSplitRejectsOnlyExternalHandler(t *testing.T) {
+	t.Parallel()
+
+	service := newConnectRPCTestService(
+		nil,
+		func(string, ...connect.HandlerOption) (string, http.Handler) {
+			return "/test.External/Call", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+		},
+		nil,
+	)
+
+	require.ErrorContains(
+		t,
+		service.Start(context.Background(), RegistrationParams{}),
+		"external and IPC ConnectRPC handlers must be configured together",
+	)
+}
+
+func TestConnectRPCSplitRejectsOnlyIPCHandler(t *testing.T) {
+	t.Parallel()
+
+	service := newConnectRPCTestService(
+		nil,
+		nil,
+		func(string, ...connect.HandlerOption) (string, http.Handler) {
+			return "/test.IPC/Call", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+		},
+	)
+
+	require.ErrorContains(
+		t,
+		service.Start(context.Background(), RegistrationParams{}),
+		"external and IPC ConnectRPC handlers must be configured together",
+	)
 }
 
 func newConnectRPCTestService(

--- a/service/pkg/serviceregistry/connectrpc_test.go
+++ b/service/pkg/serviceregistry/connectrpc_test.go
@@ -1,0 +1,82 @@
+package serviceregistry
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/opentdf/platform/service/internal/server"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestConnectRPCSplitDefaultsToExistingHandler(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	service := newConnectRPCTestService(
+		func(impl string, _ ...connect.HandlerOption) (string, http.Handler) {
+			calls = append(calls, impl)
+			return "/test.Default/Call", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+		},
+		nil,
+		nil,
+	)
+
+	require.NoError(t, service.Start(context.Background(), RegistrationParams{}))
+	require.NoError(t, service.RegisterExternalConnectRPCServiceHandler(context.Background(), newTestConnectRPC()))
+	require.NoError(t, service.RegisterIPCConnectRPCServiceHandler(context.Background(), newTestConnectRPC()))
+
+	require.Equal(t, []string{"impl", "impl"}, calls)
+}
+
+func TestConnectRPCSplitUsesExplicitExternalAndIPCHandlers(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	service := newConnectRPCTestService(
+		func(string, ...connect.HandlerOption) (string, http.Handler) {
+			calls = append(calls, "default")
+			return "/test.Default/Call", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+		},
+		func(impl string, _ ...connect.HandlerOption) (string, http.Handler) {
+			calls = append(calls, "external:"+impl)
+			return "/test.External/Call", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+		},
+		func(impl string, _ ...connect.HandlerOption) (string, http.Handler) {
+			calls = append(calls, "ipc:"+impl)
+			return "/test.IPC/Call", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+		},
+	)
+
+	require.NoError(t, service.Start(context.Background(), RegistrationParams{}))
+	require.NoError(t, service.RegisterExternalConnectRPCServiceHandler(context.Background(), newTestConnectRPC()))
+	require.NoError(t, service.RegisterIPCConnectRPCServiceHandler(context.Background(), newTestConnectRPC()))
+
+	require.Equal(t, []string{"external:impl", "ipc:impl"}, calls)
+}
+
+func newConnectRPCTestService(
+	defaultFunc func(string, ...connect.HandlerOption) (string, http.Handler),
+	externalFunc func(string, ...connect.HandlerOption) (string, http.Handler),
+	ipcFunc func(string, ...connect.HandlerOption) (string, http.Handler),
+) *Service[string] {
+	return &Service[string]{
+		ServiceOptions: ServiceOptions[string]{
+			ServiceDesc: &grpc.ServiceDesc{ServiceName: "test.Service"},
+			RegisterFunc: func(RegistrationParams) (string, HandlerServer) {
+				return "impl", nil
+			},
+			ConnectRPCFunc:         defaultFunc,
+			ExternalConnectRPCFunc: externalFunc,
+			IPCConnectRPCFunc:      ipcFunc,
+		},
+	}
+}
+
+func newTestConnectRPC() *server.ConnectRPC {
+	return &server.ConnectRPC{
+		Mux: http.NewServeMux(),
+	}
+}

--- a/service/pkg/serviceregistry/serviceregistry.go
+++ b/service/pkg/serviceregistry/serviceregistry.go
@@ -139,10 +139,10 @@ type ServiceOptions[S any] struct {
 	// ConnectRPCServiceHandler is the function that will be called to register the service with the
 	ConnectRPCFunc func(S, ...connect.HandlerOption) (string, http.Handler)
 	// ExternalConnectRPCFunc is the optional function used to register externally reachable Connect RPC handlers.
-	// If unset, ConnectRPCFunc is used to preserve existing service behavior.
+	// If set, IPCConnectRPCFunc must also be set.
 	ExternalConnectRPCFunc func(S, ...connect.HandlerOption) (string, http.Handler)
 	// IPCConnectRPCFunc is the optional function used to register in-process Connect RPC handlers.
-	// If unset, ConnectRPCFunc is used to preserve existing service behavior.
+	// If set, ExternalConnectRPCFunc must also be set.
 	IPCConnectRPCFunc func(S, ...connect.HandlerOption) (string, http.Handler)
 	// Deprecated: Registers a gRPC service with the gRPC gateway
 	GRPCGatewayFunc func(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error
@@ -187,6 +187,9 @@ func (s *Service[S]) Start(ctx context.Context, params RegistrationParams) error
 	if s.Started {
 		return errors.New("service already started")
 	}
+	if err := s.validateConnectRPCServiceHandlers(); err != nil {
+		return err
+	}
 
 	if s.DB.Required && !params.DBClient.RanMigrations() && params.DBClient.MigrationsEnabled() {
 		appliedMigrations, err := params.DBClient.RunMigrations(ctx, s.DB.Migrations)
@@ -221,10 +224,16 @@ func (s Service[S]) RegisterConfigUpdateHook(ctx context.Context, hookAppender f
 }
 
 func (s Service[S]) RegisterConnectRPCServiceHandler(_ context.Context, connectRPC *server.ConnectRPC) error {
+	if err := s.validateConnectRPCServiceHandlers(); err != nil {
+		return err
+	}
 	return s.registerConnectRPCServiceHandler(connectRPC, s.ConnectRPCFunc)
 }
 
 func (s Service[S]) RegisterExternalConnectRPCServiceHandler(_ context.Context, connectRPC *server.ConnectRPC) error {
+	if err := s.validateConnectRPCServiceHandlers(); err != nil {
+		return err
+	}
 	connectRPCFunc := s.ExternalConnectRPCFunc
 	if connectRPCFunc == nil {
 		connectRPCFunc = s.ConnectRPCFunc
@@ -233,11 +242,23 @@ func (s Service[S]) RegisterExternalConnectRPCServiceHandler(_ context.Context, 
 }
 
 func (s Service[S]) RegisterIPCConnectRPCServiceHandler(_ context.Context, connectRPC *server.ConnectRPC) error {
+	if err := s.validateConnectRPCServiceHandlers(); err != nil {
+		return err
+	}
 	connectRPCFunc := s.IPCConnectRPCFunc
 	if connectRPCFunc == nil {
 		connectRPCFunc = s.ConnectRPCFunc
 	}
 	return s.registerConnectRPCServiceHandler(connectRPC, connectRPCFunc)
+}
+
+func (s Service[S]) validateConnectRPCServiceHandlers() error {
+	hasExternalConnectRPCFunc := s.ExternalConnectRPCFunc != nil
+	hasIPCConnectRPCFunc := s.IPCConnectRPCFunc != nil
+	if hasExternalConnectRPCFunc != hasIPCConnectRPCFunc {
+		return errors.New("external and IPC ConnectRPC handlers must be configured together")
+	}
+	return nil
 }
 
 func (s Service[S]) registerConnectRPCServiceHandler(

--- a/service/pkg/serviceregistry/serviceregistry.go
+++ b/service/pkg/serviceregistry/serviceregistry.go
@@ -100,6 +100,14 @@ type IService interface {
 	RegisterHTTPHandlers(context.Context, *runtime.ServeMux) error
 }
 
+type ExternalConnectRPCService interface {
+	RegisterExternalConnectRPCServiceHandler(context.Context, *server.ConnectRPC) error
+}
+
+type IPCConnectRPCService interface {
+	RegisterIPCConnectRPCServiceHandler(context.Context, *server.ConnectRPC) error
+}
+
 // Service is a struct that holds the registration information for a service as well as the state
 // of the service within the instance of the platform.
 type Service[S any] struct {
@@ -130,6 +138,12 @@ type ServiceOptions[S any] struct {
 	httpHandlerFunc HandlerServer
 	// ConnectRPCServiceHandler is the function that will be called to register the service with the
 	ConnectRPCFunc func(S, ...connect.HandlerOption) (string, http.Handler)
+	// ExternalConnectRPCFunc is the optional function used to register externally reachable Connect RPC handlers.
+	// If unset, ConnectRPCFunc is used to preserve existing service behavior.
+	ExternalConnectRPCFunc func(S, ...connect.HandlerOption) (string, http.Handler)
+	// IPCConnectRPCFunc is the optional function used to register in-process Connect RPC handlers.
+	// If unset, ConnectRPCFunc is used to preserve existing service behavior.
+	IPCConnectRPCFunc func(S, ...connect.HandlerOption) (string, http.Handler)
 	// Deprecated: Registers a gRPC service with the gRPC gateway
 	GRPCGatewayFunc func(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error
 	// DB is optional and used to register the service with a database
@@ -207,11 +221,34 @@ func (s Service[S]) RegisterConfigUpdateHook(ctx context.Context, hookAppender f
 }
 
 func (s Service[S]) RegisterConnectRPCServiceHandler(_ context.Context, connectRPC *server.ConnectRPC) error {
-	if s.ConnectRPCFunc == nil {
+	return s.registerConnectRPCServiceHandler(connectRPC, s.ConnectRPCFunc)
+}
+
+func (s Service[S]) RegisterExternalConnectRPCServiceHandler(_ context.Context, connectRPC *server.ConnectRPC) error {
+	connectRPCFunc := s.ExternalConnectRPCFunc
+	if connectRPCFunc == nil {
+		connectRPCFunc = s.ConnectRPCFunc
+	}
+	return s.registerConnectRPCServiceHandler(connectRPC, connectRPCFunc)
+}
+
+func (s Service[S]) RegisterIPCConnectRPCServiceHandler(_ context.Context, connectRPC *server.ConnectRPC) error {
+	connectRPCFunc := s.IPCConnectRPCFunc
+	if connectRPCFunc == nil {
+		connectRPCFunc = s.ConnectRPCFunc
+	}
+	return s.registerConnectRPCServiceHandler(connectRPC, connectRPCFunc)
+}
+
+func (s Service[S]) registerConnectRPCServiceHandler(
+	connectRPC *server.ConnectRPC,
+	connectRPCFunc func(S, ...connect.HandlerOption) (string, http.Handler),
+) error {
+	if connectRPCFunc == nil {
 		return errors.New("service did not register a handler")
 	}
 	connectRPC.ServiceReflection = append(connectRPC.ServiceReflection, s.GetServiceDesc().ServiceName)
-	path, handler := s.ConnectRPCFunc(s.impl, connectRPC.Interceptors...)
+	path, handler := connectRPCFunc(s.impl, connectRPC.Interceptors...)
 	connectRPC.Mux.Handle(path, handler)
 	return nil
 }


### PR DESCRIPTION
Adds explicit external and in-process ConnectRPC registration hooks while preserving the existing ConnectRPCFunc fallback for current services.

Services can either use the legacy `ConnectRPCFunc` handler or provide both explicit external and IPC handlers. One-sided split registrations are rejected at startup. The gRPC Gateway routes through the externally registered ConnectRPC handler so external HTTP traffic cannot accidentally hit IPC-only service behavior.

| Service registration scenario | Valid? | External ConnectRPC serves | IPC ConnectRPC serves | gRPC Gateway serves | How |
| --- | --- | --- | --- | --- | --- |
| No ConnectRPC handler is set | Yes | Nothing | Nothing | Nothing | Registration returns the existing “service did not register a handler” path. |
| Only `ConnectRPCFunc` is set | Yes | `ConnectRPCFunc` | `ConnectRPCFunc` | `ConnectRPCFunc` | External and IPC registration both fall back to the existing handler, and the gateway dials the external ConnectRPC mux. |
| Both `ExternalConnectRPCFunc` and `IPCConnectRPCFunc` are set | Yes | `ExternalConnectRPCFunc` | `IPCConnectRPCFunc` | `ExternalConnectRPCFunc` | External and IPC registration use their context-specific hooks, and the gateway dials the external ConnectRPC mux. |
| Only `ExternalConnectRPCFunc` is set | No | Nothing | Nothing | Nothing | Startup fails because external and IPC handlers must be configured together. |
| Only `IPCConnectRPCFunc` is set | No | Nothing | Nothing | Nothing | Startup fails because external and IPC handlers must be configured together. |
