### PR TITLE
feat(core): Add statement timeout parameter.

### DIFF
--- a/opentdf-core-mode.yaml
+++ b/opentdf-core-mode.yaml
@@ -17,7 +17,7 @@ logger:
 #   port: 5432
 #   user: postgres
 #   password: changeme
-#   statement_timeout_seconds: 30
+#   statement_timeout: 30s
 server:
   auth:
     enabled: false

--- a/opentdf-core-mode.yaml
+++ b/opentdf-core-mode.yaml
@@ -17,7 +17,7 @@ logger:
 #   port: 5432
 #   user: postgres
 #   password: changeme
-#   statement_timeout: 30s
+#   statement_timeout_seconds: 30
 server:
   auth:
     enabled: false

--- a/opentdf-core-mode.yaml
+++ b/opentdf-core-mode.yaml
@@ -17,6 +17,7 @@ logger:
 #   port: 5432
 #   user: postgres
 #   password: changeme
+#   statement_timeout: 30s
 server:
   auth:
     enabled: false

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -10,6 +10,7 @@ logger:
 #   password: changeme
 #   sslmode: prefer
 #   connect_timeout_seconds: 15
+#   statement_timeout: 30s
 #   pool:
 #     max_connection_count: 4
 #     min_connection_count: 0

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -10,7 +10,7 @@ logger:
 #   password: changeme
 #   sslmode: prefer
 #   connect_timeout_seconds: 15
-#   statement_timeout: 30s
+#   statement_timeout_seconds: 30
 #   pool:
 #     max_connection_count: 4
 #     min_connection_count: 0

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -10,7 +10,7 @@ logger:
 #   password: changeme
 #   sslmode: prefer
 #   connect_timeout_seconds: 15
-#   statement_timeout_seconds: 30
+#   statement_timeout: 30s
 #   pool:
 #     max_connection_count: 4
 #     min_connection_count: 0

--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -10,6 +10,7 @@ db:
 #   password: changeme
 #   sslmode: prefer
 #   connect_timeout_seconds: 15
+#   statement_timeout: 30s
 #   pool:
 #     max_connection_count: 4
 #     min_connection_count: 0

--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -10,7 +10,7 @@ db:
 #   password: changeme
 #   sslmode: prefer
 #   connect_timeout_seconds: 15
-#   statement_timeout_seconds: 30
+#   statement_timeout: 30s
 #   pool:
 #     max_connection_count: 4
 #     min_connection_count: 0

--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -10,7 +10,7 @@ db:
 #   password: changeme
 #   sslmode: prefer
 #   connect_timeout_seconds: 15
-#   statement_timeout: 30s
+#   statement_timeout_seconds: 30
 #   pool:
 #     max_connection_count: 4
 #     min_connection_count: 0

