### PR TITLE
feat(sdk): add WithPolicyFrom re-wrap helper

### DIFF
--- a/.docs-drift.yaml
+++ b/.docs-drift.yaml
@@ -1,0 +1,100 @@
+# docs-drift configuration for opentdf/platform.
+#
+# This file is consumed by the docs-drift skill
+# (https://github.com/virtru-corp/agent-skills/tree/main/skills/developers/docs-drift)
+# when a contributor runs `/docs-drift` after editing SDK code. The skill scans
+# for new/changed exported Go symbols and proto RPCs, drafts MDX stubs for
+# opentdf/docs, and prepares a PR.
+#
+# Most of the values below mirror the skill's built-in OpenTDF defaults — they're
+# committed as a documentation artifact so the contract is discoverable in this
+# repo. The `mappings:` section below them adds repo-specific routing the skill
+# wouldn't otherwise know about.
+
+docs:
+  repo: ../docs                # Sibling clone of opentdf/docs
+  root: docs/sdks              # Docs root within opentdf/docs
+
+version:
+  tag_prefix: "sdk/"           # SDK is independently versioned (sdk/v0.X.Y)
+
+scan:
+  go_paths:                    # Where the scanner looks for Go source
+    - sdk/                     #   the public SDK package
+    - protocol/go/internal/    #   source-file codegen helpers (PR #3232 pattern)
+  proto_paths:                 # Where the scanner looks for .proto files
+    - service/
+  exclude_paths:               # Substring match — these are generated or test-only
+    - sdk/sdkconnect/          #   auto-generated Connect-RPC wrappers
+    - sdk/gen/                 #   generated proto code (legacy path)
+    - sdk/internal/            #   Go internal package
+
+# Mappings route new symbols to the right MDX file when the name-only sniff
+# can't find an existing reference. Keys are glob patterns matched against
+# the fully-qualified symbol name; values are doc paths (relative to the
+# docs repo root) with an optional #section anchor for the heading to
+# append under.
+#
+# First-match-wins, ordered by insertion. Put the most specific patterns
+# first; the catch-all patterns last.
+mappings:
+
+  # ── EntityIdentifier constructor helpers (PR #3232 pattern) ──────────────
+  # Live in protocol/go/internal/authorization/v2/ and get codegen-copied
+  # into protocol/go/authorization/v2/*.gen.go. They're documented in
+  # authorization.mdx under the ## EntityIdentifier section.
+  "ForToken":              docs/sdks/authorization.mdx#entityidentifier
+  "ForClientID":           docs/sdks/authorization.mdx#entityidentifier
+  "ForEmail":              docs/sdks/authorization.mdx#entityidentifier
+  "ForUserName":           docs/sdks/authorization.mdx#entityidentifier
+  "ForRegisteredResource": docs/sdks/authorization.mdx#entityidentifier
+  "WithRequestToken":      docs/sdks/authorization.mdx#entityidentifier
+
+  # ── SDK discovery / attribute checks ─────────────────────────────────────
+  # Methods on the SDK struct that read platform state without writing.
+  # All land in discovery.mdx alongside ListAttributes / AttributeExists / etc.
+  "SDK.List*":             docs/sdks/discovery.mdx
+  "SDK.Attribute*":        docs/sdks/discovery.mdx
+  "SDK.Validate*":         docs/sdks/discovery.mdx
+  "SDK.GetEntityAttributes": docs/sdks/discovery.mdx
+
+  # ── TDF mechanics and re-wrap helpers ────────────────────────────────────
+  # Package-level functions for TDF inspection and option building.
+  # CreateTDF, LoadTDF, and IsValidTdf already live in tdf.mdx; new
+  # adjacent helpers (e.g., WithPolicyFrom from DSPX-2603) belong there too.
+  "IsTDF":                 docs/sdks/tdf.mdx
+  "IsValidTdf":            docs/sdks/tdf.mdx
+  "WithPolicyFrom":        docs/sdks/tdf.mdx
+  "BulkDecrypt":           docs/sdks/tdf.mdx
+
+  # ── Platform-client setup options ────────────────────────────────────────
+  # The "Initializing the SDK client" section of platform-client.mdx is
+  # where setup-time options like WithPlatformEndpoint live. Newly-added
+  # With*-style construction options default here unless overridden above.
+  "With*":                 docs/sdks/platform-client.mdx#initializing-the-sdk-client
+
+  # ── Policy enum aliases (PR #3408 pattern) ───────────────────────────────
+  # Constants like policy.OperatorIn / policy.BooleanAnd added in
+  # protocol/go/internal/policy/enums.go. Documented under the enum tables
+  # in policy.mdx.
+  "Operator*":             docs/sdks/policy.mdx
+  "Boolean*":              docs/sdks/policy.mdx
+  "Rule*":                 docs/sdks/policy.mdx
+  "State*":                docs/sdks/policy.mdx
+
+  # ── Proto service RPCs ───────────────────────────────────────────────────
+  # Per-service mapping. Each service's RPCs map to its dedicated MDX.
+  "AuthorizationService.*":             docs/sdks/authorization.mdx
+  "AttributesService.*":                docs/sdks/policy.mdx
+  "ActionsService.*":                   docs/sdks/policy.mdx
+  "NamespaceService.*":                 docs/sdks/policy.mdx
+  "SubjectMappingService.*":            docs/sdks/policy.mdx
+  "ResourceMappingService.*":           docs/sdks/policy.mdx
+  "RegisteredResourcesService.*":       docs/sdks/policy.mdx
+  "ObligationsService.*":               docs/sdks/obligations.mdx
+  "KeyAccessServerRegistryService.*":   docs/sdks/policy.mdx
+  "KeyManagementService.*":             docs/sdks/policy.mdx
+  "UnsafeService.*":                    docs/sdks/policy.mdx
+  "EntityResolutionService.*":          docs/sdks/authorization.mdx
+  "AccessService.*":                    docs/sdks/tdf.mdx
+  "WellKnownService.*":                 docs/sdks/platform-client.mdx

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -802,6 +802,34 @@ func allowListFromKASRegistry(ctx context.Context, logger *slog.Logger, kasRegis
 	return kasAllowlist, nil
 }
 
