### PR TITLE
fix(core): Uses strict FIPS AES-GCM

### DIFF
--- a/lib/ocrypto/aes_gcm.go
+++ b/lib/ocrypto/aes_gcm.go
@@ -3,6 +3,7 @@ package ocrypto
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"errors"
 	"fmt"
 )
 
@@ -14,6 +15,9 @@ type AesGcm struct {
 const DefaultNonceSize = 16
 
 const GcmStandardNonceSize = 12
+
+// ErrUnsupportedAESGCMConfiguration is returned for AES-GCM options that Go strict FIPS mode does not allow.
+var ErrUnsupportedAESGCMConfiguration = errors.New("unsupported AES-GCM configuration")
 
 // NewAESGcm creates and returns a new AesGcm.
 func NewAESGcm(key []byte) (AesGcm, error) {
@@ -32,79 +36,47 @@ func NewAESGcm(key []byte) (AesGcm, error) {
 // Encrypt encrypts data with symmetric key.
 // NOTE: This method use nonce of 12 bytes and auth tag as aes block size(16 bytes).
 func (aesGcm AesGcm) Encrypt(data []byte) ([]byte, error) {
-	nonce, err := RandomBytes(GcmStandardNonceSize)
+	gcm, err := cipher.NewGCMWithRandomNonce(aesGcm.block)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cipher.NewGCMWithRandomNonce failed: %w", err)
 	}
 
-	gcm, err := cipher.NewGCMWithNonceSize(aesGcm.block, GcmStandardNonceSize)
-	if err != nil {
-		return nil, fmt.Errorf("cipher.NewGCMWithNonceSize failed: %w", err)
-	}
-
-	cipherText := gcm.Seal(nonce, nonce, data, nil)
+	cipherText := gcm.Seal(nil, nil, data, nil)
 	return cipherText, nil
 }
 
 func (aesGcm AesGcm) EncryptInPlace(data []byte) ([]byte, []byte, error) {
-	nonce, err := RandomBytes(GcmStandardNonceSize)
+	gcm, err := cipher.NewGCMWithRandomNonce(aesGcm.block)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("cipher.NewGCMWithRandomNonce failed: %w", err)
 	}
 
-	gcm, err := cipher.NewGCMWithNonceSize(aesGcm.block, GcmStandardNonceSize)
-	if err != nil {
-		return nil, nil, fmt.Errorf("cipher.NewGCMWithNonceSize failed: %w", err)
-	}
-
-	cipherText := gcm.Seal(data[:0], nonce, data, nil)
+	sealed := gcm.Seal(data[:0], nil, data, nil)
+	nonce, cipherText := sealed[:GcmStandardNonceSize], sealed[GcmStandardNonceSize:]
 	return cipherText, nonce, nil
 }
 
-// EncryptWithIV encrypts data with symmetric key.
-// NOTE: This method use default auth tag as aes block size(16 bytes)
-// and expects iv of 16 bytes.
-func (aesGcm AesGcm) EncryptWithIV(iv, data []byte) ([]byte, error) {
-	gcm, err := cipher.NewGCMWithNonceSize(aesGcm.block, len(iv))
-	if err != nil {
-		return nil, fmt.Errorf("cipher.NewGCMWithNonceSize failed: %w", err)
-	}
-
-	cipherText := gcm.Seal(iv, iv, data, nil)
-	return cipherText, nil
+// EncryptWithIV is unsupported because strict FIPS mode requires internally generated AES-GCM nonces.
+func (AesGcm) EncryptWithIV(_, _ []byte) ([]byte, error) {
+	return nil, fmt.Errorf("caller-managed IV encryption is not supported: %w", ErrUnsupportedAESGCMConfiguration)
 }
 
-// EncryptWithIVAndTagSize encrypts data with symmetric key.
-// NOTE: This method expects gcm standard nonce size(12) of iv.
-func (aesGcm AesGcm) EncryptWithIVAndTagSize(iv, data []byte, authTagSize int) ([]byte, error) {
-	if len(iv) != GcmStandardNonceSize {
-		return nil, ErrInvalidCiphertext
-	}
-
-	gcm, err := cipher.NewGCMWithTagSize(aesGcm.block, authTagSize)
-	if err != nil {
-		return nil, fmt.Errorf("cipher.NewGCMWithTagSize failed: %w", err)
-	}
-
-	cipherText := gcm.Seal(iv, iv, data, nil)
-	return cipherText, nil
+// EncryptWithIVAndTagSize is unsupported because strict FIPS mode requires internally generated AES-GCM nonces.
+func (AesGcm) EncryptWithIVAndTagSize(_, _ []byte, authTagSize int) ([]byte, error) {
+	return nil, fmt.Errorf("caller-managed IV encryption with tag size %d is not supported: %w", authTagSize, ErrUnsupportedAESGCMConfiguration)
 }
 
-// Decrypt decrypts data with symmetric key.
-// NOTE: This method use nonce of 12 bytes and auth tag as aes block size(16 bytes)
-// also expects IV as preamble of data.
-func (aesGcm AesGcm) Decrypt(data []byte) ([]byte, error) { // extract nonce and cipherText
+// Decrypt decrypts data with a 12-byte nonce prefix and a 16-byte AES-GCM authentication tag.
+func (aesGcm AesGcm) Decrypt(data []byte) ([]byte, error) {
 	if len(data) < GcmStandardNonceSize {
 		return nil, ErrInvalidCiphertext
 	}
-	nonce, cipherText := data[:GcmStandardNonceSize], data[GcmStandardNonceSize:]
-
-	gcm, err := cipher.NewGCMWithNonceSize(aesGcm.block, GcmStandardNonceSize)
+	gcm, err := cipher.NewGCMWithRandomNonce(aesGcm.block)
 	if err != nil {
-		return nil, fmt.Errorf("cipher.NewGCMWithNonceSize failed: %w", err)
+		return nil, fmt.Errorf("cipher.NewGCMWithRandomNonce failed: %w", err)
 	}
 
-	plainData, err := gcm.Open(nil, nonce, cipherText, nil)
+	plainData, err := gcm.Open(nil, nil, data, nil)
 	if err != nil {
 		return nil, fmt.Errorf("gcm.Open failed: %w", err)
 	}
@@ -112,44 +84,31 @@ func (aesGcm AesGcm) Decrypt(data []byte) ([]byte, error) { // extract nonce and
 	return plainData, nil
 }
 
-// DecryptWithTagSize decrypts data with symmetric key.
-// NOTE: This method expects gcm standard nonce size(12) of iv.
+// DecryptWithTagSize decrypts data when authTagSize is the standard 16-byte AES-GCM tag size.
 func (aesGcm AesGcm) DecryptWithTagSize(data []byte, authTagSize int) ([]byte, error) {
+	if authTagSize != aes.BlockSize {
+		return nil, fmt.Errorf("AES-GCM tag size %d is not supported: %w", authTagSize, ErrUnsupportedAESGCMConfiguration)
+	}
+
 	if len(data) < GcmStandardNonceSize {
 		return nil, ErrInvalidCiphertext
 	}
-	// extract nonce and cipherText
-	nonce, cipherText := data[:GcmStandardNonceSize], data[GcmStandardNonceSize:]
 
-	gcm, err := cipher.NewGCMWithTagSize(aesGcm.block, authTagSize)
-	if err != nil {
-		return nil, fmt.Errorf("cipher.NewGCMWithTagSize failed: %w", err)
-	}
-
-	plainData, err := gcm.Open(nil, nonce, cipherText, nil)
-	if err != nil {
-		return nil, fmt.Errorf("gcm.Open failed: %w", err)
-	}
-
-	return plainData, nil
+	return aesGcm.Decrypt(data)
 }
 
-// DecryptWithIVAndTagSize decrypts data with symmetric key.
-// NOTE: This method expects gcm standard nonce size(12) of iv.
+// DecryptWithIVAndTagSize decrypts split IV and ciphertext when authTagSize is the standard 16-byte AES-GCM tag size.
 func (aesGcm AesGcm) DecryptWithIVAndTagSize(iv, data []byte, authTagSize int) ([]byte, error) {
 	if len(iv) != GcmStandardNonceSize {
 		return nil, ErrInvalidCiphertext
 	}
 
-	gcm, err := cipher.NewGCMWithTagSize(aesGcm.block, authTagSize)
-	if err != nil {
-		return nil, fmt.Errorf("cipher.NewGCMWithTagSize failed: %w", err)
+	if authTagSize != aes.BlockSize {
+		return nil, fmt.Errorf("AES-GCM tag size %d is not supported: %w", authTagSize, ErrUnsupportedAESGCMConfiguration)
 	}
 
-	plainData, err := gcm.Open(nil, iv, data, nil)
-	if err != nil {
-		return nil, fmt.Errorf("gcm.Open failed: %w", err)
-	}
-
-	return plainData, nil
+	sealed := make([]byte, 0, len(iv)+len(data))
+	sealed = append(sealed, iv...)
+	sealed = append(sealed, data...)
+	return aesGcm.Decrypt(sealed)
 }

--- a/lib/ocrypto/aes_gcm.go
+++ b/lib/ocrypto/aes_gcm.go
@@ -73,28 +73,3 @@ func (aesGcm AesGcm) Decrypt(data []byte) ([]byte, error) {
 
 	return plainData, nil
 }
-
-// DecryptWithTagSize decrypts data when authTagSize is the standard 16-byte AES-GCM tag size.
-func (aesGcm AesGcm) DecryptWithTagSize(data []byte, authTagSize int) ([]byte, error) {
-	if authTagSize != aes.BlockSize {
-		return nil, fmt.Errorf("AES-GCM tag size %d is not supported: %w", authTagSize, ErrUnsupportedAESGCMConfiguration)
-	}
-
-	return aesGcm.Decrypt(data)
-}
-
-// DecryptWithIVAndTagSize decrypts split IV and ciphertext when authTagSize is the standard 16-byte AES-GCM tag size.
-func (aesGcm AesGcm) DecryptWithIVAndTagSize(iv, data []byte, authTagSize int) ([]byte, error) {
-	if len(iv) != GcmStandardNonceSize {
-		return nil, ErrInvalidCiphertext
-	}
-
-	if authTagSize != aes.BlockSize {
-		return nil, fmt.Errorf("AES-GCM tag size %d is not supported: %w", authTagSize, ErrUnsupportedAESGCMConfiguration)
-	}
-
-	sealed := make([]byte, 0, len(iv)+len(data))
-	sealed = append(sealed, iv...)
-	sealed = append(sealed, data...)
-	return aesGcm.Decrypt(sealed)
-}

--- a/lib/ocrypto/aes_gcm.go
+++ b/lib/ocrypto/aes_gcm.go
@@ -56,16 +56,6 @@ func (aesGcm AesGcm) EncryptInPlace(data []byte) ([]byte, []byte, error) {
 	return cipherText, nonce, nil
 }
 
-// EncryptWithIV is unsupported because strict FIPS mode requires internally generated AES-GCM nonces.
-func (AesGcm) EncryptWithIV(_, _ []byte) ([]byte, error) {
-	return nil, fmt.Errorf("caller-managed IV encryption is not supported: %w", ErrUnsupportedAESGCMConfiguration)
-}
-
-// EncryptWithIVAndTagSize is unsupported because strict FIPS mode requires internally generated AES-GCM nonces.
-func (AesGcm) EncryptWithIVAndTagSize(_, _ []byte, authTagSize int) ([]byte, error) {
-	return nil, fmt.Errorf("caller-managed IV encryption with tag size %d is not supported: %w", authTagSize, ErrUnsupportedAESGCMConfiguration)
-}
-
 // Decrypt decrypts data with a 12-byte nonce prefix and a 16-byte AES-GCM authentication tag.
 func (aesGcm AesGcm) Decrypt(data []byte) ([]byte, error) {
 	if len(data) < GcmStandardNonceSize+aes.BlockSize {

--- a/lib/ocrypto/aes_gcm.go
+++ b/lib/ocrypto/aes_gcm.go
@@ -51,7 +51,7 @@ func (aesGcm AesGcm) EncryptInPlace(data []byte) ([]byte, []byte, error) {
 		return nil, nil, fmt.Errorf("cipher.NewGCMWithRandomNonce failed: %w", err)
 	}
 
-	sealed := gcm.Seal(data[:0], nil, data, nil)
+	sealed := gcm.Seal(nil, nil, data, nil)
 	nonce, cipherText := sealed[:GcmStandardNonceSize], sealed[GcmStandardNonceSize:]
 	return cipherText, nonce, nil
 }
@@ -68,7 +68,7 @@ func (AesGcm) EncryptWithIVAndTagSize(_, _ []byte, authTagSize int) ([]byte, err
 
 // Decrypt decrypts data with a 12-byte nonce prefix and a 16-byte AES-GCM authentication tag.
 func (aesGcm AesGcm) Decrypt(data []byte) ([]byte, error) {
-	if len(data) < GcmStandardNonceSize {
+	if len(data) < GcmStandardNonceSize+aes.BlockSize {
 		return nil, ErrInvalidCiphertext
 	}
 	gcm, err := cipher.NewGCMWithRandomNonce(aesGcm.block)
@@ -88,10 +88,6 @@ func (aesGcm AesGcm) Decrypt(data []byte) ([]byte, error) {
 func (aesGcm AesGcm) DecryptWithTagSize(data []byte, authTagSize int) ([]byte, error) {
 	if authTagSize != aes.BlockSize {
 		return nil, fmt.Errorf("AES-GCM tag size %d is not supported: %w", authTagSize, ErrUnsupportedAESGCMConfiguration)
-	}
-
-	if len(data) < GcmStandardNonceSize {
-		return nil, ErrInvalidCiphertext
 	}
 
 	return aesGcm.Decrypt(data)

--- a/lib/ocrypto/aes_gcm_test.go
+++ b/lib/ocrypto/aes_gcm_test.go
@@ -96,25 +96,47 @@ func TestCreateAESGcm_EncryptInPlace(t *testing.T) {
 	}
 
 	plainText := []byte("Virtru")
-	cipherText, nonce, err := aesGcm.EncryptInPlace(append([]byte{}, plainText...))
-	if err != nil {
-		t.Fatalf("Fail to encrypt in place: %v", err)
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "exact capacity",
+			data: append([]byte{}, plainText...),
+		},
+		{
+			name: "spare capacity",
+			data: func() []byte {
+				buf := make([]byte, len(plainText), len(plainText)+GcmStandardNonceSize+aes.BlockSize)
+				copy(buf, plainText)
+				return buf
+			}(),
+		},
 	}
 
-	if len(nonce) != GcmStandardNonceSize {
-		t.Fatalf("unexpected nonce length: got %d", len(nonce))
-	}
-	if len(cipherText) != len(plainText)+aes.BlockSize {
-		t.Fatalf("unexpected ciphertext length: got %d", len(cipherText))
-	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cipherText, nonce, err := aesGcm.EncryptInPlace(test.data)
+			if err != nil {
+				t.Fatalf("Fail to encrypt in place: %v", err)
+			}
 
-	decipherText, err := aesGcm.DecryptWithIVAndTagSize(nonce, cipherText, aes.BlockSize)
-	if err != nil {
-		t.Fatalf("Fail to decrypt split ciphertext: %v", err)
-	}
+			if len(nonce) != GcmStandardNonceSize {
+				t.Fatalf("unexpected nonce length: got %d", len(nonce))
+			}
+			if len(cipherText) != len(plainText)+aes.BlockSize {
+				t.Fatalf("unexpected ciphertext length: got %d", len(cipherText))
+			}
 
-	if string(plainText) != string(decipherText) {
-		t.Errorf("gcm decryption test don't match: expected %v, got %v", string(plainText), string(decipherText))
+			decipherText, err := aesGcm.DecryptWithIVAndTagSize(nonce, cipherText, aes.BlockSize)
+			if err != nil {
+				t.Fatalf("Fail to decrypt split ciphertext: %v", err)
+			}
+
+			if string(plainText) != string(decipherText) {
+				t.Errorf("gcm decryption test don't match: expected %v, got %v", string(plainText), string(decipherText))
+			}
+		})
 	}
 }
 

--- a/lib/ocrypto/aes_gcm_test.go
+++ b/lib/ocrypto/aes_gcm_test.go
@@ -169,24 +169,6 @@ func TestCreateAESGcm_WithUnsupportedAuthTags(t *testing.T) {
 	}
 }
 
-func TestCreateAESGcm_EncryptWithCallerManagedIVUnsupported(t *testing.T) {
-	key, _ := hex.DecodeString("66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4")
-	aesGcm, err := NewAESGcm(key)
-	if err != nil {
-		t.Fatalf("Fail to create AesGcm: %v", err)
-	}
-
-	_, err = aesGcm.EncryptWithIV(make([]byte, GcmStandardNonceSize), []byte("test"))
-	if !errors.Is(err, ErrUnsupportedAESGCMConfiguration) {
-		t.Fatalf("expected ErrUnsupportedAESGCMConfiguration, got %v", err)
-	}
-
-	_, err = aesGcm.EncryptWithIVAndTagSize(make([]byte, GcmStandardNonceSize), []byte("test"), aes.BlockSize)
-	if !errors.Is(err, ErrUnsupportedAESGCMConfiguration) {
-		t.Fatalf("expected ErrUnsupportedAESGCMConfiguration, got %v", err)
-	}
-}
-
 func BenchmarkAESGcm_ForTDF3(b *testing.B) {
 	// Create 2mb buffer and fill with character 'X'
 	twoMB := 2 * 1024 * 1024
@@ -298,29 +280,6 @@ func TestDecryptWithTagSize_TooShortData(t *testing.T) {
 	}
 	if !errors.Is(err, ErrInvalidCiphertext) {
 		t.Errorf("expected ErrInvalidCiphertext, got %v", err)
-	}
-}
-
-func TestEncryptWithIVAndTagSize_Unsupported(t *testing.T) {
-	key, _ := hex.DecodeString("66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4")
-	aesGcm, _ := NewAESGcm(key)
-
-	ivs := [][]byte{
-		{},
-		make([]byte, 11),
-		make([]byte, 12),
-		make([]byte, 13),
-		make([]byte, 16),
-	}
-
-	for _, iv := range ivs {
-		_, err := aesGcm.EncryptWithIVAndTagSize(iv, []byte("test"), 16)
-		if err == nil {
-			t.Errorf("expected error for %d-byte IV, got nil", len(iv))
-		}
-		if !errors.Is(err, ErrUnsupportedAESGCMConfiguration) {
-			t.Errorf("expected ErrUnsupportedAESGCMConfiguration for %d-byte IV, got %v", len(iv), err)
-		}
 	}
 }
 

--- a/lib/ocrypto/aes_gcm_test.go
+++ b/lib/ocrypto/aes_gcm_test.go
@@ -1,6 +1,7 @@
 package ocrypto
 
 import (
+	"crypto/aes"
 	"encoding/hex"
 	"errors"
 	"strings"
@@ -61,88 +62,106 @@ widely adopted for its performance`,
 }
 
 func TestCreateAesGcm_EncryptWithDefaults(t *testing.T) {
-	gcmEncryptionTests := []struct {
-		symmetricKey string
-		iv           string
-		plainText    string
-		cipherText   string
-	}{
-		{
-			"66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4",
-			"29a8b044b5b6ce00e18bc6fc78ff50c6",
-			"virtru",
-			"29a8b044b5b6ce00e18bc6fc78ff50c6b3cf733137d865892e5af63dcbca08086ba1ac82aae2",
-		},
-		{
-			"120fba31c537d99ade0a0a8c8e6df535f7de86fb6e1d5948317b4596982a5e1b",
-			"ec9074bc6c6b81d6520f5a7425f8977a",
-			"",
-			"ec9074bc6c6b81d6520f5a7425f8977adabe8b28dd100eea2f58d71e3644b43d",
-		},
-		{
-			"9895f395913a3cfd974ea53c0735030c7df4602d699c986afdc5fdd10071c0a5",
-			"5142d90e8499f597802ca68cddb25ec1",
-			`In cryptography, Galois/Counter Mode (GCM)[1] is a mode of operation
-for symmetric-key cryptographic block ciphers which is
-widely adopted for its performance`,
-			`5142d90e8499f597802ca68cddb25ec101c1e44df776bfca60ed217e06421c7b945adaf328984
-9406ca5b7046c886050fe72cc0ebc429f683f9cfe3a47613e2ca8a812ef9b75d361c32d042124d3dc5d84c757225
-21df65ed7829327b5adda0ae020a778b909328a48311cc705d4c0a8b83f49430aa80febba73e27e99b3006d6e768
-a092d5b9dc894e7a634235198b1a986a3624912dec108ef03055b319f59f25fc579eb08f01820ea19edc7f9896129
-c572c36440ed80fd61fc71df37`,
-		},
-	}
-
-	for _, test := range gcmEncryptionTests {
-		key, _ := hex.DecodeString(test.symmetricKey)
-		nonce, _ := hex.DecodeString(test.iv)
-
-		aesGcm, err := NewAESGcm(key)
-		if err != nil {
-			t.Fatalf("Fail to create AesGcm: %v", err)
-		}
-
-		cipherText, err := aesGcm.EncryptWithIV(nonce, []byte(test.plainText))
-		if err != nil {
-			t.Fatalf("Fail to encrypt with iv: %v", err)
-		}
-
-		actualCipherText, _ := hex.DecodeString(strings.ReplaceAll(test.cipherText, "\n", ""))
-		if string(actualCipherText) != string(cipherText) {
-			t.Fatalf("encrypt test fail: actual:%s, expected:%s",
-				string(actualCipherText), string(cipherText))
-		}
-	}
-}
-
-func TestCreateAESGcm_WithDifferentAuthTags(t *testing.T) {
-	plainText := "Virtru"
 	key, _ := hex.DecodeString("66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4")
 	aesGcm, err := NewAESGcm(key)
 	if err != nil {
 		t.Fatalf("Fail to create AesGcm: %v", err)
 	}
 
-	nonce, err := RandomBytes(GcmStandardNonceSize)
+	plainText := []byte("virtru")
+	cipherText, err := aesGcm.Encrypt(plainText)
 	if err != nil {
-		t.Fatalf("Fail to grenerate nonce %v", err)
+		t.Fatalf("Fail to encrypt: %v", err)
 	}
 
-	authTagsToTest := []int{12, 13, 14, 15, 16}
-	for _, authTag := range authTagsToTest {
-		cipherText, err := aesGcm.EncryptWithIVAndTagSize(nonce, []byte(plainText), authTag)
-		if err != nil {
-			t.Fatalf("Fail to encrypt with auth tag:%d err:%v", authTag, err)
-		}
+	if len(cipherText) != len(plainText)+GcmStandardNonceSize+aes.BlockSize {
+		t.Fatalf("unexpected ciphertext length: got %d", len(cipherText))
+	}
 
-		decipherText, err := aesGcm.DecryptWithTagSize(cipherText, authTag)
-		if err != nil {
-			t.Fatalf("Fail to decrypt with auth tag:%d err:%v", authTag, err)
-		}
+	decipherText, err := aesGcm.Decrypt(cipherText)
+	if err != nil {
+		t.Fatalf("Fail to decrypt: %v", err)
+	}
 
-		if plainText != string(decipherText) {
-			t.Errorf("gcm decryption test don't match: expected %v, got %v", plainText, string(decipherText))
+	if string(plainText) != string(decipherText) {
+		t.Errorf("gcm decryption test don't match: expected %v, got %v", string(plainText), string(decipherText))
+	}
+}
+
+func TestCreateAESGcm_EncryptInPlace(t *testing.T) {
+	key, _ := hex.DecodeString("66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4")
+	aesGcm, err := NewAESGcm(key)
+	if err != nil {
+		t.Fatalf("Fail to create AesGcm: %v", err)
+	}
+
+	plainText := []byte("Virtru")
+	cipherText, nonce, err := aesGcm.EncryptInPlace(append([]byte{}, plainText...))
+	if err != nil {
+		t.Fatalf("Fail to encrypt in place: %v", err)
+	}
+
+	if len(nonce) != GcmStandardNonceSize {
+		t.Fatalf("unexpected nonce length: got %d", len(nonce))
+	}
+	if len(cipherText) != len(plainText)+aes.BlockSize {
+		t.Fatalf("unexpected ciphertext length: got %d", len(cipherText))
+	}
+
+	decipherText, err := aesGcm.DecryptWithIVAndTagSize(nonce, cipherText, aes.BlockSize)
+	if err != nil {
+		t.Fatalf("Fail to decrypt split ciphertext: %v", err)
+	}
+
+	if string(plainText) != string(decipherText) {
+		t.Errorf("gcm decryption test don't match: expected %v, got %v", string(plainText), string(decipherText))
+	}
+}
+
+func TestCreateAESGcm_WithUnsupportedAuthTags(t *testing.T) {
+	key, _ := hex.DecodeString("66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4")
+	aesGcm, err := NewAESGcm(key)
+	if err != nil {
+		t.Fatalf("Fail to create AesGcm: %v", err)
+	}
+
+	cipherText, err := aesGcm.Encrypt([]byte("Virtru"))
+	if err != nil {
+		t.Fatalf("Fail to encrypt: %v", err)
+	}
+
+	for _, authTag := range []int{12, 13, 14, 15} {
+		_, err := aesGcm.DecryptWithTagSize(cipherText, authTag)
+		if !errors.Is(err, ErrUnsupportedAESGCMConfiguration) {
+			t.Fatalf("expected ErrUnsupportedAESGCMConfiguration for auth tag %d, got %v", authTag, err)
 		}
+	}
+
+	decipherText, err := aesGcm.DecryptWithTagSize(cipherText, aes.BlockSize)
+	if err != nil {
+		t.Fatalf("Fail to decrypt with standard auth tag: %v", err)
+	}
+
+	if string(decipherText) != "Virtru" {
+		t.Errorf("gcm decryption test don't match: expected Virtru, got %v", string(decipherText))
+	}
+}
+
+func TestCreateAESGcm_EncryptWithCallerManagedIVUnsupported(t *testing.T) {
+	key, _ := hex.DecodeString("66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4")
+	aesGcm, err := NewAESGcm(key)
+	if err != nil {
+		t.Fatalf("Fail to create AesGcm: %v", err)
+	}
+
+	_, err = aesGcm.EncryptWithIV(make([]byte, GcmStandardNonceSize), []byte("test"))
+	if !errors.Is(err, ErrUnsupportedAESGCMConfiguration) {
+		t.Fatalf("expected ErrUnsupportedAESGCMConfiguration, got %v", err)
+	}
+
+	_, err = aesGcm.EncryptWithIVAndTagSize(make([]byte, GcmStandardNonceSize), []byte("test"), aes.BlockSize)
+	if !errors.Is(err, ErrUnsupportedAESGCMConfiguration) {
+		t.Fatalf("expected ErrUnsupportedAESGCMConfiguration, got %v", err)
 	}
 }
 
@@ -260,25 +279,25 @@ func TestDecryptWithTagSize_TooShortData(t *testing.T) {
 	}
 }
 
-func TestEncryptWithIVAndTagSize_InvalidIVSize(t *testing.T) {
+func TestEncryptWithIVAndTagSize_Unsupported(t *testing.T) {
 	key, _ := hex.DecodeString("66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4")
 	aesGcm, _ := NewAESGcm(key)
 
-	// Test various invalid IV sizes (should be 12 bytes for GCM standard)
-	invalidIVs := [][]byte{
+	ivs := [][]byte{
 		{},
 		make([]byte, 11),
+		make([]byte, 12),
 		make([]byte, 13),
 		make([]byte, 16),
 	}
 
-	for _, iv := range invalidIVs {
+	for _, iv := range ivs {
 		_, err := aesGcm.EncryptWithIVAndTagSize(iv, []byte("test"), 16)
 		if err == nil {
 			t.Errorf("expected error for %d-byte IV, got nil", len(iv))
 		}
-		if !errors.Is(err, ErrInvalidCiphertext) {
-			t.Errorf("expected ErrInvalidCiphertext for %d-byte IV, got %v", len(iv), err)
+		if !errors.Is(err, ErrUnsupportedAESGCMConfiguration) {
+			t.Errorf("expected ErrUnsupportedAESGCMConfiguration for %d-byte IV, got %v", len(iv), err)
 		}
 	}
 }

--- a/lib/ocrypto/aes_gcm_test.go
+++ b/lib/ocrypto/aes_gcm_test.go
@@ -128,44 +128,16 @@ func TestCreateAESGcm_EncryptInPlace(t *testing.T) {
 				t.Fatalf("unexpected ciphertext length: got %d", len(cipherText))
 			}
 
-			decipherText, err := aesGcm.DecryptWithIVAndTagSize(nonce, cipherText, aes.BlockSize)
+			sealed := append(append([]byte{}, nonce...), cipherText...)
+			decipherText, err := aesGcm.Decrypt(sealed)
 			if err != nil {
-				t.Fatalf("Fail to decrypt split ciphertext: %v", err)
+				t.Fatalf("Fail to decrypt ciphertext: %v", err)
 			}
 
 			if string(plainText) != string(decipherText) {
 				t.Errorf("gcm decryption test don't match: expected %v, got %v", string(plainText), string(decipherText))
 			}
 		})
-	}
-}
-
-func TestCreateAESGcm_WithUnsupportedAuthTags(t *testing.T) {
-	key, _ := hex.DecodeString("66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4")
-	aesGcm, err := NewAESGcm(key)
-	if err != nil {
-		t.Fatalf("Fail to create AesGcm: %v", err)
-	}
-
-	cipherText, err := aesGcm.Encrypt([]byte("Virtru"))
-	if err != nil {
-		t.Fatalf("Fail to encrypt: %v", err)
-	}
-
-	for _, authTag := range []int{12, 13, 14, 15} {
-		_, err := aesGcm.DecryptWithTagSize(cipherText, authTag)
-		if !errors.Is(err, ErrUnsupportedAESGCMConfiguration) {
-			t.Fatalf("expected ErrUnsupportedAESGCMConfiguration for auth tag %d, got %v", authTag, err)
-		}
-	}
-
-	decipherText, err := aesGcm.DecryptWithTagSize(cipherText, aes.BlockSize)
-	if err != nil {
-		t.Fatalf("Fail to decrypt with standard auth tag: %v", err)
-	}
-
-	if string(decipherText) != "Virtru" {
-		t.Errorf("gcm decryption test don't match: expected Virtru, got %v", string(decipherText))
 	}
 }
 
@@ -254,54 +226,5 @@ func TestDecrypt_TooShortData(t *testing.T) {
 	}
 	if !errors.Is(err, ErrInvalidCiphertext) {
 		t.Errorf("expected ErrInvalidCiphertext, got %v", err)
-	}
-}
-
-func TestDecryptWithTagSize_EmptyData(t *testing.T) {
-	key, _ := hex.DecodeString("66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4")
-	aesGcm, _ := NewAESGcm(key)
-
-	_, err := aesGcm.DecryptWithTagSize([]byte{}, 16)
-	if err == nil {
-		t.Fatal("expected error for empty data, got nil")
-	}
-	if !errors.Is(err, ErrInvalidCiphertext) {
-		t.Errorf("expected ErrInvalidCiphertext, got %v", err)
-	}
-}
-
-func TestDecryptWithTagSize_TooShortData(t *testing.T) {
-	key, _ := hex.DecodeString("66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4")
-	aesGcm, _ := NewAESGcm(key)
-
-	_, err := aesGcm.DecryptWithTagSize([]byte{0x01, 0x02}, 16)
-	if err == nil {
-		t.Fatal("expected error for short data, got nil")
-	}
-	if !errors.Is(err, ErrInvalidCiphertext) {
-		t.Errorf("expected ErrInvalidCiphertext, got %v", err)
-	}
-}
-
-func TestDecryptWithIVAndTagSize_InvalidIVSize(t *testing.T) {
-	key, _ := hex.DecodeString("66af5c10753139c6161d0f0eee125bbc9545d6704d64890e396c5c8d4f4820d4")
-	aesGcm, _ := NewAESGcm(key)
-
-	// Test various invalid IV sizes (should be 12 bytes for GCM standard)
-	invalidIVs := [][]byte{
-		{},
-		make([]byte, 11),
-		make([]byte, 13),
-		make([]byte, 16),
-	}
-
-	for _, iv := range invalidIVs {
-		_, err := aesGcm.DecryptWithIVAndTagSize(iv, []byte("test"), 16)
-		if err == nil {
-			t.Errorf("expected error for %d-byte IV, got nil", len(iv))
-		}
-		if !errors.Is(err, ErrInvalidCiphertext) {
-			t.Errorf("expected ErrInvalidCiphertext for %d-byte IV, got %v", len(iv), err)
-		}
 	}
 }

--- a/lib/ocrypto/asym_decryption.go
+++ b/lib/ocrypto/asym_decryption.go
@@ -171,24 +171,22 @@ func (e ECDecryptor) DecryptWithEphemeralKey(data, ephemeral []byte) ([]byte, er
 		return nil, fmt.Errorf("hkdf failure: %w", err)
 	}
 
-	// Encrypt data with derived key using aes-gcm
+	// Decrypt data with derived key using AES-GCM.
 	block, err := aes.NewCipher(derivedKey)
 	if err != nil {
 		return nil, fmt.Errorf("aes.NewCipher failure: %w", err)
 	}
 
-	gcm, err := cipher.NewGCM(block)
+	gcm, err := cipher.NewGCMWithRandomNonce(block)
 	if err != nil {
-		return nil, fmt.Errorf("cipher.NewGCM failure: %w", err)
+		return nil, fmt.Errorf("cipher.NewGCMWithRandomNonce failure: %w", err)
 	}
 
-	nonceSize := gcm.NonceSize()
-	if len(data) < nonceSize {
+	if len(data) < GcmStandardNonceSize+aes.BlockSize {
 		return nil, errors.New("ciphertext too short")
 	}
 
-	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
-	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	plaintext, err := gcm.Open(nil, nil, data, nil)
 	if err != nil {
 		return nil, fmt.Errorf("gcm.Open failure: %w", err)
 	}

--- a/lib/ocrypto/asym_decryption.go
+++ b/lib/ocrypto/asym_decryption.go
@@ -171,6 +171,10 @@ func (e ECDecryptor) DecryptWithEphemeralKey(data, ephemeral []byte) ([]byte, er
 		return nil, fmt.Errorf("hkdf failure: %w", err)
 	}
 
+	if len(data) < GcmStandardNonceSize+aes.BlockSize {
+		return nil, errors.New("ciphertext too short")
+	}
+
 	// Decrypt data with derived key using AES-GCM.
 	block, err := aes.NewCipher(derivedKey)
 	if err != nil {
@@ -180,10 +184,6 @@ func (e ECDecryptor) DecryptWithEphemeralKey(data, ephemeral []byte) ([]byte, er
 	gcm, err := cipher.NewGCMWithRandomNonce(block)
 	if err != nil {
 		return nil, fmt.Errorf("cipher.NewGCMWithRandomNonce failure: %w", err)
-	}
-
-	if len(data) < GcmStandardNonceSize+aes.BlockSize {
-		return nil, errors.New("ciphertext too short")
 	}
 
 	plaintext, err := gcm.Open(nil, nil, data, nil)

--- a/lib/ocrypto/asym_encryption.go
+++ b/lib/ocrypto/asym_encryption.go
@@ -255,17 +255,12 @@ func (e ECEncryptor) Encrypt(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("aes.NewCipher failed: %w", err)
 	}
 
-	gcm, err := cipher.NewGCM(block)
+	gcm, err := cipher.NewGCMWithRandomNonce(block)
 	if err != nil {
-		return nil, fmt.Errorf("cipher.NewGCM failed: %w", err)
+		return nil, fmt.Errorf("cipher.NewGCMWithRandomNonce failed: %w", err)
 	}
 
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, fmt.Errorf("nonce generation failed: %w", err)
-	}
-
-	ciphertext := gcm.Seal(nonce, nonce, data, nil)
+	ciphertext := gcm.Seal(nil, nil, data, nil)
 	return ciphertext, nil
 }
 

--- a/lib/ocrypto/protected_key.go
+++ b/lib/ocrypto/protected_key.go
@@ -2,6 +2,7 @@ package ocrypto
 
 import (
 	"context"
+	"crypto/aes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"errors"
@@ -48,8 +49,18 @@ func NewAESProtectedKey(rawKey []byte) (*AESProtectedKey, error) {
 
 // DecryptAESGCM decrypts data using AES-GCM with the protected key
 func (k *AESProtectedKey) DecryptAESGCM(iv []byte, body []byte, tagSize int) ([]byte, error) {
+	if len(iv) != GcmStandardNonceSize {
+		return nil, fmt.Errorf("invalid ciphertext or IV: %w", ErrInvalidCiphertext)
+	}
+	if tagSize != aes.BlockSize {
+		return nil, fmt.Errorf("AES-GCM tag size %d is not supported: %w", tagSize, ErrUnsupportedAESGCMConfiguration)
+	}
+
 	// Use the pre-initialized AES-GCM cipher for better performance
-	decryptedData, err := k.aesGcm.DecryptWithIVAndTagSize(iv, body, tagSize)
+	sealed := make([]byte, 0, len(iv)+len(body))
+	sealed = append(sealed, iv...)
+	sealed = append(sealed, body...)
+	decryptedData, err := k.aesGcm.Decrypt(sealed)
 	if err != nil {
 		if errors.Is(err, ErrInvalidCiphertext) {
 			return nil, fmt.Errorf("invalid ciphertext or IV: %w", err)

--- a/lib/ocrypto/protected_key_test.go
+++ b/lib/ocrypto/protected_key_test.go
@@ -60,9 +60,20 @@ func TestAESProtectedKey_DecryptAESGCM_InvalidCiphertext(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test with invalid IV size (should be 12 bytes)
-	// This triggers the ErrInvalidCiphertext check in DecryptWithIVAndTagSize
 	_, err = protectedKey.DecryptAESGCM([]byte{0x01, 0x02}, []byte("test"), 16)
 	require.ErrorIs(t, err, ErrInvalidCiphertext)
+}
+
+func TestAESProtectedKey_DecryptAESGCM_UnsupportedTagSize(t *testing.T) {
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+
+	protectedKey, err := NewAESProtectedKey(key)
+	require.NoError(t, err)
+
+	_, err = protectedKey.DecryptAESGCM(make([]byte, GcmStandardNonceSize), []byte("test"), 12)
+	require.ErrorIs(t, err, ErrUnsupportedAESGCMConfiguration)
 }
 
 func TestAESProtectedKey_DecryptAESGCM_InvalidKey(t *testing.T) {


### PR DESCRIPTION
## Summary
- switch OpenTDF AES-GCM helpers to Go's strict-FIPS-compatible random-nonce AEAD
- preserve standard nonce-prefixed AES-GCM encoding for TDF data and EC wrapping
- reject caller-managed IV encryption and non-standard GCM tag sizes explicitly
- update AES-GCM tests for standard round-trip, split nonce/ciphertext decrypt, and unsupported configurations

## Jira
- DSPX-3326

## Testing
- `go test ./...` from `lib/ocrypto`
- `go test ./internal/security/...` from `service`
- `go test ./...` from `sdk`
- `go test ./...` from `otdfctl`
- `golangci-lint run` from `lib/ocrypto`
- `GOFIPS140=v1.0.0 GODEBUG=fips140=only go test github.com/opentdf/platform/lib/ocrypto -run 'TestCreateAesGcm|TestNewAESGCM|TestDecrypt|TestAESProtectedKey'`

## Notes
- The full strict-FIPS package commands now get past AES-GCM construction and expose separate existing strict-FIPS failures around RSA-OAEP SHA-1 usage and short HMAC test keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * AES‑GCM handling now uses randomized nonces internally and simplifies encrypt/decrypt flows.
  * APIs that allowed callers to supply IVs were removed; unsupported configurations now return an error.

* **Bug Fixes**
  * Decryption now correctly interprets embedded nonces and validates IV/tag sizes to prevent misuse.

* **Tests**
  * Test suite updated for in-place encryption, nonce/ciphertext length checks, and unsupported auth‑tag rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentdf/platform/pull/3507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->