### PR TITLE
fix(sdk): correct algorithm display in mapped key debug log

### DIFF
--- a/sdk/granter.go
+++ b/sdk/granter.go
@@ -262,11 +262,12 @@ func (r *granter) addMappedKey(fqn AttributeValueFQN, sk *policy.SimpleKasKey) e
 		return fmt.Errorf("invalid KAS URL in policy service associated with [%s]: %w", fqn, err)
 	}
 	rl.identifier = key.GetKid()
+	algStr, _ := formatAlg(key.GetAlgorithm())
 	r.logger.Debug("added mapped key",
 		slog.Any("fqn", fqn),
 		slog.String("kas", sk.GetKasUri()),
 		slog.String("kid", key.GetKid()),
-		slog.String("alg", algProto2String(policy.KasPublicKeyAlgEnum(key.GetAlgorithm()))),
+		slog.String("alg", algStr),
 	)
 	rls = append(rls, rl)
 	r.mapTable[fqn.key] = rls


### PR DESCRIPTION
### Proposed Changes

 - Fix debug log at `sdk/granter.go:269` that incorrectly cast `policy.Algorithm` to `KasPublicKeyAlgEnum`
  - PQC algorithms have different numeric values in these two enums (e.g. X-Wing is 6 in Algorithm but 10 in KasPublicKeyAlgEnum), causing misleading log output
  - Replace with `formatAlg()` which correctly handles `policy.Algorithm`

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

