### PR TITLE
chore(cli): Set prune to only have one scope

### DIFF
--- a/otdfctl/migrations/namespacedpolicy/prune_execute.go
+++ b/otdfctl/migrations/namespacedpolicy/prune_execute.go
@@ -32,7 +32,7 @@ func (e *PruneExecutor) ExecutePrune(ctx context.Context, plan *PrunePlan) error
 		return err
 	}
 
-	switch plan.Scopes[0] {
+	switch plan.Scope {
 	case ScopeObligationTriggers:
 		return e.executePruneObligationTriggers(ctx, plan.ObligationTriggers)
 	case ScopeSubjectMappings:
@@ -44,7 +44,7 @@ func (e *PruneExecutor) ExecutePrune(ctx context.Context, plan *PrunePlan) error
 	case ScopeActions:
 		return e.executePruneActions(ctx, plan.Actions)
 	default:
-		return fmt.Errorf("%w: %s", ErrInvalidScope, plan.Scopes[0])
+		return fmt.Errorf("%w: %s", ErrInvalidScope, plan.Scope)
 	}
 }
 
@@ -55,11 +55,8 @@ func (e *PruneExecutor) validatePrunePlan(plan *PrunePlan) error {
 	if plan == nil {
 		return ErrNilPruneExecutionPlan
 	}
-	if len(plan.Scopes) == 0 {
+	if plan.Scope == "" {
 		return ErrEmptyPlannerScope
-	}
-	if len(plan.Scopes) != 1 {
-		return ErrMultiplePruneScopes
 	}
 
 	return nil

--- a/otdfctl/migrations/namespacedpolicy/prune_execute_test.go
+++ b/otdfctl/migrations/namespacedpolicy/prune_execute_test.go
@@ -73,7 +73,7 @@ func TestExecutePruneRecordsFailureAndStops(t *testing.T) {
 		},
 	}
 	plan := &PrunePlan{
-		Scopes: []Scope{ScopeActions},
+		Scope: ScopeActions,
 		Actions: []*PruneActionPlan{
 			{Source: &policy.Action{Id: "action-delete"}, Status: PruneStatusDelete},
 			{Source: &policy.Action{Id: "action-pending"}, Status: PruneStatusDelete},
@@ -101,11 +101,6 @@ func TestExecutePruneRequiresSingleScope(t *testing.T) {
 
 	err = executor.ExecutePrune(t.Context(), &PrunePlan{})
 	require.ErrorIs(t, err, ErrEmptyPlannerScope)
-
-	err = executor.ExecutePrune(t.Context(), &PrunePlan{
-		Scopes: []Scope{ScopeActions, ScopeRegisteredResources},
-	})
-	require.ErrorIs(t, err, ErrMultiplePruneScopes)
 }
 
 func verifyPruneActionsExecuted(t *testing.T, plan *PrunePlan) {
@@ -152,7 +147,7 @@ func verifyPruneObligationTriggersExecuted(t *testing.T, plan *PrunePlan) {
 
 func mixedPrunePlan(scope Scope) *PrunePlan {
 	return &PrunePlan{
-		Scopes: []Scope{scope},
+		Scope: scope,
 		Actions: []*PruneActionPlan{
 			{Source: &policy.Action{Id: "action-delete-1"}, Status: PruneStatusDelete},
 			{Source: &policy.Action{Id: "action-delete-2"}, Status: PruneStatusDelete},

--- a/otdfctl/migrations/namespacedpolicy/prune_plan.go
+++ b/otdfctl/migrations/namespacedpolicy/prune_plan.go
@@ -105,7 +105,7 @@ func (r PruneStatusReason) String() string {
 }
 
 type PrunePlan struct {
-	Scopes               []Scope                         `json:"scopes"`
+	Scope                Scope                           `json:"scope"`
 	Actions              []*PruneActionPlan              `json:"actions"`
 	SubjectConditionSets []*PruneSubjectConditionSetPlan `json:"subject_condition_sets"`
 	SubjectMappings      []*PruneSubjectMappingPlan      `json:"subject_mappings"`

--- a/otdfctl/migrations/namespacedpolicy/prune_plan_test.go
+++ b/otdfctl/migrations/namespacedpolicy/prune_plan_test.go
@@ -1,10 +1,12 @@
 package namespacedpolicy
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTargetRefString(t *testing.T) {
@@ -148,4 +150,16 @@ func TestPrunePlanItemSourceID(t *testing.T) {
 			assert.Equal(t, tc.want, tc.item.sourceID())
 		})
 	}
+}
+
+func TestPrunePlanMarshalsSingleScopeField(t *testing.T) {
+	t.Parallel()
+
+	plan := &PrunePlan{Scope: ScopeActions}
+
+	data, err := json.Marshal(plan)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), `"scope":"actions"`)
+	assert.NotContains(t, string(data), `"scopes"`)
 }

--- a/otdfctl/migrations/namespacedpolicy/prune_planner.go
+++ b/otdfctl/migrations/namespacedpolicy/prune_planner.go
@@ -29,7 +29,7 @@ var (
 // the migrated target context that justified that decision.
 type PrunePlanner struct {
 	planner *MigrationPlanner
-	scopes  scopeSet
+	scope   Scope
 }
 
 type prunePlannerConfig struct {
@@ -89,7 +89,7 @@ func NewPrunePlanner(handler PolicyClient, scopeCSV string, opts ...PruneOption)
 
 	return &PrunePlanner{
 		planner: planner,
-		scopes:  normalizedScopes,
+		scope:   normalizedScopes.ordered()[0],
 	}, nil
 }
 
@@ -110,25 +110,27 @@ func (p *PrunePlanner) Plan(ctx context.Context) (*PrunePlan, error) {
 	if p == nil || p.planner == nil {
 		return nil, ErrNilPlannerHandler
 	}
-	if len(p.scopes) == 0 {
+	if p.scope == "" {
 		return nil, ErrEmptyPlannerScope
 	}
-	if p.scopes.has(ScopeActions) {
+	switch p.scope {
+	case ScopeActions:
 		return p.planActions(ctx)
-	}
-	if p.scopes.has(ScopeSubjectConditionSets) {
+	case ScopeSubjectConditionSets:
 		return p.planSubjectConditionSets(ctx)
-	}
+	case ScopeSubjectMappings, ScopeRegisteredResources, ScopeObligationTriggers:
+		resolved, err := p.planner.resolve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if resolved == nil {
+			return nil, ErrNilResolvedTargets
+		}
 
-	resolved, err := p.planner.resolve(ctx)
-	if err != nil {
-		return nil, err
+		return buildPrunePlanFromResolved(p.scope, resolved)
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrInvalidScope, p.scope)
 	}
-	if resolved == nil {
-		return nil, ErrNilResolvedTargets
-	}
-
-	return buildPrunePlanFromResolved(p.scopes, resolved)
 }
 
 func (p *PrunePlanner) planActions(ctx context.Context) (*PrunePlan, error) {
@@ -139,7 +141,7 @@ func (p *PrunePlanner) planActions(ctx context.Context) (*PrunePlan, error) {
 	sourceActions = customLegacyActions(sourceActions)
 
 	plan := &PrunePlan{
-		Scopes:  p.scopes.ordered(),
+		Scope:   p.scope,
 		Actions: make([]*PruneActionPlan, 0, len(sourceActions)),
 	}
 	if len(sourceActions) == 0 {
@@ -190,7 +192,7 @@ func (p *PrunePlanner) planSubjectConditionSets(ctx context.Context) (*PrunePlan
 	}
 
 	plan := &PrunePlan{
-		Scopes:               p.scopes.ordered(),
+		Scope:                p.scope,
 		SubjectConditionSets: make([]*PruneSubjectConditionSetPlan, 0, len(sourceSCS)),
 	}
 	if len(sourceSCS) == 0 {
@@ -320,46 +322,46 @@ func (p *PrunePlanner) usedLegacySubjectConditionSetsByID(ctx context.Context, s
 	return used, nil
 }
 
-func buildPrunePlanFromResolved(scopes scopeSet, resolved *ResolvedTargets) (*PrunePlan, error) {
+func buildPrunePlanFromResolved(scope Scope, resolved *ResolvedTargets) (*PrunePlan, error) {
 	if resolved == nil {
 		return &PrunePlan{}, nil
 	}
 
-	builder := newPrunePlanBuilder(scopes, resolved)
+	builder := newPrunePlanBuilder(scope, resolved)
 	return builder.build()
 }
 
 type prunePlanBuilder struct {
-	scopes   scopeSet
+	scope    Scope
 	resolved *ResolvedTargets
 }
 
-func newPrunePlanBuilder(scopes scopeSet, resolved *ResolvedTargets) *prunePlanBuilder {
+func newPrunePlanBuilder(scope Scope, resolved *ResolvedTargets) *prunePlanBuilder {
 	return &prunePlanBuilder{
-		scopes:   scopes,
+		scope:    scope,
 		resolved: resolved,
 	}
 }
 
 func (b *prunePlanBuilder) build() (*PrunePlan, error) {
 	plan := &PrunePlan{
-		Scopes: b.scopes.ordered(),
+		Scope: b.scope,
 	}
-	if b.scopes.has(ScopeSubjectMappings) {
+	if b.scope == ScopeSubjectMappings {
 		subjectMappings, err := b.subjectMappings()
 		if err != nil {
 			return nil, err
 		}
 		plan.SubjectMappings = subjectMappings
 	}
-	if b.scopes.has(ScopeRegisteredResources) {
+	if b.scope == ScopeRegisteredResources {
 		registeredResources, err := b.registeredResources()
 		if err != nil {
 			return nil, err
 		}
 		plan.RegisteredResources = registeredResources
 	}
-	if b.scopes.has(ScopeObligationTriggers) {
+	if b.scope == ScopeObligationTriggers {
 		obligationTriggers, err := b.obligationTriggers()
 		if err != nil {
 			return nil, err

--- a/otdfctl/migrations/namespacedpolicy/prune_planner_test.go
+++ b/otdfctl/migrations/namespacedpolicy/prune_planner_test.go
@@ -699,7 +699,7 @@ func TestPrunePlannerPlanFailsWhenMigratedTargetIDIsEmpty(t *testing.T) {
 		},
 	}
 
-	_, err := buildPrunePlanFromResolved(scopesFromSlice([]Scope{ScopeSubjectMappings}), resolved)
+	_, err := buildPrunePlanFromResolved(ScopeSubjectMappings, resolved)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInvalidPruneResolvedTarget)
@@ -728,7 +728,7 @@ func TestPrunePlannerPlanClassifiesMismatchedMigrationLabelAsUnresolved(t *testi
 		},
 	}
 
-	plan, err := buildPrunePlanFromResolved(scopesFromSlice([]Scope{ScopeSubjectMappings}), resolved)
+	plan, err := buildPrunePlanFromResolved(ScopeSubjectMappings, resolved)
 
 	require.NoError(t, err)
 	require.Len(t, plan.SubjectMappings, 1)
@@ -746,7 +746,7 @@ func TestPrunePlannerPlanSkipsRegisteredResourceWhenResolvedSourceIsMissing(t *t
 	}
 
 	plan, err := buildPrunePlanFromResolved(
-		scopesFromSlice([]Scope{ScopeRegisteredResources}),
+		ScopeRegisteredResources,
 		resolved,
 	)
 

--- a/otdfctl/migrations/namespacedpolicy/prune_summary.go
+++ b/otdfctl/migrations/namespacedpolicy/prune_summary.go
@@ -33,10 +33,10 @@ const (
 )
 
 func prunePlanScopes(plan *PrunePlan) []Scope {
-	if plan == nil {
+	if plan == nil || plan.Scope == "" {
 		return nil
 	}
-	return plan.Scopes
+	return []Scope{plan.Scope}
 }
 
 func RenderNamespacedPolicyPruneSummary(plan *PrunePlan, executed bool, result PruneSummaryResult) string {

--- a/otdfctl/migrations/namespacedpolicy/prune_summary_test.go
+++ b/otdfctl/migrations/namespacedpolicy/prune_summary_test.go
@@ -19,7 +19,7 @@ func TestRenderNamespacedPolicyPruneSummaryDryRunShowsWillDelete(t *testing.T) {
 	t.Parallel()
 
 	plan := &PrunePlan{
-		Scopes: []Scope{ScopeActions},
+		Scope: ScopeActions,
 		Actions: []*PruneActionPlan{
 			{
 				Source: &policy.Action{Id: "action-delete", Name: "archive"},
@@ -67,7 +67,7 @@ func TestRenderNamespacedPolicyPruneSummaryCommitSeparatesDeletedPendingAndFaile
 	t.Parallel()
 
 	plan := &PrunePlan{
-		Scopes: []Scope{ScopeActions},
+		Scope: ScopeActions,
 		Actions: []*PruneActionPlan{
 			{
 				Source:    &policy.Action{Id: "action-deleted", Name: "archive"},
@@ -103,7 +103,7 @@ func TestRenderNamespacedPolicyPruneSummaryCommitShowsSkippedDeletes(t *testing.
 	t.Parallel()
 
 	plan := &PrunePlan{
-		Scopes: []Scope{ScopeActions},
+		Scope: ScopeActions,
 		Actions: []*PruneActionPlan{
 			{
 				Source: &policy.Action{Id: "action-skipped", Name: "archive"},
@@ -129,7 +129,7 @@ func TestRenderNamespacedPolicyPruneSummaryActionsCoversEveryStatus(t *testing.T
 	t.Parallel()
 
 	plan := &PrunePlan{
-		Scopes: []Scope{ScopeActions},
+		Scope: ScopeActions,
 		Actions: []*PruneActionPlan{
 			{
 				Source:    &policy.Action{Id: "action-deleted", Name: "archive"},
@@ -173,7 +173,7 @@ func TestRenderNamespacedPolicyPruneSummarySubjectConditionSetsCoversEveryStatus
 	t.Parallel()
 
 	plan := &PrunePlan{
-		Scopes: []Scope{ScopeSubjectConditionSets},
+		Scope: ScopeSubjectConditionSets,
 		SubjectConditionSets: []*PruneSubjectConditionSetPlan{
 			{
 				Source:    pruneSummarySubjectConditionSet("scs-deleted"),
@@ -217,7 +217,7 @@ func TestRenderNamespacedPolicyPruneSummarySubjectMappingsCoversEveryStatus(t *t
 	t.Parallel()
 
 	plan := &PrunePlan{
-		Scopes: []Scope{ScopeSubjectMappings},
+		Scope: ScopeSubjectMappings,
 		SubjectMappings: []*PruneSubjectMappingPlan{
 			{
 				Source:         pruneSummarySubjectMapping("mapping-deleted", "read"),
@@ -266,7 +266,7 @@ func TestRenderNamespacedPolicyPruneSummaryRegisteredResourcesCoversEveryStatus(
 	t.Parallel()
 
 	plan := &PrunePlan{
-		Scopes: []Scope{ScopeRegisteredResources},
+		Scope: ScopeRegisteredResources,
 		RegisteredResources: []*PruneRegisteredResourcePlan{
 			{
 				Source:         pruneSummaryRegisteredResource("resource-deleted", "dataset-deleted", "read"),
@@ -315,7 +315,7 @@ func TestRenderNamespacedPolicyPruneSummaryRegisteredResourceManualDeleteReason(
 	t.Parallel()
 
 	plan := &PrunePlan{
-		Scopes: []Scope{ScopeRegisteredResources},
+		Scope: ScopeRegisteredResources,
 		RegisteredResources: []*PruneRegisteredResourcePlan{
 			{
 				Source: pruneSummaryRegisteredResource("resource-1", "dataset", "read"),
@@ -338,7 +338,7 @@ func TestRenderNamespacedPolicyPruneSummaryObligationTriggersCoversEveryStatus(t
 	t.Parallel()
 
 	plan := &PrunePlan{
-		Scopes: []Scope{ScopeObligationTriggers},
+		Scope: ScopeObligationTriggers,
 		ObligationTriggers: []*PruneObligationTriggerPlan{
 			{
 				Source:         pruneSummaryObligationTrigger("trigger-deleted", "read"),


### PR DESCRIPTION
1. Only allow prune to have one scope within it's plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified prune plan structure to operate on a single scope instead of multiple scopes.
  * Updated executor logic, planner, and validation to align with the single-scope model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentdf/platform/pull/3492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->