### PR TITLE
chore(ci): wait for server in integration test runs after config restore

### DIFF
--- a/test/tdf-roundtrips.bats
+++ b/test/tdf-roundtrips.bats
@@ -357,5 +357,7 @@ teardown() {
 teardown_file() {
   if [ -f opentdf-test-backup.yaml.bak ]; then
     mv opentdf-test-backup.yaml.bak opentdf.yaml
+    sleep 4
+    wait_for_green
   fi
 }

--- a/test/tdf-roundtrips.bats
+++ b/test/tdf-roundtrips.bats
@@ -159,6 +159,7 @@ wait_for_green() {
     fi
     sleep 4
   done
+  return 1
 }
 
 write_opentdf_config() {

--- a/test/tdf-roundtrips.bats
+++ b/test/tdf-roundtrips.bats
@@ -159,6 +159,7 @@ wait_for_green() {
     fi
     sleep 4
   done
+  echo "WARNING: service failed health check after sleep and polling" >&2
   return 1
 }
 


### PR DESCRIPTION
The integration workflow can start policy-service BATS while the background OpenTDF server is still restarting after tdf-roundtrips restores opentdf.yaml. That leaves the next step racing a brief connection-refused window.

This waits for the restored config to be picked up and the server health check to return before tdf-roundtrips exits, so the following BATS step starts against a ready server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test suite stability by ensuring services are fully ready after restore: added a brief initialization pause, active health polling before continuing, and explicit failure if the service never becomes healthy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentdf/platform/pull/3540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->