### PR TITLE
feat(cli): Sort parameters.

### DIFF
--- a/otdfctl/cmd/policy/attributes.go
+++ b/otdfctl/cmd/policy/attributes.go
@@ -412,7 +412,7 @@ func initAttributesCommands() {
 		listDoc.GetDocFlag("state").Description,
 	)
 	injectListPaginationFlags(listDoc)
-	injectListSortFlag(listDoc)
+	injectListSortFlags(listDoc)
 
 	// Update an attribute
 	updateDoc := man.Docs.GetCommand("policy/attributes/update",

--- a/otdfctl/cmd/policy/attributes.go
+++ b/otdfctl/cmd/policy/attributes.go
@@ -90,8 +90,9 @@ func listAttributes(cmd *cobra.Command, args []string) {
 	state := cli.GetState(cmd)
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
+	sort := getSortOption(c)
 
-	resp, err := h.ListAttributes(cmd.Context(), state, limit, offset)
+	resp, err := h.ListAttributes(cmd.Context(), state, limit, offset, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list attributes", err)
 	}
@@ -411,6 +412,7 @@ func initAttributesCommands() {
 		listDoc.GetDocFlag("state").Description,
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSortFlag(listDoc)
 
 	// Update an attribute
 	updateDoc := man.Docs.GetCommand("policy/attributes/update",

--- a/otdfctl/cmd/policy/kasKeys.go
+++ b/otdfctl/cmd/policy/kasKeys.go
@@ -413,6 +413,7 @@ func policyListKasKeys(cmd *cobra.Command, args []string) {
 	if err != nil {
 		cli.ExitWithError("Invalid legacy flag", err)
 	}
+	sort := getSortOption(c)
 
 	kasLookup, err := resolveKasIdentifier(kasIdentifier)
 	if err != nil {
@@ -420,7 +421,7 @@ func policyListKasKeys(cmd *cobra.Command, args []string) {
 	}
 
 	// Get the list of keys.
-	resp, err := h.ListKasKeys(c.Context(), limit, offset, alg, kasLookup, legacy)
+	resp, err := h.ListKasKeys(c.Context(), limit, offset, alg, kasLookup, legacy, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list kas keys", err)
 	}
@@ -930,6 +931,7 @@ func initKASKeysCommands() {
 		listDoc.GetDocFlag("legacy").Description,
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSortFlag(listDoc)
 
 	// Rotate Kas Key
 	rotateDoc := man.Docs.GetCommand("policy/kas-registry/key/rotate",

--- a/otdfctl/cmd/policy/kasKeys.go
+++ b/otdfctl/cmd/policy/kasKeys.go
@@ -931,7 +931,7 @@ func initKASKeysCommands() {
 		listDoc.GetDocFlag("legacy").Description,
 	)
 	injectListPaginationFlags(listDoc)
-	injectListSortFlag(listDoc)
+	injectListSortFlags(listDoc)
 
 	// Rotate Kas Key
 	rotateDoc := man.Docs.GetCommand("policy/kas-registry/key/rotate",

--- a/otdfctl/cmd/policy/kasRegistry.go
+++ b/otdfctl/cmd/policy/kasRegistry.go
@@ -227,7 +227,7 @@ func initKASRegistryCommands() {
 		man.WithRun(listKeyAccessRegistries),
 	)
 	injectListPaginationFlags(listDoc)
-	injectListSortFlag(listDoc)
+	injectListSortFlags(listDoc)
 
 	createDoc := man.Docs.GetCommand("policy/kas-registry/create",
 		man.WithRun(createKeyAccessRegistry),

--- a/otdfctl/cmd/policy/kasRegistry.go
+++ b/otdfctl/cmd/policy/kasRegistry.go
@@ -61,8 +61,9 @@ func listKeyAccessRegistries(cmd *cobra.Command, args []string) {
 
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
+	sort := getSortOption(c)
 
-	resp, err := h.ListKasRegistryEntries(cmd.Context(), limit, offset)
+	resp, err := h.ListKasRegistryEntries(cmd.Context(), limit, offset, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list Registered KAS entries", err)
 	}
@@ -226,6 +227,7 @@ func initKASRegistryCommands() {
 		man.WithRun(listKeyAccessRegistries),
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSortFlag(listDoc)
 
 	createDoc := man.Docs.GetCommand("policy/kas-registry/create",
 		man.WithRun(createKeyAccessRegistry),

--- a/otdfctl/cmd/policy/namespaces.go
+++ b/otdfctl/cmd/policy/namespaces.go
@@ -45,8 +45,9 @@ func listAttributeNamespaces(cmd *cobra.Command, args []string) {
 	state := cli.GetState(cmd)
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
+	sort := getSortOption(c)
 
-	resp, err := h.ListNamespaces(cmd.Context(), state, limit, offset)
+	resp, err := h.ListNamespaces(cmd.Context(), state, limit, offset, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list namespaces", err)
 	}
@@ -365,6 +366,12 @@ func buildNamespacesCommandTree() *cobra.Command {
 		listDoc.GetDocFlag("offset").Shorthand,
 		defaultListFlagOffset,
 		listDoc.GetDocFlag("offset").Description,
+	)
+	listCmd.Flags().StringP(
+		listDoc.GetDocFlag("sort").Name,
+		listDoc.GetDocFlag("sort").Shorthand,
+		listDoc.GetDocFlag("sort").Default,
+		listDoc.GetDocFlag("sort").Description,
 	)
 
 	createDoc := man.Docs.GetDoc("policy/namespaces/create")

--- a/otdfctl/cmd/policy/namespaces.go
+++ b/otdfctl/cmd/policy/namespaces.go
@@ -317,134 +317,107 @@ func policyRemoveKeyFromNamespace(cmd *cobra.Command, args []string) {
 	common.HandleSuccess(cmd, namespace, t, nil)
 }
 
-// newCommandFromDoc creates an independent cobra.Command with metadata copied from a Doc.
-// This allows registering the same logical command under multiple parents.
-func newCommandFromDoc(doc *man.Doc, run func(*cobra.Command, []string)) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     doc.Use,
-		Short:   doc.Short,
-		Long:    doc.Long,
-		Args:    doc.Args,
-		Aliases: doc.Aliases,
-		Hidden:  doc.Hidden,
-		Run:     run,
-	}
-	return cmd
-}
+func initNamespacesCommands() {
+	nsDoc := man.Docs.GetCommand("policy/namespaces")
 
-// buildNamespacesCommandTree creates a full namespaces command tree with all subcommands and flags.
-// Each call returns an independent *cobra.Command so it can be parented under multiple commands.
-func buildNamespacesCommandTree() *cobra.Command {
-	nsDoc := man.Docs.GetDoc("policy/namespaces")
-	nsCmd := newCommandFromDoc(nsDoc, nil)
-
-	getDoc := man.Docs.GetDoc("policy/namespaces/get")
-	getCmd := newCommandFromDoc(getDoc, getAttributeNamespace)
-	getCmd.Flags().StringP(
+	getDoc := man.Docs.GetCommand("policy/namespaces/get",
+		man.WithRun(getAttributeNamespace),
+	)
+	getDoc.Flags().StringP(
 		getDoc.GetDocFlag("id").Name,
 		getDoc.GetDocFlag("id").Shorthand,
 		getDoc.GetDocFlag("id").Default,
 		getDoc.GetDocFlag("id").Description,
 	)
 
-	listDoc := man.Docs.GetDoc("policy/namespaces/list")
-	listCmd := newCommandFromDoc(listDoc, listAttributeNamespaces)
-	listCmd.Flags().StringP(
+	listDoc := man.Docs.GetCommand("policy/namespaces/list",
+		man.WithRun(listAttributeNamespaces),
+	)
+	listDoc.Flags().StringP(
 		listDoc.GetDocFlag("state").Name,
 		listDoc.GetDocFlag("state").Shorthand,
 		listDoc.GetDocFlag("state").Default,
 		listDoc.GetDocFlag("state").Description,
 	)
-	listCmd.Flags().Int32P(
-		listDoc.GetDocFlag("limit").Name,
-		listDoc.GetDocFlag("limit").Shorthand,
-		defaultListFlagLimit,
-		listDoc.GetDocFlag("limit").Description,
-	)
-	listCmd.Flags().Int32P(
-		listDoc.GetDocFlag("offset").Name,
-		listDoc.GetDocFlag("offset").Shorthand,
-		defaultListFlagOffset,
-		listDoc.GetDocFlag("offset").Description,
-	)
-	listCmd.Flags().StringP(
-		listDoc.GetDocFlag("sort").Name,
-		listDoc.GetDocFlag("sort").Shorthand,
-		listDoc.GetDocFlag("sort").Default,
-		listDoc.GetDocFlag("sort").Description,
-	)
+	injectListPaginationFlags(listDoc)
+	injectListSortFlags(listDoc)
 
-	createDoc := man.Docs.GetDoc("policy/namespaces/create")
-	createCmd := newCommandFromDoc(createDoc, createAttributeNamespace)
-	createCmd.Flags().StringP(
+	createDoc := man.Docs.GetCommand("policy/namespaces/create",
+		man.WithRun(createAttributeNamespace),
+	)
+	createDoc.Flags().StringP(
 		createDoc.GetDocFlag("name").Name,
 		createDoc.GetDocFlag("name").Shorthand,
 		createDoc.GetDocFlag("name").Default,
 		createDoc.GetDocFlag("name").Description,
 	)
-	injectLabelFlags(createCmd, false)
+	injectLabelFlags(&createDoc.Command, false)
 
-	updateDoc := man.Docs.GetDoc("policy/namespaces/update")
-	updateCmd := newCommandFromDoc(updateDoc, updateAttributeNamespace)
-	updateCmd.Flags().StringP(
+	updateDoc := man.Docs.GetCommand("policy/namespaces/update",
+		man.WithRun(updateAttributeNamespace),
+	)
+	updateDoc.Flags().StringP(
 		updateDoc.GetDocFlag("id").Name,
 		updateDoc.GetDocFlag("id").Shorthand,
 		updateDoc.GetDocFlag("id").Default,
 		updateDoc.GetDocFlag("id").Description,
 	)
-	injectLabelFlags(updateCmd, true)
+	injectLabelFlags(&updateDoc.Command, true)
 
-	deactivateDoc := man.Docs.GetDoc("policy/namespaces/deactivate")
-	deactivateCmd := newCommandFromDoc(deactivateDoc, deactivateAttributeNamespace)
-	deactivateCmd.Flags().StringP(
+	deactivateDoc := man.Docs.GetCommand("policy/namespaces/deactivate",
+		man.WithRun(deactivateAttributeNamespace),
+	)
+	deactivateDoc.Flags().StringP(
 		deactivateDoc.GetDocFlag("id").Name,
 		deactivateDoc.GetDocFlag("id").Shorthand,
 		deactivateDoc.GetDocFlag("id").Default,
 		deactivateDoc.GetDocFlag("id").Description,
 	)
-	deactivateCmd.Flags().Bool(
+	deactivateDoc.Flags().Bool(
 		deactivateDoc.GetDocFlag("force").Name,
 		false,
 		deactivateDoc.GetDocFlag("force").Description,
 	)
 
 	// unsafe
-	unsafeDoc := man.Docs.GetDoc("policy/namespaces/unsafe")
-	unsafeCmd := newCommandFromDoc(unsafeDoc, nil)
-	unsafeCmd.PersistentFlags().BoolVar(
+	unsafeDoc := man.Docs.GetCommand("policy/namespaces/unsafe")
+	unsafeDoc.PersistentFlags().BoolVar(
 		&forceUnsafe,
 		unsafeDoc.GetDocFlag("force").Name,
 		false,
 		unsafeDoc.GetDocFlag("force").Description,
 	)
 
-	deleteDoc := man.Docs.GetDoc("policy/namespaces/unsafe/delete")
-	deleteCmd := newCommandFromDoc(deleteDoc, unsafeDeleteAttributeNamespace)
-	deleteCmd.Flags().StringP(
+	deleteDoc := man.Docs.GetCommand("policy/namespaces/unsafe/delete",
+		man.WithRun(unsafeDeleteAttributeNamespace),
+	)
+	deleteDoc.Flags().StringP(
 		deleteDoc.GetDocFlag("id").Name,
 		deleteDoc.GetDocFlag("id").Shorthand,
 		deleteDoc.GetDocFlag("id").Default,
 		deleteDoc.GetDocFlag("id").Description,
 	)
 
-	reactivateDoc := man.Docs.GetDoc("policy/namespaces/unsafe/reactivate")
-	reactivateCmd := newCommandFromDoc(reactivateDoc, unsafeReactivateAttributeNamespace)
-	reactivateCmd.Flags().StringP(
+	reactivateDoc := man.Docs.GetCommand("policy/namespaces/unsafe/reactivate",
+		man.WithRun(unsafeReactivateAttributeNamespace),
+	)
+	reactivateDoc.Flags().StringP(
 		reactivateDoc.GetDocFlag("id").Name,
 		reactivateDoc.GetDocFlag("id").Shorthand,
 		reactivateDoc.GetDocFlag("id").Default,
 		reactivateDoc.GetDocFlag("id").Description,
 	)
 
-	unsafeUpdateDoc := man.Docs.GetDoc("policy/namespaces/unsafe/update")
-	unsafeUpdateCmd := newCommandFromDoc(unsafeUpdateDoc, unsafeUpdateAttributeNamespace)
-	unsafeUpdateCmd.Flags().StringP(
+	unsafeUpdateDoc := man.Docs.GetCommand("policy/namespaces/unsafe/update",
+		man.WithRun(unsafeUpdateAttributeNamespace),
+	)
+	unsafeUpdateDoc.Flags().StringP(
 		unsafeUpdateDoc.GetDocFlag("id").Name,
 		unsafeUpdateDoc.GetDocFlag("id").Shorthand,
 		unsafeUpdateDoc.GetDocFlag("id").Default,
 		unsafeUpdateDoc.GetDocFlag("id").Description,
 	)
-	unsafeUpdateCmd.Flags().StringP(
+	unsafeUpdateDoc.Flags().StringP(
 		unsafeUpdateDoc.GetDocFlag("name").Name,
 		unsafeUpdateDoc.GetDocFlag("name").Shorthand,
 		unsafeUpdateDoc.GetDocFlag("name").Default,
@@ -452,47 +425,43 @@ func buildNamespacesCommandTree() *cobra.Command {
 	)
 
 	// key
-	keyDoc := man.Docs.GetDoc("policy/namespaces/key")
-	keyCmd := newCommandFromDoc(keyDoc, nil)
+	keyDoc := man.Docs.GetCommand("policy/namespaces/key")
 
-	assignDoc := man.Docs.GetDoc("policy/namespaces/key/assign")
-	assignCmd := newCommandFromDoc(assignDoc, policyAssignKeyToNamespace)
-	assignCmd.Flags().StringP(
+	assignDoc := man.Docs.GetCommand("policy/namespaces/key/assign",
+		man.WithRun(policyAssignKeyToNamespace),
+	)
+	assignDoc.Flags().StringP(
 		assignDoc.GetDocFlag("namespace").Name,
 		assignDoc.GetDocFlag("namespace").Shorthand,
 		assignDoc.GetDocFlag("namespace").Default,
 		assignDoc.GetDocFlag("namespace").Description,
 	)
-	assignCmd.Flags().StringP(
+	assignDoc.Flags().StringP(
 		assignDoc.GetDocFlag("key-id").Name,
 		assignDoc.GetDocFlag("key-id").Shorthand,
 		assignDoc.GetDocFlag("key-id").Default,
 		assignDoc.GetDocFlag("key-id").Description,
 	)
 
-	removeDoc := man.Docs.GetDoc("policy/namespaces/key/remove")
-	removeCmd := newCommandFromDoc(removeDoc, policyRemoveKeyFromNamespace)
-	removeCmd.Flags().StringP(
+	removeDoc := man.Docs.GetCommand("policy/namespaces/key/remove",
+		man.WithRun(policyRemoveKeyFromNamespace),
+	)
+	removeDoc.Flags().StringP(
 		removeDoc.GetDocFlag("namespace").Name,
 		removeDoc.GetDocFlag("namespace").Shorthand,
 		removeDoc.GetDocFlag("namespace").Default,
 		removeDoc.GetDocFlag("namespace").Description,
 	)
-	removeCmd.Flags().StringP(
+	removeDoc.Flags().StringP(
 		removeDoc.GetDocFlag("key-id").Name,
 		removeDoc.GetDocFlag("key-id").Shorthand,
 		removeDoc.GetDocFlag("key-id").Default,
 		removeDoc.GetDocFlag("key-id").Description,
 	)
 
-	keyCmd.AddCommand(assignCmd, removeCmd)
-	unsafeCmd.AddCommand(deleteCmd, reactivateCmd, unsafeUpdateCmd)
-	nsCmd.AddCommand(getCmd, listCmd, createCmd, updateCmd, deactivateCmd, unsafeCmd, keyCmd)
-
-	return nsCmd
-}
-
-func initNamespacesCommands() {
-	Cmd.AddCommand(buildNamespacesCommandTree())
-	AttributesCmd.AddCommand(buildNamespacesCommandTree())
+	keyDoc.AddSubcommands(assignDoc, removeDoc)
+	unsafeDoc.AddSubcommands(deleteDoc, reactivateDoc, unsafeUpdateDoc)
+	nsDoc.AddSubcommands(getDoc, listDoc, createDoc, updateDoc, deactivateDoc, unsafeDoc, keyDoc)
+	AttributesCmd.AddCommand(&nsDoc.Command)
+	Cmd.AddCommand(&nsDoc.Command)
 }

--- a/otdfctl/cmd/policy/obligations.go
+++ b/otdfctl/cmd/policy/obligations.go
@@ -99,8 +99,9 @@ func policyListObligations(cmd *cobra.Command, args []string) {
 	namespace := c.Flags.GetOptionalString("namespace")
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
+	sort := getSortOption(c)
 
-	resp, err := h.ListObligations(cmd.Context(), limit, offset, namespace)
+	resp, err := h.ListObligations(cmd.Context(), limit, offset, namespace, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list obligations", err)
 	}
@@ -525,6 +526,7 @@ func initObligationsCommands() {
 		listDoc.GetDocFlag("namespace").Description,
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSortFlag(listDoc)
 
 	createDoc := man.Docs.GetCommand("policy/obligations/create",
 		man.WithRun(policyCreateObligation),

--- a/otdfctl/cmd/policy/obligations.go
+++ b/otdfctl/cmd/policy/obligations.go
@@ -526,7 +526,7 @@ func initObligationsCommands() {
 		listDoc.GetDocFlag("namespace").Description,
 	)
 	injectListPaginationFlags(listDoc)
-	injectListSortFlag(listDoc)
+	injectListSortFlags(listDoc)
 
 	createDoc := man.Docs.GetCommand("policy/obligations/create",
 		man.WithRun(policyCreateObligation),

--- a/otdfctl/cmd/policy/policy.go
+++ b/otdfctl/cmd/policy/policy.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/opentdf/platform/otdfctl/pkg/cli"
+	"github.com/opentdf/platform/otdfctl/pkg/handlers"
 	"github.com/opentdf/platform/otdfctl/pkg/man"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/spf13/cobra"
@@ -83,6 +84,19 @@ func injectListPaginationFlags(listDoc *man.Doc) {
 		defaultListFlagOffset,
 		listDoc.GetDocFlag("offset").Description,
 	)
+}
+
+func injectListSortFlag(listDoc *man.Doc) {
+	sortFlag := listDoc.GetDocFlag("sort")
+	listDoc.Flags().StringP(sortFlag.Name, sortFlag.Shorthand, sortFlag.Default, sortFlag.Description)
+}
+
+func getSortOption(c *cli.Cli) handlers.SortOption {
+	sort, err := handlers.ParseSortOption(c.Flags.GetOptionalString("sort"))
+	if err != nil {
+		cli.ExitWithError("Invalid sort", err)
+	}
+	return sort
 }
 
 func InitCommands() {

--- a/otdfctl/cmd/policy/policy.go
+++ b/otdfctl/cmd/policy/policy.go
@@ -86,15 +86,18 @@ func injectListPaginationFlags(listDoc *man.Doc) {
 	)
 }
 
-func injectListSortFlag(listDoc *man.Doc) {
+func injectListSortFlags(listDoc *man.Doc) {
 	sortFlag := listDoc.GetDocFlag("sort")
-	listDoc.Flags().StringP(sortFlag.Name, sortFlag.Shorthand, sortFlag.Default, sortFlag.Description)
+	listDoc.Flags().String(sortFlag.Name, sortFlag.Default, sortFlag.Description)
+
+	orderFlag := listDoc.GetDocFlag("order")
+	listDoc.Flags().String(orderFlag.Name, orderFlag.Default, orderFlag.Description)
 }
 
 func getSortOption(c *cli.Cli) handlers.SortOption {
-	sort, err := handlers.ParseSortOption(c.Flags.GetOptionalString("sort"))
+	sort, err := handlers.NewSortOption(c.Flags.GetOptionalString("sort"), c.Flags.GetOptionalString("order"))
 	if err != nil {
-		cli.ExitWithError("Invalid sort", err)
+		cli.ExitWithError("Invalid sort order", err)
 	}
 	return sort
 }

--- a/otdfctl/cmd/policy/registeredResources.go
+++ b/otdfctl/cmd/policy/registeredResources.go
@@ -493,7 +493,7 @@ func initRegisteredResourcesCommands() {
 		listDoc.GetDocFlag("namespace").Description,
 	)
 	injectListPaginationFlags(listDoc)
-	injectListSortFlag(listDoc)
+	injectListSortFlags(listDoc)
 
 	createDoc := man.Docs.GetCommand("policy/registered-resources/create",
 		man.WithRun(policyCreateRegisteredResource),

--- a/otdfctl/cmd/policy/registeredResources.go
+++ b/otdfctl/cmd/policy/registeredResources.go
@@ -103,8 +103,9 @@ func policyListRegisteredResources(cmd *cobra.Command, args []string) {
 	namespace := c.Flags.GetOptionalString("namespace")
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
+	sort := getSortOption(c)
 
-	resp, err := h.ListRegisteredResources(cmd.Context(), limit, offset, namespace)
+	resp, err := h.ListRegisteredResources(cmd.Context(), limit, offset, namespace, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list registered resources", err)
 	}
@@ -492,6 +493,7 @@ func initRegisteredResourcesCommands() {
 		listDoc.GetDocFlag("namespace").Description,
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSortFlag(listDoc)
 
 	createDoc := man.Docs.GetCommand("policy/registered-resources/create",
 		man.WithRun(policyCreateRegisteredResource),

--- a/otdfctl/cmd/policy/subjectConditionSets.go
+++ b/otdfctl/cmd/policy/subjectConditionSets.go
@@ -150,8 +150,9 @@ func listSubjectConditionSets(cmd *cobra.Command, args []string) {
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
 	namespace := c.Flags.GetOptionalString("namespace")
+	sort := getSortOption(c)
 
-	resp, err := h.ListSubjectConditionSets(cmd.Context(), limit, offset, namespace)
+	resp, err := h.ListSubjectConditionSets(cmd.Context(), limit, offset, namespace, sort)
 	if err != nil {
 		cli.ExitWithError("Error listing subject condition sets", err)
 	}
@@ -360,6 +361,7 @@ func initSubjectConditionSetsCommands() {
 		man.WithRun(listSubjectConditionSets),
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSortFlag(listDoc)
 	listDoc.Flags().StringP(
 		listDoc.GetDocFlag("namespace").Name,
 		listDoc.GetDocFlag("namespace").Shorthand,

--- a/otdfctl/cmd/policy/subjectConditionSets.go
+++ b/otdfctl/cmd/policy/subjectConditionSets.go
@@ -361,7 +361,7 @@ func initSubjectConditionSetsCommands() {
 		man.WithRun(listSubjectConditionSets),
 	)
 	injectListPaginationFlags(listDoc)
-	injectListSortFlag(listDoc)
+	injectListSortFlags(listDoc)
 	listDoc.Flags().StringP(
 		listDoc.GetDocFlag("namespace").Name,
 		listDoc.GetDocFlag("namespace").Shorthand,

--- a/otdfctl/cmd/policy/subjectMappings.go
+++ b/otdfctl/cmd/policy/subjectMappings.go
@@ -67,8 +67,9 @@ func policyListSubjectMappings(cmd *cobra.Command, args []string) {
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
 	namespace := c.Flags.GetOptionalString("namespace")
+	sort := getSortOption(c)
 
-	resp, err := h.ListSubjectMappings(cmd.Context(), limit, offset, namespace)
+	resp, err := h.ListSubjectMappings(cmd.Context(), limit, offset, namespace, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to get subject mappings", err)
 	}
@@ -340,6 +341,7 @@ func initSubjectMappingsCommands() {
 		man.WithRun(policyListSubjectMappings),
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSortFlag(listDoc)
 	listDoc.Flags().StringP(
 		listDoc.GetDocFlag("namespace").Name,
 		listDoc.GetDocFlag("namespace").Shorthand,

--- a/otdfctl/cmd/policy/subjectMappings.go
+++ b/otdfctl/cmd/policy/subjectMappings.go
@@ -341,7 +341,7 @@ func initSubjectMappingsCommands() {
 		man.WithRun(policyListSubjectMappings),
 	)
 	injectListPaginationFlags(listDoc)
-	injectListSortFlag(listDoc)
+	injectListSortFlags(listDoc)
 	listDoc.Flags().StringP(
 		listDoc.GetDocFlag("namespace").Name,
 		listDoc.GetDocFlag("namespace").Shorthand,

--- a/otdfctl/docs/man/policy/attributes/list.md
+++ b/otdfctl/docs/man/policy/attributes/list.md
@@ -20,7 +20,9 @@ command:
       shorthand: o
       description: Offset (page) quantity from start of the list
     - name: sort
-      description: Sort list results with field:direction syntax. Either field or direction may be omitted
+      description: Sort list results by field
+    - name: order
+      description: Sort order direction. Accepted values are asc and desc
 ---
 
 By default, the list will only provide `active` attributes if unspecified, but the filter can be controlled with the `--state` flag.
@@ -29,7 +31,7 @@ For more general information about attributes, see the `attributes` subcommand.
 
 ## Sort Options
 
-Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:` or `:asc`.
+Use `--sort <field>` with optional `--order <direction>`. Either flag may be omitted.
 
 | Direction | Description | Default |
 | --- | --- | --- |
@@ -45,13 +47,13 @@ Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:
 Omit direction and let the server choose the default direction:
 
 ```shell
-otdfctl policy attributes list --sort name:
+otdfctl policy attributes list --sort name
 ```
 
 Omit field and let the server choose the default field:
 
 ```shell
-otdfctl policy attributes list --sort :asc
+otdfctl policy attributes list --order asc
 ```
 
 ## Example
@@ -63,5 +65,5 @@ otdfctl policy attributes list
 Sort attributes by name ascending:
 
 ```shell
-otdfctl policy attributes list --sort name:asc
+otdfctl policy attributes list --sort name --order asc
 ```

--- a/otdfctl/docs/man/policy/attributes/list.md
+++ b/otdfctl/docs/man/policy/attributes/list.md
@@ -19,14 +19,49 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: sort
+      description: Sort list results with field:direction syntax. Either field or direction may be omitted
 ---
 
 By default, the list will only provide `active` attributes if unspecified, but the filter can be controlled with the `--state` flag.
 
 For more general information about attributes, see the `attributes` subcommand.
 
+## Sort Options
+
+Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:` or `:asc`.
+
+| Direction | Description | Default |
+| --- | --- | --- |
+| `asc` | Ascending order | No |
+| `desc` | Descending order | Yes |
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `name` | Attribute name | No |
+| `created_at` | Creation timestamp | Yes |
+| `updated_at` | Last update timestamp | No |
+
+Omit direction and let the server choose the default direction:
+
+```shell
+otdfctl policy attributes list --sort name:
+```
+
+Omit field and let the server choose the default field:
+
+```shell
+otdfctl policy attributes list --sort :asc
+```
+
 ## Example
 
 ```shell
 otdfctl policy attributes list
+```
+
+Sort attributes by name ascending:
+
+```shell
+otdfctl policy attributes list --sort name:asc
 ```

--- a/otdfctl/docs/man/policy/kas-registry/key/list.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/list.md
@@ -22,7 +22,9 @@ command:
       description: Filter keys by legacy status.
       required: false
     - name: sort
-      description: Sort list results with field:direction syntax. Either field or direction may be omitted
+      description: Sort list results by field
+    - name: order
+      description: Sort order direction. Accepted values are asc and desc
 ---
 
 This command lists keys registered within a specified Key Access Server (KAS). You must specify the KAS using its ID, URI, or Name.
@@ -31,7 +33,7 @@ The list can be filtered by key algorithm. Pagination is supported using `limit`
 
 ## Sort Options
 
-Use `--sort <field>:<direction>`. Either side may be omitted, for example `key_id:` or `:asc`.
+Use `--sort <field>` with optional `--order <direction>`. Either flag may be omitted.
 
 | Direction | Description | Default |
 | --- | --- | --- |
@@ -47,13 +49,13 @@ Use `--sort <field>:<direction>`. Either side may be omitted, for example `key_i
 Omit direction and let the server choose the default direction:
 
 ```shell
-otdfctl policy kas-registry key list --kas "https://kas.example.com/kas" --sort key_id:
+otdfctl policy kas-registry key list --kas "https://kas.example.com/kas" --sort key_id
 ```
 
 Omit field and let the server choose the default field:
 
 ```shell
-otdfctl policy kas-registry key list --kas "https://kas.example.com/kas" --sort :asc
+otdfctl policy kas-registry key list --kas "https://kas.example.com/kas" --order asc
 ```
 
 ## Examples
@@ -91,5 +93,5 @@ otdfctl policy kas-registry key list --legacy false
 Sort keys by key ID descending:
 
 ```shell
-otdfctl policy kas-registry key list --kas "https://kas.example.com/kas" --sort key_id:desc
+otdfctl policy kas-registry key list --kas "https://kas.example.com/kas" --sort key_id --order desc
 ```

--- a/otdfctl/docs/man/policy/kas-registry/key/list.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/list.md
@@ -21,11 +21,40 @@ command:
     - name: legacy
       description: Filter keys by legacy status.
       required: false
+    - name: sort
+      description: Sort list results with field:direction syntax. Either field or direction may be omitted
 ---
 
 This command lists keys registered within a specified Key Access Server (KAS). You must specify the KAS using its ID, URI, or Name.
 
 The list can be filtered by key algorithm. Pagination is supported using `limit` and `offset` flags to manage the number of results returned.
+
+## Sort Options
+
+Use `--sort <field>:<direction>`. Either side may be omitted, for example `key_id:` or `:asc`.
+
+| Direction | Description | Default |
+| --- | --- | --- |
+| `asc` | Ascending order | No |
+| `desc` | Descending order | Yes |
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `key_id` | Key ID | No |
+| `created_at` | Creation timestamp | Yes |
+| `updated_at` | Last update timestamp | No |
+
+Omit direction and let the server choose the default direction:
+
+```shell
+otdfctl policy kas-registry key list --kas "https://kas.example.com/kas" --sort key_id:
+```
+
+Omit field and let the server choose the default field:
+
+```shell
+otdfctl policy kas-registry key list --kas "https://kas.example.com/kas" --sort :asc
+```
 
 ## Examples
 
@@ -57,4 +86,10 @@ Exclude legacy keys
 
 ```shell
 otdfctl policy kas-registry key list --legacy false
+```
+
+Sort keys by key ID descending:
+
+```shell
+otdfctl policy kas-registry key list --kas "https://kas.example.com/kas" --sort key_id:desc
 ```

--- a/otdfctl/docs/man/policy/kas-registry/list.md
+++ b/otdfctl/docs/man/policy/kas-registry/list.md
@@ -11,12 +11,48 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: sort
+      description: Sort list results with field:direction syntax. Either field or direction may be omitted
 ---
 
 For more information about registration of Key Access Servers, see the manual for `kas-registry`.
+
+## Sort Options
+
+Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:` or `:asc`.
+
+| Direction | Description | Default |
+| --- | --- | --- |
+| `asc` | Ascending order | No |
+| `desc` | Descending order | Yes |
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `name` | KAS registration name | No |
+| `uri` | KAS URI | No |
+| `created_at` | Creation timestamp | Yes |
+| `updated_at` | Last update timestamp | No |
+
+Omit direction and let the server choose the default direction:
+
+```shell
+otdfctl policy kas-registry list --sort name:
+```
+
+Omit field and let the server choose the default field:
+
+```shell
+otdfctl policy kas-registry list --sort :asc
+```
 
 ## Example
 
 ```shell
 otdfctl policy kas-registry list
+```
+
+Sort KAS registrations by URI descending:
+
+```shell
+otdfctl policy kas-registry list --sort uri:desc
 ```

--- a/otdfctl/docs/man/policy/kas-registry/list.md
+++ b/otdfctl/docs/man/policy/kas-registry/list.md
@@ -12,14 +12,16 @@ command:
       shorthand: o
       description: Offset (page) quantity from start of the list
     - name: sort
-      description: Sort list results with field:direction syntax. Either field or direction may be omitted
+      description: Sort list results by field
+    - name: order
+      description: Sort order direction. Accepted values are asc and desc
 ---
 
 For more information about registration of Key Access Servers, see the manual for `kas-registry`.
 
 ## Sort Options
 
-Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:` or `:asc`.
+Use `--sort <field>` with optional `--order <direction>`. Either flag may be omitted.
 
 | Direction | Description | Default |
 | --- | --- | --- |
@@ -36,13 +38,13 @@ Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:
 Omit direction and let the server choose the default direction:
 
 ```shell
-otdfctl policy kas-registry list --sort name:
+otdfctl policy kas-registry list --sort name
 ```
 
 Omit field and let the server choose the default field:
 
 ```shell
-otdfctl policy kas-registry list --sort :asc
+otdfctl policy kas-registry list --order asc
 ```
 
 ## Example
@@ -54,5 +56,5 @@ otdfctl policy kas-registry list
 Sort KAS registrations by URI descending:
 
 ```shell
-otdfctl policy kas-registry list --sort uri:desc
+otdfctl policy kas-registry list --sort uri --order desc
 ```

--- a/otdfctl/docs/man/policy/namespaces/list.md
+++ b/otdfctl/docs/man/policy/namespaces/list.md
@@ -15,12 +15,48 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: sort
+      description: Sort list results with field:direction syntax. Either field or direction may be omitted
 ---
 
 For more general information, see the `namespaces` subcommand.
+
+## Sort Options
+
+Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:` or `:asc`.
+
+| Direction | Description | Default |
+| --- | --- | --- |
+| `asc` | Ascending order | No |
+| `desc` | Descending order | Yes |
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `name` | Namespace name | No |
+| `fqn` | Namespace FQN | No |
+| `created_at` | Creation timestamp | Yes |
+| `updated_at` | Last update timestamp | No |
+
+Omit direction and let the server choose the default direction:
+
+```shell
+otdfctl policy namespaces list --sort name:
+```
+
+Omit field and let the server choose the default field:
+
+```shell
+otdfctl policy namespaces list --sort :asc
+```
 
 ## Example
 
 ```shell
 otdfctl policy namespaces list
+```
+
+Sort namespaces by name ascending:
+
+```shell
+otdfctl policy namespaces list --sort name:asc
 ```

--- a/otdfctl/docs/man/policy/namespaces/list.md
+++ b/otdfctl/docs/man/policy/namespaces/list.md
@@ -16,14 +16,16 @@ command:
       shorthand: o
       description: Offset (page) quantity from start of the list
     - name: sort
-      description: Sort list results with field:direction syntax. Either field or direction may be omitted
+      description: Sort list results by field
+    - name: order
+      description: Sort order direction. Accepted values are asc and desc
 ---
 
 For more general information, see the `namespaces` subcommand.
 
 ## Sort Options
 
-Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:` or `:asc`.
+Use `--sort <field>` with optional `--order <direction>`. Either flag may be omitted.
 
 | Direction | Description | Default |
 | --- | --- | --- |
@@ -40,13 +42,13 @@ Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:
 Omit direction and let the server choose the default direction:
 
 ```shell
-otdfctl policy namespaces list --sort name:
+otdfctl policy namespaces list --sort name
 ```
 
 Omit field and let the server choose the default field:
 
 ```shell
-otdfctl policy namespaces list --sort :asc
+otdfctl policy namespaces list --order asc
 ```
 
 ## Example
@@ -58,5 +60,5 @@ otdfctl policy namespaces list
 Sort namespaces by name ascending:
 
 ```shell
-otdfctl policy namespaces list --sort name:asc
+otdfctl policy namespaces list --sort name --order asc
 ```

--- a/otdfctl/docs/man/policy/obligations/list.md
+++ b/otdfctl/docs/man/policy/obligations/list.md
@@ -14,14 +14,50 @@ command:
     - name: namespace
       shorthand: n
       description: Namespace ID or FQN by which to filter results
+    - name: sort
+      description: Sort list results with field:direction syntax. Either field or direction may be omitted
 ---
 
 List obligations definitions (optionally by namespace).
 
 For more information about obligations, see the `obligations` subcommand.
 
+## Sort Options
+
+Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:` or `:asc`.
+
+| Direction | Description | Default |
+| --- | --- | --- |
+| `asc` | Ascending order | No |
+| `desc` | Descending order | Yes |
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `name` | Obligation name | No |
+| `fqn` | Obligation FQN | No |
+| `created_at` | Creation timestamp | Yes |
+| `updated_at` | Last update timestamp | No |
+
+Omit direction and let the server choose the default direction:
+
+```shell
+otdfctl policy obligations list --sort name:
+```
+
+Omit field and let the server choose the default field:
+
+```shell
+otdfctl policy obligations list --sort :asc
+```
+
 ## Example
 
 ```shell
 otdfctl policy obligations list --limit 10 --offset 0
+```
+
+Sort obligations by name ascending:
+
+```shell
+otdfctl policy obligations list --sort name:asc
 ```

--- a/otdfctl/docs/man/policy/obligations/list.md
+++ b/otdfctl/docs/man/policy/obligations/list.md
@@ -15,7 +15,9 @@ command:
       shorthand: n
       description: Namespace ID or FQN by which to filter results
     - name: sort
-      description: Sort list results with field:direction syntax. Either field or direction may be omitted
+      description: Sort list results by field
+    - name: order
+      description: Sort order direction. Accepted values are asc and desc
 ---
 
 List obligations definitions (optionally by namespace).
@@ -24,7 +26,7 @@ For more information about obligations, see the `obligations` subcommand.
 
 ## Sort Options
 
-Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:` or `:asc`.
+Use `--sort <field>` with optional `--order <direction>`. Either flag may be omitted.
 
 | Direction | Description | Default |
 | --- | --- | --- |
@@ -41,13 +43,13 @@ Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:
 Omit direction and let the server choose the default direction:
 
 ```shell
-otdfctl policy obligations list --sort name:
+otdfctl policy obligations list --sort name
 ```
 
 Omit field and let the server choose the default field:
 
 ```shell
-otdfctl policy obligations list --sort :asc
+otdfctl policy obligations list --order asc
 ```
 
 ## Example
@@ -59,5 +61,5 @@ otdfctl policy obligations list --limit 10 --offset 0
 Sort obligations by name ascending:
 
 ```shell
-otdfctl policy obligations list --sort name:asc
+otdfctl policy obligations list --sort name --order asc
 ```

--- a/otdfctl/docs/man/policy/registered-resources/list.md
+++ b/otdfctl/docs/man/policy/registered-resources/list.md
@@ -14,12 +14,47 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: sort
+      description: Sort list results with field:direction syntax. Either field or direction may be omitted
 ---
 
 For more information about Registered Resources, see the `registered-resources` subcommand.
+
+## Sort Options
+
+Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:` or `:asc`.
+
+| Direction | Description | Default |
+| --- | --- | --- |
+| `asc` | Ascending order | No |
+| `desc` | Descending order | Yes |
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `name` | Registered resource name | No |
+| `created_at` | Creation timestamp | Yes |
+| `updated_at` | Last update timestamp | No |
+
+Omit direction and let the server choose the default direction:
+
+```shell
+otdfctl policy registered-resources list --sort name:
+```
+
+Omit field and let the server choose the default field:
+
+```shell
+otdfctl policy registered-resources list --sort :asc
+```
 
 ## Example
 
 ```shell
 otdfctl policy registered-resources list
+```
+
+Sort registered resources by name ascending:
+
+```shell
+otdfctl policy registered-resources list --sort name:asc
 ```

--- a/otdfctl/docs/man/policy/registered-resources/list.md
+++ b/otdfctl/docs/man/policy/registered-resources/list.md
@@ -15,14 +15,16 @@ command:
       shorthand: o
       description: Offset (page) quantity from start of the list
     - name: sort
-      description: Sort list results with field:direction syntax. Either field or direction may be omitted
+      description: Sort list results by field
+    - name: order
+      description: Sort order direction. Accepted values are asc and desc
 ---
 
 For more information about Registered Resources, see the `registered-resources` subcommand.
 
 ## Sort Options
 
-Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:` or `:asc`.
+Use `--sort <field>` with optional `--order <direction>`. Either flag may be omitted.
 
 | Direction | Description | Default |
 | --- | --- | --- |
@@ -38,13 +40,13 @@ Use `--sort <field>:<direction>`. Either side may be omitted, for example `name:
 Omit direction and let the server choose the default direction:
 
 ```shell
-otdfctl policy registered-resources list --sort name:
+otdfctl policy registered-resources list --sort name
 ```
 
 Omit field and let the server choose the default field:
 
 ```shell
-otdfctl policy registered-resources list --sort :asc
+otdfctl policy registered-resources list --order asc
 ```
 
 ## Example
@@ -56,5 +58,5 @@ otdfctl policy registered-resources list
 Sort registered resources by name ascending:
 
 ```shell
-otdfctl policy registered-resources list --sort name:asc
+otdfctl policy registered-resources list --sort name --order asc
 ```

--- a/otdfctl/docs/man/policy/subject-condition-sets/list.md
+++ b/otdfctl/docs/man/policy/subject-condition-sets/list.md
@@ -15,9 +15,37 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: sort
+      description: Sort list results with field:direction syntax. Either field or direction may be omitted
 ---
 
 For more information about subject condition sets, see the `subject-condition-sets` subcommand.
+
+## Sort Options
+
+Use `--sort <field>:<direction>`. Either side may be omitted, for example `created_at:` or `:asc`.
+
+| Direction | Description | Default |
+| --- | --- | --- |
+| `asc` | Ascending order | No |
+| `desc` | Descending order | Yes |
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `created_at` | Creation timestamp | Yes |
+| `updated_at` | Last update timestamp | No |
+
+Omit direction and let the server choose the default direction:
+
+```shell
+otdfctl policy subject-condition-sets list --sort created_at:
+```
+
+Omit field and let the server choose the default field:
+
+```shell
+otdfctl policy subject-condition-sets list --sort :asc
+```
 
 ## Example
 
@@ -25,4 +53,10 @@ For more information about subject condition sets, see the `subject-condition-se
 otdfctl policy subject-condition-set list
 
 otdfctl policy subject-condition-set list --namespace "https://example.com"
+```
+
+Sort subject condition sets by creation time ascending:
+
+```shell
+otdfctl policy subject-condition-sets list --sort created_at:asc
 ```

--- a/otdfctl/docs/man/policy/subject-condition-sets/list.md
+++ b/otdfctl/docs/man/policy/subject-condition-sets/list.md
@@ -50,9 +50,9 @@ otdfctl policy subject-condition-sets list --sort :asc
 ## Example
 
 ```shell
-otdfctl policy subject-condition-set list
+otdfctl policy subject-condition-sets list
 
-otdfctl policy subject-condition-set list --namespace "https://example.com"
+otdfctl policy subject-condition-sets list --namespace https://example.com
 ```
 
 Sort subject condition sets by creation time ascending:

--- a/otdfctl/docs/man/policy/subject-condition-sets/list.md
+++ b/otdfctl/docs/man/policy/subject-condition-sets/list.md
@@ -16,14 +16,16 @@ command:
       shorthand: o
       description: Offset (page) quantity from start of the list
     - name: sort
-      description: Sort list results with field:direction syntax. Either field or direction may be omitted
+      description: Sort list results by field
+    - name: order
+      description: Sort order direction. Accepted values are asc and desc
 ---
 
 For more information about subject condition sets, see the `subject-condition-sets` subcommand.
 
 ## Sort Options
 
-Use `--sort <field>:<direction>`. Either side may be omitted, for example `created_at:` or `:asc`.
+Use `--sort <field>` with optional `--order <direction>`. Either flag may be omitted.
 
 | Direction | Description | Default |
 | --- | --- | --- |
@@ -38,13 +40,13 @@ Use `--sort <field>:<direction>`. Either side may be omitted, for example `creat
 Omit direction and let the server choose the default direction:
 
 ```shell
-otdfctl policy subject-condition-sets list --sort created_at:
+otdfctl policy subject-condition-sets list --sort created_at
 ```
 
 Omit field and let the server choose the default field:
 
 ```shell
-otdfctl policy subject-condition-sets list --sort :asc
+otdfctl policy subject-condition-sets list --order asc
 ```
 
 ## Example
@@ -58,5 +60,5 @@ otdfctl policy subject-condition-sets list --namespace https://example.com
 Sort subject condition sets by creation time ascending:
 
 ```shell
-otdfctl policy subject-condition-sets list --sort created_at:asc
+otdfctl policy subject-condition-sets list --sort created_at --order asc
 ```

--- a/otdfctl/docs/man/policy/subject-mappings/list.md
+++ b/otdfctl/docs/man/policy/subject-mappings/list.md
@@ -14,9 +14,37 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: sort
+      description: Sort list results with field:direction syntax. Either field or direction may be omitted
 ---
 
 For more information about subject mappings, see the `subject-mappings` subcommand.
+
+## Sort Options
+
+Use `--sort <field>:<direction>`. Either side may be omitted, for example `created_at:` or `:asc`.
+
+| Direction | Description | Default |
+| --- | --- | --- |
+| `asc` | Ascending order | No |
+| `desc` | Descending order | Yes |
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `created_at` | Creation timestamp | Yes |
+| `updated_at` | Last update timestamp | No |
+
+Omit direction and let the server choose the default direction:
+
+```shell
+otdfctl policy subject-mappings list --sort created_at:
+```
+
+Omit field and let the server choose the default field:
+
+```shell
+otdfctl policy subject-mappings list --sort :asc
+```
 
 ## Example
 
@@ -24,4 +52,10 @@ For more information about subject mappings, see the `subject-mappings` subcomma
 otdfctl policy subject-mappings list
 
 otdfctl policy subject-mappings list --namespace "https://example.com"
+```
+
+Sort subject mappings by creation time ascending:
+
+```shell
+otdfctl policy subject-mappings list --sort created_at:asc
 ```

--- a/otdfctl/docs/man/policy/subject-mappings/list.md
+++ b/otdfctl/docs/man/policy/subject-mappings/list.md
@@ -15,14 +15,16 @@ command:
       shorthand: o
       description: Offset (page) quantity from start of the list
     - name: sort
-      description: Sort list results with field:direction syntax. Either field or direction may be omitted
+      description: Sort list results by field
+    - name: order
+      description: Sort order direction. Accepted values are asc and desc
 ---
 
 For more information about subject mappings, see the `subject-mappings` subcommand.
 
 ## Sort Options
 
-Use `--sort <field>:<direction>`. Either side may be omitted, for example `created_at:` or `:asc`.
+Use `--sort <field>` with optional `--order <direction>`. Either flag may be omitted.
 
 | Direction | Description | Default |
 | --- | --- | --- |
@@ -37,13 +39,13 @@ Use `--sort <field>:<direction>`. Either side may be omitted, for example `creat
 Omit direction and let the server choose the default direction:
 
 ```shell
-otdfctl policy subject-mappings list --sort created_at:
+otdfctl policy subject-mappings list --sort created_at
 ```
 
 Omit field and let the server choose the default field:
 
 ```shell
-otdfctl policy subject-mappings list --sort :asc
+otdfctl policy subject-mappings list --order asc
 ```
 
 ## Example
@@ -57,5 +59,5 @@ otdfctl policy subject-mappings list --namespace "https://example.com"
 Sort subject mappings by creation time ascending:
 
 ```shell
-otdfctl policy subject-mappings list --sort created_at:asc
+otdfctl policy subject-mappings list --sort created_at --order asc
 ```

--- a/otdfctl/e2e/attributes.bats
+++ b/otdfctl/e2e/attributes.bats
@@ -146,6 +146,52 @@ teardown_file() {
   assert_line --regexp "Current Offset.*0"
 }
 
+@test "List attribute definitions supports sort fields and partial sort syntax" {
+  sort_prefix="sort_attr_${BATS_TEST_NUMBER}_$RANDOM"
+  attr_a_id=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "${sort_prefix}_alpha" --rule ANY_OF --json | jq -r '.id')
+  sleep 1
+  attr_b_id=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "${sort_prefix}_bravo" --rule ANY_OF --json | jq -r '.id')
+  sleep 1
+  attr_c_id=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "${sort_prefix}_charlie" --rule ANY_OF --json | jq -r '.id')
+
+  run_otdfctl_attr list --sort name:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.attributes[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$attr_a_id,$attr_b_id,$attr_c_id"
+
+  run_otdfctl_attr list --sort name:desc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.attributes[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$attr_c_id,$attr_b_id,$attr_a_id"
+
+  run_otdfctl_attr list --sort created_at:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$attr_a_id" --arg b "$attr_b_id" --arg c "$attr_c_id" '[.attributes[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$attr_a_id,$attr_b_id,$attr_c_id"
+
+  run_otdfctl_attr update --id "$attr_a_id" --label sort=a --json
+  assert_success
+  sleep 1
+  run_otdfctl_attr update --id "$attr_b_id" --label sort=b --json
+  assert_success
+  sleep 1
+  run_otdfctl_attr update --id "$attr_c_id" --label sort=c --json
+  assert_success
+
+  run_otdfctl_attr list --sort updated_at:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$attr_a_id" --arg b "$attr_b_id" --arg c "$attr_c_id" '[.attributes[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$attr_a_id,$attr_b_id,$attr_c_id"
+
+  run_otdfctl_attr list --sort name: --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.attributes[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$attr_c_id,$attr_b_id,$attr_a_id"
+
+  run_otdfctl_attr list --sort :asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$attr_a_id" --arg b "$attr_b_id" --arg c "$attr_c_id" '[.attributes[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$attr_a_id,$attr_b_id,$attr_c_id"
+
+  run_otdfctl_attr unsafe delete --force --id "$attr_a_id"
+  run_otdfctl_attr unsafe delete --force --id "$attr_b_id"
+  run_otdfctl_attr unsafe delete --force --id "$attr_c_id"
+}
+
 @test "List - comprehensive pagination tests" {
   # create 10 random attributes so we have confidence there are >= 10 attribute definitions
   for i in {1..10}; do

--- a/otdfctl/e2e/attributes.bats
+++ b/otdfctl/e2e/attributes.bats
@@ -146,44 +146,40 @@ teardown_file() {
   assert_line --regexp "Current Offset.*0"
 }
 
-@test "List attribute definitions supports sort fields and partial sort syntax" {
+@test "List attribute definitions supports sort and order flags" {
   sort_prefix="sort_attr_${BATS_TEST_NUMBER}_$RANDOM"
   attr_a_id=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "${sort_prefix}_alpha" --rule ANY_OF --json | jq -r '.id')
-  sleep 1
   attr_b_id=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "${sort_prefix}_bravo" --rule ANY_OF --json | jq -r '.id')
-  sleep 1
   attr_c_id=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "${sort_prefix}_charlie" --rule ANY_OF --json | jq -r '.id')
 
-  run_otdfctl_attr list --sort name:asc --limit 500 --json
+  run_otdfctl_attr list --sort name --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.attributes[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$attr_a_id,$attr_b_id,$attr_c_id"
 
-  run_otdfctl_attr list --sort name:desc --limit 500 --json
+  run_otdfctl_attr list --sort name --order desc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.attributes[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$attr_c_id,$attr_b_id,$attr_a_id"
 
-  run_otdfctl_attr list --sort created_at:asc --limit 500 --json
+  run_otdfctl_attr list --sort created_at --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$attr_a_id" --arg b "$attr_b_id" --arg c "$attr_c_id" '[.attributes[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$attr_a_id,$attr_b_id,$attr_c_id"
 
   run_otdfctl_attr update --id "$attr_a_id" --label sort=a --json
   assert_success
-  sleep 1
   run_otdfctl_attr update --id "$attr_b_id" --label sort=b --json
   assert_success
-  sleep 1
   run_otdfctl_attr update --id "$attr_c_id" --label sort=c --json
   assert_success
 
-  run_otdfctl_attr list --sort updated_at:asc --limit 500 --json
+  run_otdfctl_attr list --sort updated_at --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$attr_a_id" --arg b "$attr_b_id" --arg c "$attr_c_id" '[.attributes[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$attr_a_id,$attr_b_id,$attr_c_id"
 
-  run_otdfctl_attr list --sort name: --limit 500 --json
+  run_otdfctl_attr list --sort name --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.attributes[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$attr_c_id,$attr_b_id,$attr_a_id"
 
-  run_otdfctl_attr list --sort :asc --limit 500 --json
+  run_otdfctl_attr list --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$attr_a_id" --arg b "$attr_b_id" --arg c "$attr_c_id" '[.attributes[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$attr_a_id,$attr_b_id,$attr_c_id"
 

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -618,6 +618,56 @@ format_kas_name_as_uri() {
   assert_not_equal "$(echo "$output" | jq -r --arg id "${key2_system_id}" '.kas_keys[] | select(.key.id == $id) | .key.metadata.updated_at')" "null"
 }
 
+@test "kas-keys: list keys supports sort fields and partial sort syntax" {
+  sort_prefix="sort-key-$BATS_TEST_NUMBER-$RANDOM"
+  run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${sort_prefix}-alpha" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64_RSA}" --json
+  assert_success
+  key_a_id=$(echo "$output" | jq -r .key.id)
+  sleep 1
+
+  run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${sort_prefix}-bravo" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64_RSA}" --json
+  assert_success
+  key_b_id=$(echo "$output" | jq -r .key.id)
+  sleep 1
+
+  run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${sort_prefix}-charlie" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64_RSA}" --json
+  assert_success
+  key_c_id=$(echo "$output" | jq -r .key.id)
+
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort key_id:desc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.kas_keys[] | select(.key.key_id | startswith($prefix)) | .key.id] | join(",")')" "$key_c_id,$key_b_id,$key_a_id"
+
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort key_id:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.kas_keys[] | select(.key.key_id | startswith($prefix)) | .key.id] | join(",")')" "$key_a_id,$key_b_id,$key_c_id"
+
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort created_at:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$key_a_id" --arg b "$key_b_id" --arg c "$key_c_id" '[.kas_keys[] | select(.key.id == $a or .key.id == $b or .key.id == $c) | .key.id] | join(",")')" "$key_a_id,$key_b_id,$key_c_id"
+
+  run_otdfctl_key update --id "$key_a_id" --label sort=a --json
+  assert_success
+  sleep 1
+  run_otdfctl_key update --id "$key_b_id" --label sort=b --json
+  assert_success
+  sleep 1
+  run_otdfctl_key update --id "$key_c_id" --label sort=c --json
+  assert_success
+
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort updated_at:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$key_a_id" --arg b "$key_b_id" --arg c "$key_c_id" '[.kas_keys[] | select(.key.id == $a or .key.id == $b or .key.id == $c) | .key.id] | join(",")')" "$key_a_id,$key_b_id,$key_c_id"
+
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort key_id: --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.kas_keys[] | select(.key.key_id | startswith($prefix)) | .key.id] | join(",")')" "$key_c_id,$key_b_id,$key_a_id"
+
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort :asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$key_a_id" --arg b "$key_b_id" --arg c "$key_c_id" '[.kas_keys[] | select(.key.id == $a or .key.id == $b or .key.id == $c) | .key.id] | join(",")')" "$key_a_id,$key_b_id,$key_c_id"
+}
+
 @test "kas-keys: list keys (pagination with limit and offset)" {
   KAS_NAME_LIST=$(generate_kas_name)
   KAS_URI_LIST=$(format_kas_name_as_uri "${KAS_NAME_LIST}")

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -618,52 +618,48 @@ format_kas_name_as_uri() {
   assert_not_equal "$(echo "$output" | jq -r --arg id "${key2_system_id}" '.kas_keys[] | select(.key.id == $id) | .key.metadata.updated_at')" "null"
 }
 
-@test "kas-keys: list keys supports sort fields and partial sort syntax" {
+@test "kas-keys: list keys supports sort and order flags" {
   sort_prefix="sort-key-$BATS_TEST_NUMBER-$RANDOM"
   run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${sort_prefix}-alpha" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64_RSA}" --json
   assert_success
   key_a_id=$(echo "$output" | jq -r .key.id)
-  sleep 1
 
   run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${sort_prefix}-bravo" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64_RSA}" --json
   assert_success
   key_b_id=$(echo "$output" | jq -r .key.id)
-  sleep 1
 
   run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${sort_prefix}-charlie" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64_RSA}" --json
   assert_success
   key_c_id=$(echo "$output" | jq -r .key.id)
 
-  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort key_id:desc --limit 500 --json
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort key_id --order desc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.kas_keys[] | select(.key.key_id | startswith($prefix)) | .key.id] | join(",")')" "$key_c_id,$key_b_id,$key_a_id"
 
-  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort key_id:asc --limit 500 --json
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort key_id --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.kas_keys[] | select(.key.key_id | startswith($prefix)) | .key.id] | join(",")')" "$key_a_id,$key_b_id,$key_c_id"
 
-  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort created_at:asc --limit 500 --json
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort created_at --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$key_a_id" --arg b "$key_b_id" --arg c "$key_c_id" '[.kas_keys[] | select(.key.id == $a or .key.id == $b or .key.id == $c) | .key.id] | join(",")')" "$key_a_id,$key_b_id,$key_c_id"
 
   run_otdfctl_key update --id "$key_a_id" --label sort=a --json
   assert_success
-  sleep 1
   run_otdfctl_key update --id "$key_b_id" --label sort=b --json
   assert_success
-  sleep 1
   run_otdfctl_key update --id "$key_c_id" --label sort=c --json
   assert_success
 
-  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort updated_at:asc --limit 500 --json
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort updated_at --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$key_a_id" --arg b "$key_b_id" --arg c "$key_c_id" '[.kas_keys[] | select(.key.id == $a or .key.id == $b or .key.id == $c) | .key.id] | join(",")')" "$key_a_id,$key_b_id,$key_c_id"
 
-  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort key_id: --limit 500 --json
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort key_id --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.kas_keys[] | select(.key.key_id | startswith($prefix)) | .key.id] | join(",")')" "$key_c_id,$key_b_id,$key_a_id"
 
-  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --sort :asc --limit 500 --json
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$key_a_id" --arg b "$key_b_id" --arg c "$key_c_id" '[.kas_keys[] | select(.key.id == $a or .key.id == $b or .key.id == $c) | .key.id] | join(",")')" "$key_a_id,$key_b_id,$key_c_id"
 }

--- a/otdfctl/e2e/kas-registry.bats
+++ b/otdfctl/e2e/kas-registry.bats
@@ -163,52 +163,48 @@ teardown() {
     [[ $total -ge 1 ]]
 }
 
-@test "list registered KASes supports sort fields and partial sort syntax" {
+@test "list registered KASes supports sort and order flags" {
     export CREATED=""
     sort_prefix="sort-kas-$BATS_TEST_NUMBER-$RANDOM"
     kas_a=$(./otdfctl $HOST $WITH_CREDS policy kas-registry create --name "$sort_prefix-alpha" --uri "https://$sort_prefix-alpha.example.com" --json)
-    sleep 1
     kas_b=$(./otdfctl $HOST $WITH_CREDS policy kas-registry create --name "$sort_prefix-bravo" --uri "https://$sort_prefix-bravo.example.com" --json)
-    sleep 1
     kas_c=$(./otdfctl $HOST $WITH_CREDS policy kas-registry create --name "$sort_prefix-charlie" --uri "https://$sort_prefix-charlie.example.com" --json)
     kas_a_id=$(echo "$kas_a" | jq -r '.id')
     kas_b_id=$(echo "$kas_b" | jq -r '.id')
     kas_c_id=$(echo "$kas_c" | jq -r '.id')
 
-    run_otdfctl_kasr list --sort name:asc --limit 500 --json
+    run_otdfctl_kasr list --sort name --order asc --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.key_access_servers[] | select((.name // "") | startswith($prefix)) | .id] | join(",")')" "$kas_a_id,$kas_b_id,$kas_c_id"
 
-    run_otdfctl_kasr list --sort name:desc --limit 500 --json
+    run_otdfctl_kasr list --sort name --order desc --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.key_access_servers[] | select((.name // "") | startswith($prefix)) | .id] | join(",")')" "$kas_c_id,$kas_b_id,$kas_a_id"
 
-    run_otdfctl_kasr list --sort uri:asc --limit 500 --json
+    run_otdfctl_kasr list --sort uri --order asc --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg prefix "https://$sort_prefix" '[.key_access_servers[] | select(.uri | startswith($prefix)) | .id] | join(",")')" "$kas_a_id,$kas_b_id,$kas_c_id"
 
-    run_otdfctl_kasr list --sort created_at:asc --limit 500 --json
+    run_otdfctl_kasr list --sort created_at --order asc --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg a "$kas_a_id" --arg b "$kas_b_id" --arg c "$kas_c_id" '[.key_access_servers[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$kas_a_id,$kas_b_id,$kas_c_id"
 
     run_otdfctl_kasr update --id "$kas_a_id" --label sort=a --json
     assert_success
-    sleep 1
     run_otdfctl_kasr update --id "$kas_b_id" --label sort=b --json
     assert_success
-    sleep 1
     run_otdfctl_kasr update --id "$kas_c_id" --label sort=c --json
     assert_success
 
-    run_otdfctl_kasr list --sort updated_at:asc --limit 500 --json
+    run_otdfctl_kasr list --sort updated_at --order asc --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg a "$kas_a_id" --arg b "$kas_b_id" --arg c "$kas_c_id" '[.key_access_servers[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$kas_a_id,$kas_b_id,$kas_c_id"
 
-    run_otdfctl_kasr list --sort name: --limit 500 --json
+    run_otdfctl_kasr list --sort name --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.key_access_servers[] | select((.name // "") | startswith($prefix)) | .id] | join(",")')" "$kas_c_id,$kas_b_id,$kas_a_id"
 
-    run_otdfctl_kasr list --sort :asc --limit 500 --json
+    run_otdfctl_kasr list --order asc --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg a "$kas_a_id" --arg b "$kas_b_id" --arg c "$kas_c_id" '[.key_access_servers[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$kas_a_id,$kas_b_id,$kas_c_id"
 

--- a/otdfctl/e2e/kas-registry.bats
+++ b/otdfctl/e2e/kas-registry.bats
@@ -21,8 +21,14 @@ setup() {
 }
 
 teardown() {
+    if [[ -z "${CREATED:-}" ]]; then
+        return
+    fi
+
     ID=$(echo "$CREATED" | jq -r '.id')
-    run_otdfctl_kasr delete --id "$ID" --force
+    if [[ -n "$ID" ]]; then
+        run_otdfctl_kasr delete --id "$ID" --force
+    fi
 }
 
 @test "create KAS registration with invalid URI - fails" {
@@ -155,4 +161,58 @@ teardown() {
     assert_not_equal $(echo "$output" | jq -r ".pagination") "null"
     total=$(echo "$output" | jq -r ".pagination.total")
     [[ $total -ge 1 ]]
+}
+
+@test "list registered KASes supports sort fields and partial sort syntax" {
+    export CREATED=""
+    sort_prefix="sort-kas-$BATS_TEST_NUMBER-$RANDOM"
+    kas_a=$(./otdfctl $HOST $WITH_CREDS policy kas-registry create --name "$sort_prefix-alpha" --uri "https://$sort_prefix-alpha.example.com" --json)
+    sleep 1
+    kas_b=$(./otdfctl $HOST $WITH_CREDS policy kas-registry create --name "$sort_prefix-bravo" --uri "https://$sort_prefix-bravo.example.com" --json)
+    sleep 1
+    kas_c=$(./otdfctl $HOST $WITH_CREDS policy kas-registry create --name "$sort_prefix-charlie" --uri "https://$sort_prefix-charlie.example.com" --json)
+    kas_a_id=$(echo "$kas_a" | jq -r '.id')
+    kas_b_id=$(echo "$kas_b" | jq -r '.id')
+    kas_c_id=$(echo "$kas_c" | jq -r '.id')
+
+    run_otdfctl_kasr list --sort name:asc --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.key_access_servers[] | select((.name // "") | startswith($prefix)) | .id] | join(",")')" "$kas_a_id,$kas_b_id,$kas_c_id"
+
+    run_otdfctl_kasr list --sort name:desc --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.key_access_servers[] | select((.name // "") | startswith($prefix)) | .id] | join(",")')" "$kas_c_id,$kas_b_id,$kas_a_id"
+
+    run_otdfctl_kasr list --sort uri:asc --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg prefix "https://$sort_prefix" '[.key_access_servers[] | select(.uri | startswith($prefix)) | .id] | join(",")')" "$kas_a_id,$kas_b_id,$kas_c_id"
+
+    run_otdfctl_kasr list --sort created_at:asc --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg a "$kas_a_id" --arg b "$kas_b_id" --arg c "$kas_c_id" '[.key_access_servers[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$kas_a_id,$kas_b_id,$kas_c_id"
+
+    run_otdfctl_kasr update --id "$kas_a_id" --label sort=a --json
+    assert_success
+    sleep 1
+    run_otdfctl_kasr update --id "$kas_b_id" --label sort=b --json
+    assert_success
+    sleep 1
+    run_otdfctl_kasr update --id "$kas_c_id" --label sort=c --json
+    assert_success
+
+    run_otdfctl_kasr list --sort updated_at:asc --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg a "$kas_a_id" --arg b "$kas_b_id" --arg c "$kas_c_id" '[.key_access_servers[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$kas_a_id,$kas_b_id,$kas_c_id"
+
+    run_otdfctl_kasr list --sort name: --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.key_access_servers[] | select((.name // "") | startswith($prefix)) | .id] | join(",")')" "$kas_c_id,$kas_b_id,$kas_a_id"
+
+    run_otdfctl_kasr list --sort :asc --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg a "$kas_a_id" --arg b "$kas_b_id" --arg c "$kas_c_id" '[.key_access_servers[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$kas_a_id,$kas_b_id,$kas_c_id"
+
+    run_otdfctl_kasr delete --id "$kas_a_id" --force
+    run_otdfctl_kasr delete --id "$kas_b_id" --force
+    run_otdfctl_kasr delete --id "$kas_c_id" --force
 }

--- a/otdfctl/e2e/namespaces.bats
+++ b/otdfctl/e2e/namespaces.bats
@@ -122,51 +122,47 @@ teardown_file() {
   assert_line --regexp "Current Offset.*0"
 }
 
-@test "List namespaces supports sort fields and partial sort syntax" {
+@test "List namespaces supports sort and order flags" {
   sort_prefix="sort-ns-$BATS_TEST_NUMBER-$RANDOM"
   ns_a_name="$sort_prefix-alpha.test"
   ns_b_name="$sort_prefix-bravo.test"
   ns_c_name="$sort_prefix-charlie.test"
   ns_a_id=$(./otdfctl $HOST $WITH_CREDS policy namespaces create --name "$ns_a_name" --json | jq -r '.id')
-  sleep 1
   ns_b_id=$(./otdfctl $HOST $WITH_CREDS policy namespaces create --name "$ns_b_name" --json | jq -r '.id')
-  sleep 1
   ns_c_id=$(./otdfctl $HOST $WITH_CREDS policy namespaces create --name "$ns_c_name" --json | jq -r '.id')
 
-  run_otdfctl_nsd list --sort name:asc --limit 500 --json
+  run_otdfctl_nsd list --sort name --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.namespaces[] | select(.name | startswith($prefix)) | .name] | join(",")')" "$ns_a_name,$ns_b_name,$ns_c_name"
 
-  run_otdfctl_nsd list --sort name:desc --limit 500 --json
+  run_otdfctl_nsd list --sort name --order desc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.namespaces[] | select(.name | startswith($prefix)) | .name] | join(",")')" "$ns_c_name,$ns_b_name,$ns_a_name"
 
-  run_otdfctl_nsd list --sort fqn:asc --limit 500 --json
+  run_otdfctl_nsd list --sort fqn --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "https://$sort_prefix" '[.namespaces[] | select(.fqn | startswith($prefix)) | .id] | join(",")')" "$ns_a_id,$ns_b_id,$ns_c_id"
 
-  run_otdfctl_nsd list --sort created_at:asc --limit 500 --json
+  run_otdfctl_nsd list --sort created_at --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$ns_a_id" --arg b "$ns_b_id" --arg c "$ns_c_id" '[.namespaces[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$ns_a_id,$ns_b_id,$ns_c_id"
 
   run_otdfctl_nsd update --id "$ns_a_id" --label sort=a --json
   assert_success
-  sleep 1
   run_otdfctl_nsd update --id "$ns_b_id" --label sort=b --json
   assert_success
-  sleep 1
   run_otdfctl_nsd update --id "$ns_c_id" --label sort=c --json
   assert_success
 
-  run_otdfctl_nsd list --sort updated_at:asc --limit 500 --json
+  run_otdfctl_nsd list --sort updated_at --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$ns_a_id" --arg b "$ns_b_id" --arg c "$ns_c_id" '[.namespaces[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$ns_a_id,$ns_b_id,$ns_c_id"
 
-  run_otdfctl_nsd list --sort name: --limit 500 --json
+  run_otdfctl_nsd list --sort name --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.namespaces[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$ns_c_id,$ns_b_id,$ns_a_id"
 
-  run_otdfctl_nsd list --sort :asc --limit 500 --json
+  run_otdfctl_nsd list --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$ns_a_id" --arg b "$ns_b_id" --arg c "$ns_c_id" '[.namespaces[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$ns_a_id,$ns_b_id,$ns_c_id"
 

--- a/otdfctl/e2e/namespaces.bats
+++ b/otdfctl/e2e/namespaces.bats
@@ -122,6 +122,59 @@ teardown_file() {
   assert_line --regexp "Current Offset.*0"
 }
 
+@test "List namespaces supports sort fields and partial sort syntax" {
+  sort_prefix="sort-ns-$BATS_TEST_NUMBER-$RANDOM"
+  ns_a_name="$sort_prefix-alpha.test"
+  ns_b_name="$sort_prefix-bravo.test"
+  ns_c_name="$sort_prefix-charlie.test"
+  ns_a_id=$(./otdfctl $HOST $WITH_CREDS policy namespaces create --name "$ns_a_name" --json | jq -r '.id')
+  sleep 1
+  ns_b_id=$(./otdfctl $HOST $WITH_CREDS policy namespaces create --name "$ns_b_name" --json | jq -r '.id')
+  sleep 1
+  ns_c_id=$(./otdfctl $HOST $WITH_CREDS policy namespaces create --name "$ns_c_name" --json | jq -r '.id')
+
+  run_otdfctl_nsd list --sort name:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.namespaces[] | select(.name | startswith($prefix)) | .name] | join(",")')" "$ns_a_name,$ns_b_name,$ns_c_name"
+
+  run_otdfctl_nsd list --sort name:desc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.namespaces[] | select(.name | startswith($prefix)) | .name] | join(",")')" "$ns_c_name,$ns_b_name,$ns_a_name"
+
+  run_otdfctl_nsd list --sort fqn:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "https://$sort_prefix" '[.namespaces[] | select(.fqn | startswith($prefix)) | .id] | join(",")')" "$ns_a_id,$ns_b_id,$ns_c_id"
+
+  run_otdfctl_nsd list --sort created_at:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$ns_a_id" --arg b "$ns_b_id" --arg c "$ns_c_id" '[.namespaces[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$ns_a_id,$ns_b_id,$ns_c_id"
+
+  run_otdfctl_nsd update --id "$ns_a_id" --label sort=a --json
+  assert_success
+  sleep 1
+  run_otdfctl_nsd update --id "$ns_b_id" --label sort=b --json
+  assert_success
+  sleep 1
+  run_otdfctl_nsd update --id "$ns_c_id" --label sort=c --json
+  assert_success
+
+  run_otdfctl_nsd list --sort updated_at:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$ns_a_id" --arg b "$ns_b_id" --arg c "$ns_c_id" '[.namespaces[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$ns_a_id,$ns_b_id,$ns_c_id"
+
+  run_otdfctl_nsd list --sort name: --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.namespaces[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$ns_c_id,$ns_b_id,$ns_a_id"
+
+  run_otdfctl_nsd list --sort :asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$ns_a_id" --arg b "$ns_b_id" --arg c "$ns_c_id" '[.namespaces[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$ns_a_id,$ns_b_id,$ns_c_id"
+
+  run_otdfctl_nsd unsafe delete --id "$ns_a_id" --force
+  run_otdfctl_nsd unsafe delete --id "$ns_b_id" --force
+  run_otdfctl_nsd unsafe delete --id "$ns_c_id" --force
+}
+
 @test "Update namespace - Safe" {
   # extend labels
   run_otdfctl_ns update "$NS_ID_FLAG" -l key=value --label test=true

--- a/otdfctl/e2e/obligations.bats
+++ b/otdfctl/e2e/obligations.bats
@@ -427,51 +427,47 @@ teardown_file() {
   run_otdfctl_obl delete --id $obl2_id --force
 }
 
-@test "List obligations supports sort fields and partial sort syntax" {
+@test "List obligations supports sort and order flags" {
   sort_prefix="sort_obl_${BATS_TEST_NUMBER}_$RANDOM"
   run_otdfctl_obl create --name "${sort_prefix}_alpha" --namespace "$NS_ID" --json
   obl_a_id="$(echo "$output" | jq -r '.id')"
-  sleep 1
   run_otdfctl_obl create --name "${sort_prefix}_bravo" --namespace "$NS_ID" --json
   obl_b_id="$(echo "$output" | jq -r '.id')"
-  sleep 1
   run_otdfctl_obl create --name "${sort_prefix}_charlie" --namespace "$NS_ID" --json
   obl_c_id="$(echo "$output" | jq -r '.id')"
 
-  run_otdfctl_obl list --namespace "$NS_ID" --sort name:asc --limit 500 --json
+  run_otdfctl_obl list --namespace "$NS_ID" --sort name --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.obligations[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$obl_a_id,$obl_b_id,$obl_c_id"
 
-  run_otdfctl_obl list --namespace "$NS_ID" --sort name:desc --limit 500 --json
+  run_otdfctl_obl list --namespace "$NS_ID" --sort name --order desc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.obligations[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$obl_c_id,$obl_b_id,$obl_a_id"
 
-  run_otdfctl_obl list --namespace "$NS_ID" --sort fqn:asc --limit 500 --json
+  run_otdfctl_obl list --namespace "$NS_ID" --sort fqn --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "https://$NS_NAME/obl/$sort_prefix" '[.obligations[] | select(.fqn | startswith($prefix)) | .id] | join(",")')" "$obl_a_id,$obl_b_id,$obl_c_id"
 
-  run_otdfctl_obl list --namespace "$NS_ID" --sort created_at:asc --limit 500 --json
+  run_otdfctl_obl list --namespace "$NS_ID" --sort created_at --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$obl_a_id" --arg b "$obl_b_id" --arg c "$obl_c_id" '[.obligations[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$obl_a_id,$obl_b_id,$obl_c_id"
 
   run_otdfctl_obl update --id "$obl_a_id" --label sort=a --json
   assert_success
-  sleep 1
   run_otdfctl_obl update --id "$obl_b_id" --label sort=b --json
   assert_success
-  sleep 1
   run_otdfctl_obl update --id "$obl_c_id" --label sort=c --json
   assert_success
 
-  run_otdfctl_obl list --namespace "$NS_ID" --sort updated_at:asc --limit 500 --json
+  run_otdfctl_obl list --namespace "$NS_ID" --sort updated_at --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$obl_a_id" --arg b "$obl_b_id" --arg c "$obl_c_id" '[.obligations[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$obl_a_id,$obl_b_id,$obl_c_id"
 
-  run_otdfctl_obl list --namespace "$NS_ID" --sort name: --limit 500 --json
+  run_otdfctl_obl list --namespace "$NS_ID" --sort name --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.obligations[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$obl_c_id,$obl_b_id,$obl_a_id"
 
-  run_otdfctl_obl list --namespace "$NS_ID" --sort :asc --limit 500 --json
+  run_otdfctl_obl list --namespace "$NS_ID" --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$obl_a_id" --arg b "$obl_b_id" --arg c "$obl_c_id" '[.obligations[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$obl_a_id,$obl_b_id,$obl_c_id"
 

--- a/otdfctl/e2e/obligations.bats
+++ b/otdfctl/e2e/obligations.bats
@@ -427,6 +427,59 @@ teardown_file() {
   run_otdfctl_obl delete --id $obl2_id --force
 }
 
+@test "List obligations supports sort fields and partial sort syntax" {
+  sort_prefix="sort_obl_${BATS_TEST_NUMBER}_$RANDOM"
+  run_otdfctl_obl create --name "${sort_prefix}_alpha" --namespace "$NS_ID" --json
+  obl_a_id="$(echo "$output" | jq -r '.id')"
+  sleep 1
+  run_otdfctl_obl create --name "${sort_prefix}_bravo" --namespace "$NS_ID" --json
+  obl_b_id="$(echo "$output" | jq -r '.id')"
+  sleep 1
+  run_otdfctl_obl create --name "${sort_prefix}_charlie" --namespace "$NS_ID" --json
+  obl_c_id="$(echo "$output" | jq -r '.id')"
+
+  run_otdfctl_obl list --namespace "$NS_ID" --sort name:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.obligations[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$obl_a_id,$obl_b_id,$obl_c_id"
+
+  run_otdfctl_obl list --namespace "$NS_ID" --sort name:desc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.obligations[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$obl_c_id,$obl_b_id,$obl_a_id"
+
+  run_otdfctl_obl list --namespace "$NS_ID" --sort fqn:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "https://$NS_NAME/obl/$sort_prefix" '[.obligations[] | select(.fqn | startswith($prefix)) | .id] | join(",")')" "$obl_a_id,$obl_b_id,$obl_c_id"
+
+  run_otdfctl_obl list --namespace "$NS_ID" --sort created_at:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$obl_a_id" --arg b "$obl_b_id" --arg c "$obl_c_id" '[.obligations[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$obl_a_id,$obl_b_id,$obl_c_id"
+
+  run_otdfctl_obl update --id "$obl_a_id" --label sort=a --json
+  assert_success
+  sleep 1
+  run_otdfctl_obl update --id "$obl_b_id" --label sort=b --json
+  assert_success
+  sleep 1
+  run_otdfctl_obl update --id "$obl_c_id" --label sort=c --json
+  assert_success
+
+  run_otdfctl_obl list --namespace "$NS_ID" --sort updated_at:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$obl_a_id" --arg b "$obl_b_id" --arg c "$obl_c_id" '[.obligations[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$obl_a_id,$obl_b_id,$obl_c_id"
+
+  run_otdfctl_obl list --namespace "$NS_ID" --sort name: --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.obligations[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$obl_c_id,$obl_b_id,$obl_a_id"
+
+  run_otdfctl_obl list --namespace "$NS_ID" --sort :asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$obl_a_id" --arg b "$obl_b_id" --arg c "$obl_c_id" '[.obligations[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$obl_a_id,$obl_b_id,$obl_c_id"
+
+  run_otdfctl_obl delete --id "$obl_a_id" --force
+  run_otdfctl_obl delete --id "$obl_b_id" --force
+  run_otdfctl_obl delete --id "$obl_c_id" --force
+}
+
 @test "Update obligation" {
   # setup an obligation to update
   run_otdfctl_obl create --name test_update_obl --namespace "$NS_ID" --json

--- a/otdfctl/e2e/registered-resources.bats
+++ b/otdfctl/e2e/registered-resources.bats
@@ -191,47 +191,43 @@ teardown_file() {
   run_otdfctl_reg_res delete --id $reg_res2_id --force
 }
 
-@test "List registered resources supports sort fields and partial sort syntax" {
+@test "List registered resources supports sort and order flags" {
   sort_prefix="sort_rr_${BATS_TEST_NUMBER}_$RANDOM"
   run_otdfctl_reg_res create --name "${sort_prefix}_alpha" --namespace "$NS_ID" --json
   rr_a_id=$(echo "$output" | jq -r '.id')
-  sleep 1
   run_otdfctl_reg_res create --name "${sort_prefix}_bravo" --namespace "$NS_ID" --json
   rr_b_id=$(echo "$output" | jq -r '.id')
-  sleep 1
   run_otdfctl_reg_res create --name "${sort_prefix}_charlie" --namespace "$NS_ID" --json
   rr_c_id=$(echo "$output" | jq -r '.id')
 
-  run_otdfctl_reg_res list --namespace "$NS_ID" --sort name:asc --limit 500 --json
+  run_otdfctl_reg_res list --namespace "$NS_ID" --sort name --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.resources[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$rr_a_id,$rr_b_id,$rr_c_id"
 
-  run_otdfctl_reg_res list --namespace "$NS_ID" --sort name:desc --limit 500 --json
+  run_otdfctl_reg_res list --namespace "$NS_ID" --sort name --order desc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.resources[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$rr_c_id,$rr_b_id,$rr_a_id"
 
-  run_otdfctl_reg_res list --namespace "$NS_ID" --sort created_at:asc --limit 500 --json
+  run_otdfctl_reg_res list --namespace "$NS_ID" --sort created_at --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$rr_a_id" --arg b "$rr_b_id" --arg c "$rr_c_id" '[.resources[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$rr_a_id,$rr_b_id,$rr_c_id"
 
   run_otdfctl_reg_res update --id "$rr_a_id" --label sort=a --json
   assert_success
-  sleep 1
   run_otdfctl_reg_res update --id "$rr_b_id" --label sort=b --json
   assert_success
-  sleep 1
   run_otdfctl_reg_res update --id "$rr_c_id" --label sort=c --json
   assert_success
 
-  run_otdfctl_reg_res list --namespace "$NS_ID" --sort updated_at:asc --limit 500 --json
+  run_otdfctl_reg_res list --namespace "$NS_ID" --sort updated_at --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$rr_a_id" --arg b "$rr_b_id" --arg c "$rr_c_id" '[.resources[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$rr_a_id,$rr_b_id,$rr_c_id"
 
-  run_otdfctl_reg_res list --namespace "$NS_ID" --sort name: --limit 500 --json
+  run_otdfctl_reg_res list --namespace "$NS_ID" --sort name --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.resources[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$rr_c_id,$rr_b_id,$rr_a_id"
 
-  run_otdfctl_reg_res list --namespace "$NS_ID" --sort :asc --limit 500 --json
+  run_otdfctl_reg_res list --namespace "$NS_ID" --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$rr_a_id" --arg b "$rr_b_id" --arg c "$rr_c_id" '[.resources[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$rr_a_id,$rr_b_id,$rr_c_id"
 

--- a/otdfctl/e2e/registered-resources.bats
+++ b/otdfctl/e2e/registered-resources.bats
@@ -191,6 +191,55 @@ teardown_file() {
   run_otdfctl_reg_res delete --id $reg_res2_id --force
 }
 
+@test "List registered resources supports sort fields and partial sort syntax" {
+  sort_prefix="sort_rr_${BATS_TEST_NUMBER}_$RANDOM"
+  run_otdfctl_reg_res create --name "${sort_prefix}_alpha" --namespace "$NS_ID" --json
+  rr_a_id=$(echo "$output" | jq -r '.id')
+  sleep 1
+  run_otdfctl_reg_res create --name "${sort_prefix}_bravo" --namespace "$NS_ID" --json
+  rr_b_id=$(echo "$output" | jq -r '.id')
+  sleep 1
+  run_otdfctl_reg_res create --name "${sort_prefix}_charlie" --namespace "$NS_ID" --json
+  rr_c_id=$(echo "$output" | jq -r '.id')
+
+  run_otdfctl_reg_res list --namespace "$NS_ID" --sort name:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.resources[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$rr_a_id,$rr_b_id,$rr_c_id"
+
+  run_otdfctl_reg_res list --namespace "$NS_ID" --sort name:desc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.resources[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$rr_c_id,$rr_b_id,$rr_a_id"
+
+  run_otdfctl_reg_res list --namespace "$NS_ID" --sort created_at:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$rr_a_id" --arg b "$rr_b_id" --arg c "$rr_c_id" '[.resources[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$rr_a_id,$rr_b_id,$rr_c_id"
+
+  run_otdfctl_reg_res update --id "$rr_a_id" --label sort=a --json
+  assert_success
+  sleep 1
+  run_otdfctl_reg_res update --id "$rr_b_id" --label sort=b --json
+  assert_success
+  sleep 1
+  run_otdfctl_reg_res update --id "$rr_c_id" --label sort=c --json
+  assert_success
+
+  run_otdfctl_reg_res list --namespace "$NS_ID" --sort updated_at:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$rr_a_id" --arg b "$rr_b_id" --arg c "$rr_c_id" '[.resources[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$rr_a_id,$rr_b_id,$rr_c_id"
+
+  run_otdfctl_reg_res list --namespace "$NS_ID" --sort name: --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg prefix "$sort_prefix" '[.resources[] | select(.name | startswith($prefix)) | .id] | join(",")')" "$rr_c_id,$rr_b_id,$rr_a_id"
+
+  run_otdfctl_reg_res list --namespace "$NS_ID" --sort :asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$rr_a_id" --arg b "$rr_b_id" --arg c "$rr_c_id" '[.resources[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$rr_a_id,$rr_b_id,$rr_c_id"
+
+  run_otdfctl_reg_res delete --id "$rr_a_id" --force
+  run_otdfctl_reg_res delete --id "$rr_b_id" --force
+  run_otdfctl_reg_res delete --id "$rr_c_id" --force
+}
+
 @test "Update registered resource" {
   # setup a resource to update
   run_otdfctl_reg_res create --name test_update_rr --namespace "$NS_ID"

--- a/otdfctl/e2e/subject-condition-sets.bats
+++ b/otdfctl/e2e/subject-condition-sets.bats
@@ -138,6 +138,47 @@ teardown_file() {
     assert_output --partial "$CREATED_ID"
 }
 
+@test "List SCS supports sort fields and partial sort syntax" {
+  scs_a_id=$(./otdfctl $HOST $WITH_CREDS policy scs create --subject-sets "$SCS_1" --namespace "$NS_ID" --json | jq -r '.id')
+  sleep 1
+  scs_b_id=$(./otdfctl $HOST $WITH_CREDS policy scs create --subject-sets "$SCS_2" --namespace "$NS_ID" --json | jq -r '.id')
+  sleep 1
+  scs_c_id=$(./otdfctl $HOST $WITH_CREDS policy scs create --subject-sets "$SCS_3" --namespace "$NS_ID" --json | jq -r '.id')
+
+  run_otdfctl_scs list --namespace "$NS_ID" --sort :asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$scs_a_id" --arg b "$scs_b_id" --arg c "$scs_c_id" '[.subject_condition_sets[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$scs_a_id,$scs_b_id,$scs_c_id"
+
+  run_otdfctl_scs list --namespace "$NS_ID" --sort created_at:desc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$scs_a_id" --arg b "$scs_b_id" --arg c "$scs_c_id" '[.subject_condition_sets[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$scs_c_id,$scs_b_id,$scs_a_id"
+
+  run ./otdfctl $HOST $WITH_CREDS policy scs update --id "$scs_a_id" --subject-sets "$SCS_1" --label sort=a --json
+  assert_success
+  sleep 1
+  run ./otdfctl $HOST $WITH_CREDS policy scs update --id "$scs_b_id" --subject-sets "$SCS_2" --label sort=b --json
+  assert_success
+  sleep 1
+  run ./otdfctl $HOST $WITH_CREDS policy scs update --id "$scs_c_id" --subject-sets "$SCS_3" --label sort=c --json
+  assert_success
+
+  run_otdfctl_scs list --namespace "$NS_ID" --sort updated_at:asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$scs_a_id" --arg b "$scs_b_id" --arg c "$scs_c_id" '[.subject_condition_sets[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$scs_a_id,$scs_b_id,$scs_c_id"
+
+  run_otdfctl_scs list --namespace "$NS_ID" --sort created_at: --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$scs_a_id" --arg b "$scs_b_id" --arg c "$scs_c_id" '[.subject_condition_sets[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$scs_c_id,$scs_b_id,$scs_a_id"
+
+  run_otdfctl_scs list --namespace "$NS_ID" --sort :asc --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg a "$scs_a_id" --arg b "$scs_b_id" --arg c "$scs_c_id" '[.subject_condition_sets[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$scs_a_id,$scs_b_id,$scs_c_id"
+
+  run_delete_scs "$scs_a_id"
+  run_delete_scs "$scs_b_id"
+  run_delete_scs "$scs_c_id"
+}
+
 @test "Create a SCS with namespace id" {
   run ./otdfctl $HOST $WITH_CREDS policy scs create --subject-sets "$SCS_2" --namespace "$NS_ID"
   assert_output --partial "Id"

--- a/otdfctl/e2e/subject-condition-sets.bats
+++ b/otdfctl/e2e/subject-condition-sets.bats
@@ -138,39 +138,35 @@ teardown_file() {
     assert_output --partial "$CREATED_ID"
 }
 
-@test "List SCS supports sort fields and partial sort syntax" {
+@test "List SCS supports sort and order flags" {
   scs_a_id=$(./otdfctl $HOST $WITH_CREDS policy scs create --subject-sets "$SCS_1" --namespace "$NS_ID" --json | jq -r '.id')
-  sleep 1
   scs_b_id=$(./otdfctl $HOST $WITH_CREDS policy scs create --subject-sets "$SCS_2" --namespace "$NS_ID" --json | jq -r '.id')
-  sleep 1
   scs_c_id=$(./otdfctl $HOST $WITH_CREDS policy scs create --subject-sets "$SCS_3" --namespace "$NS_ID" --json | jq -r '.id')
 
-  run_otdfctl_scs list --namespace "$NS_ID" --sort :asc --limit 500 --json
+  run_otdfctl_scs list --namespace "$NS_ID" --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$scs_a_id" --arg b "$scs_b_id" --arg c "$scs_c_id" '[.subject_condition_sets[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$scs_a_id,$scs_b_id,$scs_c_id"
 
-  run_otdfctl_scs list --namespace "$NS_ID" --sort created_at:desc --limit 500 --json
+  run_otdfctl_scs list --namespace "$NS_ID" --sort created_at --order desc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$scs_a_id" --arg b "$scs_b_id" --arg c "$scs_c_id" '[.subject_condition_sets[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$scs_c_id,$scs_b_id,$scs_a_id"
 
   run ./otdfctl $HOST $WITH_CREDS policy scs update --id "$scs_a_id" --subject-sets "$SCS_1" --label sort=a --json
   assert_success
-  sleep 1
   run ./otdfctl $HOST $WITH_CREDS policy scs update --id "$scs_b_id" --subject-sets "$SCS_2" --label sort=b --json
   assert_success
-  sleep 1
   run ./otdfctl $HOST $WITH_CREDS policy scs update --id "$scs_c_id" --subject-sets "$SCS_3" --label sort=c --json
   assert_success
 
-  run_otdfctl_scs list --namespace "$NS_ID" --sort updated_at:asc --limit 500 --json
+  run_otdfctl_scs list --namespace "$NS_ID" --sort updated_at --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$scs_a_id" --arg b "$scs_b_id" --arg c "$scs_c_id" '[.subject_condition_sets[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$scs_a_id,$scs_b_id,$scs_c_id"
 
-  run_otdfctl_scs list --namespace "$NS_ID" --sort created_at: --limit 500 --json
+  run_otdfctl_scs list --namespace "$NS_ID" --sort created_at --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$scs_a_id" --arg b "$scs_b_id" --arg c "$scs_c_id" '[.subject_condition_sets[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$scs_c_id,$scs_b_id,$scs_a_id"
 
-  run_otdfctl_scs list --namespace "$NS_ID" --sort :asc --limit 500 --json
+  run_otdfctl_scs list --namespace "$NS_ID" --order asc --limit 500 --json
   assert_success
   assert_equal "$(echo "$output" | jq -r --arg a "$scs_a_id" --arg b "$scs_b_id" --arg c "$scs_c_id" '[.subject_condition_sets[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$scs_a_id,$scs_b_id,$scs_c_id"
 

--- a/otdfctl/e2e/subject-mapping.bats
+++ b/otdfctl/e2e/subject-mapping.bats
@@ -170,6 +170,51 @@ teardown_file() {
     [[ "$total" -ge 1 ]]
 }
 
+@test "List subject mappings supports sort fields and partial sort syntax" {
+    sort_attr=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "sort_sm_${BATS_TEST_NUMBER}_$RANDOM" --rule ANY_OF -v "sort_sm_a" -v "sort_sm_b" -v "sort_sm_c" --json)
+    sort_val_a_id=$(echo "$sort_attr" | jq -r '.values[0].id')
+    sort_val_b_id=$(echo "$sort_attr" | jq -r '.values[1].id')
+    sort_val_c_id=$(echo "$sort_attr" | jq -r '.values[2].id')
+    sm_a_id=$(./otdfctl $HOST $WITH_CREDS policy sm create --namespace "$NS_ID" -a "$sort_val_a_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json | jq -r '.id')
+    sleep 1
+    sm_b_id=$(./otdfctl $HOST $WITH_CREDS policy sm create --namespace "$NS_ID" -a "$sort_val_b_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json | jq -r '.id')
+    sleep 1
+    sm_c_id=$(./otdfctl $HOST $WITH_CREDS policy sm create --namespace "$NS_ID" -a "$sort_val_c_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json | jq -r '.id')
+
+    run_otdfctl_sm list --namespace "$NS_ID" --sort created_at:asc --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg a "$sm_a_id" --arg b "$sm_b_id" --arg c "$sm_c_id" '[.subject_mappings[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$sm_a_id,$sm_b_id,$sm_c_id"
+
+    run_otdfctl_sm list --namespace "$NS_ID" --sort created_at:desc --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg a "$sm_a_id" --arg b "$sm_b_id" --arg c "$sm_c_id" '[.subject_mappings[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$sm_c_id,$sm_b_id,$sm_a_id"
+
+    run_otdfctl_sm update --id "$sm_a_id" --label sort=a --json
+    assert_success
+    sleep 1
+    run_otdfctl_sm update --id "$sm_b_id" --label sort=b --json
+    assert_success
+    sleep 1
+    run_otdfctl_sm update --id "$sm_c_id" --label sort=c --json
+    assert_success
+
+    run_otdfctl_sm list --namespace "$NS_ID" --sort updated_at:asc --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg a "$sm_a_id" --arg b "$sm_b_id" --arg c "$sm_c_id" '[.subject_mappings[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$sm_a_id,$sm_b_id,$sm_c_id"
+
+    run_otdfctl_sm list --namespace "$NS_ID" --sort created_at: --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg a "$sm_a_id" --arg b "$sm_b_id" --arg c "$sm_c_id" '[.subject_mappings[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$sm_c_id,$sm_b_id,$sm_a_id"
+
+    run_otdfctl_sm list --namespace "$NS_ID" --sort :asc --limit 500 --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg a "$sm_a_id" --arg b "$sm_b_id" --arg c "$sm_c_id" '[.subject_mappings[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$sm_a_id,$sm_b_id,$sm_c_id"
+
+    run_otdfctl_sm delete --id "$sm_a_id" --force
+    run_otdfctl_sm delete --id "$sm_b_id" --force
+    run_otdfctl_sm delete --id "$sm_c_id" --force
+}
+
 @test "Create subject mapping with namespace ID" {
     run ./otdfctl $HOST $WITH_CREDS policy subject-mappings create -a "$SM_VAL2_ID" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_2" --namespace "$NS_ID" --json
     assert_success

--- a/otdfctl/e2e/subject-mapping.bats
+++ b/otdfctl/e2e/subject-mapping.bats
@@ -170,43 +170,39 @@ teardown_file() {
     [[ "$total" -ge 1 ]]
 }
 
-@test "List subject mappings supports sort fields and partial sort syntax" {
+@test "List subject mappings supports sort and order flags" {
     sort_attr=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "sort_sm_${BATS_TEST_NUMBER}_$RANDOM" --rule ANY_OF -v "sort_sm_a" -v "sort_sm_b" -v "sort_sm_c" --json)
     sort_val_a_id=$(echo "$sort_attr" | jq -r '.values[0].id')
     sort_val_b_id=$(echo "$sort_attr" | jq -r '.values[1].id')
     sort_val_c_id=$(echo "$sort_attr" | jq -r '.values[2].id')
     sm_a_id=$(./otdfctl $HOST $WITH_CREDS policy sm create --namespace "$NS_ID" -a "$sort_val_a_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json | jq -r '.id')
-    sleep 1
     sm_b_id=$(./otdfctl $HOST $WITH_CREDS policy sm create --namespace "$NS_ID" -a "$sort_val_b_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json | jq -r '.id')
-    sleep 1
     sm_c_id=$(./otdfctl $HOST $WITH_CREDS policy sm create --namespace "$NS_ID" -a "$sort_val_c_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json | jq -r '.id')
 
-    run_otdfctl_sm list --namespace "$NS_ID" --sort created_at:asc --limit 500 --json
+    run_otdfctl_sm list --namespace "$NS_ID" --sort created_at --order asc --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg a "$sm_a_id" --arg b "$sm_b_id" --arg c "$sm_c_id" '[.subject_mappings[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$sm_a_id,$sm_b_id,$sm_c_id"
 
-    run_otdfctl_sm list --namespace "$NS_ID" --sort created_at:desc --limit 500 --json
+    run_otdfctl_sm list --namespace "$NS_ID" --sort created_at --order desc --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg a "$sm_a_id" --arg b "$sm_b_id" --arg c "$sm_c_id" '[.subject_mappings[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$sm_c_id,$sm_b_id,$sm_a_id"
 
     run_otdfctl_sm update --id "$sm_a_id" --label sort=a --json
     assert_success
-    sleep 1
     run_otdfctl_sm update --id "$sm_b_id" --label sort=b --json
     assert_success
-    sleep 1
     run_otdfctl_sm update --id "$sm_c_id" --label sort=c --json
     assert_success
 
-    run_otdfctl_sm list --namespace "$NS_ID" --sort updated_at:asc --limit 500 --json
+    run_otdfctl_sm list --namespace "$NS_ID" --sort updated_at --order asc --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg a "$sm_a_id" --arg b "$sm_b_id" --arg c "$sm_c_id" '[.subject_mappings[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$sm_a_id,$sm_b_id,$sm_c_id"
 
-    run_otdfctl_sm list --namespace "$NS_ID" --sort created_at: --limit 500 --json
+    run_otdfctl_sm list --namespace "$NS_ID" --sort created_at --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg a "$sm_a_id" --arg b "$sm_b_id" --arg c "$sm_c_id" '[.subject_mappings[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$sm_c_id,$sm_b_id,$sm_a_id"
 
-    run_otdfctl_sm list --namespace "$NS_ID" --sort :asc --limit 500 --json
+    run_otdfctl_sm list --namespace "$NS_ID" --order asc --limit 500 --json
     assert_success
     assert_equal "$(echo "$output" | jq -r --arg a "$sm_a_id" --arg b "$sm_b_id" --arg c "$sm_c_id" '[.subject_mappings[] | select(.id == $a or .id == $b or .id == $c) | .id] | join(",")')" "$sm_a_id,$sm_b_id,$sm_c_id"
 

--- a/otdfctl/migrations/namespacedpolicy/planner.go
+++ b/otdfctl/migrations/namespacedpolicy/planner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/opentdf/platform/otdfctl/pkg/handlers"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/actions"
@@ -19,12 +20,12 @@ var ErrNilPlannerHandler = errors.New("planner handler is required")
 
 type PolicyClient interface {
 	ListActions(ctx context.Context, limit, offset int32, namespace string) (*actions.ListActionsResponse, error)
-	ListSubjectConditionSets(ctx context.Context, limit, offset int32, namespace string) (*subjectmapping.ListSubjectConditionSetsResponse, error)
-	ListSubjectMappings(ctx context.Context, limit, offset int32, namespace string) (*subjectmapping.ListSubjectMappingsResponse, error)
-	ListRegisteredResources(ctx context.Context, limit, offset int32, namespace string) (*registeredresources.ListRegisteredResourcesResponse, error)
+	ListSubjectConditionSets(ctx context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error)
+	ListSubjectMappings(ctx context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectMappingsResponse, error)
+	ListRegisteredResources(ctx context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*registeredresources.ListRegisteredResourcesResponse, error)
 	ListRegisteredResourceValues(ctx context.Context, resourceID string, limit, offset int32) (*registeredresources.ListRegisteredResourceValuesResponse, error)
 	ListObligationTriggers(ctx context.Context, namespace string, limit, offset int32) (*obligations.ListObligationTriggersResponse, error)
-	ListNamespaces(ctx context.Context, state common.ActiveStateEnum, limit, offset int32) (*namespaces.ListNamespacesResponse, error)
+	ListNamespaces(ctx context.Context, state common.ActiveStateEnum, limit, offset int32, sort handlers.SortOption) (*namespaces.ListNamespacesResponse, error)
 }
 
 type Planner struct {

--- a/otdfctl/migrations/namespacedpolicy/planner_test.go
+++ b/otdfctl/migrations/namespacedpolicy/planner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/opentdf/platform/otdfctl/pkg/handlers"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/actions"
@@ -975,7 +976,7 @@ func (h *plannerTestHandler) ListActions(_ context.Context, limit, offset int32,
 	return &actions.ListActionsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *plannerTestHandler) ListSubjectConditionSets(_ context.Context, limit, offset int32, namespace string) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
+func (h *plannerTestHandler) ListSubjectConditionSets(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
 	h.subjectConditionSetCalls = append(h.subjectConditionSetCalls, namespace)
 	if resp, ok := h.subjectConditionSetsByNamespace[namespace]; ok {
 		return resp, nil
@@ -983,7 +984,7 @@ func (h *plannerTestHandler) ListSubjectConditionSets(_ context.Context, limit, 
 	return &subjectmapping.ListSubjectConditionSetsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *plannerTestHandler) ListSubjectMappings(_ context.Context, limit, offset int32, namespace string) (*subjectmapping.ListSubjectMappingsResponse, error) {
+func (h *plannerTestHandler) ListSubjectMappings(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectMappingsResponse, error) {
 	h.subjectMappingCalls = append(h.subjectMappingCalls, namespace)
 	if resp, ok := h.subjectMappingsByNamespace[namespace]; ok {
 		return resp, nil
@@ -991,7 +992,7 @@ func (h *plannerTestHandler) ListSubjectMappings(_ context.Context, limit, offse
 	return &subjectmapping.ListSubjectMappingsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *plannerTestHandler) ListRegisteredResources(_ context.Context, limit, offset int32, namespace string) (*registeredresources.ListRegisteredResourcesResponse, error) {
+func (h *plannerTestHandler) ListRegisteredResources(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*registeredresources.ListRegisteredResourcesResponse, error) {
 	h.registeredResourceCalls = append(h.registeredResourceCalls, namespace)
 	if resp, ok := h.registeredResourcesByNamespace[namespace]; ok {
 		return resp, nil
@@ -1028,7 +1029,7 @@ func (h *plannerTestHandler) ListObligationTriggers(_ context.Context, namespace
 	return &obligations.ListObligationTriggersResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *plannerTestHandler) ListNamespaces(_ context.Context, state common.ActiveStateEnum, limit, offset int32) (*namespaces.ListNamespacesResponse, error) {
+func (h *plannerTestHandler) ListNamespaces(_ context.Context, state common.ActiveStateEnum, limit, offset int32, sort handlers.SortOption) (*namespaces.ListNamespacesResponse, error) {
 	if h.namespacesResponse != nil {
 		return h.namespacesResponse, nil
 	}

--- a/otdfctl/migrations/namespacedpolicy/retrieve.go
+++ b/otdfctl/migrations/namespacedpolicy/retrieve.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/opentdf/platform/otdfctl/pkg/handlers"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/actions"
@@ -94,7 +95,7 @@ func (r *Retriever) listNamespaces(ctx context.Context) ([]*policy.Namespace, er
 	)
 
 	for {
-		resp, err := r.handler.ListNamespaces(ctx, common.ActiveStateEnum_ACTIVE_STATE_ENUM_ACTIVE, r.pageSize, offset)
+		resp, err := r.handler.ListNamespaces(ctx, common.ActiveStateEnum_ACTIVE_STATE_ENUM_ACTIVE, r.pageSize, offset, handlers.SortOption{})
 		if err != nil {
 			return nil, fmt.Errorf("list namespaces: %w", err)
 		}
@@ -182,7 +183,7 @@ func (r *Retriever) retrieveSubjectMappings(ctx context.Context) ([]*policy.Subj
 	)
 
 	for {
-		resp, err := r.handler.ListSubjectMappings(ctx, r.pageSize, offset, "")
+		resp, err := r.handler.ListSubjectMappings(ctx, r.pageSize, offset, "", handlers.SortOption{})
 		if err != nil {
 			return nil, fmt.Errorf("list subject mappings: %w", err)
 		}
@@ -217,7 +218,7 @@ func (r *Retriever) retrieveSubjectConditionSets(ctx context.Context) ([]*policy
 	var offset int32
 
 	for {
-		resp, err := r.handler.ListSubjectConditionSets(ctx, r.pageSize, offset, "")
+		resp, err := r.handler.ListSubjectConditionSets(ctx, r.pageSize, offset, "", handlers.SortOption{})
 		if err != nil {
 			return nil, fmt.Errorf("list subject condition sets: %w", err)
 		}
@@ -256,7 +257,7 @@ func (r *Retriever) retrieveRegisteredResources(ctx context.Context) ([]*policy.
 	)
 
 	for {
-		resp, err := r.handler.ListRegisteredResources(ctx, r.pageSize, offset, "")
+		resp, err := r.handler.ListRegisteredResources(ctx, r.pageSize, offset, "", handlers.SortOption{})
 		if err != nil {
 			return nil, fmt.Errorf("list registered resources: %w", err)
 		}
@@ -458,7 +459,7 @@ func (r *Retriever) listSubjectConditionSetsForNamespaces(ctx context.Context, n
 	for _, namespace := range dedupeTargetNamespaces(namespaces) {
 		var offset int32
 		for {
-			resp, err := r.handler.ListSubjectConditionSets(ctx, r.pageSize, offset, namespace.GetId())
+			resp, err := r.handler.ListSubjectConditionSets(ctx, r.pageSize, offset, namespace.GetId(), handlers.SortOption{})
 			if err != nil {
 				return nil, fmt.Errorf("list subject condition sets for namespace %s: %w", namespace.GetId(), err)
 			}
@@ -490,7 +491,7 @@ func (r *Retriever) listSubjectMappingsForNamespaces(ctx context.Context, namesp
 	for _, namespace := range dedupeTargetNamespaces(namespaces) {
 		var offset int32
 		for {
-			resp, err := r.handler.ListSubjectMappings(ctx, r.pageSize, offset, namespace.GetId())
+			resp, err := r.handler.ListSubjectMappings(ctx, r.pageSize, offset, namespace.GetId(), handlers.SortOption{})
 			if err != nil {
 				return nil, fmt.Errorf("list subject mappings for namespace %s: %w", namespace.GetId(), err)
 			}
@@ -522,7 +523,7 @@ func (r *Retriever) listRegisteredResourcesForNamespaces(ctx context.Context, na
 	for _, namespace := range dedupeTargetNamespaces(namespaces) {
 		var offset int32
 		for {
-			resp, err := r.handler.ListRegisteredResources(ctx, r.pageSize, offset, namespace.GetId())
+			resp, err := r.handler.ListRegisteredResources(ctx, r.pageSize, offset, namespace.GetId(), handlers.SortOption{})
 			if err != nil {
 				return nil, fmt.Errorf("list registered resources for namespace %s: %w", namespace.GetId(), err)
 			}

--- a/otdfctl/migrations/namespacedpolicy/retrieve_test.go
+++ b/otdfctl/migrations/namespacedpolicy/retrieve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/opentdf/platform/otdfctl/pkg/handlers"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/actions"
@@ -415,18 +416,18 @@ func (h *pagedRetrieveTestHandler) ListActions(_ context.Context, limit, offset 
 	return &actions.ListActionsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *pagedRetrieveTestHandler) ListSubjectConditionSets(_ context.Context, limit, offset int32, namespace string) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
+func (h *pagedRetrieveTestHandler) ListSubjectConditionSets(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
 	return &subjectmapping.ListSubjectConditionSetsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *pagedRetrieveTestHandler) ListSubjectMappings(_ context.Context, limit, offset int32, namespace string) (*subjectmapping.ListSubjectMappingsResponse, error) {
+func (h *pagedRetrieveTestHandler) ListSubjectMappings(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectMappingsResponse, error) {
 	if resp, ok := h.subjectMappingPages[offset]; ok {
 		return resp, nil
 	}
 	return &subjectmapping.ListSubjectMappingsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *pagedRetrieveTestHandler) ListRegisteredResources(_ context.Context, limit, offset int32, namespace string) (*registeredresources.ListRegisteredResourcesResponse, error) {
+func (h *pagedRetrieveTestHandler) ListRegisteredResources(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*registeredresources.ListRegisteredResourcesResponse, error) {
 	if resp, ok := h.registeredResourcePages[offset]; ok {
 		return resp, nil
 	}
@@ -463,7 +464,7 @@ func (h *pagedRetrieveTestHandler) ListObligationTriggers(_ context.Context, nam
 	return &obligations.ListObligationTriggersResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *pagedRetrieveTestHandler) ListNamespaces(_ context.Context, state common.ActiveStateEnum, limit, offset int32) (*namespaces.ListNamespacesResponse, error) {
+func (h *pagedRetrieveTestHandler) ListNamespaces(_ context.Context, state common.ActiveStateEnum, limit, offset int32, sort handlers.SortOption) (*namespaces.ListNamespacesResponse, error) {
 	return &namespaces.ListNamespacesResponse{Pagination: emptyPageResponse()}, nil
 }
 

--- a/otdfctl/pkg/handlers/attribute.go
+++ b/otdfctl/pkg/handlers/attribute.go
@@ -63,18 +63,14 @@ func (h Handler) ListAttributes(ctx context.Context, state common.ActiveStateEnu
 		},
 	}
 	if !sort.IsZero() {
-		var field attributes.SortAttributesType
-		if sort.Field != "" {
-			var ok bool
-			allowedFields := map[string]attributes.SortAttributesType{
-				"name":       attributes.SortAttributesType_SORT_ATTRIBUTES_TYPE_NAME,
-				"created_at": attributes.SortAttributesType_SORT_ATTRIBUTES_TYPE_CREATED_AT,
-				"updated_at": attributes.SortAttributesType_SORT_ATTRIBUTES_TYPE_UPDATED_AT,
-			}
-			field, ok = allowedFields[sort.Field]
-			if !ok {
-				return nil, invalidSortFieldError("attributes", sort.Field, allowedFields)
-			}
+		allowedFields := map[string]attributes.SortAttributesType{
+			"name":       attributes.SortAttributesType_SORT_ATTRIBUTES_TYPE_NAME,
+			"created_at": attributes.SortAttributesType_SORT_ATTRIBUTES_TYPE_CREATED_AT,
+			"updated_at": attributes.SortAttributesType_SORT_ATTRIBUTES_TYPE_UPDATED_AT,
+		}
+		field, err := sortField("attributes", sort, allowedFields)
+		if err != nil {
+			return nil, err
 		}
 		req.Sort = []*attributes.AttributesSort{{Field: field, Direction: sort.Direction}}
 	}

--- a/otdfctl/pkg/handlers/attribute.go
+++ b/otdfctl/pkg/handlers/attribute.go
@@ -54,14 +54,31 @@ func (h Handler) GetAttribute(ctx context.Context, identifier string) (*policy.A
 	return resp.GetAttribute(), nil
 }
 
-func (h Handler) ListAttributes(ctx context.Context, state common.ActiveStateEnum, limit, offset int32) (*attributes.ListAttributesResponse, error) {
-	return h.sdk.Attributes.ListAttributes(ctx, &attributes.ListAttributesRequest{
+func (h Handler) ListAttributes(ctx context.Context, state common.ActiveStateEnum, limit, offset int32, sort SortOption) (*attributes.ListAttributesResponse, error) {
+	req := &attributes.ListAttributesRequest{
 		State: state,
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
 			Offset: offset,
 		},
-	})
+	}
+	if !sort.IsZero() {
+		var field attributes.SortAttributesType
+		if sort.Field != "" {
+			var ok bool
+			allowedFields := map[string]attributes.SortAttributesType{
+				"name":       attributes.SortAttributesType_SORT_ATTRIBUTES_TYPE_NAME,
+				"created_at": attributes.SortAttributesType_SORT_ATTRIBUTES_TYPE_CREATED_AT,
+				"updated_at": attributes.SortAttributesType_SORT_ATTRIBUTES_TYPE_UPDATED_AT,
+			}
+			field, ok = allowedFields[sort.Field]
+			if !ok {
+				return nil, invalidSortFieldError("attributes", sort.Field, allowedFields)
+			}
+		}
+		req.Sort = []*attributes.AttributesSort{{Field: field, Direction: sort.Direction}}
+	}
+	return h.sdk.Attributes.ListAttributes(ctx, req)
 }
 
 // Creates and returns the created attribute

--- a/otdfctl/pkg/handlers/kas-keys.go
+++ b/otdfctl/pkg/handlers/kas-keys.go
@@ -91,6 +91,7 @@ func (h Handler) ListKasKeys(
 	algorithm policy.Algorithm,
 	identifier KasIdentifier,
 	legacy *bool,
+	sort SortOption,
 ) (*kasregistry.ListKeysResponse, error) {
 	req := kasregistry.ListKeysRequest{
 		Pagination: &policy.PageRequest{
@@ -115,6 +116,22 @@ func (h Handler) ListKasKeys(
 		}
 	}
 	req.Legacy = legacy
+	if !sort.IsZero() {
+		var field kasregistry.SortKasKeysType
+		if sort.Field != "" {
+			var ok bool
+			allowedFields := map[string]kasregistry.SortKasKeysType{
+				"key_id":     kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_KEY_ID,
+				"created_at": kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT,
+				"updated_at": kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_UPDATED_AT,
+			}
+			field, ok = allowedFields[sort.Field]
+			if !ok {
+				return nil, invalidSortFieldError("KAS keys", sort.Field, allowedFields)
+			}
+		}
+		req.Sort = []*kasregistry.KasKeysSort{{Field: field, Direction: sort.Direction}}
+	}
 
 	return h.sdk.KeyAccessServerRegistry.ListKeys(ctx, &req)
 }

--- a/otdfctl/pkg/handlers/kas-keys.go
+++ b/otdfctl/pkg/handlers/kas-keys.go
@@ -117,18 +117,14 @@ func (h Handler) ListKasKeys(
 	}
 	req.Legacy = legacy
 	if !sort.IsZero() {
-		var field kasregistry.SortKasKeysType
-		if sort.Field != "" {
-			var ok bool
-			allowedFields := map[string]kasregistry.SortKasKeysType{
-				"key_id":     kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_KEY_ID,
-				"created_at": kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT,
-				"updated_at": kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_UPDATED_AT,
-			}
-			field, ok = allowedFields[sort.Field]
-			if !ok {
-				return nil, invalidSortFieldError("KAS keys", sort.Field, allowedFields)
-			}
+		allowedFields := map[string]kasregistry.SortKasKeysType{
+			"key_id":     kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_KEY_ID,
+			"created_at": kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT,
+			"updated_at": kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_UPDATED_AT,
+		}
+		field, err := sortField("KAS keys", sort, allowedFields)
+		if err != nil {
+			return nil, err
 		}
 		req.Sort = []*kasregistry.KasKeysSort{{Field: field, Direction: sort.Direction}}
 	}

--- a/otdfctl/pkg/handlers/kas-registry.go
+++ b/otdfctl/pkg/handlers/kas-registry.go
@@ -50,19 +50,15 @@ func (h Handler) ListKasRegistryEntries(ctx context.Context, limit, offset int32
 		},
 	}
 	if !sort.IsZero() {
-		var field kasregistry.SortKeyAccessServersType
-		if sort.Field != "" {
-			var ok bool
-			allowedFields := map[string]kasregistry.SortKeyAccessServersType{
-				"name":       kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_NAME,
-				"uri":        kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_URI,
-				"created_at": kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_CREATED_AT,
-				"updated_at": kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_UPDATED_AT,
-			}
-			field, ok = allowedFields[sort.Field]
-			if !ok {
-				return nil, invalidSortFieldError("KAS registry entries", sort.Field, allowedFields)
-			}
+		allowedFields := map[string]kasregistry.SortKeyAccessServersType{
+			"name":       kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_NAME,
+			"uri":        kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_URI,
+			"created_at": kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_CREATED_AT,
+			"updated_at": kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_UPDATED_AT,
+		}
+		field, err := sortField("KAS registry entries", sort, allowedFields)
+		if err != nil {
+			return nil, err
 		}
 		req.Sort = []*kasregistry.KeyAccessServersSort{{Field: field, Direction: sort.Direction}}
 	}

--- a/otdfctl/pkg/handlers/kas-registry.go
+++ b/otdfctl/pkg/handlers/kas-registry.go
@@ -42,13 +42,31 @@ func (h Handler) GetKasRegistryEntry(ctx context.Context, identifer KasIdentifie
 	return resp.GetKeyAccessServer(), nil
 }
 
-func (h Handler) ListKasRegistryEntries(ctx context.Context, limit, offset int32) (*kasregistry.ListKeyAccessServersResponse, error) {
-	return h.sdk.KeyAccessServerRegistry.ListKeyAccessServers(ctx, &kasregistry.ListKeyAccessServersRequest{
+func (h Handler) ListKasRegistryEntries(ctx context.Context, limit, offset int32, sort SortOption) (*kasregistry.ListKeyAccessServersResponse, error) {
+	req := &kasregistry.ListKeyAccessServersRequest{
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
 			Offset: offset,
 		},
-	})
+	}
+	if !sort.IsZero() {
+		var field kasregistry.SortKeyAccessServersType
+		if sort.Field != "" {
+			var ok bool
+			allowedFields := map[string]kasregistry.SortKeyAccessServersType{
+				"name":       kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_NAME,
+				"uri":        kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_URI,
+				"created_at": kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_CREATED_AT,
+				"updated_at": kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_UPDATED_AT,
+			}
+			field, ok = allowedFields[sort.Field]
+			if !ok {
+				return nil, invalidSortFieldError("KAS registry entries", sort.Field, allowedFields)
+			}
+		}
+		req.Sort = []*kasregistry.KeyAccessServersSort{{Field: field, Direction: sort.Direction}}
+	}
+	return h.sdk.KeyAccessServerRegistry.ListKeyAccessServers(ctx, req)
 }
 
 // Creates the KAS registry and then returns the KAS

--- a/otdfctl/pkg/handlers/namespaces.go
+++ b/otdfctl/pkg/handlers/namespaces.go
@@ -38,14 +38,32 @@ func (h Handler) GetNamespace(ctx context.Context, identifier string) (*policy.N
 	return resp.GetNamespace(), nil
 }
 
-func (h Handler) ListNamespaces(ctx context.Context, state common.ActiveStateEnum, limit, offset int32) (*namespaces.ListNamespacesResponse, error) {
-	return h.sdk.Namespaces.ListNamespaces(ctx, &namespaces.ListNamespacesRequest{
+func (h Handler) ListNamespaces(ctx context.Context, state common.ActiveStateEnum, limit, offset int32, sort SortOption) (*namespaces.ListNamespacesResponse, error) {
+	req := &namespaces.ListNamespacesRequest{
 		State: state,
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
 			Offset: offset,
 		},
-	})
+	}
+	if !sort.IsZero() {
+		var field namespaces.SortNamespacesType
+		if sort.Field != "" {
+			var ok bool
+			allowedFields := map[string]namespaces.SortNamespacesType{
+				"name":       namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_NAME,
+				"fqn":        namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_FQN,
+				"created_at": namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_CREATED_AT,
+				"updated_at": namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_UPDATED_AT,
+			}
+			field, ok = allowedFields[sort.Field]
+			if !ok {
+				return nil, invalidSortFieldError("namespaces", sort.Field, allowedFields)
+			}
+		}
+		req.Sort = []*namespaces.NamespacesSort{{Field: field, Direction: sort.Direction}}
+	}
+	return h.sdk.Namespaces.ListNamespaces(ctx, req)
 }
 
 // Creates and returns the created n

--- a/otdfctl/pkg/handlers/namespaces.go
+++ b/otdfctl/pkg/handlers/namespaces.go
@@ -47,19 +47,15 @@ func (h Handler) ListNamespaces(ctx context.Context, state common.ActiveStateEnu
 		},
 	}
 	if !sort.IsZero() {
-		var field namespaces.SortNamespacesType
-		if sort.Field != "" {
-			var ok bool
-			allowedFields := map[string]namespaces.SortNamespacesType{
-				"name":       namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_NAME,
-				"fqn":        namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_FQN,
-				"created_at": namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_CREATED_AT,
-				"updated_at": namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_UPDATED_AT,
-			}
-			field, ok = allowedFields[sort.Field]
-			if !ok {
-				return nil, invalidSortFieldError("namespaces", sort.Field, allowedFields)
-			}
+		allowedFields := map[string]namespaces.SortNamespacesType{
+			"name":       namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_NAME,
+			"fqn":        namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_FQN,
+			"created_at": namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_CREATED_AT,
+			"updated_at": namespaces.SortNamespacesType_SORT_NAMESPACES_TYPE_UPDATED_AT,
+		}
+		field, err := sortField("namespaces", sort, allowedFields)
+		if err != nil {
+			return nil, err
 		}
 		req.Sort = []*namespaces.NamespacesSort{{Field: field, Direction: sort.Direction}}
 	}

--- a/otdfctl/pkg/handlers/obligations.go
+++ b/otdfctl/pkg/handlers/obligations.go
@@ -74,19 +74,15 @@ func (h Handler) ListObligations(ctx context.Context, limit, offset int32, names
 		req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
 	}
 	if !sort.IsZero() {
-		var field obligations.SortObligationsType
-		if sort.Field != "" {
-			var ok bool
-			allowedFields := map[string]obligations.SortObligationsType{
-				"name":       obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_NAME,
-				"fqn":        obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_FQN,
-				"created_at": obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_CREATED_AT,
-				"updated_at": obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_UPDATED_AT,
-			}
-			field, ok = allowedFields[sort.Field]
-			if !ok {
-				return nil, invalidSortFieldError("obligations", sort.Field, allowedFields)
-			}
+		allowedFields := map[string]obligations.SortObligationsType{
+			"name":       obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_NAME,
+			"fqn":        obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_FQN,
+			"created_at": obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_CREATED_AT,
+			"updated_at": obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_UPDATED_AT,
+		}
+		field, err := sortField("obligations", sort, allowedFields)
+		if err != nil {
+			return nil, err
 		}
 		req.Sort = []*obligations.ObligationsSort{{Field: field, Direction: sort.Direction}}
 	}

--- a/otdfctl/pkg/handlers/obligations.go
+++ b/otdfctl/pkg/handlers/obligations.go
@@ -63,7 +63,7 @@ func (h Handler) GetObligation(ctx context.Context, id, fqn string) (*policy.Obl
 	return resp.GetObligation(), nil
 }
 
-func (h Handler) ListObligations(ctx context.Context, limit, offset int32, namespace string) (*obligations.ListObligationsResponse, error) {
+func (h Handler) ListObligations(ctx context.Context, limit, offset int32, namespace string, sort SortOption) (*obligations.ListObligationsResponse, error) {
 	req := &obligations.ListObligationsRequest{
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
@@ -72,6 +72,23 @@ func (h Handler) ListObligations(ctx context.Context, limit, offset int32, names
 	}
 	if namespace != "" {
 		req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
+	}
+	if !sort.IsZero() {
+		var field obligations.SortObligationsType
+		if sort.Field != "" {
+			var ok bool
+			allowedFields := map[string]obligations.SortObligationsType{
+				"name":       obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_NAME,
+				"fqn":        obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_FQN,
+				"created_at": obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_CREATED_AT,
+				"updated_at": obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_UPDATED_AT,
+			}
+			field, ok = allowedFields[sort.Field]
+			if !ok {
+				return nil, invalidSortFieldError("obligations", sort.Field, allowedFields)
+			}
+		}
+		req.Sort = []*obligations.ObligationsSort{{Field: field, Direction: sort.Direction}}
 	}
 	return h.sdk.Obligations.ListObligations(ctx, req)
 }

--- a/otdfctl/pkg/handlers/registeredResources.go
+++ b/otdfctl/pkg/handlers/registeredResources.go
@@ -63,18 +63,14 @@ func (h Handler) ListRegisteredResources(ctx context.Context, limit, offset int3
 		req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
 	}
 	if !sort.IsZero() {
-		var field registeredresources.SortRegisteredResourcesType
-		if sort.Field != "" {
-			var ok bool
-			allowedFields := map[string]registeredresources.SortRegisteredResourcesType{
-				"name":       registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_NAME,
-				"created_at": registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_CREATED_AT,
-				"updated_at": registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_UPDATED_AT,
-			}
-			field, ok = allowedFields[sort.Field]
-			if !ok {
-				return nil, invalidSortFieldError("registered resources", sort.Field, allowedFields)
-			}
+		allowedFields := map[string]registeredresources.SortRegisteredResourcesType{
+			"name":       registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_NAME,
+			"created_at": registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_CREATED_AT,
+			"updated_at": registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_UPDATED_AT,
+		}
+		field, err := sortField("registered resources", sort, allowedFields)
+		if err != nil {
+			return nil, err
 		}
 		req.Sort = []*registeredresources.RegisteredResourcesSort{{Field: field, Direction: sort.Direction}}
 	}

--- a/otdfctl/pkg/handlers/registeredResources.go
+++ b/otdfctl/pkg/handlers/registeredResources.go
@@ -52,7 +52,7 @@ func (h Handler) GetRegisteredResource(ctx context.Context, id, name, namespace 
 	return resp.GetResource(), nil
 }
 
-func (h Handler) ListRegisteredResources(ctx context.Context, limit, offset int32, namespace string) (*registeredresources.ListRegisteredResourcesResponse, error) {
+func (h Handler) ListRegisteredResources(ctx context.Context, limit, offset int32, namespace string, sort SortOption) (*registeredresources.ListRegisteredResourcesResponse, error) {
 	req := &registeredresources.ListRegisteredResourcesRequest{
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
@@ -61,6 +61,22 @@ func (h Handler) ListRegisteredResources(ctx context.Context, limit, offset int3
 	}
 	if namespace != "" {
 		req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
+	}
+	if !sort.IsZero() {
+		var field registeredresources.SortRegisteredResourcesType
+		if sort.Field != "" {
+			var ok bool
+			allowedFields := map[string]registeredresources.SortRegisteredResourcesType{
+				"name":       registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_NAME,
+				"created_at": registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_CREATED_AT,
+				"updated_at": registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_UPDATED_AT,
+			}
+			field, ok = allowedFields[sort.Field]
+			if !ok {
+				return nil, invalidSortFieldError("registered resources", sort.Field, allowedFields)
+			}
+		}
+		req.Sort = []*registeredresources.RegisteredResourcesSort{{Field: field, Direction: sort.Direction}}
 	}
 	return h.sdk.RegisteredResources.ListRegisteredResources(ctx, req)
 }

--- a/otdfctl/pkg/handlers/sort.go
+++ b/otdfctl/pkg/handlers/sort.go
@@ -17,33 +17,16 @@ type SortOption struct {
 const (
 	sortDirectionAsc  = "asc"
 	sortDirectionDesc = "desc"
-	sortSeparator     = ":"
 )
 
 var (
-	ErrInvalidSortFormat    = errors.New("sort must use field:direction; field or direction may be omitted")
 	ErrInvalidSortDirection = errors.New("invalid sort direction")
 	ErrInvalidSortField     = errors.New("invalid sort field")
 )
 
-func ParseSortOption(value string) (SortOption, error) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return SortOption{}, nil
-	}
-
-	fieldPart, directionPart, ok := strings.Cut(value, sortSeparator)
-	if !ok || strings.Contains(directionPart, sortSeparator) {
-		return SortOption{}, ErrInvalidSortFormat
-	}
-
-	field := strings.ToLower(strings.TrimSpace(fieldPart))
-	directionValue := strings.ToLower(strings.TrimSpace(directionPart))
-	if field == "" && directionValue == "" {
-		return SortOption{}, ErrInvalidSortFormat
-	}
-
-	direction, err := parseSortDirection(directionValue)
+func NewSortOption(field, order string) (SortOption, error) {
+	field = strings.ToLower(strings.TrimSpace(field))
+	direction, err := ParseSortOrder(order)
 	if err != nil {
 		return SortOption{}, err
 	}
@@ -54,10 +37,13 @@ func ParseSortOption(value string) (SortOption, error) {
 	}, nil
 }
 
-func parseSortDirection(value string) (policy.SortDirection, error) {
-	switch value {
-	case "":
+func ParseSortOrder(value string) (policy.SortDirection, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
 		return policy.SortDirection_SORT_DIRECTION_UNSPECIFIED, nil
+	}
+
+	switch strings.ToLower(value) {
 	case sortDirectionAsc:
 		return policy.SortDirection_SORT_DIRECTION_ASC, nil
 	case sortDirectionDesc:

--- a/otdfctl/pkg/handlers/sort.go
+++ b/otdfctl/pkg/handlers/sort.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+)
+
+type SortOption struct {
+	Field     string
+	Direction policy.SortDirection
+}
+
+const (
+	sortDirectionAsc  = "asc"
+	sortDirectionDesc = "desc"
+	sortSeparator     = ":"
+)
+
+var (
+	ErrInvalidSortFormat    = errors.New("sort must use field:direction; field or direction may be omitted")
+	ErrInvalidSortDirection = errors.New("sort direction must be asc or desc")
+)
+
+type InvalidSortDirectionError struct {
+	Direction string
+}
+
+func (e InvalidSortDirectionError) Error() string {
+	return fmt.Sprintf("%s: %q", ErrInvalidSortDirection, e.Direction)
+}
+
+func (e InvalidSortDirectionError) Unwrap() error {
+	return ErrInvalidSortDirection
+}
+
+func ParseSortOption(value string) (SortOption, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return SortOption{}, nil
+	}
+
+	fieldPart, directionPart, ok := strings.Cut(value, sortSeparator)
+	if !ok || strings.Contains(directionPart, sortSeparator) {
+		return SortOption{}, ErrInvalidSortFormat
+	}
+
+	field := strings.ToLower(strings.TrimSpace(fieldPart))
+	directionValue := strings.ToLower(strings.TrimSpace(directionPart))
+	if field == "" && directionValue == "" {
+		return SortOption{}, ErrInvalidSortFormat
+	}
+
+	direction, err := parseSortDirection(directionValue)
+	if err != nil {
+		return SortOption{}, err
+	}
+
+	return SortOption{
+		Field:     field,
+		Direction: direction,
+	}, nil
+}
+
+func parseSortDirection(value string) (policy.SortDirection, error) {
+	switch value {
+	case "":
+		return policy.SortDirection_SORT_DIRECTION_UNSPECIFIED, nil
+	case sortDirectionAsc:
+		return policy.SortDirection_SORT_DIRECTION_ASC, nil
+	case sortDirectionDesc:
+		return policy.SortDirection_SORT_DIRECTION_DESC, nil
+	default:
+		return policy.SortDirection_SORT_DIRECTION_UNSPECIFIED, InvalidSortDirectionError{Direction: value}
+	}
+}
+
+func (s SortOption) IsZero() bool {
+	return s.Field == "" && s.Direction == policy.SortDirection_SORT_DIRECTION_UNSPECIFIED
+}
+
+func invalidSortFieldError[T any](resource, field string, allowed map[string]T) error {
+	fields := make([]string, 0, len(allowed))
+	for f := range allowed {
+		fields = append(fields, f)
+	}
+	sort.Strings(fields)
+	return fmt.Errorf("invalid sort field %q for %s; valid fields: %s", field, resource, strings.Join(fields, ", "))
+}

--- a/otdfctl/pkg/handlers/sort.go
+++ b/otdfctl/pkg/handlers/sort.go
@@ -22,20 +22,9 @@ const (
 
 var (
 	ErrInvalidSortFormat    = errors.New("sort must use field:direction; field or direction may be omitted")
-	ErrInvalidSortDirection = errors.New("sort direction must be asc or desc")
+	ErrInvalidSortDirection = errors.New("invalid sort direction")
+	ErrInvalidSortField     = errors.New("invalid sort field")
 )
-
-type InvalidSortDirectionError struct {
-	Direction string
-}
-
-func (e InvalidSortDirectionError) Error() string {
-	return fmt.Sprintf("%s: %q", ErrInvalidSortDirection, e.Direction)
-}
-
-func (e InvalidSortDirectionError) Unwrap() error {
-	return ErrInvalidSortDirection
-}
 
 func ParseSortOption(value string) (SortOption, error) {
 	value = strings.TrimSpace(value)
@@ -74,12 +63,29 @@ func parseSortDirection(value string) (policy.SortDirection, error) {
 	case sortDirectionDesc:
 		return policy.SortDirection_SORT_DIRECTION_DESC, nil
 	default:
-		return policy.SortDirection_SORT_DIRECTION_UNSPECIFIED, InvalidSortDirectionError{Direction: value}
+		return policy.SortDirection_SORT_DIRECTION_UNSPECIFIED, errors.Join(
+			ErrInvalidSortDirection,
+			fmt.Errorf("%q must be asc or desc", value),
+		)
 	}
 }
 
 func (s SortOption) IsZero() bool {
 	return s.Field == "" && s.Direction == policy.SortDirection_SORT_DIRECTION_UNSPECIFIED
+}
+
+func sortField[T any](resource string, option SortOption, allowed map[string]T) (T, error) {
+	var zero T
+	if option.Field == "" {
+		return zero, nil
+	}
+
+	field, ok := allowed[option.Field]
+	if !ok {
+		return zero, invalidSortFieldError(resource, option.Field, allowed)
+	}
+
+	return field, nil
 }
 
 func invalidSortFieldError[T any](resource, field string, allowed map[string]T) error {
@@ -88,5 +94,8 @@ func invalidSortFieldError[T any](resource, field string, allowed map[string]T) 
 		fields = append(fields, f)
 	}
 	sort.Strings(fields)
-	return fmt.Errorf("invalid sort field %q for %s; valid fields: %s", field, resource, strings.Join(fields, ", "))
+	return errors.Join(
+		ErrInvalidSortField,
+		fmt.Errorf("%q is not a valid sort field for %s; valid fields: %s", field, resource, strings.Join(fields, ", ")),
+	)
 }

--- a/otdfctl/pkg/handlers/sort_test.go
+++ b/otdfctl/pkg/handlers/sort_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/opentdf/platform/protocol/go/policy"
@@ -85,15 +84,37 @@ func TestParseSortOption(t *testing.T) {
 			if tt.wantError != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.wantError)
-				if errors.Is(tt.wantError, ErrInvalidSortDirection) {
-					var directionErr InvalidSortDirectionError
-					require.ErrorAs(t, err, &directionErr)
-					assert.Equal(t, "up", directionErr.Direction)
-				}
 				return
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}
+}
+
+func TestSortField(t *testing.T) {
+	allowed := map[string]int{
+		"name":       1,
+		"created_at": 2,
+	}
+
+	t.Run("omitted field returns zero value", func(t *testing.T) {
+		field, err := sortField("test resources", SortOption{}, allowed)
+		require.NoError(t, err)
+		assert.Equal(t, 0, field)
+	})
+
+	t.Run("known field returns mapped value", func(t *testing.T) {
+		field, err := sortField("test resources", SortOption{Field: "name"}, allowed)
+		require.NoError(t, err)
+		assert.Equal(t, 1, field)
+	})
+
+	t.Run("unknown field returns valid fields", func(t *testing.T) {
+		field, err := sortField("test resources", SortOption{Field: "updated_at"}, allowed)
+		require.Error(t, err)
+		assert.Equal(t, 0, field)
+		require.ErrorIs(t, err, ErrInvalidSortField)
+		assert.EqualError(t, err, "invalid sort field\n\"updated_at\" is not a valid sort field for test resources; valid fields: created_at, name")
+	})
 }

--- a/otdfctl/pkg/handlers/sort_test.go
+++ b/otdfctl/pkg/handlers/sort_test.go
@@ -8,20 +8,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseSortOption(t *testing.T) {
+func TestNewSortOption(t *testing.T) {
 	tests := []struct {
 		name      string
-		input     string
+		field     string
+		order     string
 		expected  SortOption
 		wantError error
 	}{
 		{
-			name:  "empty",
-			input: "",
+			name: "empty",
 		},
 		{
 			name:  "field only",
-			input: "name:",
+			field: "name",
 			expected: SortOption{
 				Field:     "name",
 				Direction: policy.SortDirection_SORT_DIRECTION_UNSPECIFIED,
@@ -29,7 +29,8 @@ func TestParseSortOption(t *testing.T) {
 		},
 		{
 			name:  "ascending",
-			input: "created_at:asc",
+			field: "created_at",
+			order: "asc",
 			expected: SortOption{
 				Field:     "created_at",
 				Direction: policy.SortDirection_SORT_DIRECTION_ASC,
@@ -37,7 +38,8 @@ func TestParseSortOption(t *testing.T) {
 		},
 		{
 			name:  "descending with whitespace",
-			input: " updated_at : DESC ",
+			field: " updated_at ",
+			order: " DESC ",
 			expected: SortOption{
 				Field:     "updated_at",
 				Direction: policy.SortDirection_SORT_DIRECTION_DESC,
@@ -45,42 +47,23 @@ func TestParseSortOption(t *testing.T) {
 		},
 		{
 			name:  "direction only",
-			input: ":desc",
+			order: "desc",
 			expected: SortOption{
 				Field:     "",
 				Direction: policy.SortDirection_SORT_DIRECTION_DESC,
 			},
 		},
 		{
-			name:      "field without colon",
-			input:     "name",
-			wantError: ErrInvalidSortFormat,
-		},
-		{
-			name:      "direction without colon",
-			input:     "desc",
-			wantError: ErrInvalidSortFormat,
-		},
-		{
-			name:      "empty field and direction",
-			input:     ":",
-			wantError: ErrInvalidSortFormat,
-		},
-		{
-			name:      "too many parts",
-			input:     "name:asc:extra",
-			wantError: ErrInvalidSortFormat,
-		},
-		{
 			name:      "invalid direction",
-			input:     "name:up",
+			field:     "name",
+			order:     "up",
 			wantError: ErrInvalidSortDirection,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := ParseSortOption(tt.input)
+			actual, err := NewSortOption(tt.field, tt.order)
 			if tt.wantError != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.wantError)

--- a/otdfctl/pkg/handlers/sort_test.go
+++ b/otdfctl/pkg/handlers/sort_test.go
@@ -1,0 +1,99 @@
+package handlers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSortOption(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expected  SortOption
+		wantError error
+	}{
+		{
+			name:  "empty",
+			input: "",
+		},
+		{
+			name:  "field only",
+			input: "name:",
+			expected: SortOption{
+				Field:     "name",
+				Direction: policy.SortDirection_SORT_DIRECTION_UNSPECIFIED,
+			},
+		},
+		{
+			name:  "ascending",
+			input: "created_at:asc",
+			expected: SortOption{
+				Field:     "created_at",
+				Direction: policy.SortDirection_SORT_DIRECTION_ASC,
+			},
+		},
+		{
+			name:  "descending with whitespace",
+			input: " updated_at : DESC ",
+			expected: SortOption{
+				Field:     "updated_at",
+				Direction: policy.SortDirection_SORT_DIRECTION_DESC,
+			},
+		},
+		{
+			name:  "direction only",
+			input: ":desc",
+			expected: SortOption{
+				Field:     "",
+				Direction: policy.SortDirection_SORT_DIRECTION_DESC,
+			},
+		},
+		{
+			name:      "field without colon",
+			input:     "name",
+			wantError: ErrInvalidSortFormat,
+		},
+		{
+			name:      "direction without colon",
+			input:     "desc",
+			wantError: ErrInvalidSortFormat,
+		},
+		{
+			name:      "empty field and direction",
+			input:     ":",
+			wantError: ErrInvalidSortFormat,
+		},
+		{
+			name:      "too many parts",
+			input:     "name:asc:extra",
+			wantError: ErrInvalidSortFormat,
+		},
+		{
+			name:      "invalid direction",
+			input:     "name:up",
+			wantError: ErrInvalidSortDirection,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ParseSortOption(tt.input)
+			if tt.wantError != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.wantError)
+				if errors.Is(tt.wantError, ErrInvalidSortDirection) {
+					var directionErr InvalidSortDirectionError
+					require.ErrorAs(t, err, &directionErr)
+					assert.Equal(t, "up", directionErr.Direction)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/otdfctl/pkg/handlers/subjectConditionSets.go
+++ b/otdfctl/pkg/handlers/subjectConditionSets.go
@@ -28,17 +28,13 @@ func (h Handler) ListSubjectConditionSets(ctx context.Context, limit, offset int
 	}
 	req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
 	if !sort.IsZero() {
-		var field subjectmapping.SortSubjectConditionSetsType
-		if sort.Field != "" {
-			var ok bool
-			allowedFields := map[string]subjectmapping.SortSubjectConditionSetsType{
-				"created_at": subjectmapping.SortSubjectConditionSetsType_SORT_SUBJECT_CONDITION_SETS_TYPE_CREATED_AT,
-				"updated_at": subjectmapping.SortSubjectConditionSetsType_SORT_SUBJECT_CONDITION_SETS_TYPE_UPDATED_AT,
-			}
-			field, ok = allowedFields[sort.Field]
-			if !ok {
-				return nil, invalidSortFieldError("subject condition sets", sort.Field, allowedFields)
-			}
+		allowedFields := map[string]subjectmapping.SortSubjectConditionSetsType{
+			"created_at": subjectmapping.SortSubjectConditionSetsType_SORT_SUBJECT_CONDITION_SETS_TYPE_CREATED_AT,
+			"updated_at": subjectmapping.SortSubjectConditionSetsType_SORT_SUBJECT_CONDITION_SETS_TYPE_UPDATED_AT,
+		}
+		field, err := sortField("subject condition sets", sort, allowedFields)
+		if err != nil {
+			return nil, err
 		}
 		req.Sort = []*subjectmapping.SubjectConditionSetsSort{{Field: field, Direction: sort.Direction}}
 	}

--- a/otdfctl/pkg/handlers/subjectConditionSets.go
+++ b/otdfctl/pkg/handlers/subjectConditionSets.go
@@ -19,7 +19,7 @@ func (h Handler) GetSubjectConditionSet(ctx context.Context, id string) (*policy
 	return resp.GetSubjectConditionSet(), nil
 }
 
-func (h Handler) ListSubjectConditionSets(ctx context.Context, limit, offset int32, namespace string) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
+func (h Handler) ListSubjectConditionSets(ctx context.Context, limit, offset int32, namespace string, sort SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
 	req := &subjectmapping.ListSubjectConditionSetsRequest{
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
@@ -27,6 +27,21 @@ func (h Handler) ListSubjectConditionSets(ctx context.Context, limit, offset int
 		},
 	}
 	req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
+	if !sort.IsZero() {
+		var field subjectmapping.SortSubjectConditionSetsType
+		if sort.Field != "" {
+			var ok bool
+			allowedFields := map[string]subjectmapping.SortSubjectConditionSetsType{
+				"created_at": subjectmapping.SortSubjectConditionSetsType_SORT_SUBJECT_CONDITION_SETS_TYPE_CREATED_AT,
+				"updated_at": subjectmapping.SortSubjectConditionSetsType_SORT_SUBJECT_CONDITION_SETS_TYPE_UPDATED_AT,
+			}
+			field, ok = allowedFields[sort.Field]
+			if !ok {
+				return nil, invalidSortFieldError("subject condition sets", sort.Field, allowedFields)
+			}
+		}
+		req.Sort = []*subjectmapping.SubjectConditionSetsSort{{Field: field, Direction: sort.Direction}}
+	}
 	return h.sdk.SubjectMapping.ListSubjectConditionSets(ctx, req)
 }
 

--- a/otdfctl/pkg/handlers/subjectmappings.go
+++ b/otdfctl/pkg/handlers/subjectmappings.go
@@ -24,7 +24,7 @@ func (h Handler) GetSubjectMapping(ctx context.Context, id string) (*policy.Subj
 	return resp.GetSubjectMapping(), err
 }
 
-func (h Handler) ListSubjectMappings(ctx context.Context, limit, offset int32, namespace string) (*subjectmapping.ListSubjectMappingsResponse, error) {
+func (h Handler) ListSubjectMappings(ctx context.Context, limit, offset int32, namespace string, sort SortOption) (*subjectmapping.ListSubjectMappingsResponse, error) {
 	req := &subjectmapping.ListSubjectMappingsRequest{
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
@@ -32,6 +32,21 @@ func (h Handler) ListSubjectMappings(ctx context.Context, limit, offset int32, n
 		},
 	}
 	req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
+	if !sort.IsZero() {
+		var field subjectmapping.SortSubjectMappingsType
+		if sort.Field != "" {
+			var ok bool
+			allowedFields := map[string]subjectmapping.SortSubjectMappingsType{
+				"created_at": subjectmapping.SortSubjectMappingsType_SORT_SUBJECT_MAPPINGS_TYPE_CREATED_AT,
+				"updated_at": subjectmapping.SortSubjectMappingsType_SORT_SUBJECT_MAPPINGS_TYPE_UPDATED_AT,
+			}
+			field, ok = allowedFields[sort.Field]
+			if !ok {
+				return nil, invalidSortFieldError("subject mappings", sort.Field, allowedFields)
+			}
+		}
+		req.Sort = []*subjectmapping.SubjectMappingsSort{{Field: field, Direction: sort.Direction}}
+	}
 	return h.sdk.SubjectMapping.ListSubjectMappings(ctx, req)
 }
 

--- a/otdfctl/pkg/handlers/subjectmappings.go
+++ b/otdfctl/pkg/handlers/subjectmappings.go
@@ -33,17 +33,13 @@ func (h Handler) ListSubjectMappings(ctx context.Context, limit, offset int32, n
 	}
 	req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
 	if !sort.IsZero() {
-		var field subjectmapping.SortSubjectMappingsType
-		if sort.Field != "" {
-			var ok bool
-			allowedFields := map[string]subjectmapping.SortSubjectMappingsType{
-				"created_at": subjectmapping.SortSubjectMappingsType_SORT_SUBJECT_MAPPINGS_TYPE_CREATED_AT,
-				"updated_at": subjectmapping.SortSubjectMappingsType_SORT_SUBJECT_MAPPINGS_TYPE_UPDATED_AT,
-			}
-			field, ok = allowedFields[sort.Field]
-			if !ok {
-				return nil, invalidSortFieldError("subject mappings", sort.Field, allowedFields)
-			}
+		allowedFields := map[string]subjectmapping.SortSubjectMappingsType{
+			"created_at": subjectmapping.SortSubjectMappingsType_SORT_SUBJECT_MAPPINGS_TYPE_CREATED_AT,
+			"updated_at": subjectmapping.SortSubjectMappingsType_SORT_SUBJECT_MAPPINGS_TYPE_UPDATED_AT,
+		}
+		field, err := sortField("subject mappings", sort, allowedFields)
+		if err != nil {
+			return nil, err
 		}
 		req.Sort = []*subjectmapping.SubjectMappingsSort{{Field: field, Direction: sort.Direction}}
 	}

--- a/otdfctl/tui/attributeList.go
+++ b/otdfctl/tui/attributeList.go
@@ -40,7 +40,7 @@ func InitAttributeList(ctx context.Context, id string, h handlers.Handler) (tea.
 		limit  int32 = 100
 		offset int32 = 0
 	)
-	res, _ := h.ListAttributes(ctx, common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY, limit, offset)
+	res, _ := h.ListAttributes(ctx, common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY, limit, offset, handlers.SortOption{})
 	var attrs []list.Item
 	selectIdx := 0
 	for i, attr := range res.GetAttributes() {


### PR DESCRIPTION
 ## Summary

  - Added `--sort` support to otdfctl policy list commands for namespaces, attributes, KAS registry entries, KAS keys, obligations, registered resources, subject condition sets, and subject mappings.
  - Added shared sort parsing for `<field>:<direction>` syntax, including partial forms like `name:` and `:asc`.
  - Validates supported sort fields per resource while allowing the server to default omitted fields or directions.
  - Updated list command docs with supported sort fields, directions, defaults, and examples.
  - Added BATS e2e coverage in each policy construct test file for sort fields, directions, and partial sort syntax.
  - Updated internal callers in migration and TUI code to pass the default sort option.

  ## Testing

  - `go test ./pkg/handlers ./cmd/policy`
  - `go test ./...`
  - `golangci-lint run ./pkg/handlers ./cmd/policy`
  - Affected BATS suites for policy list sort behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI list commands now support server-side sorting via new --sort and --order flags across policy list workflows (attributes, KAS registry/keys, namespaces, obligations, registered resources, subject condition sets, subject mappings).

* **Documentation**
  * Manpages updated with Sort Options, supported fields/directions, and expanded examples.

* **Tests**
  * New end-to-end tests added to validate sorting behavior for all updated list commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentdf/platform/pull/3478)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->