--- a/service/pkg/db/db.go
+++ b/service/pkg/db/db.go
@@ -89,15 +89,16 @@ type PoolConfig struct {
 }
 
 type Config struct {
-	Host           string     `mapstructure:"host" json:"host" default:"localhost"`
-	Port           int        `mapstructure:"port" json:"port" default:"5432"`
-	Database       string     `mapstructure:"database" json:"database" default:"opentdf"`
-	User           string     `mapstructure:"user" json:"user" default:"postgres"`
-	Password       string     `mapstructure:"password" json:"password" default:"changeme"`
-	SSLMode        string     `mapstructure:"sslmode" json:"sslmode" default:"prefer"`
-	Schema         string     `mapstructure:"schema" json:"schema" default:"opentdf"`
-	ConnectTimeout int        `mapstructure:"connect_timeout_seconds" json:"connect_timeout_seconds" default:"15"`
-	Pool           PoolConfig `mapstructure:"pool" json:"pool"`
+	Host             string     `mapstructure:"host" json:"host" default:"localhost"`
+	Port             int        `mapstructure:"port" json:"port" default:"5432"`
+	Database         string     `mapstructure:"database" json:"database" default:"opentdf"`
+	User             string     `mapstructure:"user" json:"user" default:"postgres"`
+	Password         string     `mapstructure:"password" json:"password" default:"changeme"`
+	SSLMode          string     `mapstructure:"sslmode" json:"sslmode" default:"prefer"`
+	Schema           string     `mapstructure:"schema" json:"schema" default:"opentdf"`
+	ConnectTimeout   int        `mapstructure:"connect_timeout_seconds" json:"connect_timeout_seconds" default:"15"`
+	StatementTimeout string     `mapstructure:"statement_timeout" json:"statement_timeout"`
+	Pool             PoolConfig `mapstructure:"pool" json:"pool"`
 
 	RunMigrations    bool      `mapstructure:"runMigrations" json:"runMigrations" default:"true"`
 	MigrationsFS     *embed.FS `mapstructure:"-" json:"-"`
@@ -114,6 +115,7 @@ func (c Config) LogValue() slog.Value {
 		slog.String("sslmode", c.SSLMode),
 		slog.String("schema", c.Schema),
 		slog.Int("connect_timeout_seconds", c.ConnectTimeout),
+		slog.String("statement_timeout", c.StatementTimeout),
 		slog.Group("pool",
 			slog.Int("max_connection_count", int(c.Pool.MaxConns)),
 			slog.Int("min_connection_count", int(c.Pool.MinConns)),
@@ -249,6 +251,10 @@ func (c Config) buildConfig() (*pgxpool.Config, error) {
 	parsed.MaxConnLifetime = time.Duration(c.Pool.MaxConnLifetime) * time.Second
 	parsed.MaxConnIdleTime = time.Duration(c.Pool.MaxConnIdleTime) * time.Second
 	parsed.HealthCheckPeriod = time.Duration(c.Pool.HealthCheckPeriod) * time.Second
+
+	if c.StatementTimeout != "" {
+		parsed.ConnConfig.RuntimeParams["statement_timeout"] = c.StatementTimeout
+	}
 
 	// Configure the search_path schema immediately on connection opening
 	parsed.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {

--- a/service/pkg/db/db.go
+++ b/service/pkg/db/db.go
@@ -89,16 +89,16 @@ type PoolConfig struct {
 }
 
 type Config struct {
-	Host             string     `mapstructure:"host" json:"host" default:"localhost"`
-	Port             int        `mapstructure:"port" json:"port" default:"5432"`
-	Database         string     `mapstructure:"database" json:"database" default:"opentdf"`
-	User             string     `mapstructure:"user" json:"user" default:"postgres"`
-	Password         string     `mapstructure:"password" json:"password" default:"changeme"`
-	SSLMode          string     `mapstructure:"sslmode" json:"sslmode" default:"prefer"`
-	Schema           string     `mapstructure:"schema" json:"schema" default:"opentdf"`
-	ConnectTimeout   int        `mapstructure:"connect_timeout_seconds" json:"connect_timeout_seconds" default:"15"`
-	StatementTimeout string     `mapstructure:"statement_timeout" json:"statement_timeout"`
-	Pool             PoolConfig `mapstructure:"pool" json:"pool"`
+	Host                    string     `mapstructure:"host" json:"host" default:"localhost"`
+	Port                    int        `mapstructure:"port" json:"port" default:"5432"`
+	Database                string     `mapstructure:"database" json:"database" default:"opentdf"`
+	User                    string     `mapstructure:"user" json:"user" default:"postgres"`
+	Password                string     `mapstructure:"password" json:"password" default:"changeme"`
+	SSLMode                 string     `mapstructure:"sslmode" json:"sslmode" default:"prefer"`
+	Schema                  string     `mapstructure:"schema" json:"schema" default:"opentdf"`
+	ConnectTimeout          int        `mapstructure:"connect_timeout_seconds" json:"connect_timeout_seconds" default:"15"`
+	StatementTimeoutSeconds int        `mapstructure:"statement_timeout_seconds" json:"statement_timeout_seconds"`
+	Pool                    PoolConfig `mapstructure:"pool" json:"pool"`
 
 	RunMigrations    bool      `mapstructure:"runMigrations" json:"runMigrations" default:"true"`
 	MigrationsFS     *embed.FS `mapstructure:"-" json:"-"`
@@ -115,7 +115,7 @@ func (c Config) LogValue() slog.Value {
 		slog.String("sslmode", c.SSLMode),
 		slog.String("schema", c.Schema),
 		slog.Int("connect_timeout_seconds", c.ConnectTimeout),
-		slog.String("statement_timeout", c.StatementTimeout),
+		slog.Int("statement_timeout_seconds", c.StatementTimeoutSeconds),
 		slog.Group("pool",
 			slog.Int("max_connection_count", int(c.Pool.MaxConns)),
 			slog.Int("min_connection_count", int(c.Pool.MinConns)),
@@ -252,8 +252,8 @@ func (c Config) buildConfig() (*pgxpool.Config, error) {
 	parsed.MaxConnIdleTime = time.Duration(c.Pool.MaxConnIdleTime) * time.Second
 	parsed.HealthCheckPeriod = time.Duration(c.Pool.HealthCheckPeriod) * time.Second
 
-	if c.StatementTimeout != "" {
-		parsed.ConnConfig.RuntimeParams["statement_timeout"] = c.StatementTimeout
+	if c.StatementTimeoutSeconds > 0 {
+		parsed.ConnConfig.RuntimeParams["statement_timeout"] = fmt.Sprintf("%ds", c.StatementTimeoutSeconds)
 	}
 
 	// Configure the search_path schema immediately on connection opening

--- a/service/pkg/db/db.go
+++ b/service/pkg/db/db.go
@@ -89,16 +89,16 @@ type PoolConfig struct {
 }
 
 type Config struct {
-	Host                    string     `mapstructure:"host" json:"host" default:"localhost"`
-	Port                    int        `mapstructure:"port" json:"port" default:"5432"`
-	Database                string     `mapstructure:"database" json:"database" default:"opentdf"`
-	User                    string     `mapstructure:"user" json:"user" default:"postgres"`
-	Password                string     `mapstructure:"password" json:"password" default:"changeme"`
-	SSLMode                 string     `mapstructure:"sslmode" json:"sslmode" default:"prefer"`
-	Schema                  string     `mapstructure:"schema" json:"schema" default:"opentdf"`
-	ConnectTimeout          int        `mapstructure:"connect_timeout_seconds" json:"connect_timeout_seconds" default:"15"`
-	StatementTimeoutSeconds int        `mapstructure:"statement_timeout_seconds" json:"statement_timeout_seconds"`
-	Pool                    PoolConfig `mapstructure:"pool" json:"pool"`
+	Host             string     `mapstructure:"host" json:"host" default:"localhost"`
+	Port             int        `mapstructure:"port" json:"port" default:"5432"`
+	Database         string     `mapstructure:"database" json:"database" default:"opentdf"`
+	User             string     `mapstructure:"user" json:"user" default:"postgres"`
+	Password         string     `mapstructure:"password" json:"password" default:"changeme"`
+	SSLMode          string     `mapstructure:"sslmode" json:"sslmode" default:"prefer"`
+	Schema           string     `mapstructure:"schema" json:"schema" default:"opentdf"`
+	ConnectTimeout   int        `mapstructure:"connect_timeout_seconds" json:"connect_timeout_seconds" default:"15"`
+	StatementTimeout int        `mapstructure:"statement_timeout_seconds" json:"statement_timeout_seconds"`
+	Pool             PoolConfig `mapstructure:"pool" json:"pool"`
 
 	RunMigrations    bool      `mapstructure:"runMigrations" json:"runMigrations" default:"true"`
 	MigrationsFS     *embed.FS `mapstructure:"-" json:"-"`
@@ -115,8 +115,9 @@ func (c Config) LogValue() slog.Value {
 		slog.String("sslmode", c.SSLMode),
 		slog.String("schema", c.Schema),
 		slog.Int("connect_timeout_seconds", c.ConnectTimeout),
-		slog.Int("statement_timeout_seconds", c.StatementTimeoutSeconds),
-		slog.Group("pool",
+		slog.Int("statement_timeout_seconds", c.StatementTimeout),
+		slog.Group(
+			"pool",
 			slog.Int("max_connection_count", int(c.Pool.MaxConns)),
 			slog.Int("min_connection_count", int(c.Pool.MinConns)),
 			slog.Int("max_connection_lifetime_seconds", c.Pool.MaxConnLifetime),
@@ -226,7 +227,8 @@ func (c *Client) Close() {
 }
 
 func (c Config) buildConfig() (*pgxpool.Config, error) {
-	u := fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=%s",
+	u := fmt.Sprintf(
+		"postgres://%s:%s@%s/%s?sslmode=%s",
 		c.User,
 		url.QueryEscape(c.Password),
 		net.JoinHostPort(c.Host, strconv.Itoa(c.Port)),
@@ -252,15 +254,16 @@ func (c Config) buildConfig() (*pgxpool.Config, error) {
 	parsed.MaxConnIdleTime = time.Duration(c.Pool.MaxConnIdleTime) * time.Second
 	parsed.HealthCheckPeriod = time.Duration(c.Pool.HealthCheckPeriod) * time.Second
 
-	if c.StatementTimeoutSeconds > 0 {
-		parsed.ConnConfig.RuntimeParams["statement_timeout"] = fmt.Sprintf("%ds", c.StatementTimeoutSeconds)
+	if c.StatementTimeout > 0 {
+		parsed.ConnConfig.RuntimeParams["statement_timeout"] = fmt.Sprintf("%ds", c.StatementTimeout)
 	}
 
 	// Configure the search_path schema immediately on connection opening
 	parsed.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
 		_, err := conn.Exec(ctx, "SET search_path TO "+pgx.Identifier{c.Schema}.Sanitize())
 		if err != nil {
-			slog.Error("failed to set database client search_path",
+			slog.Error(
+				"failed to set database client search_path",
 				slog.String("schema", c.Schema),
 				slog.Any("error", err),
 			)
@@ -269,6 +272,20 @@ func (c Config) buildConfig() (*pgxpool.Config, error) {
 		slog.Debug("successfully set database client search_path", slog.String("schema", c.Schema))
 		return nil
 	}
+	return parsed, nil
+}
+
+func (c Config) buildMigrationConfig() (*pgxpool.Config, error) {
+	parsed, err := c.buildConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	parsed.MaxConns = 1
+	parsed.MinConns = 0
+	parsed.MinIdleConns = 0
+	parsed.ConnConfig.RuntimeParams["statement_timeout"] = "0"
+
 	return parsed, nil
 }
 

--- a/service/pkg/db/db.go
+++ b/service/pkg/db/db.go
@@ -89,16 +89,16 @@ type PoolConfig struct {
 }
 
 type Config struct {
-	Host                    string     `mapstructure:"host" json:"host" default:"localhost"`
-	Port                    int        `mapstructure:"port" json:"port" default:"5432"`
-	Database                string     `mapstructure:"database" json:"database" default:"opentdf"`
-	User                    string     `mapstructure:"user" json:"user" default:"postgres"`
-	Password                string     `mapstructure:"password" json:"password" default:"changeme"`
-	SSLMode                 string     `mapstructure:"sslmode" json:"sslmode" default:"prefer"`
-	Schema                  string     `mapstructure:"schema" json:"schema" default:"opentdf"`
-	ConnectTimeout          int        `mapstructure:"connect_timeout_seconds" json:"connect_timeout_seconds" default:"15"`
-	StatementTimeoutSeconds int        `mapstructure:"statement_timeout_seconds" json:"statement_timeout_seconds"`
-	Pool                    PoolConfig `mapstructure:"pool" json:"pool"`
+	Host             string     `mapstructure:"host" json:"host" default:"localhost"`
+	Port             int        `mapstructure:"port" json:"port" default:"5432"`
+	Database         string     `mapstructure:"database" json:"database" default:"opentdf"`
+	User             string     `mapstructure:"user" json:"user" default:"postgres"`
+	Password         string     `mapstructure:"password" json:"password" default:"changeme"`
+	SSLMode          string     `mapstructure:"sslmode" json:"sslmode" default:"prefer"`
+	Schema           string     `mapstructure:"schema" json:"schema" default:"opentdf"`
+	ConnectTimeout   int        `mapstructure:"connect_timeout_seconds" json:"connect_timeout_seconds" default:"15"`
+	StatementTimeout string     `mapstructure:"statement_timeout" json:"statement_timeout"`
+	Pool             PoolConfig `mapstructure:"pool" json:"pool"`
 
 	RunMigrations    bool      `mapstructure:"runMigrations" json:"runMigrations" default:"true"`
 	MigrationsFS     *embed.FS `mapstructure:"-" json:"-"`
@@ -115,7 +115,7 @@ func (c Config) LogValue() slog.Value {
 		slog.String("sslmode", c.SSLMode),
 		slog.String("schema", c.Schema),
 		slog.Int("connect_timeout_seconds", c.ConnectTimeout),
-		slog.Int("statement_timeout_seconds", c.StatementTimeoutSeconds),
+		slog.String("statement_timeout", c.StatementTimeout),
 		slog.Group("pool",
 			slog.Int("max_connection_count", int(c.Pool.MaxConns)),
 			slog.Int("min_connection_count", int(c.Pool.MinConns)),
@@ -252,8 +252,8 @@ func (c Config) buildConfig() (*pgxpool.Config, error) {
 	parsed.MaxConnIdleTime = time.Duration(c.Pool.MaxConnIdleTime) * time.Second
 	parsed.HealthCheckPeriod = time.Duration(c.Pool.HealthCheckPeriod) * time.Second
 
-	if c.StatementTimeoutSeconds > 0 {
-		parsed.ConnConfig.RuntimeParams["statement_timeout"] = fmt.Sprintf("%ds", c.StatementTimeoutSeconds)
+	if c.StatementTimeout != "" {
+		parsed.ConnConfig.RuntimeParams["statement_timeout"] = c.StatementTimeout
 	}
 
 	// Configure the search_path schema immediately on connection opening

--- a/service/pkg/db/db_migration.go
+++ b/service/pkg/db/db_migration.go
@@ -18,32 +18,40 @@ func migrationInit(ctx context.Context, c *Client, migrations *embed.FS) (*goose
 		return nil, 0, nil, errors.New("migrations are disabled")
 	}
 
-	// Cast the pgxpool.Pool to a *sql.DB
-	pool, ok := c.Pgx.(*pgxpool.Pool)
-	if !ok || pool == nil {
-		return nil, 0, nil, errors.New("failed to cast pgxpool.Pool")
+	migrationPoolConfig, err := c.config.buildMigrationConfig()
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("failed to parse migration pgx config: %w", err)
 	}
-	conn := stdlib.OpenDBFromPool(pool)
+
+	migrationPool, err := pgxpool.NewWithConfig(ctx, migrationPoolConfig)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("failed to create migration pgxpool: %w", err)
+	}
+	conn := stdlib.OpenDBFromPool(migrationPool)
+	closeMigrationDB := func() {
+		if err := conn.Close(); err != nil {
+			slog.Error("failed to close migration connection", slog.Any("err", err))
+		}
+		migrationPool.Close()
+	}
 
 	// Create the goose provider
 	provider, err := goose.NewProvider(goose.DialectPostgres, conn, migrations)
 	if err != nil {
+		closeMigrationDB()
 		return nil, 0, nil, fmt.Errorf("failed to create goose provider: %w", err)
 	}
 
 	// Get the current version
 	v, e := provider.GetDBVersion(ctx)
 	if e != nil {
+		closeMigrationDB()
 		return nil, 0, nil, errors.Join(errors.New("failed to get current version"), e)
 	}
 	slog.Info("migration db info", slog.Int64("current_version", v))
 
 	// Return the provider, version, and close function
-	return provider, v, func() {
-		if err := conn.Close(); err != nil {
-			slog.Error("failed to close connection", slog.Any("err", err))
-		}
-	}, nil
+	return provider, v, closeMigrationDB, nil
 }
 
 // RunMigrations runs the migrations for the schema
@@ -52,7 +60,8 @@ func (c *Client) RunMigrations(ctx context.Context, migrations *embed.FS) (int, 
 	if migrations == nil {
 		return 0, errors.New("migrations FS is required to run migrations")
 	}
-	slog.Info("running migration up",
+	slog.Info(
+		"running migration up",
 		slog.String("schema", c.config.Schema),
 		slog.String("database", c.config.Database),
 	)
@@ -61,7 +70,8 @@ func (c *Client) RunMigrations(ctx context.Context, migrations *embed.FS) (int, 
 	q := "CREATE SCHEMA IF NOT EXISTS " + pgx.Identifier{c.config.Schema}.Sanitize()
 	tag, err := c.Pgx.Exec(ctx, q)
 	if err != nil {
-		slog.ErrorContext(ctx,
+		slog.ErrorContext(
+			ctx,
 			"error while running command",
 			slog.String("command", q),
 			slog.Any("error", err),
@@ -100,7 +110,8 @@ func (c *Client) RunMigrations(ctx context.Context, migrations *embed.FS) (int, 
 }
 
 func (c *Client) MigrationStatus(ctx context.Context) ([]*goose.MigrationStatus, error) {
-	slog.Info("running migrations status",
+	slog.Info(
+		"running migrations status",
 		slog.String("schema", c.config.Schema),
 		slog.String("database", c.config.Database),
 	)
@@ -115,7 +126,8 @@ func (c *Client) MigrationStatus(ctx context.Context) ([]*goose.MigrationStatus,
 }
 
 func (c *Client) MigrationDown(ctx context.Context, migrations *embed.FS) error {
-	slog.Info("running migration down",
+	slog.Info(
+		"running migration down",
 		slog.String("schema", c.config.Schema),
 		slog.String("database", c.config.Database),
 	)

--- a/service/pkg/db/db_test.go
+++ b/service/pkg/db/db_test.go
@@ -81,13 +81,13 @@ func Test_BuildConfig_ConnString(t *testing.T) {
 		},
 		{
 			config: &Config{
-				Host:                    "localhost",
-				Port:                    5432,
-				Database:                "opentdf",
-				User:                    "postgres",
-				Password:                "changeme",
-				SSLMode:                 "prefer",
-				StatementTimeoutSeconds: 30,
+				Host:             "localhost",
+				Port:             5432,
+				Database:         "opentdf",
+				User:             "postgres",
+				Password:         "changeme",
+				SSLMode:          "prefer",
+				StatementTimeout: "30s",
 			},
 			want: "postgres://postgres:changeme@localhost:5432/opentdf?sslmode=prefer",
 			wantRuntimeParams: map[string]string{

--- a/service/pkg/db/db_test.go
+++ b/service/pkg/db/db_test.go
@@ -81,13 +81,13 @@ func Test_BuildConfig_ConnString(t *testing.T) {
 		},
 		{
 			config: &Config{
-				Host:                    "localhost",
-				Port:                    5432,
-				Database:                "opentdf",
-				User:                    "postgres",
-				Password:                "changeme",
-				SSLMode:                 "prefer",
-				StatementTimeoutSeconds: 30,
+				Host:             "localhost",
+				Port:             5432,
+				Database:         "opentdf",
+				User:             "postgres",
+				Password:         "changeme",
+				SSLMode:          "prefer",
+				StatementTimeout: 30,
 			},
 			want: "postgres://postgres:changeme@localhost:5432/opentdf?sslmode=prefer",
 			wantRuntimeParams: map[string]string{
@@ -110,5 +110,57 @@ func Test_BuildConfig_ConnString(t *testing.T) {
 			}
 			assert.Equal(t, value, cfg.ConnConfig.RuntimeParams[key])
 		}
+	}
+}
+
+func Test_BuildMigrationConfig_OverridesForMigration(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "disables statement timeout when statement timeout is configured",
+			cfg: Config{
+				Host:             "localhost",
+				Port:             5432,
+				Database:         "opentdf",
+				User:             "postgres",
+				Password:         "changeme",
+				SSLMode:          "prefer",
+				StatementTimeout: 30,
+				Pool: PoolConfig{
+					MaxConns:     10,
+					MinConns:     2,
+					MinIdleConns: 2,
+				},
+			},
+		},
+		{
+			name: "disables statement timeout when statement timeout is not configured",
+			cfg: Config{
+				Host:     "localhost",
+				Port:     5432,
+				Database: "opentdf",
+				User:     "postgres",
+				Password: "changeme",
+				SSLMode:  "prefer",
+				Pool: PoolConfig{
+					MaxConns:     10,
+					MinConns:     2,
+					MinIdleConns: 2,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, err := test.cfg.buildMigrationConfig()
+			require.NoError(t, err)
+			assert.Equal(t, "0", cfg.ConnConfig.RuntimeParams["statement_timeout"])
+			assert.EqualValues(t, 1, cfg.MaxConns)
+			assert.EqualValues(t, 0, cfg.MinConns)
+			assert.EqualValues(t, 0, cfg.MinIdleConns)
+		})
 	}
 }

--- a/service/pkg/db/db_test.go
+++ b/service/pkg/db/db_test.go
@@ -9,8 +9,9 @@ import (
 
 func Test_BuildConfig_ConnString(t *testing.T) {
 	tests := []struct {
-		config *Config
-		want   string
+		config            *Config
+		want              string
+		wantRuntimeParams map[string]string
 	}{
 		{
 			config: &Config{
@@ -63,6 +64,36 @@ func Test_BuildConfig_ConnString(t *testing.T) {
 			},
 			want: "postgres://myuser:mypassword@myhost:1234/mydb?sslmode=require",
 		},
+		// Statement timeout should not be added as a runtime parameter unless configured.
+		{
+			config: &Config{
+				Host:     "localhost",
+				Port:     5432,
+				Database: "opentdf",
+				User:     "postgres",
+				Password: "changeme",
+				SSLMode:  "prefer",
+			},
+			want: "postgres://postgres:changeme@localhost:5432/opentdf?sslmode=prefer",
+			wantRuntimeParams: map[string]string{
+				"statement_timeout": "",
+			},
+		},
+		{
+			config: &Config{
+				Host:             "localhost",
+				Port:             5432,
+				Database:         "opentdf",
+				User:             "postgres",
+				Password:         "changeme",
+				SSLMode:          "prefer",
+				StatementTimeout: "30s",
+			},
+			want: "postgres://postgres:changeme@localhost:5432/opentdf?sslmode=prefer",
+			wantRuntimeParams: map[string]string{
+				"statement_timeout": "30s",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -71,5 +102,13 @@ func Test_BuildConfig_ConnString(t *testing.T) {
 		assert.Equal(t, test.want, cfg.ConnString())
 		// AfterConnect hook was defined when building
 		assert.NotNil(t, cfg.AfterConnect)
+
+		for key, value := range test.wantRuntimeParams {
+			if value == "" {
+				assert.NotContains(t, cfg.ConnConfig.RuntimeParams, key)
+				continue
+			}
+			assert.Equal(t, value, cfg.ConnConfig.RuntimeParams[key])
+		}
 	}
 }

--- a/service/pkg/db/db_test.go
+++ b/service/pkg/db/db_test.go
@@ -81,13 +81,13 @@ func Test_BuildConfig_ConnString(t *testing.T) {
 		},
 		{
 			config: &Config{
-				Host:             "localhost",
-				Port:             5432,
-				Database:         "opentdf",
-				User:             "postgres",
-				Password:         "changeme",
-				SSLMode:          "prefer",
-				StatementTimeout: "30s",
+				Host:                    "localhost",
+				Port:                    5432,
+				Database:                "opentdf",
+				User:                    "postgres",
+				Password:                "changeme",
+				SSLMode:                 "prefer",
+				StatementTimeoutSeconds: 30,
 			},
 			want: "postgres://postgres:changeme@localhost:5432/opentdf?sslmode=prefer",
 			wantRuntimeParams: map[string]string{


### PR DESCRIPTION
>[!NOTE]
>Adding a query timeout will be useful for protecting the database from
>long running searches when substring search is added to the List RPCs.

Summary

  - Added statement_timeout_seconds support to DB config so normal service DB connections set PostgreSQL statement_timeout.
  - Updated migration initialization to use a separate short-lived migration pgx pool.
  - Migration pool overrides statement_timeout to 0 and caps pool sizing to MaxConns=1, MinConns=0, MinIdleConns=0.
  - Added unit coverage for normal DB timeout config and migration-specific overrides.

  Verification

  - cd service && go test ./pkg/db
  - cd service && golangci-lint run ./pkg/db
  - Runtime verified with statement_timeout_seconds: 1:
      - normal DB query timed out after ~1s
      - migration containing a 2s DB sleep completed successfully via migration pool.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional database statement timeout setting to limit how long queries can run per connection.

* **Configuration**
  * Updated example and local development configuration files with a commented statement timeout line.

* **Bug Fixes / Improvements**
  * Improved migration execution by using a dedicated migration database connection/pool and tightened migration-related logging.

* **Tests**
  * Extended automated tests to verify statement timeout runtime parameter behavior and migration overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->