+// WithPolicyFrom returns a [TDFOption] that binds the source TDF's policy
+// (its attribute value FQNs) to the new TDF being created.
+//
+// Use this in re-wrap pipelines to preserve the source policy without
+// having to know about the manifest's base64 + JSON encoding:
+//
+//	if ok, _ := sdk.IsValidTdf(file); !ok {
+//	    // pass through unchanged
+//	}
+//	reader, _ := s.LoadTDF(file)
+//	_ = reader.Init(ctx)
+//	_, _ = s.CreateTDF(out, transformed, sdk.WithPolicyFrom(reader))
+//
+// The reader must be initialized via [Reader.Init] before being passed here —
+// [Reader.DataAttributes] requires the policy field to be parsed.
+func WithPolicyFrom(r *Reader) TDFOption {
+	return func(c *TDFConfig) error {
+		if r == nil {
+			return errors.New("WithPolicyFrom: nil Reader")
+		}
+		attrs, err := r.DataAttributes()
+		if err != nil {
+			return fmt.Errorf("WithPolicyFrom: extracting source attributes: %w", err)
+		}
+		return WithDataAttributes(attrs...)(c)
+	}
+}
+
 // LoadTDF loads the tdf and prepare for reading the payload from TDF
 func (s SDK) LoadTDF(reader io.ReadSeeker, opts ...TDFReaderOption) (*Reader, error) {
 	if s.kasSessionKey != nil {

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -811,12 +811,15 @@ func allowListFromKASRegistry(ctx context.Context, logger *slog.Logger, kasRegis
 //	if ok, _ := sdk.IsValidTdf(file); !ok {
 //	    // pass through unchanged
 //	}
-//	reader, _ := s.LoadTDF(file)
-//	_ = reader.Init(ctx)
-//	_, _ = s.CreateTDF(out, transformed, sdk.WithPolicyFrom(reader))
+//	reader, err := s.LoadTDF(file)
+//	if err != nil {
+//	    return err
+//	}
+//	_, err = s.CreateTDF(out, transformed, sdk.WithPolicyFrom(reader))
 //
-// The reader must be initialized via [Reader.Init] before being passed here —
-// [Reader.DataAttributes] requires the policy field to be parsed.
+// [Reader.Init] is not required: [Reader.DataAttributes] reads the policy
+// from the manifest, which [SDK.LoadTDF] has already populated. Calling
+// Init would trigger an unnecessary KAS rewrap.
 func WithPolicyFrom(r *Reader) TDFOption {
 	return func(c *TDFConfig) error {
 		if r == nil {

--- a/sdk/tdf_rewrap_test.go
+++ b/sdk/tdf_rewrap_test.go
@@ -1,0 +1,17 @@
+package sdk
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWithPolicyFrom_NilReader(t *testing.T) {
+	cfg := &TDFConfig{}
+	err := WithPolicyFrom(nil)(cfg)
+	if err == nil {
+		t.Fatal("expected error for nil Reader")
+	}
+	if !strings.Contains(err.Error(), "nil Reader") {
+		t.Errorf("error = %v, want to mention nil Reader", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `sdk.WithPolicyFrom(r *Reader) TDFOption` — a builder that binds the source TDF's policy (its attribute value FQNs) to a new TDF being created via `CreateTDF`. Targets re-wrap pipelines where the source policy should carry forward to the output without callers having to handle the manifest's base64 + JSON encoding themselves.

Call site is a single line, matching the existing `With*` option-builder idiom in this package (e.g., `WithDataAttributes`, `WithKasInformation`):

```go
if ok, _ := sdk.IsValidTdf(file); !ok {
    // pass through unchanged
    return
}
reader, _ := s.LoadTDF(file)
_ = reader.Init(ctx)
_, _ = s.CreateTDF(out, transformed, sdk.WithPolicyFrom(reader))
```

## Implementation

Thin wrapper over `Reader.DataAttributes` (which already handles the base64 + JSON decoding) + `WithDataAttributes` (which already builds the TDF option). The only new logic is the `nil` Reader check.

## Test plan

- [x] `sdk/tdf_rewrap_test.go` — unit test for the `nil` Reader error path
- [x] `go test ./sdk/... -count=1` passes (including `TestREADMECodeBlocks`)
- [x] `gofumpt` clean
- [x] `golangci-lint` clean on the changed files
- [ ] Real re-wrap fixture test — follow-up. The helper delegates to two well-tested primitives, so the integration coverage is more useful as part of an end-to-end re-wrap example than as a unit test that constructs a full TDF in-place.

## Companion docs

The corresponding `tdf.mdx` section is drafted on [opentdf/docs `demo/docs-drift-with-policy-from`](https://github.com/opentdf/docs/compare/main...demo/docs-drift-with-policy-from). That branch was generated by the [docs-drift skill](https://github.com/virtru-corp/agent-skills/pull/49) mining this function's godoc example verbatim — the doc PR is a demo of that workflow as well as a real doc addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable extracting policy attributes from an existing encrypted document and applying them to newly created ones for easier policy reuse.

* **Documentation**
  * Added configuration for automated docs discovery and mapping to keep SDK and RPC docs in sync.

* **Tests**
  * Added a unit test ensuring an error is returned when attempting to extract policy from a nil source.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentdf/platform/pull/3476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->