### PR TITLE
feat(cli): Extend migrate command.

### DIFF
--- a/otdfctl/cmd/migrate/migrate.go
+++ b/otdfctl/cmd/migrate/migrate.go
@@ -1,16 +1,29 @@
 package migrate
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/opentdf/platform/otdfctl/cmd/migrate/prune"
 	"github.com/opentdf/platform/otdfctl/pkg/man"
+	"github.com/spf13/cobra"
 )
 
 var (
 	migrateDoc = man.Docs.GetDoc("migrate")
 
 	Cmd = &migrateDoc.Command
+
+	initialized bool
+
+	ErrNilParentCommand                = errors.New("parent command is nil")
+	ErrNilMigrateCommand               = errors.New("migrate command is nil")
+	ErrEmptyMigrateCommandName         = errors.New("migrate command name is empty")
+	ErrMigrateCommandAlreadyRegistered = errors.New("migrate command is already registered")
+	ErrMigrateCommandsNotInitialized   = errors.New("migrate commands are not initialized")
 )
 
+// InitCommands wires the built-in migrate command tree.
 func InitCommands() {
 	Cmd.PersistentFlags().BoolP(
 		migrateDoc.GetDocFlag("commit").Name,
@@ -32,4 +45,65 @@ func InitCommands() {
 		migrateNamespacedPolicyCmd(),
 		prune.Cmd,
 	)
+	initialized = true
+}
+
+// AddCommands appends migration subcommands to the shared migrate command.
+func AddCommands(commands ...*cobra.Command) error {
+	if !initialized {
+		return ErrMigrateCommandsNotInitialized
+	}
+	if Cmd == nil {
+		return ErrNilParentCommand
+	}
+
+	registeredNames := registeredCommandNames(Cmd)
+	for _, command := range commands {
+		if err := validateCommandCanBeAdded(registeredNames, command); err != nil {
+			return err
+		}
+		for name := range commandNames(command) {
+			registeredNames[name] = struct{}{}
+		}
+	}
+
+	Cmd.AddCommand(commands...)
+	return nil
+}
+
+func validateCommandCanBeAdded(registeredNames map[string]struct{}, command *cobra.Command) error {
+	if command == nil {
+		return ErrNilMigrateCommand
+	}
+	if command.Name() == "" {
+		return ErrEmptyMigrateCommandName
+	}
+
+	for name := range commandNames(command) {
+		if _, ok := registeredNames[name]; ok {
+			return fmt.Errorf("%w: %q", ErrMigrateCommandAlreadyRegistered, name)
+		}
+	}
+
+	return nil
+}
+
+func registeredCommandNames(parent *cobra.Command) map[string]struct{} {
+	names := make(map[string]struct{})
+	for _, command := range parent.Commands() {
+		for name := range commandNames(command) {
+			names[name] = struct{}{}
+		}
+	}
+	return names
+}
+
+func commandNames(command *cobra.Command) map[string]struct{} {
+	names := map[string]struct{}{
+		command.Name(): {},
+	}
+	for _, alias := range command.Aliases {
+		names[alias] = struct{}{}
+	}
+	return names
 }

--- a/otdfctl/cmd/migrate/migrate_test.go
+++ b/otdfctl/cmd/migrate/migrate_test.go
@@ -1,0 +1,143 @@
+package migrate
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddCommandsPreservesExistingAndAddsExtension(t *testing.T) {
+	parent := &cobra.Command{Use: "migrate"}
+	useMigrateCommand(t, parent)
+
+	baseRan := false
+	base := &cobra.Command{
+		Use:   "namespaced-policy",
+		Short: "base migration",
+		Run: func(cmd *cobra.Command, args []string) {
+			baseRan = true
+		},
+	}
+
+	extensionRan := false
+	extension := &cobra.Command{
+		Use:   "tenant-policy",
+		Short: "tenant migration",
+		Run: func(cmd *cobra.Command, args []string) {
+			extensionRan = true
+		},
+	}
+
+	require.NoError(t, AddCommands(base))
+	require.NoError(t, AddCommands(extension))
+
+	foundBase, _, err := parent.Find([]string{"namespaced-policy"})
+	require.NoError(t, err)
+	assert.Same(t, base, foundBase)
+
+	parent.SetArgs([]string{"tenant-policy"})
+	require.NoError(t, parent.Execute())
+	assert.False(t, baseRan)
+	assert.True(t, extensionRan)
+
+	var help bytes.Buffer
+	parent.SetOut(&help)
+	parent.SetErr(&bytes.Buffer{})
+	parent.SetArgs([]string{"--help"})
+	require.NoError(t, parent.Execute())
+	assert.Contains(t, help.String(), "namespaced-policy")
+	assert.Contains(t, help.String(), "tenant-policy")
+}
+
+func TestAddCommandsRejectsDuplicateNamesAndAliases(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []*cobra.Command
+		add      []*cobra.Command
+		wantErr  error
+		wantMsg  string
+	}{
+		{
+			name:     "duplicate name",
+			existing: []*cobra.Command{{Use: "namespaced-policy"}},
+			add:      []*cobra.Command{{Use: "namespaced-policy"}},
+			wantErr:  ErrMigrateCommandAlreadyRegistered,
+			wantMsg:  `"namespaced-policy"`,
+		},
+		{
+			name:     "duplicate alias",
+			existing: []*cobra.Command{{Use: "namespaced-policy", Aliases: []string{"np"}}},
+			add:      []*cobra.Command{{Use: "tenant-policy", Aliases: []string{"np"}}},
+			wantErr:  ErrMigrateCommandAlreadyRegistered,
+			wantMsg:  `"np"`,
+		},
+		{
+			name:     "incoming command name matches existing alias",
+			existing: []*cobra.Command{{Use: "namespaced-policy", Aliases: []string{"np"}}},
+			add:      []*cobra.Command{{Use: "np"}},
+			wantErr:  ErrMigrateCommandAlreadyRegistered,
+			wantMsg:  `"np"`,
+		},
+		{
+			name:    "duplicate in same call",
+			add:     []*cobra.Command{{Use: "tenant-policy"}, {Use: "tenant-policy"}},
+			wantErr: ErrMigrateCommandAlreadyRegistered,
+			wantMsg: `"tenant-policy"`,
+		},
+		{
+			name:    "nil command",
+			add:     []*cobra.Command{nil},
+			wantErr: ErrNilMigrateCommand,
+		},
+		{
+			name:    "empty command name",
+			add:     []*cobra.Command{{}},
+			wantErr: ErrEmptyMigrateCommandName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := &cobra.Command{Use: "migrate"}
+			useMigrateCommand(t, parent)
+			require.NoError(t, AddCommands(tt.existing...))
+
+			err := AddCommands(tt.add...)
+			require.Error(t, err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected errors.Is(%v), got %v", tt.wantErr, err)
+			}
+			if tt.wantMsg != "" {
+				assert.ErrorContains(t, err, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestAddCommandsRequiresInitialization(t *testing.T) {
+	parent := &cobra.Command{Use: "migrate"}
+	useMigrateCommand(t, parent, false)
+
+	err := AddCommands(&cobra.Command{Use: "tenant-policy"})
+	require.ErrorIs(t, err, ErrMigrateCommandsNotInitialized)
+}
+
+func useMigrateCommand(t *testing.T, command *cobra.Command, isInitialized ...bool) {
+	t.Helper()
+
+	originalCmd := Cmd
+	originalInitialized := initialized
+	Cmd = command
+	initialized = true
+	if len(isInitialized) > 0 {
+		initialized = isInitialized[0]
+	}
+	t.Cleanup(func() {
+		Cmd = originalCmd
+		initialized = originalInitialized
+	})
+}

--- a/otdfctl/cmd/migrate/migrate_test.go
+++ b/otdfctl/cmd/migrate/migrate_test.go
@@ -126,6 +126,13 @@ func TestAddCommandsRequiresInitialization(t *testing.T) {
 	require.ErrorIs(t, err, ErrMigrateCommandsNotInitialized)
 }
 
+func TestAddCommandsRejectsNilParent(t *testing.T) {
+	useMigrateCommand(t, nil)
+
+	err := AddCommands(&cobra.Command{Use: "tenant-policy"})
+	require.ErrorIs(t, err, ErrNilParentCommand)
+}
+
 func useMigrateCommand(t *testing.T, command *cobra.Command, isInitialized ...bool) {
 	t.Helper()
 

--- a/otdfctl/docs/man/migrate/_index.md
+++ b/otdfctl/docs/man/migrate/_index.md
@@ -5,7 +5,7 @@ command:
   name: migrate
   aliases:
     - migration
-  description: Migrate policy resources
+  description: Run migration workflows for platform resources
   flags:
     - name: commit
       shorthand: c
@@ -17,20 +17,10 @@ command:
       default: false
 ---
 
-`migrate` groups commands used to migrate policy resources and related state.
+`migrate` groups commands used to move existing platform data or configuration from
+an older model to a newer model. Migration commands can be used to preview planned
+changes, apply compatible updates, and clean up data that is no longer needed after
+a migration.
 
-The end-to-end workflow is not implemented yet, but the command surface is in place.
-
-Available subcommands currently include `namespaced-policy` for migration planning and execution, and `prune` for cleanup flows.
-
-The parent `migrate` command owns the shared `--commit` and `--interactive` flags.
-
-`migrate prune` is separate from the existing destructive `otdfctl policy subject-condition-sets prune` command.
-
-## Planned examples
-
-```shell
-otdfctl migrate namespaced-policy --scope=registered-resources --output=policy-migration.json
-otdfctl migrate prune namespaced-policy --scope=registered-resources
-otdfctl migrate namespaced-policy --scope=actions,subject-mappings,registered-resources --output=policy-migration.json --commit
-```
+The parent `migrate` command owns shared flags used by migration subcommands that
+support applying changes or interactive review.


### PR DESCRIPTION
1.) Add extension point for `migrate` command
2.) Ensure that subcommands that are trying to be added to the `migrate` command have a different name and aliases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to register additional subcommands under the migrate command with validation for duplicates and conflicts.

* **Documentation**
  * Updated migrate command documentation to describe platform resource workflows and shared command flags.

* **Tests**
  * Added comprehensive test coverage for command registration, validation, and conflict detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentdf/platform/pull/3480)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->