### PR TITLE
feat(core): Add external interceptor factory with named config

### DIFF
--- a/service/pkg/config/config.go
+++ b/service/pkg/config/config.go
@@ -25,6 +25,12 @@ type ServicesMap map[string]ServiceConfig
 // Config structure holding a single service.
 type ServiceConfig map[string]any
 
+// InterceptorsMap holds freeform configuration for named interceptors.
+type InterceptorsMap map[string]InterceptorConfig
+
+// InterceptorConfig holds freeform configuration for a single named interceptor.
+type InterceptorConfig map[string]any
+
 func (cfg ServiceConfig) String() string {
 	// Create a shallow copy so we don't mutate the original map.
 	redacted := make(map[string]any, len(cfg))
@@ -88,6 +94,9 @@ type Config struct {
 
 	// Services represents the configuration settings for the services.
 	Services ServicesMap `mapstructure:"services" json:"services"`
+
+	// Interceptors represents configuration settings for named interceptors.
+	Interceptors InterceptorsMap `mapstructure:"interceptors" json:"interceptors"`
 
 	// onConfigChangeHooks is a list of functions to call when the configuration changes.
 	onConfigChangeHooks []ChangeHook

--- a/service/pkg/config/config_test.go
+++ b/service/pkg/config/config_test.go
@@ -295,6 +295,10 @@ services:
   service_a:
     value1: abc
     value2: def
+interceptors:
+  interceptor_a:
+    value1: ghi
+    value2: jkl
 server:
   port: 9999
 `
@@ -335,6 +339,10 @@ server:
 	assert.Len(t, config.Services, 1)
 	assert.Equal(t, "abc", config.Services["service_a"]["value1"])
 	assert.Equal(t, "def", config.Services["service_a"]["value2"])
+	// interceptors
+	assert.Len(t, config.Interceptors, 1)
+	assert.Equal(t, "ghi", config.Interceptors["interceptor_a"]["value1"])
+	assert.Equal(t, "jkl", config.Interceptors["interceptor_a"]["value2"])
 }
 
 // TestLoad_Precedence is a matrix test that verifies the loading order

--- a/service/pkg/server/options.go
+++ b/service/pkg/server/options.go
@@ -5,6 +5,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/casbin/casbin/v2/persist"
+	"github.com/opentdf/platform/sdk"
 	"github.com/opentdf/platform/service/pkg/authz"
 	"github.com/opentdf/platform/service/pkg/config"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
@@ -12,6 +13,12 @@ import (
 )
 
 type StartOptions func(StartConfig) StartConfig
+
+type ExternalConnectInterceptorContext struct {
+	SDK *sdk.SDK
+}
+
+type ExternalConnectInterceptorFactory func(ExternalConnectInterceptorContext) (connect.Interceptor, error)
 
 type StartConfig struct {
 	ConfigKey             string
@@ -28,6 +35,7 @@ type StartConfig struct {
 
 	extraConnectInterceptors []connect.Interceptor
 	extraIPCInterceptors     []connect.Interceptor
+	externalConnectFactories []ExternalConnectInterceptorFactory
 
 	trustKeyManagerCtxs []trust.NamedKeyManagerCtxFactory
 
@@ -174,6 +182,17 @@ func WithConfigLoaderOrder(loaderOrder []string) StartOptions {
 func WithConnectInterceptors(interceptors ...connect.Interceptor) StartOptions {
 	return func(c StartConfig) StartConfig {
 		c.extraConnectInterceptors = append(c.extraConnectInterceptors, interceptors...)
+		return c
+	}
+}
+
+// WithExternalConnectInterceptorFactories appends factories for external
+// Connect interceptors that need access to startup-created clients, such as the
+// IPC SDK connection. Factories are evaluated after the SDK is created and
+// before externally reachable service handlers are registered.
+func WithExternalConnectInterceptorFactories(factories ...ExternalConnectInterceptorFactory) StartOptions {
+	return func(c StartConfig) StartConfig {
+		c.externalConnectFactories = append(c.externalConnectFactories, factories...)
 		return c
 	}
 }

--- a/service/pkg/server/options.go
+++ b/service/pkg/server/options.go
@@ -35,8 +35,8 @@ type StartConfig struct {
 	configLoaders         []config.Loader
 	configLoaderOrder     []string
 
-	extraConnectInterceptors []connect.Interceptor
-	extraIPCInterceptors     []connect.Interceptor
+	extraConnectInterceptors     []connect.Interceptor
+	extraIPCInterceptors         []connect.Interceptor
 	externalInterceptorFactories []InterceptorFactory
 
 	trustKeyManagerCtxs []trust.NamedKeyManagerCtxFactory

--- a/service/pkg/server/options.go
+++ b/service/pkg/server/options.go
@@ -6,6 +6,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/casbin/casbin/v2/persist"
 	"github.com/opentdf/platform/sdk"
+	"github.com/opentdf/platform/service/logger"
 	"github.com/opentdf/platform/service/pkg/authz"
 	"github.com/opentdf/platform/service/pkg/config"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
@@ -14,11 +15,12 @@ import (
 
 type StartOptions func(StartConfig) StartConfig
 
-type ExternalConnectInterceptorContext struct {
-	SDK *sdk.SDK
+type InterceptorParams struct {
+	SDK    *sdk.SDK
+	Logger *logger.Logger
 }
 
-type ExternalConnectInterceptorFactory func(ExternalConnectInterceptorContext) (connect.Interceptor, error)
+type InterceptorFactory func(InterceptorParams) (connect.Interceptor, error)
 
 type StartConfig struct {
 	ConfigKey             string
@@ -35,7 +37,7 @@ type StartConfig struct {
 
 	extraConnectInterceptors []connect.Interceptor
 	extraIPCInterceptors     []connect.Interceptor
-	externalConnectFactories []ExternalConnectInterceptorFactory
+	externalInterceptorFactories []InterceptorFactory
 
 	trustKeyManagerCtxs []trust.NamedKeyManagerCtxFactory
 
@@ -186,13 +188,13 @@ func WithConnectInterceptors(interceptors ...connect.Interceptor) StartOptions {
 	}
 }
 
-// WithExternalConnectInterceptorFactories appends factories for external
+// WithExternalInterceptorFactories appends factories for external
 // Connect interceptors that need access to startup-created clients, such as the
 // IPC SDK connection. Factories are evaluated after the SDK is created and
 // before externally reachable service handlers are registered.
-func WithExternalConnectInterceptorFactories(factories ...ExternalConnectInterceptorFactory) StartOptions {
+func WithExternalInterceptorFactories(factories ...InterceptorFactory) StartOptions {
 	return func(c StartConfig) StartConfig {
-		c.externalConnectFactories = append(c.externalConnectFactories, factories...)
+		c.externalInterceptorFactories = append(c.externalInterceptorFactories, factories...)
 		return c
 	}
 }

--- a/service/pkg/server/options.go
+++ b/service/pkg/server/options.go
@@ -18,9 +18,13 @@ type StartOptions func(StartConfig) StartConfig
 type InterceptorParams struct {
 	SDK    *sdk.SDK
 	Logger *logger.Logger
+	Config config.InterceptorConfig
 }
 
-type InterceptorFactory func(InterceptorParams) (connect.Interceptor, error)
+type InterceptorFactory struct {
+	Name    string
+	Factory func(InterceptorParams) (connect.Interceptor, error)
+}
 
 type StartConfig struct {
 	ConfigKey             string
@@ -188,7 +192,7 @@ func WithConnectInterceptors(interceptors ...connect.Interceptor) StartOptions {
 	}
 }
 
-// WithExternalInterceptorFactories appends factories for external
+// WithExternalInterceptorFactories appends named factories for external
 // Connect interceptors that need access to startup-created clients, such as the
 // IPC SDK connection. Factories are evaluated after the SDK is created and
 // before externally reachable service handlers are registered.

--- a/service/pkg/server/options.go
+++ b/service/pkg/server/options.go
@@ -21,6 +21,8 @@ type InterceptorParams struct {
 	Config config.InterceptorConfig
 }
 
+// InterceptorFactory creates a named external Connect interceptor. Returning a
+// nil interceptor skips registration for that factory.
 type InterceptorFactory struct {
 	Name    string
 	Factory func(InterceptorParams) (connect.Interceptor, error)

--- a/service/pkg/server/options_test.go
+++ b/service/pkg/server/options_test.go
@@ -73,6 +73,63 @@ func TestWithConnectInterceptors(t *testing.T) {
 	}
 }
 
+func TestWithExternalConnectInterceptorFactories(t *testing.T) {
+	factory := func(ExternalConnectInterceptorContext) (connect.Interceptor, error) {
+		return noopInterceptor(), nil
+	}
+
+	tests := []struct {
+		name      string
+		apply     func(*StartConfig)
+		wantCount int
+	}{
+		{
+			name: "single factory is appended",
+			apply: func(c *StartConfig) {
+				*c = WithExternalConnectInterceptorFactories(factory)(*c)
+			},
+			wantCount: 1,
+		},
+		{
+			name: "multiple factories are appended in order",
+			apply: func(c *StartConfig) {
+				*c = WithExternalConnectInterceptorFactories(factory, factory, factory)(*c)
+			},
+			wantCount: 3,
+		},
+		{
+			name: "calling twice accumulates factories",
+			apply: func(c *StartConfig) {
+				*c = WithExternalConnectInterceptorFactories(factory)(*c)
+				*c = WithExternalConnectInterceptorFactories(factory, factory)(*c)
+			},
+			wantCount: 3,
+		},
+		{
+			name: "empty call leaves slice nil",
+			apply: func(c *StartConfig) {
+				*c = WithExternalConnectInterceptorFactories()(*c)
+			},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg StartConfig
+			tt.apply(&cfg)
+
+			if tt.wantCount == 0 {
+				assert.Nil(t, cfg.externalConnectFactories)
+			} else {
+				require.Len(t, cfg.externalConnectFactories, tt.wantCount)
+			}
+			assert.Nil(t, cfg.extraConnectInterceptors)
+			assert.Nil(t, cfg.extraIPCInterceptors)
+		})
+	}
+}
+
 func TestWithIPCInterceptors(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/service/pkg/server/options_test.go
+++ b/service/pkg/server/options_test.go
@@ -73,8 +73,8 @@ func TestWithConnectInterceptors(t *testing.T) {
 	}
 }
 
-func TestWithExternalConnectInterceptorFactories(t *testing.T) {
-	factory := func(ExternalConnectInterceptorContext) (connect.Interceptor, error) {
+func TestWithExternalInterceptorFactories(t *testing.T) {
+	factory := func(InterceptorParams) (connect.Interceptor, error) {
 		return noopInterceptor(), nil
 	}
 
@@ -86,29 +86,29 @@ func TestWithExternalConnectInterceptorFactories(t *testing.T) {
 		{
 			name: "single factory is appended",
 			apply: func(c *StartConfig) {
-				*c = WithExternalConnectInterceptorFactories(factory)(*c)
+				*c = WithExternalInterceptorFactories(factory)(*c)
 			},
 			wantCount: 1,
 		},
 		{
 			name: "multiple factories are appended in order",
 			apply: func(c *StartConfig) {
-				*c = WithExternalConnectInterceptorFactories(factory, factory, factory)(*c)
+				*c = WithExternalInterceptorFactories(factory, factory, factory)(*c)
 			},
 			wantCount: 3,
 		},
 		{
 			name: "calling twice accumulates factories",
 			apply: func(c *StartConfig) {
-				*c = WithExternalConnectInterceptorFactories(factory)(*c)
-				*c = WithExternalConnectInterceptorFactories(factory, factory)(*c)
+				*c = WithExternalInterceptorFactories(factory)(*c)
+				*c = WithExternalInterceptorFactories(factory, factory)(*c)
 			},
 			wantCount: 3,
 		},
 		{
 			name: "empty call leaves slice nil",
 			apply: func(c *StartConfig) {
-				*c = WithExternalConnectInterceptorFactories()(*c)
+				*c = WithExternalInterceptorFactories()(*c)
 			},
 			wantCount: 0,
 		},
@@ -120,9 +120,9 @@ func TestWithExternalConnectInterceptorFactories(t *testing.T) {
 			tt.apply(&cfg)
 
 			if tt.wantCount == 0 {
-				assert.Nil(t, cfg.externalConnectFactories)
+				assert.Nil(t, cfg.externalInterceptorFactories)
 			} else {
-				require.Len(t, cfg.externalConnectFactories, tt.wantCount)
+				require.Len(t, cfg.externalInterceptorFactories, tt.wantCount)
 			}
 			assert.Nil(t, cfg.extraConnectInterceptors)
 			assert.Nil(t, cfg.extraIPCInterceptors)

--- a/service/pkg/server/options_test.go
+++ b/service/pkg/server/options_test.go
@@ -184,6 +184,12 @@ func TestValidateExternalInterceptorFactoryRequiresName(t *testing.T) {
 	require.ErrorIs(t, err, ErrExternalInterceptorFactoryNameRequired)
 }
 
+func TestValidateExternalInterceptorFactoryRequiresFactoryFunc(t *testing.T) {
+	err := validateExternalInterceptorFactory(InterceptorFactory{Name: "test"})
+
+	require.ErrorIs(t, err, ErrExternalInterceptorFactoryFuncRequired)
+}
+
 func TestWithIPCInterceptors(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/service/pkg/server/options_test.go
+++ b/service/pkg/server/options_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/opentdf/platform/service/pkg/authz"
+	"github.com/opentdf/platform/service/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -74,8 +76,11 @@ func TestWithConnectInterceptors(t *testing.T) {
 }
 
 func TestWithExternalInterceptorFactories(t *testing.T) {
-	factory := func(InterceptorParams) (connect.Interceptor, error) {
-		return noopInterceptor(), nil
+	factory := InterceptorFactory{
+		Name: "test",
+		Factory: func(InterceptorParams) (connect.Interceptor, error) {
+			return noopInterceptor(), nil
+		},
 	}
 
 	tests := []struct {
@@ -128,6 +133,55 @@ func TestWithExternalInterceptorFactories(t *testing.T) {
 			assert.Nil(t, cfg.extraIPCInterceptors)
 		})
 	}
+}
+
+func TestExternalInterceptorFactoryReceivesNamedConfig(t *testing.T) {
+	type auditConfig struct {
+		Enabled bool     `mapstructure:"enabled"`
+		Headers []string `mapstructure:"headers"`
+	}
+
+	factory := InterceptorFactory{
+		Name: "audit_enrichment",
+		Factory: func(params InterceptorParams) (connect.Interceptor, error) {
+			var cfg auditConfig
+			if err := mapstructure.Decode(params.Config, &cfg); err != nil {
+				return nil, err
+			}
+
+			require.Equal(t, auditConfig{
+				Enabled: true,
+				Headers: []string{
+					"x-request-id",
+					"x-forwarded-for",
+				},
+			}, cfg)
+
+			return noopInterceptor(), nil
+		},
+	}
+
+	params := newInterceptorParams(factory, &config.Config{
+		Interceptors: config.InterceptorsMap{
+			"audit_enrichment": {
+				"enabled": true,
+				"headers": []string{
+					"x-request-id",
+					"x-forwarded-for",
+				},
+			},
+		},
+	}, nil, nil)
+
+	interceptor, err := factory.Factory(params)
+	require.NoError(t, err)
+	require.NotNil(t, interceptor)
+}
+
+func TestValidateExternalInterceptorFactoryRequiresName(t *testing.T) {
+	err := validateExternalInterceptorFactory(InterceptorFactory{})
+
+	require.ErrorIs(t, err, ErrExternalInterceptorFactoryNameRequired)
 }
 
 func TestWithIPCInterceptors(t *testing.T) {

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -282,10 +282,11 @@ func Start(f ...StartOptions) error {
 
 	defer client.Close()
 
-	if len(startConfig.externalConnectFactories) > 0 {
-		for _, factory := range startConfig.externalConnectFactories {
-			interceptor, err := factory(ExternalConnectInterceptorContext{
-				SDK: client,
+	if len(startConfig.externalInterceptorFactories) > 0 {
+		for _, factory := range startConfig.externalInterceptorFactories {
+			interceptor, err := factory(InterceptorParams{
+				SDK:    client,
+				Logger: logger,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create external connect interceptor: %w", err)

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -37,7 +37,10 @@ const devModeMessage = `
 `
 const dpopKeySize = 2048
 
-var ErrExternalInterceptorFactoryNameRequired = errors.New("external connect interceptor factory name is required")
+var (
+	ErrExternalInterceptorFactoryNameRequired = errors.New("external connect interceptor factory name is required")
+	ErrExternalInterceptorFactoryFuncRequired = errors.New("external connect interceptor factory func is required")
+)
 
 func Start(f ...StartOptions) error {
 	startConfig := StartConfig{}
@@ -284,18 +287,16 @@ func Start(f ...StartOptions) error {
 
 	defer client.Close()
 
-	if len(startConfig.externalInterceptorFactories) > 0 {
-		for _, factory := range startConfig.externalInterceptorFactories {
-			if err := validateExternalInterceptorFactory(factory); err != nil {
-				return err
-			}
-			interceptor, err := factory.Factory(newInterceptorParams(factory, cfg, client, logger))
-			if err != nil {
-				return fmt.Errorf("failed to create external connect interceptor %q: %w", factory.Name, err)
-			}
-			if interceptor != nil {
-				otdf.ConnectRPC.Interceptors = append(otdf.ConnectRPC.Interceptors, connect.WithInterceptors(interceptor))
-			}
+	for _, factory := range startConfig.externalInterceptorFactories {
+		if err := validateExternalInterceptorFactory(factory); err != nil {
+			return err
+		}
+		interceptor, err := factory.Factory(newInterceptorParams(factory, cfg, client, logger))
+		if err != nil {
+			return fmt.Errorf("failed to create external connect interceptor %q: %w", factory.Name, err)
+		}
+		if interceptor != nil {
+			otdf.ConnectRPC.Interceptors = append(otdf.ConnectRPC.Interceptors, connect.WithInterceptors(interceptor))
 		}
 	}
 
@@ -352,6 +353,9 @@ func Start(f ...StartOptions) error {
 func validateExternalInterceptorFactory(factory InterceptorFactory) error {
 	if factory.Name == "" {
 		return ErrExternalInterceptorFactoryNameRequired
+	}
+	if factory.Factory == nil {
+		return ErrExternalInterceptorFactoryFuncRequired
 	}
 	return nil
 }

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -37,6 +37,8 @@ const devModeMessage = `
 `
 const dpopKeySize = 2048
 
+var ErrExternalInterceptorFactoryNameRequired = errors.New("external connect interceptor factory name is required")
+
 func Start(f ...StartOptions) error {
 	startConfig := StartConfig{}
 	for _, fn := range f {
@@ -284,12 +286,12 @@ func Start(f ...StartOptions) error {
 
 	if len(startConfig.externalInterceptorFactories) > 0 {
 		for _, factory := range startConfig.externalInterceptorFactories {
-			interceptor, err := factory(InterceptorParams{
-				SDK:    client,
-				Logger: logger,
-			})
+			if err := validateExternalInterceptorFactory(factory); err != nil {
+				return err
+			}
+			interceptor, err := factory.Factory(newInterceptorParams(factory, cfg, client, logger))
 			if err != nil {
-				return fmt.Errorf("failed to create external connect interceptor: %w", err)
+				return fmt.Errorf("failed to create external connect interceptor %q: %w", factory.Name, err)
 			}
 			if interceptor != nil {
 				otdf.ConnectRPC.Interceptors = append(otdf.ConnectRPC.Interceptors, connect.WithInterceptors(interceptor))
@@ -345,6 +347,21 @@ func Start(f ...StartOptions) error {
 	}
 
 	return nil
+}
+
+func validateExternalInterceptorFactory(factory InterceptorFactory) error {
+	if factory.Name == "" {
+		return ErrExternalInterceptorFactoryNameRequired
+	}
+	return nil
+}
+
+func newInterceptorParams(factory InterceptorFactory, cfg *config.Config, client *sdk.SDK, logger *logger.Logger) InterceptorParams {
+	return InterceptorParams{
+		SDK:    client,
+		Logger: logger,
+		Config: cfg.Interceptors[factory.Name],
+	}
 }
 
 // waitForShutdownSignal blocks until a SIGINT or SIGTERM is received.

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -282,6 +282,20 @@ func Start(f ...StartOptions) error {
 
 	defer client.Close()
 
+	if len(startConfig.externalConnectFactories) > 0 {
+		for _, factory := range startConfig.externalConnectFactories {
+			interceptor, err := factory(ExternalConnectInterceptorContext{
+				SDK: client,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create external connect interceptor: %w", err)
+			}
+			if interceptor != nil {
+				otdf.ConnectRPC.Interceptors = append(otdf.ConnectRPC.Interceptors, connect.WithInterceptors(interceptor))
+			}
+		}
+	}
+
 	logger.Info("starting services")
 	err = startServices(ctx, startServicesParams{
 		cfg:                    cfg,


### PR DESCRIPTION
### Proposed Changes

* Give server interceptors added via functional With Option access to an initialized SDK with IPC connection and logger
* Open up freeform config for interceptors to name and read into their factory startup

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

