### PR TITLE
chore(ci): bump protoc-gen-connect-openapi to v0.25.6

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -617,7 +617,7 @@ jobs:
             examples/go.sum
       - run: cd service && go get github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
       - run: cd service && go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
-      - run: cd service && go install github.com/sudorandom/protoc-gen-connect-openapi@v0.18.0
+      - run: cd service && go install github.com/sudorandom/protoc-gen-connect-openapi@v0.25.6
       - run: cd service && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
       - run: make proto-generate
       - name: generate connect wrappers

--- a/docs/openapi/authorization/authorization.openapi.yaml
+++ b/docs/openapi/authorization/authorization.openapi.yaml
@@ -109,65 +109,6 @@ paths:
                 $ref: '#/components/schemas/authorization.GetEntitlementsResponse'
 components:
   schemas:
-    authorization.DecisionResponse.Decision:
-      type: string
-      title: Decision
-      enum:
-        - DECISION_UNSPECIFIED
-        - DECISION_DENY
-        - DECISION_PERMIT
-    authorization.Entity.Category:
-      type: string
-      title: Category
-      enum:
-        - CATEGORY_UNSPECIFIED
-        - CATEGORY_SUBJECT
-        - CATEGORY_ENVIRONMENT
-    policy.Action.StandardAction:
-      type: string
-      title: StandardAction
-      enum:
-        - STANDARD_ACTION_UNSPECIFIED
-        - STANDARD_ACTION_DECRYPT
-        - STANDARD_ACTION_TRANSMIT
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
     authorization.DecisionRequest:
       type: object
       properties:
@@ -192,7 +133,6 @@ components:
         Example Request Get Decisions to answer the question -  Do Bob (represented by entity chain ec1)
         and Alice (represented by entity chain ec2) have TRANSMIT authorization for
         2 resources; resource1 (attr-set-1) defined by attributes foo:bar  resource2 (attr-set-2) defined by attribute foo:bar, color:red ?
-
         {
         "actions": [
         {
@@ -264,13 +204,11 @@ components:
         Example response for a Decision Request -  Do Bob (represented by entity chain ec1)
         and Alice (represented by entity chain ec2) have TRANSMIT authorization for
         2 resources; resource1 (attr-set-1) defined by attributes foo:bar  resource2 (attr-set-2) defined by attribute foo:bar, color:red ?
-
         Results:
         - bob has permitted authorization to transmit for a resource defined by attr-set-1 attributes and has a watermark obligation
         - bob has denied authorization to transmit a for a resource defined by attr-set-2 attributes
         - alice has permitted authorization to transmit for a resource defined by attr-set-1 attributes
         - alice has denied authorization to transmit a for a resource defined by attr-set-2 attributes
-
         {
         "entityChainId":  "ec1",
         "resourceAttributesId":  "attr-set-1",
@@ -294,70 +232,92 @@ components:
         "resourceAttributesId":  "attr-set-2",
         "decision":  "DECISION_DENY"
         }
+    authorization.DecisionResponse.Decision:
+      type: string
+      title: Decision
+      enum:
+        - DECISION_UNSPECIFIED
+        - DECISION_DENY
+        - DECISION_PERMIT
     authorization.Entity:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            claims:
+            id:
+              type: string
+              title: id
+              description: ephemeral id for tracking between request and response
+            category:
+              title: category
+              $ref: '#/components/schemas/authorization.Entity.Category'
+        - oneOf:
+            - type: object
+              properties:
+                claims:
+                  title: claims
+                  $ref: '#/components/schemas/google.protobuf.Any'
               title: claims
-              $ref: '#/components/schemas/google.protobuf.Any'
-          title: claims
-          required:
-            - claims
-        - properties:
-            clientId:
-              type: string
+              required:
+                - claims
+            - type: object
+              properties:
+                clientId:
+                  type: string
+                  title: client_id
               title: client_id
-          title: client_id
-          required:
-            - clientId
-        - properties:
-            custom:
+              required:
+                - clientId
+            - type: object
+              properties:
+                custom:
+                  title: custom
+                  $ref: '#/components/schemas/authorization.EntityCustom'
               title: custom
-              $ref: '#/components/schemas/authorization.EntityCustom'
-          title: custom
-          required:
-            - custom
-        - properties:
-            emailAddress:
-              type: string
+              required:
+                - custom
+            - type: object
+              properties:
+                emailAddress:
+                  type: string
+                  title: email_address
+                  description: one of the entity options must be set
               title: email_address
-              description: one of the entity options must be set
-          title: email_address
-          required:
-            - emailAddress
-        - properties:
-            remoteClaimsUrl:
-              type: string
+              required:
+                - emailAddress
+            - type: object
+              properties:
+                remoteClaimsUrl:
+                  type: string
+                  title: remote_claims_url
               title: remote_claims_url
-          title: remote_claims_url
-          required:
-            - remoteClaimsUrl
-        - properties:
-            userName:
-              type: string
+              required:
+                - remoteClaimsUrl
+            - type: object
+              properties:
+                userName:
+                  type: string
+                  title: user_name
               title: user_name
-          title: user_name
-          required:
-            - userName
-        - properties:
-            uuid:
-              type: string
+              required:
+                - userName
+            - type: object
+              properties:
+                uuid:
+                  type: string
+                  title: uuid
               title: uuid
-          title: uuid
-          required:
-            - uuid
-      properties:
-        id:
-          type: string
-          title: id
-          description: ephemeral id for tracking between request and response
-        category:
-          title: category
-          $ref: '#/components/schemas/authorization.Entity.Category'
+              required:
+                - uuid
       title: Entity
       additionalProperties: false
       description: PE (Person Entity) or NPE (Non-Person Entity)
+    authorization.Entity.Category:
+      type: string
+      title: Category
+      enum:
+        - CATEGORY_UNSPECIFIED
+        - CATEGORY_SUBJECT
+        - CATEGORY_ENVIRONMENT
     authorization.EntityChain:
       type: object
       properties:
@@ -445,22 +405,22 @@ components:
           title: entities
           description: list of requested entities
         scope:
+          oneOf:
+            - $ref: '#/components/schemas/authorization.ResourceAttribute'
+            - type: "null"
           title: scope
           description: optional attribute fqn as a scope
-          nullable: true
-          $ref: '#/components/schemas/authorization.ResourceAttribute'
         withComprehensiveHierarchy:
-          type: boolean
+          type:
+            - boolean
+            - "null"
           title: with_comprehensive_hierarchy
           description: optional parameter to return a full list of entitlements - returns lower hierarchy attributes
-          nullable: true
       title: GetEntitlementsRequest
       additionalProperties: false
       description: |-
         Request to get entitlements for one or more entities for an optional attribute scope
-
         Example: Get entitlements for bob and alice (both represented using an email address
-
         {
         "entities": [
         {
@@ -491,7 +451,6 @@ components:
       additionalProperties: false
       description: |-
         Example Response for a request of : Get entitlements for bob and alice (both represented using an email address
-
         {
         "entitlements":  [
         {
@@ -563,7 +522,6 @@ components:
         Example Request Get Decisions by Token to answer the question -  Do Bob and client1 (represented by token tok1)
         and Alice and client2 (represented by token tok2) have TRANSMIT authorization for
         2 resources; resource1 (attr-set-1) defined by attributes foo:bar  resource2 (attr-set-2) defined by attribute foo:bar, color:red ?
-
         {
         "actions": [
         {
@@ -626,6 +584,75 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.Any:
       type: object
       properties:
@@ -634,9 +661,6 @@ components:
         value:
           type: string
           format: binary
-        debug:
-          type: object
-          additionalProperties: true
       additionalProperties: true
       description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
     google.protobuf.BoolValue:
@@ -651,8 +675,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -746,41 +770,65 @@ components:
          ) to obtain a formatter capable of generating timestamps in this format.
     policy.Action:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            custom:
+            id:
               type: string
+              title: id
+              description: Generated uuid in database
+            name:
+              type: string
+              title: name
+            namespace:
+              title: namespace
+              description: Namespace context for this action
+              $ref: '#/components/schemas/policy.Namespace'
+            metadata:
+              title: metadata
+              $ref: '#/components/schemas/common.Metadata'
+        - oneOf:
+            - type: object
+              properties:
+                custom:
+                  type: string
+                  title: custom
+                  description: Deprecated
               title: custom
-              description: Deprecated
-          title: custom
-          required:
-            - custom
-        - properties:
-            standard:
+              required:
+                - custom
+            - type: object
+              properties:
+                standard:
+                  title: standard
+                  description: Deprecated
+                  $ref: '#/components/schemas/policy.Action.StandardAction'
               title: standard
-              description: Deprecated
-              $ref: '#/components/schemas/policy.Action.StandardAction'
-          title: standard
-          required:
-            - standard
-      properties:
-        id:
-          type: string
-          title: id
-          description: Generated uuid in database
-        name:
-          type: string
-          title: name
-        namespace:
-          title: namespace
-          description: Namespace context for this action
-          $ref: '#/components/schemas/policy.Namespace'
-        metadata:
-          title: metadata
-          $ref: '#/components/schemas/common.Metadata'
+              required:
+                - standard
       title: Action
       additionalProperties: false
       description: An action an entity can take
+    policy.Action.StandardAction:
+      type: string
+      title: StandardAction
+      enum:
+        - STANDARD_ACTION_UNSPECIFIED
+        - STANDARD_ACTION_DECRYPT
+        - STANDARD_ACTION_TRANSMIT
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.KasPublicKey:
       type: object
       properties:
@@ -799,7 +847,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -811,6 +859,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -833,13 +894,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -907,7 +964,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -915,17 +973,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -963,50 +1018,17 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
+    policy.SourceType:
+      type: string
+      title: SourceType
       enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
 security: []
 tags:
   - name: authorization.AuthorizationService

--- a/docs/openapi/authorization/v2/authorization.openapi.yaml
+++ b/docs/openapi/authorization/v2/authorization.openapi.yaml
@@ -37,41 +37,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/authorization.v2.GetDecisionResponse'
-  /authorization.v2.AuthorizationService/GetDecisionMultiResource:
-    post:
-      tags:
-        - authorization.v2.AuthorizationService
-      summary: GetDecisionMultiResource
-      operationId: authorization.v2.AuthorizationService.GetDecisionMultiResource
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/authorization.v2.GetDecisionMultiResourceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/authorization.v2.GetDecisionMultiResourceResponse'
   /authorization.v2.AuthorizationService/GetDecisionBulk:
     post:
       tags:
@@ -107,6 +72,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/authorization.v2.GetDecisionBulkResponse'
+  /authorization.v2.AuthorizationService/GetDecisionMultiResource:
+    post:
+      tags:
+        - authorization.v2.AuthorizationService
+      summary: GetDecisionMultiResource
+      operationId: authorization.v2.AuthorizationService.GetDecisionMultiResource
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/authorization.v2.GetDecisionMultiResourceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/authorization.v2.GetDecisionMultiResourceResponse'
   /authorization.v2.AuthorizationService/GetEntitlements:
     post:
       tags:
@@ -151,58 +151,6 @@ components:
         - DECISION_UNSPECIFIED
         - DECISION_DENY
         - DECISION_PERMIT
-    entity.Entity.Category:
-      type: string
-      title: Category
-      enum:
-        - CATEGORY_UNSPECIFIED
-        - CATEGORY_SUBJECT
-        - CATEGORY_ENVIRONMENT
-    policy.Action.StandardAction:
-      type: string
-      title: StandardAction
-      enum:
-        - STANDARD_ACTION_UNSPECIFIED
-        - STANDARD_ACTION_DECRYPT
-        - STANDARD_ACTION_TRANSMIT
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
     authorization.v2.EntityEntitlements:
       type: object
       properties:
@@ -243,21 +191,19 @@ components:
     authorization.v2.EntityIdentifier:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             entityChain:
               title: entity_chain
-              description: |+
+              description: |
                 chain of one or more entities and at most 10
-                entities must be provided and between 1 and 10 in count:
-                ```
-                has(this.entities) && this.entities.size() > 0 && this.entities.size() <= 10
-                ```
-
+                entity_chain_required // entities must be provided and between 1 and 10 in count
               $ref: '#/components/schemas/entity.EntityChain'
           title: entity_chain
           required:
             - entityChain
-        - properties:
+        - type: object
+          properties:
             registeredResourceValueFqn:
               type: string
               title: registered_resource_value_fqn
@@ -269,30 +215,24 @@ components:
           title: registered_resource_value_fqn
           required:
             - registeredResourceValueFqn
-        - properties:
+        - type: object
+          properties:
             token:
               title: token
-              description: |+
+              description: |
                 access token (JWT), which is used to create an entity chain (comprising one or more entities)
-                token must be provided:
-                ```
-                has(this.jwt) && this.jwt.size() > 0
-                ```
-
+                token_required // token must be provided
               $ref: '#/components/schemas/entity.Token'
           title: token
           required:
             - token
-        - properties:
+        - type: object
+          properties:
             withRequestToken:
               title: with_request_token
-              description: |+
+              description: |
                 derive the entity from the request's authorization access token JWT, rather than passing in the body
-                with_request_token must be true when set:
-                ```
-                this == true
-                ```
-
+                with_request_token_must_be_true // with_request_token must be true when set
               $ref: '#/components/schemas/google.protobuf.BoolValue'
           title: with_request_token
           required:
@@ -352,27 +292,19 @@ components:
           type: array
           items:
             type: string
-            description: |+
-              if provided, fulfillable_obligation_fqns must be between 1 and 50 in count with all valid FQNs:
-              ```
-              this.size() == 0 || (this.size() <= 50 && this.all(item, item.isUri()))
-              ```
-
+            description: |
+              obligation_value_fqns_valid // if provided, fulfillable_obligation_fqns must be between 1 and 50 in count with all valid FQNs
           title: fulfillable_obligation_fqns
-          description: |+
+          description: |
             obligations (fully qualified values) the requester is capable of fulfilling
              i.e. https://<namespace>/obl/<definition name>/value/<value>
-            if provided, fulfillable_obligation_fqns must be between 1 and 50 in count with all valid FQNs:
-            ```
-            this.size() == 0 || (this.size() <= 50 && this.all(item, item.isUri()))
-            ```
-
+            obligation_value_fqns_valid // if provided, fulfillable_obligation_fqns must be between 1 and 50 in count with all valid FQNs
       title: GetDecisionMultiResourceRequest
       required:
         - entityIdentifier
         - action
       additionalProperties: false
-      description: |+
+      description: |
         Can the identified entity/entities access?
          1. one entity reference (actor)
          2. one action
@@ -381,11 +313,7 @@ components:
          If entitled, checks obligation policy: fulfillable obligations must satisfy all triggered.
 
          Note: this is a more performant bulk request for multiple resource decisions, up to 1000 per request
-        action.name must be provided:
-        ```
-        has(this.action.name)
-        ```
-
+        get_decision_multi_request.action_name_required // action.name must be provided
     authorization.v2.GetDecisionMultiResourceResponse:
       type: object
       properties:
@@ -419,39 +347,27 @@ components:
           type: array
           items:
             type: string
-            description: |+
-              if provided, fulfillable_obligation_fqns must be between 1 and 50 in count with all valid FQNs:
-              ```
-              this.size() == 0 || (this.size() <= 50 && this.all(item, item.isUri()))
-              ```
-
+            description: |
+              obligation_value_fqns_valid // if provided, fulfillable_obligation_fqns must be between 1 and 50 in count with all valid FQNs
           title: fulfillable_obligation_fqns
-          description: |+
+          description: |
             obligations (fully qualified values) the requester is capable of fulfilling
              i.e. https://<namespace>/obl/<definition name>/value/<value>
-            if provided, fulfillable_obligation_fqns must be between 1 and 50 in count with all valid FQNs:
-            ```
-            this.size() == 0 || (this.size() <= 50 && this.all(item, item.isUri()))
-            ```
-
+            obligation_value_fqns_valid // if provided, fulfillable_obligation_fqns must be between 1 and 50 in count with all valid FQNs
       title: GetDecisionRequest
       required:
         - entityIdentifier
         - action
         - resource
       additionalProperties: false
-      description: |+
+      description: |
         Can the identified entity/entities access?
          1. one entity reference (actor)
          2. one action
          3. one resource
 
          If entitled, checks obligation policy: fulfillable obligations must satisfy all triggered.
-        action.name must be provided:
-        ```
-        has(this.action.name)
-        ```
-
+        get_decision_request.action_name_required // action.name must be provided
     authorization.v2.GetDecisionResponse:
       type: object
       properties:
@@ -469,12 +385,13 @@ components:
           description: an entity must be identified for entitlement decisioning
           $ref: '#/components/schemas/authorization.v2.EntityIdentifier'
         withComprehensiveHierarchy:
-          type: boolean
+          type:
+            - boolean
+            - "null"
           title: with_comprehensive_hierarchy
           description: |-
             optional parameter to return all entitled values for attribute definitions with hierarchy rules, propagating
              down the hierarchical values instead of returning solely the value that is directly entitled
-          nullable: true
       title: GetEntitlementsRequest
       required:
         - entityIdentifier
@@ -496,36 +413,35 @@ components:
       additionalProperties: false
     authorization.v2.Resource:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            attributeValues:
-              title: attribute_values
-              description: |+
-                a set of attribute value FQNs, such as those on a TDF, between 1 and 20 in count
-                if provided, resource.attribute_values must be between 1 and 20 in count with all valid FQNs:
-                ```
-                this.fqns.size() > 0 && this.fqns.size() <= 20 && this.fqns.all(item, item.isUri())
-                ```
-
-              $ref: '#/components/schemas/authorization.v2.Resource.AttributeValues'
-          title: attribute_values
-          required:
-            - attributeValues
-        - properties:
-            registeredResourceValueFqn:
+            ephemeralId:
               type: string
+              title: ephemeral_id
+              description: ephemeral id for tracking between request and response
+        - oneOf:
+            - type: object
+              properties:
+                attributeValues:
+                  title: attribute_values
+                  description: |
+                    a set of attribute value FQNs, such as those on a TDF, between 1 and 20 in count
+                    attribute_values_required // if provided, resource.attribute_values must be between 1 and 20 in count with all valid FQNs
+                  $ref: '#/components/schemas/authorization.v2.Resource.AttributeValues'
+              title: attribute_values
+              required:
+                - attributeValues
+            - type: object
+              properties:
+                registeredResourceValueFqn:
+                  type: string
+                  title: registered_resource_value_fqn
+                  minLength: 1
+                  format: uri
+                  description: fully qualified name of the registered resource value stored in platform policy
               title: registered_resource_value_fqn
-              minLength: 1
-              format: uri
-              description: fully qualified name of the registered resource value stored in platform policy
-          title: registered_resource_value_fqn
-          required:
-            - registeredResourceValueFqn
-      properties:
-        ephemeralId:
-          type: string
-          title: ephemeral_id
-          description: ephemeral id for tracking between request and response
+              required:
+                - registeredResourceValueFqn
       title: Resource
       additionalProperties: false
       description: Either a set of attribute values (such as those on a TDF) or a registered resource value
@@ -592,49 +508,130 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     entity.Entity:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            claims:
+            ephemeralId:
+              type: string
+              title: ephemeral_id
+              description: ephemeral id for tracking between request and response
+            category:
+              title: category
+              $ref: '#/components/schemas/entity.Entity.Category'
+        - oneOf:
+            - type: object
+              properties:
+                claims:
+                  title: claims
+                  description: used by ERS claims mode
+                  $ref: '#/components/schemas/google.protobuf.Any'
               title: claims
-              description: used by ERS claims mode
-              $ref: '#/components/schemas/google.protobuf.Any'
-          title: claims
-          required:
-            - claims
-        - properties:
-            clientId:
-              type: string
+              required:
+                - claims
+            - type: object
+              properties:
+                clientId:
+                  type: string
+                  title: client_id
               title: client_id
-          title: client_id
-          required:
-            - clientId
-        - properties:
-            emailAddress:
-              type: string
+              required:
+                - clientId
+            - type: object
+              properties:
+                emailAddress:
+                  type: string
+                  title: email_address
               title: email_address
-          title: email_address
-          required:
-            - emailAddress
-        - properties:
-            userName:
-              type: string
+              required:
+                - emailAddress
+            - type: object
+              properties:
+                userName:
+                  type: string
+                  title: user_name
               title: user_name
-          title: user_name
-          required:
-            - userName
-      properties:
-        ephemeralId:
-          type: string
-          title: ephemeral_id
-          description: ephemeral id for tracking between request and response
-        category:
-          title: category
-          $ref: '#/components/schemas/entity.Entity.Category'
+              required:
+                - userName
       title: Entity
       additionalProperties: false
       description: PE (Person Entity) or NPE (Non-Person Entity)
+    entity.Entity.Category:
+      type: string
+      title: Category
+      enum:
+        - CATEGORY_UNSPECIFIED
+        - CATEGORY_SUBJECT
+        - CATEGORY_ENVIRONMENT
     entity.EntityChain:
       type: object
       properties:
@@ -673,9 +670,6 @@ components:
         value:
           type: string
           format: binary
-        debug:
-          type: object
-          additionalProperties: true
       additionalProperties: true
       description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
     google.protobuf.BoolValue:
@@ -690,8 +684,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -785,41 +779,65 @@ components:
          ) to obtain a formatter capable of generating timestamps in this format.
     policy.Action:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            custom:
+            id:
               type: string
+              title: id
+              description: Generated uuid in database
+            name:
+              type: string
+              title: name
+            namespace:
+              title: namespace
+              description: Namespace context for this action
+              $ref: '#/components/schemas/policy.Namespace'
+            metadata:
+              title: metadata
+              $ref: '#/components/schemas/common.Metadata'
+        - oneOf:
+            - type: object
+              properties:
+                custom:
+                  type: string
+                  title: custom
+                  description: Deprecated
               title: custom
-              description: Deprecated
-          title: custom
-          required:
-            - custom
-        - properties:
-            standard:
+              required:
+                - custom
+            - type: object
+              properties:
+                standard:
+                  title: standard
+                  description: Deprecated
+                  $ref: '#/components/schemas/policy.Action.StandardAction'
               title: standard
-              description: Deprecated
-              $ref: '#/components/schemas/policy.Action.StandardAction'
-          title: standard
-          required:
-            - standard
-      properties:
-        id:
-          type: string
-          title: id
-          description: Generated uuid in database
-        name:
-          type: string
-          title: name
-        namespace:
-          title: namespace
-          description: Namespace context for this action
-          $ref: '#/components/schemas/policy.Namespace'
-        metadata:
-          title: metadata
-          $ref: '#/components/schemas/common.Metadata'
+              required:
+                - standard
       title: Action
       additionalProperties: false
       description: An action an entity can take
+    policy.Action.StandardAction:
+      type: string
+      title: StandardAction
+      enum:
+        - STANDARD_ACTION_UNSPECIFIED
+        - STANDARD_ACTION_DECRYPT
+        - STANDARD_ACTION_TRANSMIT
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.KasPublicKey:
       type: object
       properties:
@@ -838,7 +856,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -850,6 +868,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -872,13 +903,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -946,7 +973,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -954,17 +982,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -1002,50 +1027,17 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
+    policy.SourceType:
+      type: string
+      title: SourceType
       enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
 security: []
 tags:
   - name: authorization.v2.AuthorizationService

--- a/docs/openapi/common/common.openapi.yaml
+++ b/docs/openapi/common/common.openapi.yaml
@@ -13,15 +13,14 @@ components:
         - ACTIVE_STATE_ENUM_INACTIVE
         - ACTIVE_STATE_ENUM_ANY
       description: 'buflint ENUM_VALUE_PREFIX: to make sure that C++ scoping rules aren''t violated when users add new enum values to an enum in a given package'
-    common.MetadataUpdateEnum:
-      type: string
-      title: MetadataUpdateEnum
-      enum:
-        - METADATA_UPDATE_ENUM_UNSPECIFIED
-        - METADATA_UPDATE_ENUM_EXTEND
-        - METADATA_UPDATE_ENUM_REPLACE
     common.IdFqnIdentifier:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - id
+            - required:
+                - fqn
       properties:
         id:
           type: string
@@ -36,6 +35,12 @@ components:
       additionalProperties: false
     common.IdNameIdentifier:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - id
+            - required:
+                - name
       properties:
         id:
           type: string
@@ -46,12 +51,8 @@ components:
           title: name
           maxLength: 253
           minLength: 1
-          description: |+
-            Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+          description: |
+            name_format // Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.
       title: IdNameIdentifier
       additionalProperties: false
     common.Metadata:
@@ -109,11 +110,18 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    common.MetadataUpdateEnum:
+      type: string
+      title: MetadataUpdateEnum
+      enum:
+        - METADATA_UPDATE_ENUM_UNSPECIFIED
+        - METADATA_UPDATE_ENUM_EXTEND
+        - METADATA_UPDATE_ENUM_REPLACE
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local

--- a/docs/openapi/entity/entity.openapi.yaml
+++ b/docs/openapi/entity/entity.openapi.yaml
@@ -4,6 +4,54 @@ info:
 paths: {}
 components:
   schemas:
+    entity.Entity:
+      type: object
+      allOf:
+        - properties:
+            ephemeralId:
+              type: string
+              title: ephemeral_id
+              description: ephemeral id for tracking between request and response
+            category:
+              title: category
+              $ref: '#/components/schemas/entity.Entity.Category'
+        - oneOf:
+            - type: object
+              properties:
+                claims:
+                  title: claims
+                  description: used by ERS claims mode
+                  $ref: '#/components/schemas/google.protobuf.Any'
+              title: claims
+              required:
+                - claims
+            - type: object
+              properties:
+                clientId:
+                  type: string
+                  title: client_id
+              title: client_id
+              required:
+                - clientId
+            - type: object
+              properties:
+                emailAddress:
+                  type: string
+                  title: email_address
+              title: email_address
+              required:
+                - emailAddress
+            - type: object
+              properties:
+                userName:
+                  type: string
+                  title: user_name
+              title: user_name
+              required:
+                - userName
+      title: Entity
+      additionalProperties: false
+      description: PE (Person Entity) or NPE (Non-Person Entity)
     entity.Entity.Category:
       type: string
       title: Category
@@ -11,49 +59,6 @@ components:
         - CATEGORY_UNSPECIFIED
         - CATEGORY_SUBJECT
         - CATEGORY_ENVIRONMENT
-    entity.Entity:
-      type: object
-      oneOf:
-        - properties:
-            claims:
-              title: claims
-              description: used by ERS claims mode
-              $ref: '#/components/schemas/google.protobuf.Any'
-          title: claims
-          required:
-            - claims
-        - properties:
-            clientId:
-              type: string
-              title: client_id
-          title: client_id
-          required:
-            - clientId
-        - properties:
-            emailAddress:
-              type: string
-              title: email_address
-          title: email_address
-          required:
-            - emailAddress
-        - properties:
-            userName:
-              type: string
-              title: user_name
-          title: user_name
-          required:
-            - userName
-      properties:
-        ephemeralId:
-          type: string
-          title: ephemeral_id
-          description: ephemeral id for tracking between request and response
-        category:
-          title: category
-          $ref: '#/components/schemas/entity.Entity.Category'
-      title: Entity
-      additionalProperties: false
-      description: PE (Person Entity) or NPE (Non-Person Entity)
     entity.EntityChain:
       type: object
       properties:
@@ -92,9 +97,6 @@ components:
         value:
           type: string
           format: binary
-        debug:
-          type: object
-          additionalProperties: true
       additionalProperties: true
       description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []

--- a/docs/openapi/entityresolution/entity_resolution.openapi.yaml
+++ b/docs/openapi/entityresolution/entity_resolution.openapi.yaml
@@ -2,42 +2,6 @@ openapi: 3.1.0
 info:
   title: entityresolution
 paths:
-  /entityresolution.EntityResolutionService/ResolveEntities:
-    post:
-      tags:
-        - entityresolution.EntityResolutionService
-      summary: ResolveEntities
-      description: 'Deprecated: use v2 ResolveEntities instead'
-      operationId: entityresolution.EntityResolutionService.ResolveEntities
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/entityresolution.ResolveEntitiesRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/entityresolution.ResolveEntitiesResponse'
   /entityresolution.EntityResolutionService/CreateEntityChainFromJwt:
     post:
       tags:
@@ -74,8 +38,116 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/entityresolution.CreateEntityChainFromJwtResponse'
+  /entityresolution.EntityResolutionService/ResolveEntities:
+    post:
+      tags:
+        - entityresolution.EntityResolutionService
+      summary: ResolveEntities
+      description: 'Deprecated: use v2 ResolveEntities instead'
+      operationId: entityresolution.EntityResolutionService.ResolveEntities
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/entityresolution.ResolveEntitiesRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/entityresolution.ResolveEntitiesResponse'
 components:
   schemas:
+    authorization.Entity:
+      type: object
+      allOf:
+        - properties:
+            id:
+              type: string
+              title: id
+              description: ephemeral id for tracking between request and response
+            category:
+              title: category
+              $ref: '#/components/schemas/authorization.Entity.Category'
+        - oneOf:
+            - type: object
+              properties:
+                claims:
+                  title: claims
+                  $ref: '#/components/schemas/google.protobuf.Any'
+              title: claims
+              required:
+                - claims
+            - type: object
+              properties:
+                clientId:
+                  type: string
+                  title: client_id
+              title: client_id
+              required:
+                - clientId
+            - type: object
+              properties:
+                custom:
+                  title: custom
+                  $ref: '#/components/schemas/authorization.EntityCustom'
+              title: custom
+              required:
+                - custom
+            - type: object
+              properties:
+                emailAddress:
+                  type: string
+                  title: email_address
+                  description: one of the entity options must be set
+              title: email_address
+              required:
+                - emailAddress
+            - type: object
+              properties:
+                remoteClaimsUrl:
+                  type: string
+                  title: remote_claims_url
+              title: remote_claims_url
+              required:
+                - remoteClaimsUrl
+            - type: object
+              properties:
+                userName:
+                  type: string
+                  title: user_name
+              title: user_name
+              required:
+                - userName
+            - type: object
+              properties:
+                uuid:
+                  type: string
+                  title: uuid
+              title: uuid
+              required:
+                - uuid
+      title: Entity
+      additionalProperties: false
+      description: PE (Person Entity) or NPE (Non-Person Entity)
     authorization.Entity.Category:
       type: string
       title: Category
@@ -83,80 +155,6 @@ components:
         - CATEGORY_UNSPECIFIED
         - CATEGORY_SUBJECT
         - CATEGORY_ENVIRONMENT
-    google.protobuf.NullValue:
-      type: string
-      title: NullValue
-      enum:
-        - NULL_VALUE
-      description: |-
-        `NullValue` is a singleton enumeration to represent the null value for the
-         `Value` type union.
-
-         The JSON representation for `NullValue` is JSON `null`.
-    authorization.Entity:
-      type: object
-      oneOf:
-        - properties:
-            claims:
-              title: claims
-              $ref: '#/components/schemas/google.protobuf.Any'
-          title: claims
-          required:
-            - claims
-        - properties:
-            clientId:
-              type: string
-              title: client_id
-          title: client_id
-          required:
-            - clientId
-        - properties:
-            custom:
-              title: custom
-              $ref: '#/components/schemas/authorization.EntityCustom'
-          title: custom
-          required:
-            - custom
-        - properties:
-            emailAddress:
-              type: string
-              title: email_address
-              description: one of the entity options must be set
-          title: email_address
-          required:
-            - emailAddress
-        - properties:
-            remoteClaimsUrl:
-              type: string
-              title: remote_claims_url
-          title: remote_claims_url
-          required:
-            - remoteClaimsUrl
-        - properties:
-            userName:
-              type: string
-              title: user_name
-          title: user_name
-          required:
-            - userName
-        - properties:
-            uuid:
-              type: string
-              title: uuid
-          title: uuid
-          required:
-            - uuid
-      properties:
-        id:
-          type: string
-          title: id
-          description: ephemeral id for tracking between request and response
-        category:
-          title: category
-          $ref: '#/components/schemas/authorization.Entity.Category'
-      title: Entity
-      additionalProperties: false
-      description: PE (Person Entity) or NPE (Non-Person Entity)
     authorization.EntityChain:
       type: object
       properties:
@@ -194,6 +192,75 @@ components:
           description: the token
       title: Token
       additionalProperties: false
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     entityresolution.CreateEntityChainFromJwtRequest:
       type: object
       properties:
@@ -335,9 +402,6 @@ components:
         value:
           type: string
           format: binary
-        debug:
-          type: object
-          additionalProperties: true
       additionalProperties: true
       description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
     google.protobuf.ListValue:
@@ -355,6 +419,16 @@ components:
         `ListValue` is a wrapper around a repeated field of values.
 
          The JSON representation for `ListValue` is JSON array.
+    google.protobuf.NullValue:
+      type: string
+      title: NullValue
+      enum:
+        - NULL_VALUE
+      description: |-
+        `NullValue` is a singleton enumeration to represent the null value for the
+         `Value` type union.
+
+         The JSON representation for `NullValue` is JSON `null`.
     google.protobuf.Struct:
       type: object
       additionalProperties:
@@ -395,50 +469,6 @@ components:
          variants. Absence of any variant indicates an error.
 
          The JSON representation for `Value` is JSON value.
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
 security: []
 tags:
   - name: entityresolution.EntityResolutionService

--- a/docs/openapi/entityresolution/v2/entity_resolution.openapi.yaml
+++ b/docs/openapi/entityresolution/v2/entity_resolution.openapi.yaml
@@ -2,41 +2,6 @@ openapi: 3.1.0
 info:
   title: entityresolution.v2
 paths:
-  /entityresolution.v2.EntityResolutionService/ResolveEntities:
-    post:
-      tags:
-        - entityresolution.v2.EntityResolutionService
-      summary: ResolveEntities
-      operationId: entityresolution.v2.EntityResolutionService.ResolveEntities
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/entityresolution.v2.ResolveEntitiesRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/entityresolution.v2.ResolveEntitiesResponse'
   /entityresolution.v2.EntityResolutionService/CreateEntityChainsFromTokens:
     post:
       tags:
@@ -72,57 +37,74 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/entityresolution.v2.CreateEntityChainsFromTokensResponse'
+  /entityresolution.v2.EntityResolutionService/ResolveEntities:
+    post:
+      tags:
+        - entityresolution.v2.EntityResolutionService
+      summary: ResolveEntities
+      operationId: entityresolution.v2.EntityResolutionService.ResolveEntities
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/entityresolution.v2.ResolveEntitiesRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/entityresolution.v2.ResolveEntitiesResponse'
 components:
   schemas:
-    entity.Entity.Category:
-      type: string
-      title: Category
-      enum:
-        - CATEGORY_UNSPECIFIED
-        - CATEGORY_SUBJECT
-        - CATEGORY_ENVIRONMENT
-    google.protobuf.NullValue:
-      type: string
-      title: NullValue
-      enum:
-        - NULL_VALUE
-      description: |-
-        `NullValue` is a singleton enumeration to represent the null value for the
-         `Value` type union.
-
-         The JSON representation for `NullValue` is JSON `null`.
     authorization.v2.Resource:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            attributeValues:
-              title: attribute_values
-              description: |+
-                a set of attribute value FQNs, such as those on a TDF, between 1 and 20 in count
-                if provided, resource.attribute_values must be between 1 and 20 in count with all valid FQNs:
-                ```
-                this.fqns.size() > 0 && this.fqns.size() <= 20 && this.fqns.all(item, item.isUri())
-                ```
-
-              $ref: '#/components/schemas/authorization.v2.Resource.AttributeValues'
-          title: attribute_values
-          required:
-            - attributeValues
-        - properties:
-            registeredResourceValueFqn:
+            ephemeralId:
               type: string
+              title: ephemeral_id
+              description: ephemeral id for tracking between request and response
+        - oneOf:
+            - type: object
+              properties:
+                attributeValues:
+                  title: attribute_values
+                  description: |
+                    a set of attribute value FQNs, such as those on a TDF, between 1 and 20 in count
+                    attribute_values_required // if provided, resource.attribute_values must be between 1 and 20 in count with all valid FQNs
+                  $ref: '#/components/schemas/authorization.v2.Resource.AttributeValues'
+              title: attribute_values
+              required:
+                - attributeValues
+            - type: object
+              properties:
+                registeredResourceValueFqn:
+                  type: string
+                  title: registered_resource_value_fqn
+                  minLength: 1
+                  format: uri
+                  description: fully qualified name of the registered resource value stored in platform policy
               title: registered_resource_value_fqn
-              minLength: 1
-              format: uri
-              description: fully qualified name of the registered resource value stored in platform policy
-          title: registered_resource_value_fqn
-          required:
-            - registeredResourceValueFqn
-      properties:
-        ephemeralId:
-          type: string
-          title: ephemeral_id
-          description: ephemeral id for tracking between request and response
+              required:
+                - registeredResourceValueFqn
       title: Resource
       additionalProperties: false
       description: Either a set of attribute values (such as those on a TDF) or a registered resource value
@@ -136,49 +118,130 @@ components:
           title: fqns
       title: AttributeValues
       additionalProperties: false
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     entity.Entity:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            claims:
+            ephemeralId:
+              type: string
+              title: ephemeral_id
+              description: ephemeral id for tracking between request and response
+            category:
+              title: category
+              $ref: '#/components/schemas/entity.Entity.Category'
+        - oneOf:
+            - type: object
+              properties:
+                claims:
+                  title: claims
+                  description: used by ERS claims mode
+                  $ref: '#/components/schemas/google.protobuf.Any'
               title: claims
-              description: used by ERS claims mode
-              $ref: '#/components/schemas/google.protobuf.Any'
-          title: claims
-          required:
-            - claims
-        - properties:
-            clientId:
-              type: string
+              required:
+                - claims
+            - type: object
+              properties:
+                clientId:
+                  type: string
+                  title: client_id
               title: client_id
-          title: client_id
-          required:
-            - clientId
-        - properties:
-            emailAddress:
-              type: string
+              required:
+                - clientId
+            - type: object
+              properties:
+                emailAddress:
+                  type: string
+                  title: email_address
               title: email_address
-          title: email_address
-          required:
-            - emailAddress
-        - properties:
-            userName:
-              type: string
+              required:
+                - emailAddress
+            - type: object
+              properties:
+                userName:
+                  type: string
+                  title: user_name
               title: user_name
-          title: user_name
-          required:
-            - userName
-      properties:
-        ephemeralId:
-          type: string
-          title: ephemeral_id
-          description: ephemeral id for tracking between request and response
-        category:
-          title: category
-          $ref: '#/components/schemas/entity.Entity.Category'
+              required:
+                - userName
       title: Entity
       additionalProperties: false
       description: PE (Person Entity) or NPE (Non-Person Entity)
+    entity.Entity.Category:
+      type: string
+      title: Category
+      enum:
+        - CATEGORY_UNSPECIFIED
+        - CATEGORY_SUBJECT
+        - CATEGORY_ENVIRONMENT
     entity.EntityChain:
       type: object
       properties:
@@ -322,9 +385,6 @@ components:
         value:
           type: string
           format: binary
-        debug:
-          type: object
-          additionalProperties: true
       additionalProperties: true
       description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
     google.protobuf.ListValue:
@@ -342,6 +402,16 @@ components:
         `ListValue` is a wrapper around a repeated field of values.
 
          The JSON representation for `ListValue` is JSON array.
+    google.protobuf.NullValue:
+      type: string
+      title: NullValue
+      enum:
+        - NULL_VALUE
+      description: |-
+        `NullValue` is a singleton enumeration to represent the null value for the
+         `Value` type union.
+
+         The JSON representation for `NullValue` is JSON `null`.
     google.protobuf.Struct:
       type: object
       additionalProperties:
@@ -382,50 +452,6 @@ components:
          variants. Absence of any variant indicates an error.
 
          The JSON representation for `Value` is JSON value.
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
 security: []
 tags:
   - name: entityresolution.v2.EntityResolutionService

--- a/docs/openapi/kas/kas.openapi.yaml
+++ b/docs/openapi/kas/kas.openapi.yaml
@@ -2,6 +2,46 @@ openapi: 3.1.0
 info:
   title: kas
 paths:
+  /kas.AccessService/LegacyPublicKey:
+    post:
+      tags:
+        - kas.AccessService
+      summary: Endpoint intended for gRPC Gateway's REST endpoint to provide v1 compatibility with older TDF clients
+      description: |-
+        This endpoint is not recommended for use in new applications, prefer the v2 endpoint ('PublicKey') instead.
+
+         buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+      operationId: kas.AccessService.LegacyPublicKey
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/kas.LegacyPublicKeyRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/google.protobuf.StringValue'
+      deprecated: true
   /kas.AccessService/PublicKey:
     post:
       tags:
@@ -37,48 +77,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/kas.PublicKeyResponse'
-  /kas.AccessService/LegacyPublicKey:
-    post:
-      tags:
-        - kas.AccessService
-      summary: LegacyPublicKey
-      description: |-
-        Endpoint intended for gRPC Gateway's REST endpoint to provide v1 compatibility with older TDF clients
-
-         This endpoint is not recommended for use in new applications, prefer the v2 endpoint ('PublicKey') instead.
-
-         buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
-      operationId: kas.AccessService.LegacyPublicKey
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/kas.LegacyPublicKeyRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/google.protobuf.StringValue'
-      deprecated: true
   /kas.AccessService/Rewrap:
     post:
       tags:
@@ -116,16 +114,75 @@ paths:
                 $ref: '#/components/schemas/kas.RewrapResponse'
 components:
   schemas:
-    google.protobuf.NullValue:
-      type: string
-      title: NullValue
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
       enum:
-        - NULL_VALUE
-      description: |-
-        `NullValue` is a singleton enumeration to represent the null value for the
-         `Value` type union.
-
-         The JSON representation for `NullValue` is JSON `null`.
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.ListValue:
       type: object
       properties:
@@ -141,6 +198,16 @@ components:
         `ListValue` is a wrapper around a repeated field of values.
 
          The JSON representation for `ListValue` is JSON array.
+    google.protobuf.NullValue:
+      type: string
+      title: NullValue
+      enum:
+        - NULL_VALUE
+      description: |-
+        `NullValue` is a singleton enumeration to represent the null value for the
+         `Value` type union.
+
+         The JSON representation for `NullValue` is JSON `null`.
     google.protobuf.StringValue:
       type: string
       description: |-
@@ -290,54 +357,57 @@ components:
       description: Key Access Object containing cryptographic material and metadata for TDF decryption
     kas.KeyAccessRewrapResult:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            error:
+            metadata:
+              type: object
+              title: metadata
+              additionalProperties:
+                title: value
+                $ref: '#/components/schemas/google.protobuf.Value'
+              description: |-
+                Metadata associated with this KAO result (e.g., required obligations)
+                 Optional: May contain obligation requirements or other policy metadata
+                 Common keys: "X-Required-Obligations" with array of obligation FQNs
+            keyAccessObjectId:
               type: string
+              title: key_access_object_id
+              description: |-
+                Identifier matching the key_access_object_id from the request
+                 Required: Always matches the ID from UnsignedRewrapRequest_WithKeyAccessObject
+            status:
+              type: string
+              title: status
+              description: |-
+                Status of the rewrap operation for this KAO
+                 Required: Always
+                 Values: "permit" (success), "fail" (failure)
+        - oneOf:
+            - type: object
+              properties:
+                error:
+                  type: string
+                  title: error
+                  description: |-
+                    Error message when rewrap failed
+                     Present when status="fail"
+                     Human-readable description of the failure reason
               title: error
-              description: |-
-                Error message when rewrap failed
-                 Present when status="fail"
-                 Human-readable description of the failure reason
-          title: error
-          required:
-            - error
-        - properties:
-            kasWrappedKey:
-              type: string
+              required:
+                - error
+            - type: object
+              properties:
+                kasWrappedKey:
+                  type: string
+                  title: kas_wrapped_key
+                  format: byte
+                  description: |-
+                    Successfully rewrapped key encrypted with the session key
+                     Present when status="permit"
+                     Contains the DEK encrypted with the ephemeral session key
               title: kas_wrapped_key
-              format: byte
-              description: |-
-                Successfully rewrapped key encrypted with the session key
-                 Present when status="permit"
-                 Contains the DEK encrypted with the ephemeral session key
-          title: kas_wrapped_key
-          required:
-            - kasWrappedKey
-      properties:
-        metadata:
-          type: object
-          title: metadata
-          additionalProperties:
-            title: value
-            $ref: '#/components/schemas/google.protobuf.Value'
-          description: |-
-            Metadata associated with this KAO result (e.g., required obligations)
-             Optional: May contain obligation requirements or other policy metadata
-             Common keys: "X-Required-Obligations" with array of obligation FQNs
-        keyAccessObjectId:
-          type: string
-          title: key_access_object_id
-          description: |-
-            Identifier matching the key_access_object_id from the request
-             Required: Always matches the ID from UnsignedRewrapRequest_WithKeyAccessObject
-        status:
-          type: string
-          title: status
-          description: |-
-            Status of the rewrap operation for this KAO
-             Required: Always
-             Values: "permit" (success), "fail" (failure)
+              required:
+                - kasWrappedKey
       title: KeyAccessRewrapResult
       additionalProperties: false
       description: Result of a key access object rewrap operation
@@ -619,63 +689,6 @@ components:
       title: WithPolicyRequest
       additionalProperties: false
       description: Request grouping policy with associated key access objects
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: kas.AccessService

--- a/docs/openapi/policy/actions/actions.openapi.yaml
+++ b/docs/openapi/policy/actions/actions.openapi.yaml
@@ -2,6 +2,76 @@ openapi: 3.1.0
 info:
   title: policy.actions
 paths:
+  /policy.actions.ActionService/CreateAction:
+    post:
+      tags:
+        - policy.actions.ActionService
+      summary: CreateAction
+      operationId: policy.actions.ActionService.CreateAction
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.actions.CreateActionRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.actions.CreateActionResponse'
+  /policy.actions.ActionService/DeleteAction:
+    post:
+      tags:
+        - policy.actions.ActionService
+      summary: DeleteAction
+      operationId: policy.actions.ActionService.DeleteAction
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.actions.DeleteActionRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.actions.DeleteActionResponse'
   /policy.actions.ActionService/GetAction:
     post:
       tags:
@@ -72,41 +142,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.actions.ListActionsResponse'
-  /policy.actions.ActionService/CreateAction:
-    post:
-      tags:
-        - policy.actions.ActionService
-      summary: CreateAction
-      operationId: policy.actions.ActionService.CreateAction
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.actions.CreateActionRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.actions.CreateActionResponse'
   /policy.actions.ActionService/UpdateAction:
     post:
       tags:
@@ -142,118 +177,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.actions.UpdateActionResponse'
-  /policy.actions.ActionService/DeleteAction:
-    post:
-      tags:
-        - policy.actions.ActionService
-      summary: DeleteAction
-      operationId: policy.actions.ActionService.DeleteAction
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.actions.DeleteActionRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.actions.DeleteActionResponse'
 components:
   schemas:
-    common.MetadataUpdateEnum:
-      type: string
-      title: MetadataUpdateEnum
-      enum:
-        - METADATA_UPDATE_ENUM_UNSPECIFIED
-        - METADATA_UPDATE_ENUM_EXTEND
-        - METADATA_UPDATE_ENUM_REPLACE
-    policy.Action.StandardAction:
-      type: string
-      title: StandardAction
-      enum:
-        - STANDARD_ACTION_UNSPECIFIED
-        - STANDARD_ACTION_DECRYPT
-        - STANDARD_ACTION_TRANSMIT
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.AttributeRuleTypeEnum:
-      type: string
-      title: AttributeRuleTypeEnum
-      enum:
-        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
-        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
-    policy.ConditionBooleanTypeEnum:
-      type: string
-      title: ConditionBooleanTypeEnum
-      enum:
-        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
-        - CONDITION_BOOLEAN_TYPE_ENUM_AND
-        - CONDITION_BOOLEAN_TYPE_ENUM_OR
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
-    policy.SubjectMappingOperatorEnum:
-      type: string
-      title: SubjectMappingOperatorEnum
-      enum:
-        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     common.Metadata:
       type: object
       properties:
@@ -309,6 +234,82 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    common.MetadataUpdateEnum:
+      type: string
+      title: MetadataUpdateEnum
+      enum:
+        - METADATA_UPDATE_ENUM_UNSPECIFIED
+        - METADATA_UPDATE_ENUM_EXTEND
+        - METADATA_UPDATE_ENUM_REPLACE
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.BoolValue:
       type: boolean
       description: |-
@@ -321,8 +322,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -416,41 +417,65 @@ components:
          ) to obtain a formatter capable of generating timestamps in this format.
     policy.Action:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            custom:
+            id:
               type: string
+              title: id
+              description: Generated uuid in database
+            name:
+              type: string
+              title: name
+            namespace:
+              title: namespace
+              description: Namespace context for this action
+              $ref: '#/components/schemas/policy.Namespace'
+            metadata:
+              title: metadata
+              $ref: '#/components/schemas/common.Metadata'
+        - oneOf:
+            - type: object
+              properties:
+                custom:
+                  type: string
+                  title: custom
+                  description: Deprecated
               title: custom
-              description: Deprecated
-          title: custom
-          required:
-            - custom
-        - properties:
-            standard:
+              required:
+                - custom
+            - type: object
+              properties:
+                standard:
+                  title: standard
+                  description: Deprecated
+                  $ref: '#/components/schemas/policy.Action.StandardAction'
               title: standard
-              description: Deprecated
-              $ref: '#/components/schemas/policy.Action.StandardAction'
-          title: standard
-          required:
-            - standard
-      properties:
-        id:
-          type: string
-          title: id
-          description: Generated uuid in database
-        name:
-          type: string
-          title: name
-        namespace:
-          title: namespace
-          description: Namespace context for this action
-          $ref: '#/components/schemas/policy.Namespace'
-        metadata:
-          title: metadata
-          $ref: '#/components/schemas/common.Metadata'
+              required:
+                - standard
       title: Action
       additionalProperties: false
       description: An action an entity can take
+    policy.Action.StandardAction:
+      type: string
+      title: StandardAction
+      enum:
+        - STANDARD_ACTION_UNSPECIFIED
+        - STANDARD_ACTION_DECRYPT
+        - STANDARD_ACTION_TRANSMIT
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.Attribute:
       type: object
       properties:
@@ -507,6 +532,14 @@ components:
       required:
         - rule
       additionalProperties: false
+    policy.AttributeRuleTypeEnum:
+      type: string
+      title: AttributeRuleTypeEnum
+      enum:
+        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
+        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
     policy.Condition:
       type: object
       properties:
@@ -524,7 +557,6 @@ components:
           type: array
           items:
             type: string
-            minItems: 1
           title: subject_external_values
           minItems: 1
           description: |-
@@ -540,6 +572,13 @@ components:
         *
         A Condition defines a rule of <the value at the flattened 'selector value'
         location> <operator> <subject external values>
+    policy.ConditionBooleanTypeEnum:
+      type: string
+      title: ConditionBooleanTypeEnum
+      enum:
+        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
+        - CONDITION_BOOLEAN_TYPE_ENUM_AND
+        - CONDITION_BOOLEAN_TYPE_ENUM_OR
     policy.ConditionGroup:
       type: object
       properties:
@@ -576,7 +615,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -588,6 +627,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -610,13 +662,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -814,7 +862,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -822,17 +871,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -940,6 +986,17 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
+    policy.SourceType:
+      type: string
+      title: SourceType
+      enum:
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
     policy.SubjectConditionSet:
       type: object
       properties:
@@ -1005,6 +1062,14 @@ components:
       description: |-
         Subject Mapping: A Policy assigning Subject Set(s) to a permitted attribute
         value + action(s) combination
+    policy.SubjectMappingOperatorEnum:
+      type: string
+      title: SubjectMappingOperatorEnum
+      enum:
+        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     policy.SubjectSet:
       type: object
       properties:
@@ -1078,13 +1143,9 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Required
-            Action name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored action name will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+            action_name_format // Action name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored action name will be normalized to lower case.
         namespaceId:
           type: string
           title: namespace_id
@@ -1140,45 +1201,44 @@ components:
       additionalProperties: false
     policy.actions.GetActionRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            id:
+            namespaceId:
               type: string
-              title: id
+              title: namespace_id
               format: uuid
-          title: id
-          required:
-            - id
-        - properties:
-            name:
+              description: |-
+                Optional namespace ID to scope name-based lookup.
+                 If omitted for name-based lookup, action search is limited to legacy (namespace_id = NULL) actions.
+            namespaceFqn:
               type: string
+              title: namespace_fqn
+              minLength: 1
+              format: uri
+              description: |-
+                Optional namespace FQN to scope name-based lookup.
+                 If omitted for name-based lookup, action search is limited to legacy (namespace_id = NULL) actions.
+        - oneOf:
+            - type: object
+              properties:
+                id:
+                  type: string
+                  title: id
+                  format: uuid
+              title: id
+              required:
+                - id
+            - type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  maxLength: 253
+                  description: |
+                    action_name_format // Action name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored action name will be normalized to lower case.
               title: name
-              maxLength: 253
-              description: |+
-                Action name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored action name will be normalized to lower case.:
-                ```
-                this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-                ```
-
-          title: name
-          required:
-            - name
-      properties:
-        namespaceId:
-          type: string
-          title: namespace_id
-          format: uuid
-          description: |-
-            Optional namespace ID to scope name-based lookup.
-             If omitted for name-based lookup, action search is limited to legacy (namespace_id = NULL) actions.
-        namespaceFqn:
-          type: string
-          title: namespace_fqn
-          minLength: 1
-          format: uri
-          description: |-
-            Optional namespace FQN to scope name-based lookup.
-             If omitted for name-based lookup, action search is limited to legacy (namespace_id = NULL) actions.
+              required:
+                - name
       title: GetActionRequest
       additionalProperties: false
     policy.actions.GetActionResponse:
@@ -1245,14 +1305,10 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Optional
              Custom actions only: replaces the existing action name
-            Action name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored action name will be normalized to lower case.:
-            ```
-            size(this) == 0 || this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+            action_name_format // Action name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored action name will be normalized to lower case.
         metadata:
           title: metadata
           description: Common metadata
@@ -1273,63 +1329,6 @@ components:
           $ref: '#/components/schemas/policy.Action'
       title: UpdateActionResponse
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: policy.actions.ActionService

--- a/docs/openapi/policy/attributes/attributes.openapi.yaml
+++ b/docs/openapi/policy/attributes/attributes.openapi.yaml
@@ -2,16 +2,13 @@ openapi: 3.1.0
 info:
   title: policy.attributes
 paths:
-  /policy.attributes.AttributesService/ListAttributes:
+  /policy.attributes.AttributesService/AssignKeyAccessServerToAttribute:
     post:
       tags:
         - policy.attributes.AttributesService
-      summary: ListAttributes
-      description: |-
-        --------------------------------------*
-         Attribute RPCs
-        ---------------------------------------
-      operationId: policy.attributes.AttributesService.ListAttributes
+      summary: AssignKeyAccessServerToAttribute
+      description: 'Deprecated: utilize AssignPublicKeyToAttribute'
+      operationId: policy.attributes.AttributesService.AssignKeyAccessServerToAttribute
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -26,7 +23,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.ListAttributesRequest'
+              $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToAttributeRequest'
         required: true
       responses:
         default:
@@ -40,52 +37,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.ListAttributesResponse'
-  /policy.attributes.AttributesService/ListAttributeValues:
-    post:
-      tags:
-        - policy.attributes.AttributesService
-      summary: ListAttributeValues
-      description: |-
-        Deprecated
-         Use GetAttribute
-      operationId: policy.attributes.AttributesService.ListAttributeValues
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.attributes.ListAttributeValuesRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.ListAttributeValuesResponse'
+                $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToAttributeResponse'
       deprecated: true
-  /policy.attributes.AttributesService/GetAttribute:
+  /policy.attributes.AttributesService/AssignKeyAccessServerToValue:
     post:
       tags:
         - policy.attributes.AttributesService
-      summary: GetAttribute
-      operationId: policy.attributes.AttributesService.GetAttribute
+      summary: AssignKeyAccessServerToValue
+      description: 'Deprecated: utilize AssignPublicKeyToValue'
+      operationId: policy.attributes.AttributesService.AssignKeyAccessServerToValue
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -100,7 +60,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.GetAttributeRequest'
+              $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToValueRequest'
         required: true
       responses:
         default:
@@ -114,13 +74,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.GetAttributeResponse'
-  /policy.attributes.AttributesService/GetAttributeValuesByFqns:
+                $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToValueResponse'
+      deprecated: true
+  /policy.attributes.AttributesService/AssignPublicKeyToAttribute:
     post:
       tags:
         - policy.attributes.AttributesService
-      summary: GetAttributeValuesByFqns
-      operationId: policy.attributes.AttributesService.GetAttributeValuesByFqns
+      summary: AssignPublicKeyToAttribute
+      operationId: policy.attributes.AttributesService.AssignPublicKeyToAttribute
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -135,7 +96,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.GetAttributeValuesByFqnsRequest'
+              $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToAttributeRequest'
         required: true
       responses:
         default:
@@ -149,7 +110,42 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.GetAttributeValuesByFqnsResponse'
+                $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToAttributeResponse'
+  /policy.attributes.AttributesService/AssignPublicKeyToValue:
+    post:
+      tags:
+        - policy.attributes.AttributesService
+      summary: AssignPublicKeyToValue
+      operationId: policy.attributes.AttributesService.AssignPublicKeyToValue
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToValueRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToValueResponse'
   /policy.attributes.AttributesService/CreateAttribute:
     post:
       tags:
@@ -185,12 +181,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.attributes.CreateAttributeResponse'
-  /policy.attributes.AttributesService/UpdateAttribute:
+  /policy.attributes.AttributesService/CreateAttributeValue:
     post:
       tags:
         - policy.attributes.AttributesService
-      summary: UpdateAttribute
-      operationId: policy.attributes.AttributesService.UpdateAttribute
+      summary: CreateAttributeValue
+      operationId: policy.attributes.AttributesService.CreateAttributeValue
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -205,7 +201,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.UpdateAttributeRequest'
+              $ref: '#/components/schemas/policy.attributes.CreateAttributeValueRequest'
         required: true
       responses:
         default:
@@ -219,7 +215,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.UpdateAttributeResponse'
+                $ref: '#/components/schemas/policy.attributes.CreateAttributeValueResponse'
   /policy.attributes.AttributesService/DeactivateAttribute:
     post:
       tags:
@@ -255,6 +251,76 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.attributes.DeactivateAttributeResponse'
+  /policy.attributes.AttributesService/DeactivateAttributeValue:
+    post:
+      tags:
+        - policy.attributes.AttributesService
+      summary: DeactivateAttributeValue
+      operationId: policy.attributes.AttributesService.DeactivateAttributeValue
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.attributes.DeactivateAttributeValueRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.attributes.DeactivateAttributeValueResponse'
+  /policy.attributes.AttributesService/GetAttribute:
+    post:
+      tags:
+        - policy.attributes.AttributesService
+      summary: GetAttribute
+      operationId: policy.attributes.AttributesService.GetAttribute
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.attributes.GetAttributeRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.attributes.GetAttributeResponse'
   /policy.attributes.AttributesService/GetAttributeValue:
     post:
       tags:
@@ -294,12 +360,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.attributes.GetAttributeValueResponse'
-  /policy.attributes.AttributesService/CreateAttributeValue:
+  /policy.attributes.AttributesService/GetAttributeValuesByFqns:
     post:
       tags:
         - policy.attributes.AttributesService
-      summary: CreateAttributeValue
-      operationId: policy.attributes.AttributesService.CreateAttributeValue
+      summary: GetAttributeValuesByFqns
+      operationId: policy.attributes.AttributesService.GetAttributeValuesByFqns
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -314,7 +380,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.CreateAttributeValueRequest'
+              $ref: '#/components/schemas/policy.attributes.GetAttributeValuesByFqnsRequest'
         required: true
       responses:
         default:
@@ -328,13 +394,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.CreateAttributeValueResponse'
-  /policy.attributes.AttributesService/UpdateAttributeValue:
+                $ref: '#/components/schemas/policy.attributes.GetAttributeValuesByFqnsResponse'
+  /policy.attributes.AttributesService/ListAttributeValues:
     post:
       tags:
         - policy.attributes.AttributesService
-      summary: UpdateAttributeValue
-      operationId: policy.attributes.AttributesService.UpdateAttributeValue
+      summary: ListAttributeValues
+      description: |-
+        Deprecated
+         Use GetAttribute
+      operationId: policy.attributes.AttributesService.ListAttributeValues
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -349,7 +418,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.attributes.UpdateAttributeValueRequest'
+              $ref: '#/components/schemas/policy.attributes.ListAttributeValuesRequest'
         required: true
       responses:
         default:
@@ -363,79 +432,47 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.attributes.UpdateAttributeValueResponse'
-  /policy.attributes.AttributesService/DeactivateAttributeValue:
-    post:
-      tags:
-        - policy.attributes.AttributesService
-      summary: DeactivateAttributeValue
-      operationId: policy.attributes.AttributesService.DeactivateAttributeValue
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.attributes.DeactivateAttributeValueRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.DeactivateAttributeValueResponse'
-  /policy.attributes.AttributesService/AssignKeyAccessServerToAttribute:
-    post:
-      tags:
-        - policy.attributes.AttributesService
-      summary: AssignKeyAccessServerToAttribute
-      description: 'Deprecated: utilize AssignPublicKeyToAttribute'
-      operationId: policy.attributes.AttributesService.AssignKeyAccessServerToAttribute
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToAttributeRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToAttributeResponse'
+                $ref: '#/components/schemas/policy.attributes.ListAttributeValuesResponse'
       deprecated: true
+  /policy.attributes.AttributesService/ListAttributes:
+    post:
+      tags:
+        - policy.attributes.AttributesService
+      summary: ListAttributes
+      description: |-
+        --------------------------------------*
+         Attribute RPCs
+        ---------------------------------------
+      operationId: policy.attributes.AttributesService.ListAttributes
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.attributes.ListAttributesRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.attributes.ListAttributesResponse'
   /policy.attributes.AttributesService/RemoveKeyAccessServerFromAttribute:
     post:
       tags:
@@ -472,43 +509,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.attributes.RemoveKeyAccessServerFromAttributeResponse'
-      deprecated: true
-  /policy.attributes.AttributesService/AssignKeyAccessServerToValue:
-    post:
-      tags:
-        - policy.attributes.AttributesService
-      summary: AssignKeyAccessServerToValue
-      description: 'Deprecated: utilize AssignPublicKeyToValue'
-      operationId: policy.attributes.AttributesService.AssignKeyAccessServerToValue
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToValueRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.AssignKeyAccessServerToValueResponse'
       deprecated: true
   /policy.attributes.AttributesService/RemoveKeyAccessServerFromValue:
     post:
@@ -547,41 +547,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/policy.attributes.RemoveKeyAccessServerFromValueResponse'
       deprecated: true
-  /policy.attributes.AttributesService/AssignPublicKeyToAttribute:
-    post:
-      tags:
-        - policy.attributes.AttributesService
-      summary: AssignPublicKeyToAttribute
-      operationId: policy.attributes.AttributesService.AssignPublicKeyToAttribute
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToAttributeRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToAttributeResponse'
   /policy.attributes.AttributesService/RemovePublicKeyFromAttribute:
     post:
       tags:
@@ -617,41 +582,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.attributes.RemovePublicKeyFromAttributeResponse'
-  /policy.attributes.AttributesService/AssignPublicKeyToValue:
-    post:
-      tags:
-        - policy.attributes.AttributesService
-      summary: AssignPublicKeyToValue
-      operationId: policy.attributes.AttributesService.AssignPublicKeyToValue
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToValueRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.attributes.AssignPublicKeyToValueResponse'
   /policy.attributes.AttributesService/RemovePublicKeyFromValue:
     post:
       tags:
@@ -687,6 +617,76 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.attributes.RemovePublicKeyFromValueResponse'
+  /policy.attributes.AttributesService/UpdateAttribute:
+    post:
+      tags:
+        - policy.attributes.AttributesService
+      summary: UpdateAttribute
+      operationId: policy.attributes.AttributesService.UpdateAttribute
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.attributes.UpdateAttributeRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.attributes.UpdateAttributeResponse'
+  /policy.attributes.AttributesService/UpdateAttributeValue:
+    post:
+      tags:
+        - policy.attributes.AttributesService
+      summary: UpdateAttributeValue
+      operationId: policy.attributes.AttributesService.UpdateAttributeValue
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.attributes.UpdateAttributeValueRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.attributes.UpdateAttributeValueResponse'
 components:
   schemas:
     common.ActiveStateEnum:
@@ -698,103 +698,14 @@ components:
         - ACTIVE_STATE_ENUM_INACTIVE
         - ACTIVE_STATE_ENUM_ANY
       description: 'buflint ENUM_VALUE_PREFIX: to make sure that C++ scoping rules aren''t violated when users add new enum values to an enum in a given package'
-    common.MetadataUpdateEnum:
-      type: string
-      title: MetadataUpdateEnum
-      enum:
-        - METADATA_UPDATE_ENUM_UNSPECIFIED
-        - METADATA_UPDATE_ENUM_EXTEND
-        - METADATA_UPDATE_ENUM_REPLACE
-    policy.Action.StandardAction:
-      type: string
-      title: StandardAction
-      enum:
-        - STANDARD_ACTION_UNSPECIFIED
-        - STANDARD_ACTION_DECRYPT
-        - STANDARD_ACTION_TRANSMIT
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.AttributeRuleTypeEnum:
-      type: string
-      title: AttributeRuleTypeEnum
-      enum:
-        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
-        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
-    policy.ConditionBooleanTypeEnum:
-      type: string
-      title: ConditionBooleanTypeEnum
-      enum:
-        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
-        - CONDITION_BOOLEAN_TYPE_ENUM_AND
-        - CONDITION_BOOLEAN_TYPE_ENUM_OR
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.SortDirection:
-      type: string
-      title: SortDirection
-      enum:
-        - SORT_DIRECTION_UNSPECIFIED
-        - SORT_DIRECTION_ASC
-        - SORT_DIRECTION_DESC
-      description: |-
-        Sorting direction shared across list APIs.
-         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
-         the endpoint's request message defines the default ordering; see the
-         specific List* request docs.
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
-    policy.SubjectMappingOperatorEnum:
-      type: string
-      title: SubjectMappingOperatorEnum
-      enum:
-        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
-    policy.attributes.SortAttributesType:
-      type: string
-      title: SortAttributesType
-      enum:
-        - SORT_ATTRIBUTES_TYPE_UNSPECIFIED
-        - SORT_ATTRIBUTES_TYPE_NAME
-        - SORT_ATTRIBUTES_TYPE_CREATED_AT
-        - SORT_ATTRIBUTES_TYPE_UPDATED_AT
     common.IdFqnIdentifier:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - id
+            - required:
+                - fqn
       properties:
         id:
           type: string
@@ -809,6 +720,12 @@ components:
       additionalProperties: false
     common.IdNameIdentifier:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - id
+            - required:
+                - name
       properties:
         id:
           type: string
@@ -819,12 +736,8 @@ components:
           title: name
           maxLength: 253
           minLength: 1
-          description: |+
-            Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+          description: |
+            name_format // Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.
       title: IdNameIdentifier
       additionalProperties: false
     common.Metadata:
@@ -882,6 +795,82 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    common.MetadataUpdateEnum:
+      type: string
+      title: MetadataUpdateEnum
+      enum:
+        - METADATA_UPDATE_ENUM_UNSPECIFIED
+        - METADATA_UPDATE_ENUM_EXTEND
+        - METADATA_UPDATE_ENUM_REPLACE
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.BoolValue:
       type: boolean
       description: |-
@@ -894,8 +883,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -989,41 +978,65 @@ components:
          ) to obtain a formatter capable of generating timestamps in this format.
     policy.Action:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            custom:
+            id:
               type: string
+              title: id
+              description: Generated uuid in database
+            name:
+              type: string
+              title: name
+            namespace:
+              title: namespace
+              description: Namespace context for this action
+              $ref: '#/components/schemas/policy.Namespace'
+            metadata:
+              title: metadata
+              $ref: '#/components/schemas/common.Metadata'
+        - oneOf:
+            - type: object
+              properties:
+                custom:
+                  type: string
+                  title: custom
+                  description: Deprecated
               title: custom
-              description: Deprecated
-          title: custom
-          required:
-            - custom
-        - properties:
-            standard:
+              required:
+                - custom
+            - type: object
+              properties:
+                standard:
+                  title: standard
+                  description: Deprecated
+                  $ref: '#/components/schemas/policy.Action.StandardAction'
               title: standard
-              description: Deprecated
-              $ref: '#/components/schemas/policy.Action.StandardAction'
-          title: standard
-          required:
-            - standard
-      properties:
-        id:
-          type: string
-          title: id
-          description: Generated uuid in database
-        name:
-          type: string
-          title: name
-        namespace:
-          title: namespace
-          description: Namespace context for this action
-          $ref: '#/components/schemas/policy.Namespace'
-        metadata:
-          title: metadata
-          $ref: '#/components/schemas/common.Metadata'
+              required:
+                - standard
       title: Action
       additionalProperties: false
       description: An action an entity can take
+    policy.Action.StandardAction:
+      type: string
+      title: StandardAction
+      enum:
+        - STANDARD_ACTION_UNSPECIFIED
+        - STANDARD_ACTION_DECRYPT
+        - STANDARD_ACTION_TRANSMIT
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.Attribute:
       type: object
       properties:
@@ -1080,6 +1093,14 @@ components:
       required:
         - rule
       additionalProperties: false
+    policy.AttributeRuleTypeEnum:
+      type: string
+      title: AttributeRuleTypeEnum
+      enum:
+        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
+        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
     policy.Condition:
       type: object
       properties:
@@ -1097,7 +1118,6 @@ components:
           type: array
           items:
             type: string
-            minItems: 1
           title: subject_external_values
           minItems: 1
           description: |-
@@ -1113,6 +1133,13 @@ components:
         *
         A Condition defines a rule of <the value at the flattened 'selector value'
         location> <operator> <subject external values>
+    policy.ConditionBooleanTypeEnum:
+      type: string
+      title: ConditionBooleanTypeEnum
+      enum:
+        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
+        - CONDITION_BOOLEAN_TYPE_ENUM_AND
+        - CONDITION_BOOLEAN_TYPE_ENUM_OR
     policy.ConditionGroup:
       type: object
       properties:
@@ -1149,7 +1176,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -1161,6 +1188,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -1183,13 +1223,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -1387,7 +1423,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -1395,17 +1432,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -1513,6 +1547,29 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
+    policy.SortDirection:
+      type: string
+      title: SortDirection
+      enum:
+        - SORT_DIRECTION_UNSPECIFIED
+        - SORT_DIRECTION_ASC
+        - SORT_DIRECTION_DESC
+      description: |-
+        Sorting direction shared across list APIs.
+         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
+         the endpoint's request message defines the default ordering; see the
+         specific List* request docs.
+    policy.SourceType:
+      type: string
+      title: SourceType
+      enum:
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
     policy.SubjectConditionSet:
       type: object
       properties:
@@ -1578,6 +1635,14 @@ components:
       description: |-
         Subject Mapping: A Policy assigning Subject Set(s) to a permitted attribute
         value + action(s) combination
+    policy.SubjectMappingOperatorEnum:
+      type: string
+      title: SubjectMappingOperatorEnum
+      enum:
+        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     policy.SubjectSet:
       type: object
       properties:
@@ -1801,13 +1866,9 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Required
-            Attribute name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored attribute name will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+            attribute_name_format // Attribute name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored attribute name will be normalized to lower case.
         rule:
           title: rule
           description: Required
@@ -1818,7 +1879,6 @@ components:
             type: string
             maxLength: 253
             pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$
-            uniqueItems: true
           title: values
           uniqueItems: true
           description: |-
@@ -1864,13 +1924,9 @@ components:
           type: string
           title: value
           maxLength: 253
-          description: |+
+          description: |
             Required
-            Attribute value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored attribute value will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+            attribute_value_format // Attribute value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored attribute value will be normalized to lower case.
         obligationTriggers:
           type: array
           items:
@@ -1935,45 +1991,40 @@ components:
       additionalProperties: false
     policy.attributes.GetAttributeRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            attributeId:
+            id:
               type: string
-              title: attribute_id
+              title: id
               format: uuid
-              description: 'option (buf.validate.oneof).required = true; // TODO: enable this when we remove the deprecated field'
-          title: attribute_id
-          required:
-            - attributeId
-        - properties:
-            fqn:
-              type: string
+              description: 'Deprecated: utilize identifier'
+              deprecated: true
+        - oneOf:
+            - type: object
+              properties:
+                attributeId:
+                  type: string
+                  title: attribute_id
+                  format: uuid
+                  description: 'option (buf.validate.oneof).required = true; // TODO: enable this when we remove the deprecated field'
+              title: attribute_id
+              required:
+                - attributeId
+            - type: object
+              properties:
+                fqn:
+                  type: string
+                  title: fqn
+                  minLength: 1
+                  format: uri
               title: fqn
-              minLength: 1
-              format: uri
-          title: fqn
-          required:
-            - fqn
-      properties:
-        id:
-          type: string
-          title: id
-          format: uuid
-          description: 'Deprecated: utilize identifier'
-          deprecated: true
+              required:
+                - fqn
       title: GetAttributeRequest
       additionalProperties: false
-      description: |+
-        Either use deprecated 'id' field or one of 'attribute_id' or 'fqn', but not both:
-        ```
-        !(has(this.id) && (has(this.attribute_id) || has(this.fqn)))
-        ```
-
-        Either id or one of attribute_id or fqn must be set:
-        ```
-        has(this.id) || has(this.attribute_id) || has(this.fqn)
-        ```
-
+      description: |
+        exclusive_fields // Either use deprecated 'id' field or one of 'attribute_id' or 'fqn', but not both
+        required_fields // Either id or one of attribute_id or fqn must be set
     policy.attributes.GetAttributeResponse:
       type: object
       properties:
@@ -1984,48 +2035,43 @@ components:
       additionalProperties: false
     policy.attributes.GetAttributeValueRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            fqn:
+            id:
               type: string
-              title: fqn
-              minLength: 1
-              format: uri
-          title: fqn
-          required:
-            - fqn
-        - properties:
-            valueId:
-              type: string
-              title: value_id
+              title: id
               format: uuid
-              description: 'option (buf.validate.oneof).required = true; // TODO: enable this when we remove the deprecated field'
-          title: value_id
-          required:
-            - valueId
-      properties:
-        id:
-          type: string
-          title: id
-          format: uuid
-          description: 'Deprecated: utilize identifier'
-          deprecated: true
+              description: 'Deprecated: utilize identifier'
+              deprecated: true
+        - oneOf:
+            - type: object
+              properties:
+                fqn:
+                  type: string
+                  title: fqn
+                  minLength: 1
+                  format: uri
+              title: fqn
+              required:
+                - fqn
+            - type: object
+              properties:
+                valueId:
+                  type: string
+                  title: value_id
+                  format: uuid
+                  description: 'option (buf.validate.oneof).required = true; // TODO: enable this when we remove the deprecated field'
+              title: value_id
+              required:
+                - valueId
       title: GetAttributeValueRequest
       additionalProperties: false
-      description: |+
+      description: |
         /
         / Value RPC messages
         /
-        Either use deprecated 'id' field or one of 'value_id' or 'fqn', but not both:
-        ```
-        !(has(this.id) && (has(this.value_id) || has(this.fqn)))
-        ```
-
-        Either id or one of value_id or fqn must be set:
-        ```
-        has(this.id) || has(this.value_id) || has(this.fqn)
-        ```
-
+        exclusive_fields // Either use deprecated 'id' field or one of 'value_id' or 'fqn', but not both
+        required_fields // Either id or one of value_id or fqn must be set
     policy.attributes.GetAttributeValueResponse:
       type: object
       properties:
@@ -2041,8 +2087,6 @@ components:
           type: array
           items:
             type: string
-            maxItems: 250
-            minItems: 1
           title: fqns
           maxItems: 250
           minItems: 1
@@ -2240,6 +2284,14 @@ components:
           $ref: '#/components/schemas/policy.attributes.ValueKey'
       title: RemovePublicKeyFromValueResponse
       additionalProperties: false
+    policy.attributes.SortAttributesType:
+      type: string
+      title: SortAttributesType
+      enum:
+        - SORT_ATTRIBUTES_TYPE_UNSPECIFIED
+        - SORT_ATTRIBUTES_TYPE_NAME
+        - SORT_ATTRIBUTES_TYPE_CREATED_AT
+        - SORT_ATTRIBUTES_TYPE_UPDATED_AT
     policy.attributes.UpdateAttributeRequest:
       type: object
       properties:
@@ -2325,63 +2377,6 @@ components:
           description: Required
       title: ValueKeyAccessServer
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: policy.attributes.AttributesService

--- a/docs/openapi/policy/kasregistry/key_access_server_registry.openapi.yaml
+++ b/docs/openapi/policy/kasregistry/key_access_server_registry.openapi.yaml
@@ -2,218 +2,6 @@ openapi: 3.1.0
 info:
   title: policy.kasregistry
 paths:
-  /policy.kasregistry.KeyAccessServerRegistryService/ListKeyAccessServers:
-    post:
-      tags:
-        - policy.kasregistry.KeyAccessServerRegistryService
-      summary: ListKeyAccessServers
-      operationId: policy.kasregistry.KeyAccessServerRegistryService.ListKeyAccessServers
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.kasregistry.ListKeyAccessServersRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.kasregistry.ListKeyAccessServersResponse'
-  /policy.kasregistry.KeyAccessServerRegistryService/GetKeyAccessServer:
-    post:
-      tags:
-        - policy.kasregistry.KeyAccessServerRegistryService
-      summary: GetKeyAccessServer
-      operationId: policy.kasregistry.KeyAccessServerRegistryService.GetKeyAccessServer
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.kasregistry.GetKeyAccessServerRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.kasregistry.GetKeyAccessServerResponse'
-  /policy.kasregistry.KeyAccessServerRegistryService/CreateKeyAccessServer:
-    post:
-      tags:
-        - policy.kasregistry.KeyAccessServerRegistryService
-      summary: CreateKeyAccessServer
-      operationId: policy.kasregistry.KeyAccessServerRegistryService.CreateKeyAccessServer
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.kasregistry.CreateKeyAccessServerRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.kasregistry.CreateKeyAccessServerResponse'
-  /policy.kasregistry.KeyAccessServerRegistryService/UpdateKeyAccessServer:
-    post:
-      tags:
-        - policy.kasregistry.KeyAccessServerRegistryService
-      summary: UpdateKeyAccessServer
-      operationId: policy.kasregistry.KeyAccessServerRegistryService.UpdateKeyAccessServer
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.kasregistry.UpdateKeyAccessServerRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.kasregistry.UpdateKeyAccessServerResponse'
-  /policy.kasregistry.KeyAccessServerRegistryService/DeleteKeyAccessServer:
-    post:
-      tags:
-        - policy.kasregistry.KeyAccessServerRegistryService
-      summary: DeleteKeyAccessServer
-      operationId: policy.kasregistry.KeyAccessServerRegistryService.DeleteKeyAccessServer
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.kasregistry.DeleteKeyAccessServerRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.kasregistry.DeleteKeyAccessServerResponse'
-  /policy.kasregistry.KeyAccessServerRegistryService/ListKeyAccessServerGrants:
-    post:
-      tags:
-        - policy.kasregistry.KeyAccessServerRegistryService
-      summary: ListKeyAccessServerGrants
-      description: Deprecated
-      operationId: policy.kasregistry.KeyAccessServerRegistryService.ListKeyAccessServerGrants
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.kasregistry.ListKeyAccessServerGrantsRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.kasregistry.ListKeyAccessServerGrantsResponse'
-      deprecated: true
   /policy.kasregistry.KeyAccessServerRegistryService/CreateKey:
     post:
       tags:
@@ -252,6 +40,112 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.kasregistry.CreateKeyResponse'
+  /policy.kasregistry.KeyAccessServerRegistryService/CreateKeyAccessServer:
+    post:
+      tags:
+        - policy.kasregistry.KeyAccessServerRegistryService
+      summary: CreateKeyAccessServer
+      operationId: policy.kasregistry.KeyAccessServerRegistryService.CreateKeyAccessServer
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.kasregistry.CreateKeyAccessServerRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.kasregistry.CreateKeyAccessServerResponse'
+  /policy.kasregistry.KeyAccessServerRegistryService/DeleteKeyAccessServer:
+    post:
+      tags:
+        - policy.kasregistry.KeyAccessServerRegistryService
+      summary: DeleteKeyAccessServer
+      operationId: policy.kasregistry.KeyAccessServerRegistryService.DeleteKeyAccessServer
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.kasregistry.DeleteKeyAccessServerRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.kasregistry.DeleteKeyAccessServerResponse'
+  /policy.kasregistry.KeyAccessServerRegistryService/GetBaseKey:
+    post:
+      tags:
+        - policy.kasregistry.KeyAccessServerRegistryService
+      summary: GetBaseKey
+      description: Get Default kas keys
+      operationId: policy.kasregistry.KeyAccessServerRegistryService.GetBaseKey
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.kasregistry.GetBaseKeyRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.kasregistry.GetBaseKeyResponse'
   /policy.kasregistry.KeyAccessServerRegistryService/GetKey:
     post:
       tags:
@@ -288,6 +182,149 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.kasregistry.GetKeyResponse'
+  /policy.kasregistry.KeyAccessServerRegistryService/GetKeyAccessServer:
+    post:
+      tags:
+        - policy.kasregistry.KeyAccessServerRegistryService
+      summary: GetKeyAccessServer
+      operationId: policy.kasregistry.KeyAccessServerRegistryService.GetKeyAccessServer
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.kasregistry.GetKeyAccessServerRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.kasregistry.GetKeyAccessServerResponse'
+  /policy.kasregistry.KeyAccessServerRegistryService/ListKeyAccessServerGrants:
+    post:
+      tags:
+        - policy.kasregistry.KeyAccessServerRegistryService
+      summary: ListKeyAccessServerGrants
+      description: Deprecated
+      operationId: policy.kasregistry.KeyAccessServerRegistryService.ListKeyAccessServerGrants
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.kasregistry.ListKeyAccessServerGrantsRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.kasregistry.ListKeyAccessServerGrantsResponse'
+      deprecated: true
+  /policy.kasregistry.KeyAccessServerRegistryService/ListKeyAccessServers:
+    post:
+      tags:
+        - policy.kasregistry.KeyAccessServerRegistryService
+      summary: ListKeyAccessServers
+      operationId: policy.kasregistry.KeyAccessServerRegistryService.ListKeyAccessServers
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.kasregistry.ListKeyAccessServersRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.kasregistry.ListKeyAccessServersResponse'
+  /policy.kasregistry.KeyAccessServerRegistryService/ListKeyMappings:
+    post:
+      tags:
+        - policy.kasregistry.KeyAccessServerRegistryService
+      summary: ListKeyMappings
+      description: Request to list key mappings in the Key Access Service.
+      operationId: policy.kasregistry.KeyAccessServerRegistryService.ListKeyMappings
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.kasregistry.ListKeyMappingsRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.kasregistry.ListKeyMappingsResponse'
   /policy.kasregistry.KeyAccessServerRegistryService/ListKeys:
     post:
       tags:
@@ -324,42 +361,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.kasregistry.ListKeysResponse'
-  /policy.kasregistry.KeyAccessServerRegistryService/UpdateKey:
-    post:
-      tags:
-        - policy.kasregistry.KeyAccessServerRegistryService
-      summary: UpdateKey
-      description: Request to update a key in the Key Access Service.
-      operationId: policy.kasregistry.KeyAccessServerRegistryService.UpdateKey
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.kasregistry.UpdateKeyRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.kasregistry.UpdateKeyResponse'
   /policy.kasregistry.KeyAccessServerRegistryService/RotateKey:
     post:
       tags:
@@ -432,13 +433,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.kasregistry.SetBaseKeyResponse'
-  /policy.kasregistry.KeyAccessServerRegistryService/GetBaseKey:
+  /policy.kasregistry.KeyAccessServerRegistryService/UpdateKey:
     post:
       tags:
         - policy.kasregistry.KeyAccessServerRegistryService
-      summary: GetBaseKey
-      description: Get Default kas keys
-      operationId: policy.kasregistry.KeyAccessServerRegistryService.GetBaseKey
+      summary: UpdateKey
+      description: Request to update a key in the Key Access Service.
+      operationId: policy.kasregistry.KeyAccessServerRegistryService.UpdateKey
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -453,7 +454,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.kasregistry.GetBaseKeyRequest'
+              $ref: '#/components/schemas/policy.kasregistry.UpdateKeyRequest'
         required: true
       responses:
         default:
@@ -467,14 +468,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.kasregistry.GetBaseKeyResponse'
-  /policy.kasregistry.KeyAccessServerRegistryService/ListKeyMappings:
+                $ref: '#/components/schemas/policy.kasregistry.UpdateKeyResponse'
+  /policy.kasregistry.KeyAccessServerRegistryService/UpdateKeyAccessServer:
     post:
       tags:
         - policy.kasregistry.KeyAccessServerRegistryService
-      summary: ListKeyMappings
-      description: Request to list key mappings in the Key Access Service.
-      operationId: policy.kasregistry.KeyAccessServerRegistryService.ListKeyMappings
+      summary: UpdateKeyAccessServer
+      operationId: policy.kasregistry.KeyAccessServerRegistryService.UpdateKeyAccessServer
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -489,7 +489,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.kasregistry.ListKeyMappingsRequest'
+              $ref: '#/components/schemas/policy.kasregistry.UpdateKeyAccessServerRequest'
         required: true
       responses:
         default:
@@ -503,101 +503,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.kasregistry.ListKeyMappingsResponse'
+                $ref: '#/components/schemas/policy.kasregistry.UpdateKeyAccessServerResponse'
 components:
   schemas:
-    common.MetadataUpdateEnum:
-      type: string
-      title: MetadataUpdateEnum
-      enum:
-        - METADATA_UPDATE_ENUM_UNSPECIFIED
-        - METADATA_UPDATE_ENUM_EXTEND
-        - METADATA_UPDATE_ENUM_REPLACE
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.KeyMode:
-      type: string
-      title: KeyMode
-      enum:
-        - KEY_MODE_UNSPECIFIED
-        - KEY_MODE_CONFIG_ROOT_KEY
-        - KEY_MODE_PROVIDER_ROOT_KEY
-        - KEY_MODE_REMOTE
-        - KEY_MODE_PUBLIC_KEY_ONLY
-      description: Describes the management and operational mode of a cryptographic key.
-    policy.KeyStatus:
-      type: string
-      title: KeyStatus
-      enum:
-        - KEY_STATUS_UNSPECIFIED
-        - KEY_STATUS_ACTIVE
-        - KEY_STATUS_ROTATED
-      description: The status of the key
-    policy.SortDirection:
-      type: string
-      title: SortDirection
-      enum:
-        - SORT_DIRECTION_UNSPECIFIED
-        - SORT_DIRECTION_ASC
-        - SORT_DIRECTION_DESC
-      description: |-
-        Sorting direction shared across list APIs.
-         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
-         the endpoint's request message defines the default ordering; see the
-         specific List* request docs.
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
-    policy.kasregistry.SortKasKeysType:
-      type: string
-      title: SortKasKeysType
-      enum:
-        - SORT_KAS_KEYS_TYPE_UNSPECIFIED
-        - SORT_KAS_KEYS_TYPE_KEY_ID
-        - SORT_KAS_KEYS_TYPE_CREATED_AT
-        - SORT_KAS_KEYS_TYPE_UPDATED_AT
-    policy.kasregistry.SortKeyAccessServersType:
-      type: string
-      title: SortKeyAccessServersType
-      enum:
-        - SORT_KEY_ACCESS_SERVERS_TYPE_UNSPECIFIED
-        - SORT_KEY_ACCESS_SERVERS_TYPE_NAME
-        - SORT_KEY_ACCESS_SERVERS_TYPE_URI
-        - SORT_KEY_ACCESS_SERVERS_TYPE_CREATED_AT
-        - SORT_KEY_ACCESS_SERVERS_TYPE_UPDATED_AT
     common.Metadata:
       type: object
       properties:
@@ -653,6 +561,82 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    common.MetadataUpdateEnum:
+      type: string
+      title: MetadataUpdateEnum
+      enum:
+        - METADATA_UPDATE_ENUM_UNSPECIFIED
+        - METADATA_UPDATE_ENUM_EXTEND
+        - METADATA_UPDATE_ENUM_REPLACE
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.BoolValue:
       type: boolean
       description: |-
@@ -665,8 +649,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -758,6 +742,20 @@ components:
          the Joda Time's [`ISODateTimeFormat.dateTime()`](
          http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
          ) to obtain a formatter capable of generating timestamps in this format.
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.AsymmetricKey:
       type: object
       properties:
@@ -835,7 +833,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -847,6 +845,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -894,13 +905,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -928,6 +935,16 @@ components:
       title: KeyAccessServer
       additionalProperties: false
       description: Key Access Server Registry
+    policy.KeyMode:
+      type: string
+      title: KeyMode
+      enum:
+        - KEY_MODE_UNSPECIFIED
+        - KEY_MODE_CONFIG_ROOT_KEY
+        - KEY_MODE_PROVIDER_ROOT_KEY
+        - KEY_MODE_REMOTE
+        - KEY_MODE_PUBLIC_KEY_ONLY
+      description: Describes the management and operational mode of a cryptographic key.
     policy.KeyProviderConfig:
       type: object
       properties:
@@ -950,6 +967,14 @@ components:
           $ref: '#/components/schemas/common.Metadata'
       title: KeyProviderConfig
       additionalProperties: false
+    policy.KeyStatus:
+      type: string
+      title: KeyStatus
+      enum:
+        - KEY_STATUS_UNSPECIFIED
+        - KEY_STATUS_ACTIVE
+        - KEY_STATUS_ROTATED
+      description: The status of the key
     policy.PageRequest:
       type: object
       properties:
@@ -1009,7 +1034,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -1017,17 +1043,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -1075,6 +1098,29 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
+    policy.SortDirection:
+      type: string
+      title: SortDirection
+      enum:
+        - SORT_DIRECTION_UNSPECIFIED
+        - SORT_DIRECTION_ASC
+        - SORT_DIRECTION_DESC
+      description: |-
+        Sorting direction shared across list APIs.
+         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
+         the endpoint's request message defines the default ordering; see the
+         specific List* request docs.
+    policy.SourceType:
+      type: string
+      title: SourceType
+      enum:
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
     policy.kasregistry.ActivatePublicKeyRequest:
       type: object
       properties:
@@ -1112,13 +1158,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Required
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.isUri()
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: Deprecated
@@ -1131,13 +1173,9 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Optional
-            Registered KAS name must be an alphanumeric string, allowing hyphens, and underscores but not as the first or last character. The stored KAS name will be normalized to lower case.:
-            ```
-            size(this) > 0 ? this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$') : true
-            ```
-
+            kas_name_format // Registered KAS name must be an alphanumeric string, allowing hyphens, and underscores but not as the first or last character. The stored KAS name will be normalized to lower case.
         metadata:
           title: metadata
           description: Common metadata
@@ -1167,23 +1205,15 @@ components:
           description: Required A user-defined identifier for the key
         keyAlgorithm:
           title: key_algorithm
-          description: |+
+          description: |
             Required The algorithm to be used for the key
-            The key_algorithm must be one of the defined values.:
-            ```
-            this in [1, 2, 3, 4, 5, 6, 7, 8]
-            ```
-
+            key_algorithm_defined // The key_algorithm must be one of the defined values.
           $ref: '#/components/schemas/policy.Algorithm'
         keyMode:
           title: key_mode
-          description: |+
+          description: |
             Required The mode of the key (e.g., local or external)
-            The key_mode must be one of the defined values (1-4).:
-            ```
-            this >= 1 && this <= 4
-            ```
-
+            key_mode_defined // The key_mode must be one of the defined values (1-4).
           $ref: '#/components/schemas/policy.KeyMode'
         publicKeyCtx:
           title: public_key_ctx
@@ -1209,23 +1239,11 @@ components:
       required:
         - publicKeyCtx
       additionalProperties: false
-      description: |+
+      description: |
         Create a new asymmetric key for the specified Key Access Server (KAS)
-        The wrapped_key is required if key_mode is KEY_MODE_CONFIG_ROOT_KEY or KEY_MODE_PROVIDER_ROOT_KEY. The wrapped_key must be empty if key_mode is KEY_MODE_REMOTE or KEY_MODE_PUBLIC_KEY_ONLY.:
-        ```
-        ((this.key_mode == 1 || this.key_mode == 2) && this.private_key_ctx.wrapped_key != '') || ((this.key_mode == 3 || this.key_mode == 4) && this.private_key_ctx.wrapped_key == '')
-        ```
-
-        Provider config id is required if key_mode is KEY_MODE_PROVIDER_ROOT_KEY or KEY_MODE_REMOTE. It must be empty for KEY_MODE_CONFIG_ROOT_KEY and KEY_MODE_PUBLIC_KEY_ONLY.:
-        ```
-        ((this.key_mode == 1 || this.key_mode == 4) && this.provider_config_id == '') || ((this.key_mode == 2 || this.key_mode == 3) && this.provider_config_id != '')
-        ```
-
-        private_key_ctx must not be set if key_mode is KEY_MODE_PUBLIC_KEY_ONLY.:
-        ```
-        !(this.key_mode == 4 && has(this.private_key_ctx))
-        ```
-
+        private_key_ctx_for_public_key_only // private_key_ctx must not be set if key_mode is KEY_MODE_PUBLIC_KEY_ONLY.
+        private_key_ctx_optionally_required // The wrapped_key is required if key_mode is KEY_MODE_CONFIG_ROOT_KEY or KEY_MODE_PROVIDER_ROOT_KEY. The wrapped_key must be empty if key_mode is KEY_MODE_REMOTE or KEY_MODE_PUBLIC_KEY_ONLY.
+        provider_config_id_optionally_required // Provider config id is required if key_mode is KEY_MODE_PROVIDER_ROOT_KEY or KEY_MODE_REMOTE. It must be empty for KEY_MODE_CONFIG_ROOT_KEY and KEY_MODE_PUBLIC_KEY_ONLY.
     policy.kasregistry.CreateKeyResponse:
       type: object
       properties:
@@ -1314,53 +1332,49 @@ components:
       additionalProperties: false
     policy.kasregistry.GetKeyAccessServerRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            kasId:
+            id:
               type: string
-              title: kas_id
+              title: id
               format: uuid
-              description: 'option (buf.validate.oneof).required = true; // TODO: enable this when we remove the deprecated field'
-          title: kas_id
-          required:
-            - kasId
-        - properties:
-            name:
-              type: string
+              description: Deprecated
+              deprecated: true
+        - oneOf:
+            - type: object
+              properties:
+                kasId:
+                  type: string
+                  title: kas_id
+                  format: uuid
+                  description: 'option (buf.validate.oneof).required = true; // TODO: enable this when we remove the deprecated field'
+              title: kas_id
+              required:
+                - kasId
+            - type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  minLength: 1
               title: name
-              minLength: 1
-          title: name
-          required:
-            - name
-        - properties:
-            uri:
-              type: string
+              required:
+                - name
+            - type: object
+              properties:
+                uri:
+                  type: string
+                  title: uri
+                  minLength: 1
+                  format: uri
               title: uri
-              minLength: 1
-              format: uri
-          title: uri
-          required:
-            - uri
-      properties:
-        id:
-          type: string
-          title: id
-          format: uuid
-          description: Deprecated
-          deprecated: true
+              required:
+                - uri
       title: GetKeyAccessServerRequest
       additionalProperties: false
-      description: |+
-        Either use deprecated 'id' field or one of 'kas_id' or 'uri', but not both:
-        ```
-        !(has(this.id) && (has(this.kas_id) || has(this.uri) || has(this.name)))
-        ```
-
-        Either id or one of kas_id or uri must be set:
-        ```
-        has(this.id) || has(this.kas_id) || has(this.uri) || has(this.name)
-        ```
-
+      description: |
+        exclusive_fields // Either use deprecated 'id' field or one of 'kas_id' or 'uri', but not both
+        required_fields // Either id or one of kas_id or uri must be set
     policy.kasregistry.GetKeyAccessServerResponse:
       type: object
       properties:
@@ -1372,7 +1386,8 @@ components:
     policy.kasregistry.GetKeyRequest:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             id:
               type: string
               title: id
@@ -1381,7 +1396,8 @@ components:
           title: id
           required:
             - id
-        - properties:
+        - type: object
+          properties:
             key:
               title: key
               $ref: '#/components/schemas/policy.kasregistry.KasKeyIdentifier'
@@ -1404,7 +1420,8 @@ components:
     policy.kasregistry.GetPublicKeyRequest:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             id:
               type: string
               title: id
@@ -1436,38 +1453,42 @@ components:
       description: Can be namespace, attribute definition, or value
     policy.kasregistry.KasKeyIdentifier:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            kasId:
+            kid:
               type: string
+              title: kid
+              minLength: 1
+              description: Required Key ID of the key in question
+        - oneOf:
+            - type: object
+              properties:
+                kasId:
+                  type: string
+                  title: kas_id
+                  format: uuid
               title: kas_id
-              format: uuid
-          title: kas_id
-          required:
-            - kasId
-        - properties:
-            name:
-              type: string
+              required:
+                - kasId
+            - type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  minLength: 1
               title: name
-              minLength: 1
-          title: name
-          required:
-            - name
-        - properties:
-            uri:
-              type: string
+              required:
+                - name
+            - type: object
+              properties:
+                uri:
+                  type: string
+                  title: uri
+                  minLength: 1
+                  format: uri
               title: uri
-              minLength: 1
-              format: uri
-          title: uri
-          required:
-            - uri
-      properties:
-        kid:
-          type: string
-          title: kid
-          minLength: 1
-          description: Required Key ID of the key in question
+              required:
+                - uri
       title: KasKeyIdentifier
       additionalProperties: false
       description: Nested message for specifying the active key using KAS ID and Key ID
@@ -1552,43 +1573,31 @@ components:
         kasId:
           type: string
           title: kas_id
-          description: |+
+          description: |
             Optional
              Filter LIST by ID of a registered Key Access Server.
              If neither is provided, grants from all registered KASs to policy attribute
              objects are returned.
-            Optional field must be a valid UUID:
-            ```
-            size(this) == 0 || this.matches('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
-            ```
-
+            optional_uuid_format // Optional field must be a valid UUID
         kasUri:
           type: string
           title: kas_uri
-          description: |+
+          description: |
             Optional
              Filter LIST by URI of a registered Key Access Server.
              If none is provided, grants from all registered KASs to policy attribute
              objects are returned.
-            Optional URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            size(this) == 0 || this.isUri()
-            ```
-
+            optional_uri_format // Optional URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         kasName:
           type: string
           title: kas_name
           maxLength: 253
-          description: |+
+          description: |
             Optional
              Filter LIST by name of a registered Key Access Server.
              If none are provided, grants from all registered KASs to policy attribute
              objects are returned.
-            Registered KAS name must be an alphanumeric string, allowing hyphens, and underscores but not as the first or last character. The stored KAS name will be normalized to lower case.:
-            ```
-            size(this) == 0 || this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+            kas_name_format // Registered KAS name must be an alphanumeric string, allowing hyphens, and underscores but not as the first or last character. The stored KAS name will be normalized to lower case.
         pagination:
           title: pagination
           description: Optional
@@ -1651,28 +1660,31 @@ components:
       additionalProperties: false
     policy.kasregistry.ListKeyMappingsRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            id:
-              type: string
+            pagination:
+              title: pagination
+              description: Pagination request for the list of keys
+              $ref: '#/components/schemas/policy.PageRequest'
+        - oneOf:
+            - type: object
+              properties:
+                id:
+                  type: string
+                  title: id
+                  format: uuid
+                  description: The unique identifier of the key to retrieve
               title: id
-              format: uuid
-              description: The unique identifier of the key to retrieve
-          title: id
-          required:
-            - id
-        - properties:
-            key:
+              required:
+                - id
+            - type: object
+              properties:
+                key:
+                  title: key
+                  $ref: '#/components/schemas/policy.kasregistry.KasKeyIdentifier'
               title: key
-              $ref: '#/components/schemas/policy.kasregistry.KasKeyIdentifier'
-          title: key
-          required:
-            - key
-      properties:
-        pagination:
-          title: pagination
-          description: Pagination request for the list of keys
-          $ref: '#/components/schemas/policy.PageRequest'
+              required:
+                - key
       title: ListKeyMappingsRequest
       additionalProperties: false
     policy.kasregistry.ListKeyMappingsResponse:
@@ -1692,67 +1704,68 @@ components:
       additionalProperties: false
     policy.kasregistry.ListKeysRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            kasId:
-              type: string
+            keyAlgorithm:
+              title: key_algorithm
+              description: |
+                Filter keys by algorithm
+                key_algorithm_defined // The key_algorithm must be one of the defined values.
+              $ref: '#/components/schemas/policy.Algorithm'
+            legacy:
+              type:
+                - boolean
+                - "null"
+              title: legacy
+              description: Optional Filter for legacy keys
+            pagination:
+              title: pagination
+              description: Optional Pagination request for the list of keys
+              $ref: '#/components/schemas/policy.PageRequest'
+            sort:
+              type: array
+              items:
+                $ref: '#/components/schemas/policy.kasregistry.KasKeysSort'
+              title: sort
+              maxItems: 1
+              description: |-
+                Optional - CONSTRAINT: max 1 item
+                 Sort defaults:
+                   - direction UNSPECIFIED defaults to DESC for the specified field
+                   - field UNSPECIFIED defaults to created_at with the specified direction
+                   - both UNSPECIFIED or sort omitted defaults to created_at DESC
+        - oneOf:
+            - type: object
+              properties:
+                kasId:
+                  type: string
+                  title: kas_id
+                  format: uuid
+                  description: Filter keys by the KAS ID
               title: kas_id
-              format: uuid
-              description: Filter keys by the KAS ID
-          title: kas_id
-          required:
-            - kasId
-        - properties:
-            kasName:
-              type: string
+              required:
+                - kasId
+            - type: object
+              properties:
+                kasName:
+                  type: string
+                  title: kas_name
+                  minLength: 1
+                  description: Filter keys by the KAS name
               title: kas_name
-              minLength: 1
-              description: Filter keys by the KAS name
-          title: kas_name
-          required:
-            - kasName
-        - properties:
-            kasUri:
-              type: string
+              required:
+                - kasName
+            - type: object
+              properties:
+                kasUri:
+                  type: string
+                  title: kas_uri
+                  minLength: 1
+                  format: uri
+                  description: Filter keys by the KAS URI
               title: kas_uri
-              minLength: 1
-              format: uri
-              description: Filter keys by the KAS URI
-          title: kas_uri
-          required:
-            - kasUri
-      properties:
-        keyAlgorithm:
-          title: key_algorithm
-          description: |+
-            Filter keys by algorithm
-            The key_algorithm must be one of the defined values.:
-            ```
-            this in [0, 1, 2, 3, 4, 5, 6, 7, 8]
-            ```
-
-          $ref: '#/components/schemas/policy.Algorithm'
-        legacy:
-          type: boolean
-          title: legacy
-          description: Optional Filter for legacy keys
-          nullable: true
-        pagination:
-          title: pagination
-          description: Optional Pagination request for the list of keys
-          $ref: '#/components/schemas/policy.PageRequest'
-        sort:
-          type: array
-          items:
-            $ref: '#/components/schemas/policy.kasregistry.KasKeysSort'
-          title: sort
-          maxItems: 1
-          description: |-
-            Optional - CONSTRAINT: max 1 item
-             Sort defaults:
-               - direction UNSPECIFIED defaults to DESC for the specified field
-               - field UNSPECIFIED defaults to created_at with the specified direction
-               - both UNSPECIFIED or sort omitted defaults to created_at DESC
+              required:
+                - kasUri
       title: ListKeysRequest
       additionalProperties: false
       description: List all asymmetric keys managed by a specific Key Access Server or with a given algorithm
@@ -1774,45 +1787,49 @@ components:
       description: Response to a ListKeysRequest, containing the list of asymmetric keys and pagination information
     policy.kasregistry.ListPublicKeyMappingRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            kasId:
+            publicKeyId:
               type: string
-              title: kas_id
+              title: public_key_id
               format: uuid
+              description: Optional Public Key ID
+            pagination:
+              title: pagination
               description: Optional
-          title: kas_id
-          required:
-            - kasId
-        - properties:
-            kasName:
-              type: string
+              $ref: '#/components/schemas/policy.PageRequest'
+        - oneOf:
+            - type: object
+              properties:
+                kasId:
+                  type: string
+                  title: kas_id
+                  format: uuid
+                  description: Optional
+              title: kas_id
+              required:
+                - kasId
+            - type: object
+              properties:
+                kasName:
+                  type: string
+                  title: kas_name
+                  minLength: 1
+                  description: Optional
               title: kas_name
-              minLength: 1
-              description: Optional
-          title: kas_name
-          required:
-            - kasName
-        - properties:
-            kasUri:
-              type: string
+              required:
+                - kasName
+            - type: object
+              properties:
+                kasUri:
+                  type: string
+                  title: kas_uri
+                  minLength: 1
+                  format: uri
+                  description: Optional
               title: kas_uri
-              minLength: 1
-              format: uri
-              description: Optional
-          title: kas_uri
-          required:
-            - kasUri
-      properties:
-        publicKeyId:
-          type: string
-          title: public_key_id
-          format: uuid
-          description: Optional Public Key ID
-        pagination:
-          title: pagination
-          description: Optional
-          $ref: '#/components/schemas/policy.PageRequest'
+              required:
+                - kasUri
       title: ListPublicKeyMappingRequest
       additionalProperties: false
     policy.kasregistry.ListPublicKeyMappingResponse:
@@ -1883,40 +1900,44 @@ components:
       additionalProperties: false
     policy.kasregistry.ListPublicKeysRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            kasId:
-              type: string
+            pagination:
+              title: pagination
+              description: Optional
+              $ref: '#/components/schemas/policy.PageRequest'
+        - oneOf:
+            - type: object
+              properties:
+                kasId:
+                  type: string
+                  title: kas_id
+                  format: uuid
+                  description: Optional
               title: kas_id
-              format: uuid
-              description: Optional
-          title: kas_id
-          required:
-            - kasId
-        - properties:
-            kasName:
-              type: string
+              required:
+                - kasId
+            - type: object
+              properties:
+                kasName:
+                  type: string
+                  title: kas_name
+                  minLength: 1
+                  description: Optional
               title: kas_name
-              minLength: 1
-              description: Optional
-          title: kas_name
-          required:
-            - kasName
-        - properties:
-            kasUri:
-              type: string
+              required:
+                - kasName
+            - type: object
+              properties:
+                kasUri:
+                  type: string
+                  title: kas_uri
+                  minLength: 1
+                  format: uri
+                  description: Optional
               title: kas_uri
-              minLength: 1
-              format: uri
-              description: Optional
-          title: kas_uri
-          required:
-            - kasUri
-      properties:
-        pagination:
-          title: pagination
-          description: Optional
-          $ref: '#/components/schemas/policy.PageRequest'
+              required:
+                - kasUri
       title: ListPublicKeysRequest
       additionalProperties: false
     policy.kasregistry.ListPublicKeysResponse:
@@ -1947,47 +1968,38 @@ components:
       additionalProperties: false
     policy.kasregistry.RotateKeyRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            id:
-              type: string
+            newKey:
+              title: new_key
+              description: Information about the new key to be rotated in
+              $ref: '#/components/schemas/policy.kasregistry.RotateKeyRequest.NewKey'
+        - oneOf:
+            - type: object
+              properties:
+                id:
+                  type: string
+                  title: id
+                  format: uuid
+                  description: Current Active Key UUID
               title: id
-              format: uuid
-              description: Current Active Key UUID
-          title: id
-          required:
-            - id
-        - properties:
-            key:
+              required:
+                - id
+            - type: object
+              properties:
+                key:
+                  title: key
+                  description: Alternative way to specify the active key using KAS ID and Key ID
+                  $ref: '#/components/schemas/policy.kasregistry.KasKeyIdentifier'
               title: key
-              description: Alternative way to specify the active key using KAS ID and Key ID
-              $ref: '#/components/schemas/policy.kasregistry.KasKeyIdentifier'
-          title: key
-          required:
-            - key
-      properties:
-        newKey:
-          title: new_key
-          description: Information about the new key to be rotated in
-          $ref: '#/components/schemas/policy.kasregistry.RotateKeyRequest.NewKey'
+              required:
+                - key
       title: RotateKeyRequest
       additionalProperties: false
-      description: |+
-        For the new key, the wrapped_key is required if key_mode is KEY_MODE_CONFIG_ROOT_KEY or KEY_MODE_PROVIDER_ROOT_KEY. The wrapped_key must be empty if key_mode is KEY_MODE_REMOTE or KEY_MODE_PUBLIC_KEY_ONLY.:
-        ```
-        ((this.new_key.key_mode == 1 || this.new_key.key_mode == 2) && this.new_key.private_key_ctx.wrapped_key != '') || ((this.new_key.key_mode == 3 || this.new_key.key_mode == 4) && this.new_key.private_key_ctx.wrapped_key == '')
-        ```
-
-        For the new key, provider config id is required if key_mode is KEY_MODE_PROVIDER_ROOT_KEY or KEY_MODE_REMOTE. It must be empty for KEY_MODE_CONFIG_ROOT_KEY and KEY_MODE_PUBLIC_KEY_ONLY.:
-        ```
-        ((this.new_key.key_mode == 1 || this.new_key.key_mode == 4) && this.new_key.provider_config_id == '') || ((this.new_key.key_mode == 2 || this.new_key.key_mode == 3) && this.new_key.provider_config_id != '')
-        ```
-
-        private_key_ctx must not be set if key_mode is KEY_MODE_PUBLIC_KEY_ONLY.:
-        ```
-        !(this.new_key.key_mode == 4 && has(this.new_key.private_key_ctx))
-        ```
-
+      description: |
+        private_key_ctx_for_public_key_only // private_key_ctx must not be set if key_mode is KEY_MODE_PUBLIC_KEY_ONLY.
+        private_key_ctx_optionally_required // For the new key, the wrapped_key is required if key_mode is KEY_MODE_CONFIG_ROOT_KEY or KEY_MODE_PROVIDER_ROOT_KEY. The wrapped_key must be empty if key_mode is KEY_MODE_REMOTE or KEY_MODE_PUBLIC_KEY_ONLY.
+        provider_config_id_optionally_required // For the new key, provider config id is required if key_mode is KEY_MODE_PROVIDER_ROOT_KEY or KEY_MODE_REMOTE. It must be empty for KEY_MODE_CONFIG_ROOT_KEY and KEY_MODE_PUBLIC_KEY_ONLY.
     policy.kasregistry.RotateKeyRequest.NewKey:
       type: object
       properties:
@@ -1998,23 +2010,15 @@ components:
           description: Required
         algorithm:
           title: algorithm
-          description: |+
+          description: |
             Required
-            The key_algorithm must be one of the defined values.:
-            ```
-            this in [1, 2, 3, 4, 5, 6, 7, 8]
-            ```
-
+            key_algorithm_defined // The key_algorithm must be one of the defined values.
           $ref: '#/components/schemas/policy.Algorithm'
         keyMode:
           title: key_mode
-          description: |+
+          description: |
             Required
-            The new key_mode must be one of the defined values (1-4).:
-            ```
-            this in [1, 2, 3, 4]
-            ```
-
+            new_key_mode_defined // The new key_mode must be one of the defined values (1-4).
           $ref: '#/components/schemas/policy.KeyMode'
         publicKeyCtx:
           title: public_key_ctx
@@ -2079,7 +2083,8 @@ components:
     policy.kasregistry.SetBaseKeyRequest:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             id:
               type: string
               title: id
@@ -2088,7 +2093,8 @@ components:
           title: id
           required:
             - id
-        - properties:
+        - type: object
+          properties:
             key:
               title: key
               description: Alternative way to specify the key using KAS ID and Key ID
@@ -2114,6 +2120,23 @@ components:
           $ref: '#/components/schemas/policy.SimpleKasKey'
       title: SetBaseKeyResponse
       additionalProperties: false
+    policy.kasregistry.SortKasKeysType:
+      type: string
+      title: SortKasKeysType
+      enum:
+        - SORT_KAS_KEYS_TYPE_UNSPECIFIED
+        - SORT_KAS_KEYS_TYPE_KEY_ID
+        - SORT_KAS_KEYS_TYPE_CREATED_AT
+        - SORT_KAS_KEYS_TYPE_UPDATED_AT
+    policy.kasregistry.SortKeyAccessServersType:
+      type: string
+      title: SortKeyAccessServersType
+      enum:
+        - SORT_KEY_ACCESS_SERVERS_TYPE_UNSPECIFIED
+        - SORT_KEY_ACCESS_SERVERS_TYPE_NAME
+        - SORT_KEY_ACCESS_SERVERS_TYPE_URI
+        - SORT_KEY_ACCESS_SERVERS_TYPE_CREATED_AT
+        - SORT_KEY_ACCESS_SERVERS_TYPE_UPDATED_AT
     policy.kasregistry.UpdateKeyAccessServerRequest:
       type: object
       properties:
@@ -2125,13 +2148,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Optional
-            Optional URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            size(this) == 0 || this.isUri()
-            ```
-
+            optional_uri_format // Optional URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: |-
@@ -2151,13 +2170,9 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Optional
-            Registered KAS name must be an alphanumeric string, allowing hyphens, and underscores but not as the first or last character. The stored KAS name will be normalized to lower case.:
-            ```
-            size(this) == 0 || this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+            kas_name_format // Registered KAS name must be an alphanumeric string, allowing hyphens, and underscores but not as the first or last character. The stored KAS name will be normalized to lower case.
         metadata:
           title: metadata
           description: |-
@@ -2197,13 +2212,9 @@ components:
           $ref: '#/components/schemas/common.MetadataUpdateEnum'
       title: UpdateKeyRequest
       additionalProperties: false
-      description: |+
+      description: |
         Update an existing asymmetric key in the Key Management System
-        Metadata update behavior must be either APPEND or REPLACE, when updating metadata.:
-        ```
-        ((!has(this.metadata)) || (has(this.metadata) && this.metadata_update_behavior != 0))
-        ```
-
+        metadata_update_behavior // Metadata update behavior must be either APPEND or REPLACE, when updating metadata.
     policy.kasregistry.UpdateKeyResponse:
       type: object
       properties:
@@ -2241,63 +2252,6 @@ components:
           $ref: '#/components/schemas/policy.Key'
       title: UpdatePublicKeyResponse
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: policy.kasregistry.KeyAccessServerRegistryService

--- a/docs/openapi/policy/keymanagement/key_management.openapi.yaml
+++ b/docs/openapi/policy/keymanagement/key_management.openapi.yaml
@@ -40,6 +40,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.keymanagement.CreateProviderConfigResponse'
+  /policy.keymanagement.KeyManagementService/DeleteProviderConfig:
+    post:
+      tags:
+        - policy.keymanagement.KeyManagementService
+      summary: DeleteProviderConfig
+      operationId: policy.keymanagement.KeyManagementService.DeleteProviderConfig
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.keymanagement.DeleteProviderConfigRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.keymanagement.DeleteProviderConfigResponse'
   /policy.keymanagement.KeyManagementService/GetProviderConfig:
     post:
       tags:
@@ -145,50 +180,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.keymanagement.UpdateProviderConfigResponse'
-  /policy.keymanagement.KeyManagementService/DeleteProviderConfig:
-    post:
-      tags:
-        - policy.keymanagement.KeyManagementService
-      summary: DeleteProviderConfig
-      operationId: policy.keymanagement.KeyManagementService.DeleteProviderConfig
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.keymanagement.DeleteProviderConfigRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.keymanagement.DeleteProviderConfigResponse'
 components:
   schemas:
-    common.MetadataUpdateEnum:
-      type: string
-      title: MetadataUpdateEnum
-      enum:
-        - METADATA_UPDATE_ENUM_UNSPECIFIED
-        - METADATA_UPDATE_ENUM_EXTEND
-        - METADATA_UPDATE_ENUM_REPLACE
     common.Metadata:
       type: object
       properties:
@@ -244,11 +237,87 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    common.MetadataUpdateEnum:
+      type: string
+      title: MetadataUpdateEnum
+      enum:
+        - METADATA_UPDATE_ENUM_UNSPECIFIED
+        - METADATA_UPDATE_ENUM_EXTEND
+        - METADATA_UPDATE_ENUM_REPLACE
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -466,28 +535,31 @@ components:
       additionalProperties: false
     policy.keymanagement.GetProviderConfigRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            id:
+            manager:
               type: string
+              title: manager
+              description: Optional - filter by manager type when searching by name
+        - oneOf:
+            - type: object
+              properties:
+                id:
+                  type: string
+                  title: id
+                  format: uuid
               title: id
-              format: uuid
-          title: id
-          required:
-            - id
-        - properties:
-            name:
-              type: string
+              required:
+                - id
+            - type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  minLength: 1
               title: name
-              minLength: 1
-          title: name
-          required:
-            - name
-      properties:
-        manager:
-          type: string
-          title: manager
-          description: Optional - filter by manager type when searching by name
+              required:
+                - name
       title: GetProviderConfigRequest
       additionalProperties: false
     policy.keymanagement.GetProviderConfigResponse:
@@ -560,63 +632,6 @@ components:
           $ref: '#/components/schemas/policy.KeyProviderConfig'
       title: UpdateProviderConfigResponse
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: policy.keymanagement.KeyManagementService

--- a/docs/openapi/policy/namespaces/namespaces.openapi.yaml
+++ b/docs/openapi/policy/namespaces/namespaces.openapi.yaml
@@ -2,6 +2,152 @@ openapi: 3.1.0
 info:
   title: policy.namespaces
 paths:
+  /policy.namespaces.NamespaceService/AssignKeyAccessServerToNamespace:
+    post:
+      tags:
+        - policy.namespaces.NamespaceService
+      summary: AssignKeyAccessServerToNamespace
+      description: 'Deprecated: utilize AssignPublicKeyToNamespace'
+      operationId: policy.namespaces.NamespaceService.AssignKeyAccessServerToNamespace
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.namespaces.AssignKeyAccessServerToNamespaceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.namespaces.AssignKeyAccessServerToNamespaceResponse'
+      deprecated: true
+  /policy.namespaces.NamespaceService/AssignPublicKeyToNamespace:
+    post:
+      tags:
+        - policy.namespaces.NamespaceService
+      summary: AssignPublicKeyToNamespace
+      description: |-
+        --------------------------------------*
+         Namespace <> Key RPCs
+        ---------------------------------------
+      operationId: policy.namespaces.NamespaceService.AssignPublicKeyToNamespace
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.namespaces.AssignPublicKeyToNamespaceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.namespaces.AssignPublicKeyToNamespaceResponse'
+  /policy.namespaces.NamespaceService/CreateNamespace:
+    post:
+      tags:
+        - policy.namespaces.NamespaceService
+      summary: CreateNamespace
+      operationId: policy.namespaces.NamespaceService.CreateNamespace
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.namespaces.CreateNamespaceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.namespaces.CreateNamespaceResponse'
+  /policy.namespaces.NamespaceService/DeactivateNamespace:
+    post:
+      tags:
+        - policy.namespaces.NamespaceService
+      summary: DeactivateNamespace
+      operationId: policy.namespaces.NamespaceService.DeactivateNamespace
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.namespaces.DeactivateNamespaceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.namespaces.DeactivateNamespaceResponse'
   /policy.namespaces.NamespaceService/GetNamespace:
     post:
       tags:
@@ -72,148 +218,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.namespaces.ListNamespacesResponse'
-  /policy.namespaces.NamespaceService/CreateNamespace:
-    post:
-      tags:
-        - policy.namespaces.NamespaceService
-      summary: CreateNamespace
-      operationId: policy.namespaces.NamespaceService.CreateNamespace
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.namespaces.CreateNamespaceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.namespaces.CreateNamespaceResponse'
-  /policy.namespaces.NamespaceService/UpdateNamespace:
-    post:
-      tags:
-        - policy.namespaces.NamespaceService
-      summary: UpdateNamespace
-      operationId: policy.namespaces.NamespaceService.UpdateNamespace
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.namespaces.UpdateNamespaceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.namespaces.UpdateNamespaceResponse'
-  /policy.namespaces.NamespaceService/DeactivateNamespace:
-    post:
-      tags:
-        - policy.namespaces.NamespaceService
-      summary: DeactivateNamespace
-      operationId: policy.namespaces.NamespaceService.DeactivateNamespace
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.namespaces.DeactivateNamespaceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.namespaces.DeactivateNamespaceResponse'
-  /policy.namespaces.NamespaceService/AssignKeyAccessServerToNamespace:
-    post:
-      tags:
-        - policy.namespaces.NamespaceService
-      summary: AssignKeyAccessServerToNamespace
-      description: 'Deprecated: utilize AssignPublicKeyToNamespace'
-      operationId: policy.namespaces.NamespaceService.AssignKeyAccessServerToNamespace
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.namespaces.AssignKeyAccessServerToNamespaceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.namespaces.AssignKeyAccessServerToNamespaceResponse'
-      deprecated: true
   /policy.namespaces.NamespaceService/RemoveKeyAccessServerFromNamespace:
     post:
       tags:
@@ -251,45 +255,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/policy.namespaces.RemoveKeyAccessServerFromNamespaceResponse'
       deprecated: true
-  /policy.namespaces.NamespaceService/AssignPublicKeyToNamespace:
-    post:
-      tags:
-        - policy.namespaces.NamespaceService
-      summary: AssignPublicKeyToNamespace
-      description: |-
-        --------------------------------------*
-         Namespace <> Key RPCs
-        ---------------------------------------
-      operationId: policy.namespaces.NamespaceService.AssignPublicKeyToNamespace
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.namespaces.AssignPublicKeyToNamespaceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.namespaces.AssignPublicKeyToNamespaceResponse'
   /policy.namespaces.NamespaceService/RemovePublicKeyFromNamespace:
     post:
       tags:
@@ -325,6 +290,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.namespaces.RemovePublicKeyFromNamespaceResponse'
+  /policy.namespaces.NamespaceService/UpdateNamespace:
+    post:
+      tags:
+        - policy.namespaces.NamespaceService
+      summary: UpdateNamespace
+      operationId: policy.namespaces.NamespaceService.UpdateNamespace
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.namespaces.UpdateNamespaceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.namespaces.UpdateNamespaceResponse'
 components:
   schemas:
     common.ActiveStateEnum:
@@ -336,72 +336,6 @@ components:
         - ACTIVE_STATE_ENUM_INACTIVE
         - ACTIVE_STATE_ENUM_ANY
       description: 'buflint ENUM_VALUE_PREFIX: to make sure that C++ scoping rules aren''t violated when users add new enum values to an enum in a given package'
-    common.MetadataUpdateEnum:
-      type: string
-      title: MetadataUpdateEnum
-      enum:
-        - METADATA_UPDATE_ENUM_UNSPECIFIED
-        - METADATA_UPDATE_ENUM_EXTEND
-        - METADATA_UPDATE_ENUM_REPLACE
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.SortDirection:
-      type: string
-      title: SortDirection
-      enum:
-        - SORT_DIRECTION_UNSPECIFIED
-        - SORT_DIRECTION_ASC
-        - SORT_DIRECTION_DESC
-      description: |-
-        Sorting direction shared across list APIs.
-         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
-         the endpoint's request message defines the default ordering; see the
-         specific List* request docs.
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
-    policy.namespaces.SortNamespacesType:
-      type: string
-      title: SortNamespacesType
-      enum:
-        - SORT_NAMESPACES_TYPE_UNSPECIFIED
-        - SORT_NAMESPACES_TYPE_NAME
-        - SORT_NAMESPACES_TYPE_FQN
-        - SORT_NAMESPACES_TYPE_CREATED_AT
-        - SORT_NAMESPACES_TYPE_UPDATED_AT
     common.Metadata:
       type: object
       properties:
@@ -457,6 +391,82 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    common.MetadataUpdateEnum:
+      type: string
+      title: MetadataUpdateEnum
+      enum:
+        - METADATA_UPDATE_ENUM_UNSPECIFIED
+        - METADATA_UPDATE_ENUM_EXTEND
+        - METADATA_UPDATE_ENUM_REPLACE
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.BoolValue:
       type: boolean
       description: |-
@@ -469,8 +479,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -562,6 +572,20 @@ components:
          the Joda Time's [`ISODateTimeFormat.dateTime()`](
          http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
          ) to obtain a formatter capable of generating timestamps in this format.
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.KasPublicKey:
       type: object
       properties:
@@ -580,7 +604,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -592,6 +616,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -614,13 +651,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -730,7 +763,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -738,17 +772,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -786,6 +817,29 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
+    policy.SortDirection:
+      type: string
+      title: SortDirection
+      enum:
+        - SORT_DIRECTION_UNSPECIFIED
+        - SORT_DIRECTION_ASC
+        - SORT_DIRECTION_DESC
+      description: |-
+        Sorting direction shared across list APIs.
+         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
+         the endpoint's request message defines the default ordering; see the
+         specific List* request docs.
+    policy.SourceType:
+      type: string
+      title: SourceType
+      enum:
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
     policy.namespaces.AssignKeyAccessServerToNamespaceRequest:
       type: object
       properties:
@@ -829,13 +883,9 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Required
-            Namespace must be a valid hostname. It should include at least one dot, with each segment (label) starting and ending with an alphanumeric character. Each label must be 1 to 63 characters long, allowing hyphens but not as the first or last character. The top-level domain (the last segment after the final dot) must consist of at least two alphabetic characters. The stored namespace will be normalized to lower case.:
-            ```
-            this.matches('^([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}$')
-            ```
-
+            namespace_format // Namespace must be a valid hostname. It should include at least one dot, with each segment (label) starting and ending with an alphanumeric character. Each label must be 1 to 63 characters long, allowing hyphens but not as the first or last character. The top-level domain (the last segment after the final dot) must consist of at least two alphabetic characters. The stored namespace will be normalized to lower case.
         metadata:
           title: metadata
           description: Optional
@@ -868,45 +918,40 @@ components:
       additionalProperties: false
     policy.namespaces.GetNamespaceRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            fqn:
+            id:
               type: string
-              title: fqn
-              minLength: 1
-              format: uri
-          title: fqn
-          required:
-            - fqn
-        - properties:
-            namespaceId:
-              type: string
-              title: namespace_id
+              title: id
               format: uuid
-              description: 'option (buf.validate.oneof).required = true; // TODO: enable this when we remove the deprecated field'
-          title: namespace_id
-          required:
-            - namespaceId
-      properties:
-        id:
-          type: string
-          title: id
-          format: uuid
-          description: Deprecated
-          deprecated: true
+              description: Deprecated
+              deprecated: true
+        - oneOf:
+            - type: object
+              properties:
+                fqn:
+                  type: string
+                  title: fqn
+                  minLength: 1
+                  format: uri
+              title: fqn
+              required:
+                - fqn
+            - type: object
+              properties:
+                namespaceId:
+                  type: string
+                  title: namespace_id
+                  format: uuid
+                  description: 'option (buf.validate.oneof).required = true; // TODO: enable this when we remove the deprecated field'
+              title: namespace_id
+              required:
+                - namespaceId
       title: GetNamespaceRequest
       additionalProperties: false
-      description: |+
-        Either use deprecated 'id' field or one of 'namespace_id' or 'fqn', but not both:
-        ```
-        !(has(this.id) && (has(this.namespace_id) || has(this.fqn)))
-        ```
-
-        Either id or one of namespace_id or fqn must be set:
-        ```
-        has(this.id) || has(this.namespace_id) || has(this.fqn)
-        ```
-
+      description: |
+        exclusive_fields // Either use deprecated 'id' field or one of 'namespace_id' or 'fqn', but not both
+        required_fields // Either id or one of namespace_id or fqn must be set
     policy.namespaces.GetNamespaceResponse:
       type: object
       properties:
@@ -1035,6 +1080,15 @@ components:
           $ref: '#/components/schemas/policy.namespaces.NamespaceKey'
       title: RemovePublicKeyFromNamespaceResponse
       additionalProperties: false
+    policy.namespaces.SortNamespacesType:
+      type: string
+      title: SortNamespacesType
+      enum:
+        - SORT_NAMESPACES_TYPE_UNSPECIFIED
+        - SORT_NAMESPACES_TYPE_NAME
+        - SORT_NAMESPACES_TYPE_FQN
+        - SORT_NAMESPACES_TYPE_CREATED_AT
+        - SORT_NAMESPACES_TYPE_UPDATED_AT
     policy.namespaces.UpdateNamespaceRequest:
       type: object
       properties:
@@ -1060,63 +1114,6 @@ components:
           $ref: '#/components/schemas/policy.Namespace'
       title: UpdateNamespaceResponse
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: policy.namespaces.NamespaceService

--- a/docs/openapi/policy/objects.openapi.yaml
+++ b/docs/openapi/policy/objects.openapi.yaml
@@ -4,92 +4,6 @@ info:
 paths: {}
 components:
   schemas:
-    policy.Action.StandardAction:
-      type: string
-      title: StandardAction
-      enum:
-        - STANDARD_ACTION_UNSPECIFIED
-        - STANDARD_ACTION_DECRYPT
-        - STANDARD_ACTION_TRANSMIT
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.AttributeRuleTypeEnum:
-      type: string
-      title: AttributeRuleTypeEnum
-      enum:
-        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
-        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
-    policy.ConditionBooleanTypeEnum:
-      type: string
-      title: ConditionBooleanTypeEnum
-      enum:
-        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
-        - CONDITION_BOOLEAN_TYPE_ENUM_AND
-        - CONDITION_BOOLEAN_TYPE_ENUM_OR
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.KeyMode:
-      type: string
-      title: KeyMode
-      enum:
-        - KEY_MODE_UNSPECIFIED
-        - KEY_MODE_CONFIG_ROOT_KEY
-        - KEY_MODE_PROVIDER_ROOT_KEY
-        - KEY_MODE_REMOTE
-        - KEY_MODE_PUBLIC_KEY_ONLY
-      description: Describes the management and operational mode of a cryptographic key.
-    policy.KeyStatus:
-      type: string
-      title: KeyStatus
-      enum:
-        - KEY_STATUS_UNSPECIFIED
-        - KEY_STATUS_ACTIVE
-        - KEY_STATUS_ROTATED
-      description: The status of the key
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
-    policy.SubjectMappingOperatorEnum:
-      type: string
-      title: SubjectMappingOperatorEnum
-      enum:
-        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     common.Metadata:
       type: object
       properties:
@@ -134,8 +48,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -229,41 +143,65 @@ components:
          ) to obtain a formatter capable of generating timestamps in this format.
     policy.Action:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            custom:
+            id:
               type: string
+              title: id
+              description: Generated uuid in database
+            name:
+              type: string
+              title: name
+            namespace:
+              title: namespace
+              description: Namespace context for this action
+              $ref: '#/components/schemas/policy.Namespace'
+            metadata:
+              title: metadata
+              $ref: '#/components/schemas/common.Metadata'
+        - oneOf:
+            - type: object
+              properties:
+                custom:
+                  type: string
+                  title: custom
+                  description: Deprecated
               title: custom
-              description: Deprecated
-          title: custom
-          required:
-            - custom
-        - properties:
-            standard:
+              required:
+                - custom
+            - type: object
+              properties:
+                standard:
+                  title: standard
+                  description: Deprecated
+                  $ref: '#/components/schemas/policy.Action.StandardAction'
               title: standard
-              description: Deprecated
-              $ref: '#/components/schemas/policy.Action.StandardAction'
-          title: standard
-          required:
-            - standard
-      properties:
-        id:
-          type: string
-          title: id
-          description: Generated uuid in database
-        name:
-          type: string
-          title: name
-        namespace:
-          title: namespace
-          description: Namespace context for this action
-          $ref: '#/components/schemas/policy.Namespace'
-        metadata:
-          title: metadata
-          $ref: '#/components/schemas/common.Metadata'
+              required:
+                - standard
       title: Action
       additionalProperties: false
       description: An action an entity can take
+    policy.Action.StandardAction:
+      type: string
+      title: StandardAction
+      enum:
+        - STANDARD_ACTION_UNSPECIFIED
+        - STANDARD_ACTION_DECRYPT
+        - STANDARD_ACTION_TRANSMIT
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.AsymmetricKey:
       type: object
       properties:
@@ -365,6 +303,14 @@ components:
       required:
         - rule
       additionalProperties: false
+    policy.AttributeRuleTypeEnum:
+      type: string
+      title: AttributeRuleTypeEnum
+      enum:
+        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
+        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
     policy.Condition:
       type: object
       properties:
@@ -382,7 +328,6 @@ components:
           type: array
           items:
             type: string
-            minItems: 1
           title: subject_external_values
           minItems: 1
           description: |-
@@ -398,6 +343,13 @@ components:
         *
         A Condition defines a rule of <the value at the flattened 'selector value'
         location> <operator> <subject external values>
+    policy.ConditionBooleanTypeEnum:
+      type: string
+      title: ConditionBooleanTypeEnum
+      enum:
+        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
+        - CONDITION_BOOLEAN_TYPE_ENUM_AND
+        - CONDITION_BOOLEAN_TYPE_ENUM_OR
     policy.ConditionGroup:
       type: object
       properties:
@@ -448,7 +400,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -460,6 +412,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -507,13 +472,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -541,6 +502,16 @@ components:
       title: KeyAccessServer
       additionalProperties: false
       description: Key Access Server Registry
+    policy.KeyMode:
+      type: string
+      title: KeyMode
+      enum:
+        - KEY_MODE_UNSPECIFIED
+        - KEY_MODE_CONFIG_ROOT_KEY
+        - KEY_MODE_PROVIDER_ROOT_KEY
+        - KEY_MODE_REMOTE
+        - KEY_MODE_PUBLIC_KEY_ONLY
+      description: Describes the management and operational mode of a cryptographic key.
     policy.KeyProviderConfig:
       type: object
       properties:
@@ -563,6 +534,14 @@ components:
           $ref: '#/components/schemas/common.Metadata'
       title: KeyProviderConfig
       additionalProperties: false
+    policy.KeyStatus:
+      type: string
+      title: KeyStatus
+      enum:
+        - KEY_STATUS_UNSPECIFIED
+        - KEY_STATUS_ACTIVE
+        - KEY_STATUS_ROTATED
+      description: The status of the key
     policy.Namespace:
       type: object
       properties:
@@ -705,7 +684,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -713,17 +693,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -908,6 +885,17 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
+    policy.SourceType:
+      type: string
+      title: SourceType
+      enum:
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
     policy.SubjectConditionSet:
       type: object
       properties:
@@ -973,6 +961,14 @@ components:
       description: |-
         Subject Mapping: A Policy assigning Subject Set(s) to a permitted attribute
         value + action(s) combination
+    policy.SubjectMappingOperatorEnum:
+      type: string
+      title: SubjectMappingOperatorEnum
+      enum:
+        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     policy.SubjectProperty:
       type: object
       properties:
@@ -993,7 +989,6 @@ components:
         authoritative source such as an IDP (Identity Provider) or User Store.
         Examples include such ADFS/LDAP, OKTA, etc. For now, a valid property must
         contain both a selector expression & a resulting value.
-
         The external_selector_value is a specifier to select a value from a flattened
         external representation of an Entity (such as from idP/LDAP), and the
         external_value is the value selected by the external_selector_value on that

--- a/docs/openapi/policy/obligations/obligations.openapi.yaml
+++ b/docs/openapi/policy/obligations/obligations.openapi.yaml
@@ -2,12 +2,12 @@ openapi: 3.1.0
 info:
   title: policy.obligations
 paths:
-  /policy.obligations.Service/ListObligations:
+  /policy.obligations.Service/AddObligationTrigger:
     post:
       tags:
         - policy.obligations.Service
-      summary: ListObligations
-      operationId: policy.obligations.Service.ListObligations
+      summary: AddObligationTrigger
+      operationId: policy.obligations.Service.AddObligationTrigger
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -22,7 +22,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.obligations.ListObligationsRequest'
+              $ref: '#/components/schemas/policy.obligations.AddObligationTriggerRequest'
         required: true
       responses:
         default:
@@ -36,77 +36,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.obligations.ListObligationsResponse'
-  /policy.obligations.Service/GetObligation:
-    post:
-      tags:
-        - policy.obligations.Service
-      summary: GetObligation
-      operationId: policy.obligations.Service.GetObligation
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.obligations.GetObligationRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.obligations.GetObligationResponse'
-  /policy.obligations.Service/GetObligationsByFQNs:
-    post:
-      tags:
-        - policy.obligations.Service
-      summary: GetObligationsByFQNs
-      operationId: policy.obligations.Service.GetObligationsByFQNs
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.obligations.GetObligationsByFQNsRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.obligations.GetObligationsByFQNsResponse'
+                $ref: '#/components/schemas/policy.obligations.AddObligationTriggerResponse'
   /policy.obligations.Service/CreateObligation:
     post:
       tags:
@@ -142,12 +72,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.obligations.CreateObligationResponse'
-  /policy.obligations.Service/UpdateObligation:
+  /policy.obligations.Service/CreateObligationValue:
     post:
       tags:
         - policy.obligations.Service
-      summary: UpdateObligation
-      operationId: policy.obligations.Service.UpdateObligation
+      summary: CreateObligationValue
+      operationId: policy.obligations.Service.CreateObligationValue
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -162,7 +92,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.obligations.UpdateObligationRequest'
+              $ref: '#/components/schemas/policy.obligations.CreateObligationValueRequest'
         required: true
       responses:
         default:
@@ -176,7 +106,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.obligations.UpdateObligationResponse'
+                $ref: '#/components/schemas/policy.obligations.CreateObligationValueResponse'
   /policy.obligations.Service/DeleteObligation:
     post:
       tags:
@@ -212,6 +142,111 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.obligations.DeleteObligationResponse'
+  /policy.obligations.Service/DeleteObligationValue:
+    post:
+      tags:
+        - policy.obligations.Service
+      summary: DeleteObligationValue
+      operationId: policy.obligations.Service.DeleteObligationValue
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.obligations.DeleteObligationValueRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.obligations.DeleteObligationValueResponse'
+  /policy.obligations.Service/GetObligation:
+    post:
+      tags:
+        - policy.obligations.Service
+      summary: GetObligation
+      operationId: policy.obligations.Service.GetObligation
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.obligations.GetObligationRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.obligations.GetObligationResponse'
+  /policy.obligations.Service/GetObligationTrigger:
+    post:
+      tags:
+        - policy.obligations.Service
+      summary: GetObligationTrigger
+      operationId: policy.obligations.Service.GetObligationTrigger
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.obligations.GetObligationTriggerRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.obligations.GetObligationTriggerResponse'
   /policy.obligations.Service/GetObligationValue:
     post:
       tags:
@@ -282,12 +317,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.obligations.GetObligationValuesByFQNsResponse'
-  /policy.obligations.Service/CreateObligationValue:
+  /policy.obligations.Service/GetObligationsByFQNs:
     post:
       tags:
         - policy.obligations.Service
-      summary: CreateObligationValue
-      operationId: policy.obligations.Service.CreateObligationValue
+      summary: GetObligationsByFQNs
+      operationId: policy.obligations.Service.GetObligationsByFQNs
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -302,7 +337,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.obligations.CreateObligationValueRequest'
+              $ref: '#/components/schemas/policy.obligations.GetObligationsByFQNsRequest'
         required: true
       responses:
         default:
@@ -316,182 +351,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.obligations.CreateObligationValueResponse'
-  /policy.obligations.Service/UpdateObligationValue:
-    post:
-      tags:
-        - policy.obligations.Service
-      summary: UpdateObligationValue
-      operationId: policy.obligations.Service.UpdateObligationValue
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.obligations.UpdateObligationValueRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.obligations.UpdateObligationValueResponse'
-  /policy.obligations.Service/DeleteObligationValue:
-    post:
-      tags:
-        - policy.obligations.Service
-      summary: DeleteObligationValue
-      operationId: policy.obligations.Service.DeleteObligationValue
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.obligations.DeleteObligationValueRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.obligations.DeleteObligationValueResponse'
-  /policy.obligations.Service/GetObligationTrigger:
-    post:
-      tags:
-        - policy.obligations.Service
-      summary: GetObligationTrigger
-      operationId: policy.obligations.Service.GetObligationTrigger
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.obligations.GetObligationTriggerRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.obligations.GetObligationTriggerResponse'
-  /policy.obligations.Service/AddObligationTrigger:
-    post:
-      tags:
-        - policy.obligations.Service
-      summary: AddObligationTrigger
-      operationId: policy.obligations.Service.AddObligationTrigger
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.obligations.AddObligationTriggerRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.obligations.AddObligationTriggerResponse'
-  /policy.obligations.Service/RemoveObligationTrigger:
-    post:
-      tags:
-        - policy.obligations.Service
-      summary: RemoveObligationTrigger
-      operationId: policy.obligations.Service.RemoveObligationTrigger
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.obligations.RemoveObligationTriggerRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.obligations.RemoveObligationTriggerResponse'
+                $ref: '#/components/schemas/policy.obligations.GetObligationsByFQNsResponse'
   /policy.obligations.Service/ListObligationTriggers:
     post:
       tags:
@@ -527,106 +387,156 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.obligations.ListObligationTriggersResponse'
+  /policy.obligations.Service/ListObligations:
+    post:
+      tags:
+        - policy.obligations.Service
+      summary: ListObligations
+      operationId: policy.obligations.Service.ListObligations
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.obligations.ListObligationsRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.obligations.ListObligationsResponse'
+  /policy.obligations.Service/RemoveObligationTrigger:
+    post:
+      tags:
+        - policy.obligations.Service
+      summary: RemoveObligationTrigger
+      operationId: policy.obligations.Service.RemoveObligationTrigger
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.obligations.RemoveObligationTriggerRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.obligations.RemoveObligationTriggerResponse'
+  /policy.obligations.Service/UpdateObligation:
+    post:
+      tags:
+        - policy.obligations.Service
+      summary: UpdateObligation
+      operationId: policy.obligations.Service.UpdateObligation
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.obligations.UpdateObligationRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.obligations.UpdateObligationResponse'
+  /policy.obligations.Service/UpdateObligationValue:
+    post:
+      tags:
+        - policy.obligations.Service
+      summary: UpdateObligationValue
+      operationId: policy.obligations.Service.UpdateObligationValue
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.obligations.UpdateObligationValueRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.obligations.UpdateObligationValueResponse'
 components:
   schemas:
-    common.MetadataUpdateEnum:
-      type: string
-      title: MetadataUpdateEnum
-      enum:
-        - METADATA_UPDATE_ENUM_UNSPECIFIED
-        - METADATA_UPDATE_ENUM_EXTEND
-        - METADATA_UPDATE_ENUM_REPLACE
-    policy.Action.StandardAction:
-      type: string
-      title: StandardAction
-      enum:
-        - STANDARD_ACTION_UNSPECIFIED
-        - STANDARD_ACTION_DECRYPT
-        - STANDARD_ACTION_TRANSMIT
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.AttributeRuleTypeEnum:
-      type: string
-      title: AttributeRuleTypeEnum
-      enum:
-        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
-        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
-    policy.ConditionBooleanTypeEnum:
-      type: string
-      title: ConditionBooleanTypeEnum
-      enum:
-        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
-        - CONDITION_BOOLEAN_TYPE_ENUM_AND
-        - CONDITION_BOOLEAN_TYPE_ENUM_OR
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.SortDirection:
-      type: string
-      title: SortDirection
-      enum:
-        - SORT_DIRECTION_UNSPECIFIED
-        - SORT_DIRECTION_ASC
-        - SORT_DIRECTION_DESC
-      description: |-
-        Sorting direction shared across list APIs.
-         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
-         the endpoint's request message defines the default ordering; see the
-         specific List* request docs.
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
-    policy.SubjectMappingOperatorEnum:
-      type: string
-      title: SubjectMappingOperatorEnum
-      enum:
-        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
-    policy.obligations.SortObligationsType:
-      type: string
-      title: SortObligationsType
-      enum:
-        - SORT_OBLIGATIONS_TYPE_UNSPECIFIED
-        - SORT_OBLIGATIONS_TYPE_NAME
-        - SORT_OBLIGATIONS_TYPE_FQN
-        - SORT_OBLIGATIONS_TYPE_CREATED_AT
-        - SORT_OBLIGATIONS_TYPE_UPDATED_AT
     common.IdFqnIdentifier:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - id
+            - required:
+                - fqn
       properties:
         id:
           type: string
@@ -641,6 +551,12 @@ components:
       additionalProperties: false
     common.IdNameIdentifier:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - id
+            - required:
+                - name
       properties:
         id:
           type: string
@@ -651,12 +567,8 @@ components:
           title: name
           maxLength: 253
           minLength: 1
-          description: |+
-            Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+          description: |
+            name_format // Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.
       title: IdNameIdentifier
       additionalProperties: false
     common.Metadata:
@@ -714,6 +626,82 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    common.MetadataUpdateEnum:
+      type: string
+      title: MetadataUpdateEnum
+      enum:
+        - METADATA_UPDATE_ENUM_UNSPECIFIED
+        - METADATA_UPDATE_ENUM_EXTEND
+        - METADATA_UPDATE_ENUM_REPLACE
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.BoolValue:
       type: boolean
       description: |-
@@ -726,8 +714,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -821,41 +809,65 @@ components:
          ) to obtain a formatter capable of generating timestamps in this format.
     policy.Action:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            custom:
+            id:
               type: string
+              title: id
+              description: Generated uuid in database
+            name:
+              type: string
+              title: name
+            namespace:
+              title: namespace
+              description: Namespace context for this action
+              $ref: '#/components/schemas/policy.Namespace'
+            metadata:
+              title: metadata
+              $ref: '#/components/schemas/common.Metadata'
+        - oneOf:
+            - type: object
+              properties:
+                custom:
+                  type: string
+                  title: custom
+                  description: Deprecated
               title: custom
-              description: Deprecated
-          title: custom
-          required:
-            - custom
-        - properties:
-            standard:
+              required:
+                - custom
+            - type: object
+              properties:
+                standard:
+                  title: standard
+                  description: Deprecated
+                  $ref: '#/components/schemas/policy.Action.StandardAction'
               title: standard
-              description: Deprecated
-              $ref: '#/components/schemas/policy.Action.StandardAction'
-          title: standard
-          required:
-            - standard
-      properties:
-        id:
-          type: string
-          title: id
-          description: Generated uuid in database
-        name:
-          type: string
-          title: name
-        namespace:
-          title: namespace
-          description: Namespace context for this action
-          $ref: '#/components/schemas/policy.Namespace'
-        metadata:
-          title: metadata
-          $ref: '#/components/schemas/common.Metadata'
+              required:
+                - standard
       title: Action
       additionalProperties: false
       description: An action an entity can take
+    policy.Action.StandardAction:
+      type: string
+      title: StandardAction
+      enum:
+        - STANDARD_ACTION_UNSPECIFIED
+        - STANDARD_ACTION_DECRYPT
+        - STANDARD_ACTION_TRANSMIT
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.Attribute:
       type: object
       properties:
@@ -912,6 +924,14 @@ components:
       required:
         - rule
       additionalProperties: false
+    policy.AttributeRuleTypeEnum:
+      type: string
+      title: AttributeRuleTypeEnum
+      enum:
+        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
+        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
     policy.Condition:
       type: object
       properties:
@@ -929,7 +949,6 @@ components:
           type: array
           items:
             type: string
-            minItems: 1
           title: subject_external_values
           minItems: 1
           description: |-
@@ -945,6 +964,13 @@ components:
         *
         A Condition defines a rule of <the value at the flattened 'selector value'
         location> <operator> <subject external values>
+    policy.ConditionBooleanTypeEnum:
+      type: string
+      title: ConditionBooleanTypeEnum
+      enum:
+        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
+        - CONDITION_BOOLEAN_TYPE_ENUM_AND
+        - CONDITION_BOOLEAN_TYPE_ENUM_OR
     policy.ConditionGroup:
       type: object
       properties:
@@ -981,7 +1007,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -993,6 +1019,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -1015,13 +1054,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -1219,7 +1254,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -1227,17 +1263,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -1345,6 +1378,29 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
+    policy.SortDirection:
+      type: string
+      title: SortDirection
+      enum:
+        - SORT_DIRECTION_UNSPECIFIED
+        - SORT_DIRECTION_ASC
+        - SORT_DIRECTION_DESC
+      description: |-
+        Sorting direction shared across list APIs.
+         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
+         the endpoint's request message defines the default ordering; see the
+         specific List* request docs.
+    policy.SourceType:
+      type: string
+      title: SourceType
+      enum:
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
     policy.SubjectConditionSet:
       type: object
       properties:
@@ -1410,6 +1466,14 @@ components:
       description: |-
         Subject Mapping: A Policy assigning Subject Set(s) to a permitted attribute
         value + action(s) combination
+    policy.SubjectMappingOperatorEnum:
+      type: string
+      title: SubjectMappingOperatorEnum
+      enum:
+        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     policy.SubjectSet:
       type: object
       properties:
@@ -1523,6 +1587,12 @@ components:
       additionalProperties: false
     policy.obligations.CreateObligationRequest:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - namespaceId
+            - required:
+                - namespaceFqn
       properties:
         namespaceId:
           type: string
@@ -1537,19 +1607,14 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
-            Obligation name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+          description: |
+            obligation_name_format // Obligation name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.
         values:
           type: array
           items:
             type: string
             maxLength: 253
             pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$
-            uniqueItems: true
           title: values
           uniqueItems: true
           description: Optional
@@ -1573,6 +1638,12 @@ components:
       additionalProperties: false
     policy.obligations.CreateObligationValueRequest:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - obligationId
+            - required:
+                - obligationFqn
       properties:
         obligationId:
           type: string
@@ -1587,12 +1658,8 @@ components:
           type: string
           title: value
           maxLength: 253
-          description: |+
-            Obligation value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored value will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+          description: |
+            obligation_value_format // Obligation value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored value will be normalized to lower case.
         triggers:
           type: array
           items:
@@ -1621,6 +1688,12 @@ components:
       additionalProperties: false
     policy.obligations.DeleteObligationRequest:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - id
+            - required:
+                - fqn
       properties:
         id:
           type: string
@@ -1643,6 +1716,12 @@ components:
       additionalProperties: false
     policy.obligations.DeleteObligationValueRequest:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - id
+            - required:
+                - fqn
       properties:
         id:
           type: string
@@ -1665,6 +1744,12 @@ components:
       additionalProperties: false
     policy.obligations.GetObligationRequest:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - id
+            - required:
+                - fqn
       properties:
         id:
           type: string
@@ -1706,6 +1791,12 @@ components:
       additionalProperties: false
     policy.obligations.GetObligationValueRequest:
       type: object
+      allOf:
+        - oneOf:
+            - required:
+                - id
+            - required:
+                - fqn
       properties:
         id:
           type: string
@@ -1736,9 +1827,6 @@ components:
             type: string
             minLength: 1
             format: uri
-            maxItems: 250
-            minItems: 1
-            uniqueItems: true
           title: fqns
           maxItems: 250
           minItems: 1
@@ -1776,9 +1864,6 @@ components:
             type: string
             minLength: 1
             format: uri
-            maxItems: 250
-            minItems: 1
-            uniqueItems: true
           title: fqns
           maxItems: 250
           minItems: 1
@@ -1910,6 +1995,15 @@ components:
           $ref: '#/components/schemas/policy.ObligationTrigger'
       title: RemoveObligationTriggerResponse
       additionalProperties: false
+    policy.obligations.SortObligationsType:
+      type: string
+      title: SortObligationsType
+      enum:
+        - SORT_OBLIGATIONS_TYPE_UNSPECIFIED
+        - SORT_OBLIGATIONS_TYPE_NAME
+        - SORT_OBLIGATIONS_TYPE_FQN
+        - SORT_OBLIGATIONS_TYPE_CREATED_AT
+        - SORT_OBLIGATIONS_TYPE_UPDATED_AT
     policy.obligations.UpdateObligationRequest:
       type: object
       properties:
@@ -1922,13 +2016,9 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Optional
-            Obligation name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.:
-            ```
-            size(this) > 0 ? this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$') : true
-            ```
-
+            obligation_name_format // Obligation name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.
         metadata:
           title: metadata
           $ref: '#/components/schemas/common.MetadataMutable'
@@ -1957,13 +2047,9 @@ components:
           type: string
           title: value
           maxLength: 253
-          description: |+
+          description: |
             Optional
-            Obligation value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored value will be normalized to lower case.:
-            ```
-            size(this) > 0 ? this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$') : true
-            ```
-
+            obligation_value_format // Obligation value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored value will be normalized to lower case.
         triggers:
           type: array
           items:
@@ -2011,63 +2097,6 @@ components:
         - action
         - attributeValue
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: policy.obligations.Service

--- a/docs/openapi/policy/registeredresources/registered_resources.openapi.yaml
+++ b/docs/openapi/policy/registeredresources/registered_resources.openapi.yaml
@@ -37,146 +37,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.registeredresources.CreateRegisteredResourceResponse'
-  /policy.registeredresources.RegisteredResourcesService/GetRegisteredResource:
-    post:
-      tags:
-        - policy.registeredresources.RegisteredResourcesService
-      summary: GetRegisteredResource
-      operationId: policy.registeredresources.RegisteredResourcesService.GetRegisteredResource
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.registeredresources.GetRegisteredResourceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.registeredresources.GetRegisteredResourceResponse'
-  /policy.registeredresources.RegisteredResourcesService/ListRegisteredResources:
-    post:
-      tags:
-        - policy.registeredresources.RegisteredResourcesService
-      summary: ListRegisteredResources
-      operationId: policy.registeredresources.RegisteredResourcesService.ListRegisteredResources
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.registeredresources.ListRegisteredResourcesRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.registeredresources.ListRegisteredResourcesResponse'
-  /policy.registeredresources.RegisteredResourcesService/UpdateRegisteredResource:
-    post:
-      tags:
-        - policy.registeredresources.RegisteredResourcesService
-      summary: UpdateRegisteredResource
-      operationId: policy.registeredresources.RegisteredResourcesService.UpdateRegisteredResource
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.registeredresources.UpdateRegisteredResourceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.registeredresources.UpdateRegisteredResourceResponse'
-  /policy.registeredresources.RegisteredResourcesService/DeleteRegisteredResource:
-    post:
-      tags:
-        - policy.registeredresources.RegisteredResourcesService
-      summary: DeleteRegisteredResource
-      operationId: policy.registeredresources.RegisteredResourcesService.DeleteRegisteredResource
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.registeredresources.DeleteRegisteredResourceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.registeredresources.DeleteRegisteredResourceResponse'
   /policy.registeredresources.RegisteredResourcesService/CreateRegisteredResourceValue:
     post:
       tags:
@@ -212,6 +72,111 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.registeredresources.CreateRegisteredResourceValueResponse'
+  /policy.registeredresources.RegisteredResourcesService/DeleteRegisteredResource:
+    post:
+      tags:
+        - policy.registeredresources.RegisteredResourcesService
+      summary: DeleteRegisteredResource
+      operationId: policy.registeredresources.RegisteredResourcesService.DeleteRegisteredResource
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.registeredresources.DeleteRegisteredResourceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.registeredresources.DeleteRegisteredResourceResponse'
+  /policy.registeredresources.RegisteredResourcesService/DeleteRegisteredResourceValue:
+    post:
+      tags:
+        - policy.registeredresources.RegisteredResourcesService
+      summary: DeleteRegisteredResourceValue
+      operationId: policy.registeredresources.RegisteredResourcesService.DeleteRegisteredResourceValue
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.registeredresources.DeleteRegisteredResourceValueRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.registeredresources.DeleteRegisteredResourceValueResponse'
+  /policy.registeredresources.RegisteredResourcesService/GetRegisteredResource:
+    post:
+      tags:
+        - policy.registeredresources.RegisteredResourcesService
+      summary: GetRegisteredResource
+      operationId: policy.registeredresources.RegisteredResourcesService.GetRegisteredResource
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.registeredresources.GetRegisteredResourceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.registeredresources.GetRegisteredResourceResponse'
   /policy.registeredresources.RegisteredResourcesService/GetRegisteredResourceValue:
     post:
       tags:
@@ -317,6 +282,76 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.registeredresources.ListRegisteredResourceValuesResponse'
+  /policy.registeredresources.RegisteredResourcesService/ListRegisteredResources:
+    post:
+      tags:
+        - policy.registeredresources.RegisteredResourcesService
+      summary: ListRegisteredResources
+      operationId: policy.registeredresources.RegisteredResourcesService.ListRegisteredResources
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.registeredresources.ListRegisteredResourcesRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.registeredresources.ListRegisteredResourcesResponse'
+  /policy.registeredresources.RegisteredResourcesService/UpdateRegisteredResource:
+    post:
+      tags:
+        - policy.registeredresources.RegisteredResourcesService
+      summary: UpdateRegisteredResource
+      operationId: policy.registeredresources.RegisteredResourcesService.UpdateRegisteredResource
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.registeredresources.UpdateRegisteredResourceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.registeredresources.UpdateRegisteredResourceResponse'
   /policy.registeredresources.RegisteredResourcesService/UpdateRegisteredResourceValue:
     post:
       tags:
@@ -352,138 +387,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.registeredresources.UpdateRegisteredResourceValueResponse'
-  /policy.registeredresources.RegisteredResourcesService/DeleteRegisteredResourceValue:
-    post:
-      tags:
-        - policy.registeredresources.RegisteredResourcesService
-      summary: DeleteRegisteredResourceValue
-      operationId: policy.registeredresources.RegisteredResourcesService.DeleteRegisteredResourceValue
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.registeredresources.DeleteRegisteredResourceValueRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.registeredresources.DeleteRegisteredResourceValueResponse'
 components:
   schemas:
-    common.MetadataUpdateEnum:
-      type: string
-      title: MetadataUpdateEnum
-      enum:
-        - METADATA_UPDATE_ENUM_UNSPECIFIED
-        - METADATA_UPDATE_ENUM_EXTEND
-        - METADATA_UPDATE_ENUM_REPLACE
-    policy.Action.StandardAction:
-      type: string
-      title: StandardAction
-      enum:
-        - STANDARD_ACTION_UNSPECIFIED
-        - STANDARD_ACTION_DECRYPT
-        - STANDARD_ACTION_TRANSMIT
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.AttributeRuleTypeEnum:
-      type: string
-      title: AttributeRuleTypeEnum
-      enum:
-        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
-        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
-    policy.ConditionBooleanTypeEnum:
-      type: string
-      title: ConditionBooleanTypeEnum
-      enum:
-        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
-        - CONDITION_BOOLEAN_TYPE_ENUM_AND
-        - CONDITION_BOOLEAN_TYPE_ENUM_OR
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.SortDirection:
-      type: string
-      title: SortDirection
-      enum:
-        - SORT_DIRECTION_UNSPECIFIED
-        - SORT_DIRECTION_ASC
-        - SORT_DIRECTION_DESC
-      description: |-
-        Sorting direction shared across list APIs.
-         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
-         the endpoint's request message defines the default ordering; see the
-         specific List* request docs.
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
-    policy.SubjectMappingOperatorEnum:
-      type: string
-      title: SubjectMappingOperatorEnum
-      enum:
-        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
-    policy.registeredresources.SortRegisteredResourcesType:
-      type: string
-      title: SortRegisteredResourcesType
-      enum:
-        - SORT_REGISTERED_RESOURCES_TYPE_UNSPECIFIED
-        - SORT_REGISTERED_RESOURCES_TYPE_NAME
-        - SORT_REGISTERED_RESOURCES_TYPE_CREATED_AT
-        - SORT_REGISTERED_RESOURCES_TYPE_UPDATED_AT
     common.Metadata:
       type: object
       properties:
@@ -539,6 +444,82 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    common.MetadataUpdateEnum:
+      type: string
+      title: MetadataUpdateEnum
+      enum:
+        - METADATA_UPDATE_ENUM_UNSPECIFIED
+        - METADATA_UPDATE_ENUM_EXTEND
+        - METADATA_UPDATE_ENUM_REPLACE
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.BoolValue:
       type: boolean
       description: |-
@@ -551,8 +532,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -646,41 +627,65 @@ components:
          ) to obtain a formatter capable of generating timestamps in this format.
     policy.Action:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            custom:
+            id:
               type: string
+              title: id
+              description: Generated uuid in database
+            name:
+              type: string
+              title: name
+            namespace:
+              title: namespace
+              description: Namespace context for this action
+              $ref: '#/components/schemas/policy.Namespace'
+            metadata:
+              title: metadata
+              $ref: '#/components/schemas/common.Metadata'
+        - oneOf:
+            - type: object
+              properties:
+                custom:
+                  type: string
+                  title: custom
+                  description: Deprecated
               title: custom
-              description: Deprecated
-          title: custom
-          required:
-            - custom
-        - properties:
-            standard:
+              required:
+                - custom
+            - type: object
+              properties:
+                standard:
+                  title: standard
+                  description: Deprecated
+                  $ref: '#/components/schemas/policy.Action.StandardAction'
               title: standard
-              description: Deprecated
-              $ref: '#/components/schemas/policy.Action.StandardAction'
-          title: standard
-          required:
-            - standard
-      properties:
-        id:
-          type: string
-          title: id
-          description: Generated uuid in database
-        name:
-          type: string
-          title: name
-        namespace:
-          title: namespace
-          description: Namespace context for this action
-          $ref: '#/components/schemas/policy.Namespace'
-        metadata:
-          title: metadata
-          $ref: '#/components/schemas/common.Metadata'
+              required:
+                - standard
       title: Action
       additionalProperties: false
       description: An action an entity can take
+    policy.Action.StandardAction:
+      type: string
+      title: StandardAction
+      enum:
+        - STANDARD_ACTION_UNSPECIFIED
+        - STANDARD_ACTION_DECRYPT
+        - STANDARD_ACTION_TRANSMIT
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.Attribute:
       type: object
       properties:
@@ -737,6 +742,14 @@ components:
       required:
         - rule
       additionalProperties: false
+    policy.AttributeRuleTypeEnum:
+      type: string
+      title: AttributeRuleTypeEnum
+      enum:
+        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
+        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
     policy.Condition:
       type: object
       properties:
@@ -754,7 +767,6 @@ components:
           type: array
           items:
             type: string
-            minItems: 1
           title: subject_external_values
           minItems: 1
           description: |-
@@ -770,6 +782,13 @@ components:
         *
         A Condition defines a rule of <the value at the flattened 'selector value'
         location> <operator> <subject external values>
+    policy.ConditionBooleanTypeEnum:
+      type: string
+      title: ConditionBooleanTypeEnum
+      enum:
+        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
+        - CONDITION_BOOLEAN_TYPE_ENUM_AND
+        - CONDITION_BOOLEAN_TYPE_ENUM_OR
     policy.ConditionGroup:
       type: object
       properties:
@@ -806,7 +825,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -818,6 +837,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -840,13 +872,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -1044,7 +1072,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -1052,17 +1081,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -1237,6 +1263,29 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
+    policy.SortDirection:
+      type: string
+      title: SortDirection
+      enum:
+        - SORT_DIRECTION_UNSPECIFIED
+        - SORT_DIRECTION_ASC
+        - SORT_DIRECTION_DESC
+      description: |-
+        Sorting direction shared across list APIs.
+         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
+         the endpoint's request message defines the default ordering; see the
+         specific List* request docs.
+    policy.SourceType:
+      type: string
+      title: SourceType
+      enum:
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
     policy.SubjectConditionSet:
       type: object
       properties:
@@ -1302,6 +1351,14 @@ components:
       description: |-
         Subject Mapping: A Policy assigning Subject Set(s) to a permitted attribute
         value + action(s) combination
+    policy.SubjectMappingOperatorEnum:
+      type: string
+      title: SubjectMappingOperatorEnum
+      enum:
+        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     policy.SubjectSet:
       type: object
       properties:
@@ -1372,7 +1429,8 @@ components:
       type: object
       allOf:
         - oneOf:
-            - properties:
+            - type: object
+              properties:
                 actionId:
                   type: string
                   title: action_id
@@ -1380,22 +1438,20 @@ components:
               title: action_id
               required:
                 - actionId
-            - properties:
+            - type: object
+              properties:
                 actionName:
                   type: string
                   title: action_name
                   maxLength: 253
-                  description: |+
-                    Action name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored action name will be normalized to lower case.:
-                    ```
-                    this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-                    ```
-
+                  description: |
+                    action_name_format // Action name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored action name will be normalized to lower case.
               title: action_name
               required:
                 - actionName
         - oneOf:
-            - properties:
+            - type: object
+              properties:
                 attributeValueFqn:
                   type: string
                   title: attribute_value_fqn
@@ -1404,7 +1460,8 @@ components:
               title: attribute_value_fqn
               required:
                 - attributeValueFqn
-            - properties:
+            - type: object
+              properties:
                 attributeValueId:
                   type: string
                   title: attribute_value_id
@@ -1421,20 +1478,15 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Required
-            Registered Resource Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+            rr_name_format // Registered Resource Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.
         values:
           type: array
           items:
             type: string
             maxLength: 253
             pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$
-            uniqueItems: true
           title: values
           uniqueItems: true
           description: |-
@@ -1480,13 +1532,9 @@ components:
           type: string
           title: value
           maxLength: 253
-          description: |+
+          description: |
             Required
-            Registered Resource Value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored value will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+            rr_value_format // Registered Resource Value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored value will be normalized to lower case.
         actionAttributeValues:
           type: array
           items:
@@ -1552,39 +1600,38 @@ components:
       additionalProperties: false
     policy.registeredresources.GetRegisteredResourceRequest:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            id:
+            namespaceFqn:
               type: string
-              title: id
+              title: namespace_fqn
+              minLength: 1
+              format: uri
+            namespaceId:
+              type: string
+              title: namespace_id
               format: uuid
-          title: id
-          required:
-            - id
-        - properties:
-            name:
-              type: string
+        - oneOf:
+            - type: object
+              properties:
+                id:
+                  type: string
+                  title: id
+                  format: uuid
+              title: id
+              required:
+                - id
+            - type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  maxLength: 253
+                  description: |
+                    rr_name_format // Registered Resource Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.
               title: name
-              maxLength: 253
-              description: |+
-                Registered Resource Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.:
-                ```
-                size(this) > 0 ? this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$') : true
-                ```
-
-          title: name
-          required:
-            - name
-      properties:
-        namespaceFqn:
-          type: string
-          title: namespace_fqn
-          minLength: 1
-          format: uri
-        namespaceId:
-          type: string
-          title: namespace_id
-          format: uuid
+              required:
+                - name
       title: GetRegisteredResourceRequest
       additionalProperties: false
     policy.registeredresources.GetRegisteredResourceResponse:
@@ -1598,7 +1645,8 @@ components:
     policy.registeredresources.GetRegisteredResourceValueRequest:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             fqn:
               type: string
               title: fqn
@@ -1607,7 +1655,8 @@ components:
           title: fqn
           required:
             - fqn
-        - properties:
+        - type: object
+          properties:
             id:
               type: string
               title: id
@@ -1634,8 +1683,6 @@ components:
             type: string
             minLength: 1
             format: uri
-            minItems: 1
-            uniqueItems: true
           title: fqns
           minItems: 1
           uniqueItems: true
@@ -1670,13 +1717,9 @@ components:
         resourceId:
           type: string
           title: resource_id
-          description: |+
+          description: |
             Optional
-            Optional field must be a valid UUID:
-            ```
-            size(this) == 0 || this.matches('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
-            ```
-
+            optional_uuid_format // Optional field must be a valid UUID
         pagination:
           title: pagination
           description: Optional
@@ -1750,6 +1793,14 @@ components:
           $ref: '#/components/schemas/policy.SortDirection'
       title: RegisteredResourcesSort
       additionalProperties: false
+    policy.registeredresources.SortRegisteredResourcesType:
+      type: string
+      title: SortRegisteredResourcesType
+      enum:
+        - SORT_REGISTERED_RESOURCES_TYPE_UNSPECIFIED
+        - SORT_REGISTERED_RESOURCES_TYPE_NAME
+        - SORT_REGISTERED_RESOURCES_TYPE_CREATED_AT
+        - SORT_REGISTERED_RESOURCES_TYPE_UPDATED_AT
     policy.registeredresources.UpdateRegisteredResourceRequest:
       type: object
       properties:
@@ -1762,13 +1813,9 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Optional
-            Registered Resource Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.:
-            ```
-            size(this) > 0 ? this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$') : true
-            ```
-
+            rr_name_format // Registered Resource Name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored name will be normalized to lower case.
         metadata:
           title: metadata
           description: |-
@@ -1800,13 +1847,9 @@ components:
           type: string
           title: value
           maxLength: 253
-          description: |+
+          description: |
             Optional
-            Registered Resource Value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored value will be normalized to lower case.:
-            ```
-            size(this) > 0 ? this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$') : true
-            ```
-
+            rr_value_format // Registered Resource Value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored value will be normalized to lower case.
         actionAttributeValues:
           type: array
           items:
@@ -1834,63 +1877,6 @@ components:
           $ref: '#/components/schemas/policy.RegisteredResourceValue'
       title: UpdateRegisteredResourceValueResponse
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: policy.registeredresources.RegisteredResourcesService

--- a/docs/openapi/policy/resourcemapping/resource_mapping.openapi.yaml
+++ b/docs/openapi/policy/resourcemapping/resource_mapping.openapi.yaml
@@ -2,12 +2,12 @@ openapi: 3.1.0
 info:
   title: policy.resourcemapping
 paths:
-  /policy.resourcemapping.ResourceMappingService/ListResourceMappingGroups:
+  /policy.resourcemapping.ResourceMappingService/CreateResourceMapping:
     post:
       tags:
         - policy.resourcemapping.ResourceMappingService
-      summary: ListResourceMappingGroups
-      operationId: policy.resourcemapping.ResourceMappingService.ListResourceMappingGroups
+      summary: CreateResourceMapping
+      operationId: policy.resourcemapping.ResourceMappingService.CreateResourceMapping
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -22,7 +22,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.resourcemapping.ListResourceMappingGroupsRequest'
+              $ref: '#/components/schemas/policy.resourcemapping.CreateResourceMappingRequest'
         required: true
       responses:
         default:
@@ -36,42 +36,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.resourcemapping.ListResourceMappingGroupsResponse'
-  /policy.resourcemapping.ResourceMappingService/GetResourceMappingGroup:
-    post:
-      tags:
-        - policy.resourcemapping.ResourceMappingService
-      summary: GetResourceMappingGroup
-      operationId: policy.resourcemapping.ResourceMappingService.GetResourceMappingGroup
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.resourcemapping.GetResourceMappingGroupRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.resourcemapping.GetResourceMappingGroupResponse'
+                $ref: '#/components/schemas/policy.resourcemapping.CreateResourceMappingResponse'
   /policy.resourcemapping.ResourceMappingService/CreateResourceMappingGroup:
     post:
       tags:
@@ -107,12 +72,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.resourcemapping.CreateResourceMappingGroupResponse'
-  /policy.resourcemapping.ResourceMappingService/UpdateResourceMappingGroup:
+  /policy.resourcemapping.ResourceMappingService/DeleteResourceMapping:
     post:
       tags:
         - policy.resourcemapping.ResourceMappingService
-      summary: UpdateResourceMappingGroup
-      operationId: policy.resourcemapping.ResourceMappingService.UpdateResourceMappingGroup
+      summary: DeleteResourceMapping
+      operationId: policy.resourcemapping.ResourceMappingService.DeleteResourceMapping
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -127,7 +92,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.resourcemapping.UpdateResourceMappingGroupRequest'
+              $ref: '#/components/schemas/policy.resourcemapping.DeleteResourceMappingRequest'
         required: true
       responses:
         default:
@@ -141,7 +106,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.resourcemapping.UpdateResourceMappingGroupResponse'
+                $ref: '#/components/schemas/policy.resourcemapping.DeleteResourceMappingResponse'
   /policy.resourcemapping.ResourceMappingService/DeleteResourceMappingGroup:
     post:
       tags:
@@ -177,6 +142,111 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.resourcemapping.DeleteResourceMappingGroupResponse'
+  /policy.resourcemapping.ResourceMappingService/GetResourceMapping:
+    post:
+      tags:
+        - policy.resourcemapping.ResourceMappingService
+      summary: GetResourceMapping
+      operationId: policy.resourcemapping.ResourceMappingService.GetResourceMapping
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.resourcemapping.GetResourceMappingRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.resourcemapping.GetResourceMappingResponse'
+  /policy.resourcemapping.ResourceMappingService/GetResourceMappingGroup:
+    post:
+      tags:
+        - policy.resourcemapping.ResourceMappingService
+      summary: GetResourceMappingGroup
+      operationId: policy.resourcemapping.ResourceMappingService.GetResourceMappingGroup
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.resourcemapping.GetResourceMappingGroupRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.resourcemapping.GetResourceMappingGroupResponse'
+  /policy.resourcemapping.ResourceMappingService/ListResourceMappingGroups:
+    post:
+      tags:
+        - policy.resourcemapping.ResourceMappingService
+      summary: ListResourceMappingGroups
+      operationId: policy.resourcemapping.ResourceMappingService.ListResourceMappingGroups
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.resourcemapping.ListResourceMappingGroupsRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.resourcemapping.ListResourceMappingGroupsResponse'
   /policy.resourcemapping.ResourceMappingService/ListResourceMappings:
     post:
       tags:
@@ -247,76 +317,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.resourcemapping.ListResourceMappingsByGroupFqnsResponse'
-  /policy.resourcemapping.ResourceMappingService/GetResourceMapping:
-    post:
-      tags:
-        - policy.resourcemapping.ResourceMappingService
-      summary: GetResourceMapping
-      operationId: policy.resourcemapping.ResourceMappingService.GetResourceMapping
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.resourcemapping.GetResourceMappingRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.resourcemapping.GetResourceMappingResponse'
-  /policy.resourcemapping.ResourceMappingService/CreateResourceMapping:
-    post:
-      tags:
-        - policy.resourcemapping.ResourceMappingService
-      summary: CreateResourceMapping
-      operationId: policy.resourcemapping.ResourceMappingService.CreateResourceMapping
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.resourcemapping.CreateResourceMappingRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.resourcemapping.CreateResourceMappingResponse'
   /policy.resourcemapping.ResourceMappingService/UpdateResourceMapping:
     post:
       tags:
@@ -352,12 +352,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.resourcemapping.UpdateResourceMappingResponse'
-  /policy.resourcemapping.ResourceMappingService/DeleteResourceMapping:
+  /policy.resourcemapping.ResourceMappingService/UpdateResourceMappingGroup:
     post:
       tags:
         - policy.resourcemapping.ResourceMappingService
-      summary: DeleteResourceMapping
-      operationId: policy.resourcemapping.ResourceMappingService.DeleteResourceMapping
+      summary: UpdateResourceMappingGroup
+      operationId: policy.resourcemapping.ResourceMappingService.UpdateResourceMappingGroup
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -372,7 +372,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.resourcemapping.DeleteResourceMappingRequest'
+              $ref: '#/components/schemas/policy.resourcemapping.UpdateResourceMappingGroupRequest'
         required: true
       responses:
         default:
@@ -386,84 +386,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.resourcemapping.DeleteResourceMappingResponse'
+                $ref: '#/components/schemas/policy.resourcemapping.UpdateResourceMappingGroupResponse'
 components:
   schemas:
-    common.MetadataUpdateEnum:
-      type: string
-      title: MetadataUpdateEnum
-      enum:
-        - METADATA_UPDATE_ENUM_UNSPECIFIED
-        - METADATA_UPDATE_ENUM_EXTEND
-        - METADATA_UPDATE_ENUM_REPLACE
-    policy.Action.StandardAction:
-      type: string
-      title: StandardAction
-      enum:
-        - STANDARD_ACTION_UNSPECIFIED
-        - STANDARD_ACTION_DECRYPT
-        - STANDARD_ACTION_TRANSMIT
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.AttributeRuleTypeEnum:
-      type: string
-      title: AttributeRuleTypeEnum
-      enum:
-        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
-        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
-    policy.ConditionBooleanTypeEnum:
-      type: string
-      title: ConditionBooleanTypeEnum
-      enum:
-        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
-        - CONDITION_BOOLEAN_TYPE_ENUM_AND
-        - CONDITION_BOOLEAN_TYPE_ENUM_OR
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
-    policy.SubjectMappingOperatorEnum:
-      type: string
-      title: SubjectMappingOperatorEnum
-      enum:
-        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     common.Metadata:
       type: object
       properties:
@@ -519,6 +444,82 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    common.MetadataUpdateEnum:
+      type: string
+      title: MetadataUpdateEnum
+      enum:
+        - METADATA_UPDATE_ENUM_UNSPECIFIED
+        - METADATA_UPDATE_ENUM_EXTEND
+        - METADATA_UPDATE_ENUM_REPLACE
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.BoolValue:
       type: boolean
       description: |-
@@ -531,8 +532,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -626,41 +627,65 @@ components:
          ) to obtain a formatter capable of generating timestamps in this format.
     policy.Action:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            custom:
+            id:
               type: string
+              title: id
+              description: Generated uuid in database
+            name:
+              type: string
+              title: name
+            namespace:
+              title: namespace
+              description: Namespace context for this action
+              $ref: '#/components/schemas/policy.Namespace'
+            metadata:
+              title: metadata
+              $ref: '#/components/schemas/common.Metadata'
+        - oneOf:
+            - type: object
+              properties:
+                custom:
+                  type: string
+                  title: custom
+                  description: Deprecated
               title: custom
-              description: Deprecated
-          title: custom
-          required:
-            - custom
-        - properties:
-            standard:
+              required:
+                - custom
+            - type: object
+              properties:
+                standard:
+                  title: standard
+                  description: Deprecated
+                  $ref: '#/components/schemas/policy.Action.StandardAction'
               title: standard
-              description: Deprecated
-              $ref: '#/components/schemas/policy.Action.StandardAction'
-          title: standard
-          required:
-            - standard
-      properties:
-        id:
-          type: string
-          title: id
-          description: Generated uuid in database
-        name:
-          type: string
-          title: name
-        namespace:
-          title: namespace
-          description: Namespace context for this action
-          $ref: '#/components/schemas/policy.Namespace'
-        metadata:
-          title: metadata
-          $ref: '#/components/schemas/common.Metadata'
+              required:
+                - standard
       title: Action
       additionalProperties: false
       description: An action an entity can take
+    policy.Action.StandardAction:
+      type: string
+      title: StandardAction
+      enum:
+        - STANDARD_ACTION_UNSPECIFIED
+        - STANDARD_ACTION_DECRYPT
+        - STANDARD_ACTION_TRANSMIT
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.Attribute:
       type: object
       properties:
@@ -717,6 +742,14 @@ components:
       required:
         - rule
       additionalProperties: false
+    policy.AttributeRuleTypeEnum:
+      type: string
+      title: AttributeRuleTypeEnum
+      enum:
+        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
+        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
     policy.Condition:
       type: object
       properties:
@@ -734,7 +767,6 @@ components:
           type: array
           items:
             type: string
-            minItems: 1
           title: subject_external_values
           minItems: 1
           description: |-
@@ -750,6 +782,13 @@ components:
         *
         A Condition defines a rule of <the value at the flattened 'selector value'
         location> <operator> <subject external values>
+    policy.ConditionBooleanTypeEnum:
+      type: string
+      title: ConditionBooleanTypeEnum
+      enum:
+        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
+        - CONDITION_BOOLEAN_TYPE_ENUM_AND
+        - CONDITION_BOOLEAN_TYPE_ENUM_OR
     policy.ConditionGroup:
       type: object
       properties:
@@ -786,7 +825,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -798,6 +837,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -820,13 +872,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -1024,7 +1072,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -1032,17 +1081,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -1150,6 +1196,17 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
+    policy.SourceType:
+      type: string
+      title: SourceType
+      enum:
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
     policy.SubjectConditionSet:
       type: object
       properties:
@@ -1215,6 +1272,14 @@ components:
       description: |-
         Subject Mapping: A Policy assigning Subject Set(s) to a permitted attribute
         value + action(s) combination
+    policy.SubjectMappingOperatorEnum:
+      type: string
+      title: SubjectMappingOperatorEnum
+      enum:
+        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     policy.SubjectSet:
       type: object
       properties:
@@ -1321,8 +1386,6 @@ components:
           type: array
           items:
             type: string
-            maxItems: 1000
-            minItems: 1
           title: terms
           maxItems: 1000
           minItems: 1
@@ -1330,13 +1393,9 @@ components:
         groupId:
           type: string
           title: group_id
-          description: |+
+          description: |
             Optional
-            Optional field must be a valid UUID:
-            ```
-            size(this) == 0 || this.matches('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
-            ```
-
+            optional_uuid_format // Optional field must be a valid UUID
         metadata:
           title: metadata
           description: Optional
@@ -1429,13 +1488,9 @@ components:
         namespaceId:
           type: string
           title: namespace_id
-          description: |+
+          description: |
             Optional
-            Optional field must be a valid UUID:
-            ```
-            size(this) == 0 || this.matches('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
-            ```
-
+            optional_uuid_format // Optional field must be a valid UUID
         pagination:
           title: pagination
           description: Optional
@@ -1462,7 +1517,6 @@ components:
           type: array
           items:
             type: string
-            minItems: 1
           title: fqns
           minItems: 1
           description: |-
@@ -1498,13 +1552,9 @@ components:
         groupId:
           type: string
           title: group_id
-          description: |+
+          description: |
             Optional
-            Optional field must be a valid UUID:
-            ```
-            size(this) == 0 || this.matches('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
-            ```
-
+            optional_uuid_format // Optional field must be a valid UUID
         pagination:
           title: pagination
           description: Optional
@@ -1548,24 +1598,16 @@ components:
         namespaceId:
           type: string
           title: namespace_id
-          description: |+
+          description: |
             Optional
-            Optional field must be a valid UUID:
-            ```
-            size(this) == 0 || this.matches('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
-            ```
-
+            optional_uuid_format // Optional field must be a valid UUID
         name:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Optional
-            Optional field must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored group name will be normalized to lower case.:
-            ```
-            size(this) == 0 || this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+            optional_name_format // Optional field must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored group name will be normalized to lower case.
         metadata:
           title: metadata
           description: Common metadata
@@ -1594,31 +1636,22 @@ components:
         attributeValueId:
           type: string
           title: attribute_value_id
-          description: |+
+          description: |
             Optional
-            Optional field must be a valid UUID:
-            ```
-            size(this) == 0 || this.matches('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
-            ```
-
+            optional_uuid_format // Optional field must be a valid UUID
         terms:
           type: array
           items:
             type: string
-            maxItems: 1000
           title: terms
           maxItems: 1000
           description: Optional
         groupId:
           type: string
           title: group_id
-          description: |+
+          description: |
             Optional
-            Optional field must be a valid UUID:
-            ```
-            size(this) == 0 || this.matches('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
-            ```
-
+            optional_uuid_format // Optional field must be a valid UUID
         metadata:
           title: metadata
           description: |-
@@ -1638,63 +1671,6 @@ components:
           $ref: '#/components/schemas/policy.ResourceMapping'
       title: UpdateResourceMappingResponse
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: policy.resourcemapping.ResourceMappingService

--- a/docs/openapi/policy/selectors.openapi.yaml
+++ b/docs/openapi/policy/selectors.openapi.yaml
@@ -4,18 +4,6 @@ info:
 paths: {}
 components:
   schemas:
-    policy.SortDirection:
-      type: string
-      title: SortDirection
-      enum:
-        - SORT_DIRECTION_UNSPECIFIED
-        - SORT_DIRECTION_ASC
-        - SORT_DIRECTION_DESC
-      description: |-
-        Sorting direction shared across list APIs.
-         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
-         the endpoint's request message defines the default ordering; see the
-         specific List* request docs.
     policy.AttributeDefinitionSelector:
       type: object
       properties:
@@ -164,4 +152,16 @@ components:
           description: Total count of entire list
       title: PageResponse
       additionalProperties: false
+    policy.SortDirection:
+      type: string
+      title: SortDirection
+      enum:
+        - SORT_DIRECTION_UNSPECIFIED
+        - SORT_DIRECTION_ASC
+        - SORT_DIRECTION_DESC
+      description: |-
+        Sorting direction shared across list APIs.
+         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
+         the endpoint's request message defines the default ordering; see the
+         specific List* request docs.
 security: []

--- a/docs/openapi/policy/subjectmapping/subject_mapping.openapi.yaml
+++ b/docs/openapi/policy/subjectmapping/subject_mapping.openapi.yaml
@@ -2,6 +2,321 @@ openapi: 3.1.0
 info:
   title: policy.subjectmapping
 paths:
+  /policy.subjectmapping.SubjectMappingService/CreateSubjectConditionSet:
+    post:
+      tags:
+        - policy.subjectmapping.SubjectMappingService
+      summary: CreateSubjectConditionSet
+      operationId: policy.subjectmapping.SubjectMappingService.CreateSubjectConditionSet
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.subjectmapping.CreateSubjectConditionSetRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.subjectmapping.CreateSubjectConditionSetResponse'
+  /policy.subjectmapping.SubjectMappingService/CreateSubjectMapping:
+    post:
+      tags:
+        - policy.subjectmapping.SubjectMappingService
+      summary: CreateSubjectMapping
+      operationId: policy.subjectmapping.SubjectMappingService.CreateSubjectMapping
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.subjectmapping.CreateSubjectMappingRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.subjectmapping.CreateSubjectMappingResponse'
+  /policy.subjectmapping.SubjectMappingService/DeleteAllUnmappedSubjectConditionSets:
+    post:
+      tags:
+        - policy.subjectmapping.SubjectMappingService
+      summary: DeleteAllUnmappedSubjectConditionSets
+      operationId: policy.subjectmapping.SubjectMappingService.DeleteAllUnmappedSubjectConditionSets
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.subjectmapping.DeleteAllUnmappedSubjectConditionSetsRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.subjectmapping.DeleteAllUnmappedSubjectConditionSetsResponse'
+  /policy.subjectmapping.SubjectMappingService/DeleteSubjectConditionSet:
+    post:
+      tags:
+        - policy.subjectmapping.SubjectMappingService
+      summary: DeleteSubjectConditionSet
+      operationId: policy.subjectmapping.SubjectMappingService.DeleteSubjectConditionSet
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.subjectmapping.DeleteSubjectConditionSetRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.subjectmapping.DeleteSubjectConditionSetResponse'
+  /policy.subjectmapping.SubjectMappingService/DeleteSubjectMapping:
+    post:
+      tags:
+        - policy.subjectmapping.SubjectMappingService
+      summary: DeleteSubjectMapping
+      operationId: policy.subjectmapping.SubjectMappingService.DeleteSubjectMapping
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.subjectmapping.DeleteSubjectMappingRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.subjectmapping.DeleteSubjectMappingResponse'
+  /policy.subjectmapping.SubjectMappingService/GetSubjectConditionSet:
+    post:
+      tags:
+        - policy.subjectmapping.SubjectMappingService
+      summary: GetSubjectConditionSet
+      operationId: policy.subjectmapping.SubjectMappingService.GetSubjectConditionSet
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.subjectmapping.GetSubjectConditionSetRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.subjectmapping.GetSubjectConditionSetResponse'
+  /policy.subjectmapping.SubjectMappingService/GetSubjectMapping:
+    post:
+      tags:
+        - policy.subjectmapping.SubjectMappingService
+      summary: GetSubjectMapping
+      operationId: policy.subjectmapping.SubjectMappingService.GetSubjectMapping
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.subjectmapping.GetSubjectMappingRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.subjectmapping.GetSubjectMappingResponse'
+  /policy.subjectmapping.SubjectMappingService/ListSubjectConditionSets:
+    post:
+      tags:
+        - policy.subjectmapping.SubjectMappingService
+      summary: ListSubjectConditionSets
+      operationId: policy.subjectmapping.SubjectMappingService.ListSubjectConditionSets
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.subjectmapping.ListSubjectConditionSetsRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.subjectmapping.ListSubjectConditionSetsResponse'
+  /policy.subjectmapping.SubjectMappingService/ListSubjectMappings:
+    post:
+      tags:
+        - policy.subjectmapping.SubjectMappingService
+      summary: ListSubjectMappings
+      operationId: policy.subjectmapping.SubjectMappingService.ListSubjectMappings
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.subjectmapping.ListSubjectMappingsRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.subjectmapping.ListSubjectMappingsResponse'
   /policy.subjectmapping.SubjectMappingService/MatchSubjectMappings:
     post:
       tags:
@@ -38,286 +353,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.subjectmapping.MatchSubjectMappingsResponse'
-  /policy.subjectmapping.SubjectMappingService/ListSubjectMappings:
-    post:
-      tags:
-        - policy.subjectmapping.SubjectMappingService
-      summary: ListSubjectMappings
-      operationId: policy.subjectmapping.SubjectMappingService.ListSubjectMappings
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.subjectmapping.ListSubjectMappingsRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.subjectmapping.ListSubjectMappingsResponse'
-  /policy.subjectmapping.SubjectMappingService/GetSubjectMapping:
-    post:
-      tags:
-        - policy.subjectmapping.SubjectMappingService
-      summary: GetSubjectMapping
-      operationId: policy.subjectmapping.SubjectMappingService.GetSubjectMapping
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.subjectmapping.GetSubjectMappingRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.subjectmapping.GetSubjectMappingResponse'
-  /policy.subjectmapping.SubjectMappingService/CreateSubjectMapping:
-    post:
-      tags:
-        - policy.subjectmapping.SubjectMappingService
-      summary: CreateSubjectMapping
-      operationId: policy.subjectmapping.SubjectMappingService.CreateSubjectMapping
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.subjectmapping.CreateSubjectMappingRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.subjectmapping.CreateSubjectMappingResponse'
-  /policy.subjectmapping.SubjectMappingService/UpdateSubjectMapping:
-    post:
-      tags:
-        - policy.subjectmapping.SubjectMappingService
-      summary: UpdateSubjectMapping
-      operationId: policy.subjectmapping.SubjectMappingService.UpdateSubjectMapping
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.subjectmapping.UpdateSubjectMappingRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.subjectmapping.UpdateSubjectMappingResponse'
-  /policy.subjectmapping.SubjectMappingService/DeleteSubjectMapping:
-    post:
-      tags:
-        - policy.subjectmapping.SubjectMappingService
-      summary: DeleteSubjectMapping
-      operationId: policy.subjectmapping.SubjectMappingService.DeleteSubjectMapping
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.subjectmapping.DeleteSubjectMappingRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.subjectmapping.DeleteSubjectMappingResponse'
-  /policy.subjectmapping.SubjectMappingService/ListSubjectConditionSets:
-    post:
-      tags:
-        - policy.subjectmapping.SubjectMappingService
-      summary: ListSubjectConditionSets
-      operationId: policy.subjectmapping.SubjectMappingService.ListSubjectConditionSets
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.subjectmapping.ListSubjectConditionSetsRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.subjectmapping.ListSubjectConditionSetsResponse'
-  /policy.subjectmapping.SubjectMappingService/GetSubjectConditionSet:
-    post:
-      tags:
-        - policy.subjectmapping.SubjectMappingService
-      summary: GetSubjectConditionSet
-      operationId: policy.subjectmapping.SubjectMappingService.GetSubjectConditionSet
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.subjectmapping.GetSubjectConditionSetRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.subjectmapping.GetSubjectConditionSetResponse'
-  /policy.subjectmapping.SubjectMappingService/CreateSubjectConditionSet:
-    post:
-      tags:
-        - policy.subjectmapping.SubjectMappingService
-      summary: CreateSubjectConditionSet
-      operationId: policy.subjectmapping.SubjectMappingService.CreateSubjectConditionSet
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.subjectmapping.CreateSubjectConditionSetRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.subjectmapping.CreateSubjectConditionSetResponse'
   /policy.subjectmapping.SubjectMappingService/UpdateSubjectConditionSet:
     post:
       tags:
@@ -353,12 +388,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.subjectmapping.UpdateSubjectConditionSetResponse'
-  /policy.subjectmapping.SubjectMappingService/DeleteSubjectConditionSet:
+  /policy.subjectmapping.SubjectMappingService/UpdateSubjectMapping:
     post:
       tags:
         - policy.subjectmapping.SubjectMappingService
-      summary: DeleteSubjectConditionSet
-      operationId: policy.subjectmapping.SubjectMappingService.DeleteSubjectConditionSet
+      summary: UpdateSubjectMapping
+      operationId: policy.subjectmapping.SubjectMappingService.UpdateSubjectMapping
       parameters:
         - name: Connect-Protocol-Version
           in: header
@@ -373,7 +408,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/policy.subjectmapping.DeleteSubjectConditionSetRequest'
+              $ref: '#/components/schemas/policy.subjectmapping.UpdateSubjectMappingRequest'
         required: true
       responses:
         default:
@@ -387,145 +422,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/policy.subjectmapping.DeleteSubjectConditionSetResponse'
-  /policy.subjectmapping.SubjectMappingService/DeleteAllUnmappedSubjectConditionSets:
-    post:
-      tags:
-        - policy.subjectmapping.SubjectMappingService
-      summary: DeleteAllUnmappedSubjectConditionSets
-      operationId: policy.subjectmapping.SubjectMappingService.DeleteAllUnmappedSubjectConditionSets
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.subjectmapping.DeleteAllUnmappedSubjectConditionSetsRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.subjectmapping.DeleteAllUnmappedSubjectConditionSetsResponse'
+                $ref: '#/components/schemas/policy.subjectmapping.UpdateSubjectMappingResponse'
 components:
   schemas:
-    common.MetadataUpdateEnum:
-      type: string
-      title: MetadataUpdateEnum
-      enum:
-        - METADATA_UPDATE_ENUM_UNSPECIFIED
-        - METADATA_UPDATE_ENUM_EXTEND
-        - METADATA_UPDATE_ENUM_REPLACE
-    policy.Action.StandardAction:
-      type: string
-      title: StandardAction
-      enum:
-        - STANDARD_ACTION_UNSPECIFIED
-        - STANDARD_ACTION_DECRYPT
-        - STANDARD_ACTION_TRANSMIT
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.AttributeRuleTypeEnum:
-      type: string
-      title: AttributeRuleTypeEnum
-      enum:
-        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
-        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
-    policy.ConditionBooleanTypeEnum:
-      type: string
-      title: ConditionBooleanTypeEnum
-      enum:
-        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
-        - CONDITION_BOOLEAN_TYPE_ENUM_AND
-        - CONDITION_BOOLEAN_TYPE_ENUM_OR
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.SortDirection:
-      type: string
-      title: SortDirection
-      enum:
-        - SORT_DIRECTION_UNSPECIFIED
-        - SORT_DIRECTION_ASC
-        - SORT_DIRECTION_DESC
-      description: |-
-        Sorting direction shared across list APIs.
-         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
-         the endpoint's request message defines the default ordering; see the
-         specific List* request docs.
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
-    policy.SubjectMappingOperatorEnum:
-      type: string
-      title: SubjectMappingOperatorEnum
-      enum:
-        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
-    policy.subjectmapping.SortSubjectConditionSetsType:
-      type: string
-      title: SortSubjectConditionSetsType
-      enum:
-        - SORT_SUBJECT_CONDITION_SETS_TYPE_UNSPECIFIED
-        - SORT_SUBJECT_CONDITION_SETS_TYPE_CREATED_AT
-        - SORT_SUBJECT_CONDITION_SETS_TYPE_UPDATED_AT
-    policy.subjectmapping.SortSubjectMappingsType:
-      type: string
-      title: SortSubjectMappingsType
-      enum:
-        - SORT_SUBJECT_MAPPINGS_TYPE_UNSPECIFIED
-        - SORT_SUBJECT_MAPPINGS_TYPE_CREATED_AT
-        - SORT_SUBJECT_MAPPINGS_TYPE_UPDATED_AT
     common.Metadata:
       type: object
       properties:
@@ -581,6 +480,82 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    common.MetadataUpdateEnum:
+      type: string
+      title: MetadataUpdateEnum
+      enum:
+        - METADATA_UPDATE_ENUM_UNSPECIFIED
+        - METADATA_UPDATE_ENUM_EXTEND
+        - METADATA_UPDATE_ENUM_REPLACE
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.BoolValue:
       type: boolean
       description: |-
@@ -593,8 +568,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -688,41 +663,65 @@ components:
          ) to obtain a formatter capable of generating timestamps in this format.
     policy.Action:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            custom:
+            id:
               type: string
+              title: id
+              description: Generated uuid in database
+            name:
+              type: string
+              title: name
+            namespace:
+              title: namespace
+              description: Namespace context for this action
+              $ref: '#/components/schemas/policy.Namespace'
+            metadata:
+              title: metadata
+              $ref: '#/components/schemas/common.Metadata'
+        - oneOf:
+            - type: object
+              properties:
+                custom:
+                  type: string
+                  title: custom
+                  description: Deprecated
               title: custom
-              description: Deprecated
-          title: custom
-          required:
-            - custom
-        - properties:
-            standard:
+              required:
+                - custom
+            - type: object
+              properties:
+                standard:
+                  title: standard
+                  description: Deprecated
+                  $ref: '#/components/schemas/policy.Action.StandardAction'
               title: standard
-              description: Deprecated
-              $ref: '#/components/schemas/policy.Action.StandardAction'
-          title: standard
-          required:
-            - standard
-      properties:
-        id:
-          type: string
-          title: id
-          description: Generated uuid in database
-        name:
-          type: string
-          title: name
-        namespace:
-          title: namespace
-          description: Namespace context for this action
-          $ref: '#/components/schemas/policy.Namespace'
-        metadata:
-          title: metadata
-          $ref: '#/components/schemas/common.Metadata'
+              required:
+                - standard
       title: Action
       additionalProperties: false
       description: An action an entity can take
+    policy.Action.StandardAction:
+      type: string
+      title: StandardAction
+      enum:
+        - STANDARD_ACTION_UNSPECIFIED
+        - STANDARD_ACTION_DECRYPT
+        - STANDARD_ACTION_TRANSMIT
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.Attribute:
       type: object
       properties:
@@ -779,6 +778,14 @@ components:
       required:
         - rule
       additionalProperties: false
+    policy.AttributeRuleTypeEnum:
+      type: string
+      title: AttributeRuleTypeEnum
+      enum:
+        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
+        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
     policy.Condition:
       type: object
       properties:
@@ -796,7 +803,6 @@ components:
           type: array
           items:
             type: string
-            minItems: 1
           title: subject_external_values
           minItems: 1
           description: |-
@@ -812,6 +818,13 @@ components:
         *
         A Condition defines a rule of <the value at the flattened 'selector value'
         location> <operator> <subject external values>
+    policy.ConditionBooleanTypeEnum:
+      type: string
+      title: ConditionBooleanTypeEnum
+      enum:
+        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
+        - CONDITION_BOOLEAN_TYPE_ENUM_AND
+        - CONDITION_BOOLEAN_TYPE_ENUM_OR
     policy.ConditionGroup:
       type: object
       properties:
@@ -848,7 +861,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -860,6 +873,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -882,13 +908,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -1086,7 +1108,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -1094,17 +1117,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -1212,6 +1232,29 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
+    policy.SortDirection:
+      type: string
+      title: SortDirection
+      enum:
+        - SORT_DIRECTION_UNSPECIFIED
+        - SORT_DIRECTION_ASC
+        - SORT_DIRECTION_DESC
+      description: |-
+        Sorting direction shared across list APIs.
+         When the 'sort' field is omitted or the chosen sort 'field' is UNSPECIFIED,
+         the endpoint's request message defines the default ordering; see the
+         specific List* request docs.
+    policy.SourceType:
+      type: string
+      title: SourceType
+      enum:
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
     policy.SubjectConditionSet:
       type: object
       properties:
@@ -1277,6 +1320,14 @@ components:
       description: |-
         Subject Mapping: A Policy assigning Subject Set(s) to a permitted attribute
         value + action(s) combination
+    policy.SubjectMappingOperatorEnum:
+      type: string
+      title: SubjectMappingOperatorEnum
+      enum:
+        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     policy.SubjectProperty:
       type: object
       properties:
@@ -1297,7 +1348,6 @@ components:
         authoritative source such as an IDP (Identity Provider) or User Store.
         Examples include such ADFS/LDAP, OKTA, etc. For now, a valid property must
         contain both a selector expression & a resulting value.
-
         The external_selector_value is a specifier to select a value from a flattened
         external representation of an Entity (such as from idP/LDAP), and the
         external_value is the value selected by the external_selector_value on that
@@ -1411,25 +1461,17 @@ components:
             $ref: '#/components/schemas/policy.Action'
           title: actions
           minItems: 1
-          description: |+
+          description: |
             Required
              The actions permitted by subjects in this mapping
-            Action name or ID must not be empty if provided:
-            ```
-            this.all(item, item.name != '' || item.id != '')
-            ```
-
+            action_name_or_id_not_empty // Action name or ID must not be empty if provided
         existingSubjectConditionSetId:
           type: string
           title: existing_subject_condition_set_id
-          description: |+
+          description: |
             Either of the following:
              Reuse existing SubjectConditionSet (NOTE: prioritized over new_subject_condition_set)
-            Optional field must be a valid UUID:
-            ```
-            size(this) == 0 || this.matches('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
-            ```
-
+            optional_uuid_format // Optional field must be a valid UUID
         newSubjectConditionSet:
           title: new_subject_condition_set
           description: 'Create new SubjectConditionSet (NOTE: ignored if existing_subject_condition_set_id is provided)'
@@ -1666,6 +1708,20 @@ components:
           title: subject_mappings
       title: MatchSubjectMappingsResponse
       additionalProperties: false
+    policy.subjectmapping.SortSubjectConditionSetsType:
+      type: string
+      title: SortSubjectConditionSetsType
+      enum:
+        - SORT_SUBJECT_CONDITION_SETS_TYPE_UNSPECIFIED
+        - SORT_SUBJECT_CONDITION_SETS_TYPE_CREATED_AT
+        - SORT_SUBJECT_CONDITION_SETS_TYPE_UPDATED_AT
+    policy.subjectmapping.SortSubjectMappingsType:
+      type: string
+      title: SortSubjectMappingsType
+      enum:
+        - SORT_SUBJECT_MAPPINGS_TYPE_UNSPECIFIED
+        - SORT_SUBJECT_MAPPINGS_TYPE_CREATED_AT
+        - SORT_SUBJECT_MAPPINGS_TYPE_UPDATED_AT
     policy.subjectmapping.SubjectConditionSetCreate:
       type: object
       properties:
@@ -1751,27 +1807,19 @@ components:
         subjectConditionSetId:
           type: string
           title: subject_condition_set_id
-          description: |+
+          description: |
             Optional
              Replaces the existing SubjectConditionSet id with a new one
-            Optional field must be a valid UUID:
-            ```
-            size(this) == 0 || this.matches('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
-            ```
-
+            optional_uuid_format // Optional field must be a valid UUID
         actions:
           type: array
           items:
             $ref: '#/components/schemas/policy.Action'
           title: actions
-          description: |+
+          description: |
             Optional
              Replaces entire list of actions permitted by subjects
-            Action name or ID must not be empty if provided:
-            ```
-            this.size() == 0 || this.all(item, item.name != '' || item.id != '')
-            ```
-
+            action_name_or_id_not_empty // Action name or ID must not be empty if provided
         metadata:
           title: metadata
           description: Common metadata
@@ -1790,63 +1838,6 @@ components:
           $ref: '#/components/schemas/policy.SubjectMapping'
       title: UpdateSubjectMappingResponse
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: policy.subjectmapping.SubjectMappingService

--- a/docs/openapi/policy/unsafe/unsafe.openapi.yaml
+++ b/docs/openapi/policy/unsafe/unsafe.openapi.yaml
@@ -2,189 +2,6 @@ openapi: 3.1.0
 info:
   title: policy.unsafe
 paths:
-  /policy.unsafe.UnsafeService/UnsafeUpdateNamespace:
-    post:
-      tags:
-        - policy.unsafe.UnsafeService
-      summary: UnsafeUpdateNamespace
-      description: |-
-        --------------------------------------*
-         Namespace RPCs
-        ---------------------------------------
-      operationId: policy.unsafe.UnsafeService.UnsafeUpdateNamespace
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateNamespaceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateNamespaceResponse'
-  /policy.unsafe.UnsafeService/UnsafeReactivateNamespace:
-    post:
-      tags:
-        - policy.unsafe.UnsafeService
-      summary: UnsafeReactivateNamespace
-      operationId: policy.unsafe.UnsafeService.UnsafeReactivateNamespace
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateNamespaceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateNamespaceResponse'
-  /policy.unsafe.UnsafeService/UnsafeDeleteNamespace:
-    post:
-      tags:
-        - policy.unsafe.UnsafeService
-      summary: UnsafeDeleteNamespace
-      operationId: policy.unsafe.UnsafeService.UnsafeDeleteNamespace
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.unsafe.UnsafeDeleteNamespaceRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.unsafe.UnsafeDeleteNamespaceResponse'
-  /policy.unsafe.UnsafeService/UnsafeUpdateAttribute:
-    post:
-      tags:
-        - policy.unsafe.UnsafeService
-      summary: UnsafeUpdateAttribute
-      description: |-
-        --------------------------------------*
-         Attribute RPCs
-        ---------------------------------------
-      operationId: policy.unsafe.UnsafeService.UnsafeUpdateAttribute
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateAttributeRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateAttributeResponse'
-  /policy.unsafe.UnsafeService/UnsafeReactivateAttribute:
-    post:
-      tags:
-        - policy.unsafe.UnsafeService
-      summary: UnsafeReactivateAttribute
-      operationId: policy.unsafe.UnsafeService.UnsafeReactivateAttribute
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateAttributeRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateAttributeResponse'
   /policy.unsafe.UnsafeService/UnsafeDeleteAttribute:
     post:
       tags:
@@ -220,80 +37,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.unsafe.UnsafeDeleteAttributeResponse'
-  /policy.unsafe.UnsafeService/UnsafeUpdateAttributeValue:
-    post:
-      tags:
-        - policy.unsafe.UnsafeService
-      summary: UnsafeUpdateAttributeValue
-      description: |-
-        --------------------------------------*
-         Value RPCs
-        ---------------------------------------
-      operationId: policy.unsafe.UnsafeService.UnsafeUpdateAttributeValue
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateAttributeValueRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateAttributeValueResponse'
-  /policy.unsafe.UnsafeService/UnsafeReactivateAttributeValue:
-    post:
-      tags:
-        - policy.unsafe.UnsafeService
-      summary: UnsafeReactivateAttributeValue
-      operationId: policy.unsafe.UnsafeService.UnsafeReactivateAttributeValue
-      parameters:
-        - name: Connect-Protocol-Version
-          in: header
-          required: true
-          schema:
-            $ref: '#/components/schemas/connect-protocol-version'
-        - name: Connect-Timeout-Ms
-          in: header
-          schema:
-            $ref: '#/components/schemas/connect-timeout-header'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateAttributeValueRequest'
-        required: true
-      responses:
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/connect.error'
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateAttributeValueResponse'
   /policy.unsafe.UnsafeService/UnsafeDeleteAttributeValue:
     post:
       tags:
@@ -368,94 +111,265 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/policy.unsafe.UnsafeDeleteKasKeyResponse'
+  /policy.unsafe.UnsafeService/UnsafeDeleteNamespace:
+    post:
+      tags:
+        - policy.unsafe.UnsafeService
+      summary: UnsafeDeleteNamespace
+      operationId: policy.unsafe.UnsafeService.UnsafeDeleteNamespace
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.unsafe.UnsafeDeleteNamespaceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.unsafe.UnsafeDeleteNamespaceResponse'
+  /policy.unsafe.UnsafeService/UnsafeReactivateAttribute:
+    post:
+      tags:
+        - policy.unsafe.UnsafeService
+      summary: UnsafeReactivateAttribute
+      operationId: policy.unsafe.UnsafeService.UnsafeReactivateAttribute
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateAttributeRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateAttributeResponse'
+  /policy.unsafe.UnsafeService/UnsafeReactivateAttributeValue:
+    post:
+      tags:
+        - policy.unsafe.UnsafeService
+      summary: UnsafeReactivateAttributeValue
+      operationId: policy.unsafe.UnsafeService.UnsafeReactivateAttributeValue
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateAttributeValueRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateAttributeValueResponse'
+  /policy.unsafe.UnsafeService/UnsafeReactivateNamespace:
+    post:
+      tags:
+        - policy.unsafe.UnsafeService
+      summary: UnsafeReactivateNamespace
+      operationId: policy.unsafe.UnsafeService.UnsafeReactivateNamespace
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateNamespaceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.unsafe.UnsafeReactivateNamespaceResponse'
+  /policy.unsafe.UnsafeService/UnsafeUpdateAttribute:
+    post:
+      tags:
+        - policy.unsafe.UnsafeService
+      summary: UnsafeUpdateAttribute
+      description: |-
+        --------------------------------------*
+         Attribute RPCs
+        ---------------------------------------
+      operationId: policy.unsafe.UnsafeService.UnsafeUpdateAttribute
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateAttributeRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateAttributeResponse'
+  /policy.unsafe.UnsafeService/UnsafeUpdateAttributeValue:
+    post:
+      tags:
+        - policy.unsafe.UnsafeService
+      summary: UnsafeUpdateAttributeValue
+      description: |-
+        --------------------------------------*
+         Value RPCs
+        ---------------------------------------
+      operationId: policy.unsafe.UnsafeService.UnsafeUpdateAttributeValue
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateAttributeValueRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateAttributeValueResponse'
+  /policy.unsafe.UnsafeService/UnsafeUpdateNamespace:
+    post:
+      tags:
+        - policy.unsafe.UnsafeService
+      summary: UnsafeUpdateNamespace
+      description: |-
+        --------------------------------------*
+         Namespace RPCs
+        ---------------------------------------
+      operationId: policy.unsafe.UnsafeService.UnsafeUpdateNamespace
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateNamespaceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/policy.unsafe.UnsafeUpdateNamespaceResponse'
 components:
   schemas:
-    policy.Action.StandardAction:
-      type: string
-      title: StandardAction
-      enum:
-        - STANDARD_ACTION_UNSPECIFIED
-        - STANDARD_ACTION_DECRYPT
-        - STANDARD_ACTION_TRANSMIT
-    policy.Algorithm:
-      type: string
-      title: Algorithm
-      enum:
-        - ALGORITHM_UNSPECIFIED
-        - ALGORITHM_RSA_2048
-        - ALGORITHM_RSA_4096
-        - ALGORITHM_EC_P256
-        - ALGORITHM_EC_P384
-        - ALGORITHM_EC_P521
-        - ALGORITHM_HPQT_XWING
-        - ALGORITHM_HPQT_SECP256R1_MLKEM768
-        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
-      description: Supported key algorithms.
-    policy.AttributeRuleTypeEnum:
-      type: string
-      title: AttributeRuleTypeEnum
-      enum:
-        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
-        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
-        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
-    policy.ConditionBooleanTypeEnum:
-      type: string
-      title: ConditionBooleanTypeEnum
-      enum:
-        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
-        - CONDITION_BOOLEAN_TYPE_ENUM_AND
-        - CONDITION_BOOLEAN_TYPE_ENUM_OR
-    policy.KasPublicKeyAlgEnum:
-      type: string
-      title: KasPublicKeyAlgEnum
-      enum:
-        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
-        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
-        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
-    policy.KeyMode:
-      type: string
-      title: KeyMode
-      enum:
-        - KEY_MODE_UNSPECIFIED
-        - KEY_MODE_CONFIG_ROOT_KEY
-        - KEY_MODE_PROVIDER_ROOT_KEY
-        - KEY_MODE_REMOTE
-        - KEY_MODE_PUBLIC_KEY_ONLY
-      description: Describes the management and operational mode of a cryptographic key.
-    policy.KeyStatus:
-      type: string
-      title: KeyStatus
-      enum:
-        - KEY_STATUS_UNSPECIFIED
-        - KEY_STATUS_ACTIVE
-        - KEY_STATUS_ROTATED
-      description: The status of the key
-    policy.SourceType:
-      type: string
-      title: SourceType
-      enum:
-        - SOURCE_TYPE_UNSPECIFIED
-        - SOURCE_TYPE_INTERNAL
-        - SOURCE_TYPE_EXTERNAL
-      description: |-
-        Describes whether this kas is managed by the organization or if they imported
-         the kas information from an external party. These two modes are necessary in order
-         to encrypt a tdf dek with an external parties kas public key.
-    policy.SubjectMappingOperatorEnum:
-      type: string
-      title: SubjectMappingOperatorEnum
-      enum:
-        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
-        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     common.Metadata:
       type: object
       properties:
@@ -488,6 +402,75 @@ components:
           title: value
       title: LabelsEntry
       additionalProperties: false
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.BoolValue:
       type: boolean
       description: |-
@@ -500,8 +483,8 @@ components:
     google.protobuf.Timestamp:
       type: string
       examples:
-        - 1s
-        - 1.000340012s
+        - "2023-01-15T01:30:15.01Z"
+        - "2024-12-25T12:00:00Z"
       format: date-time
       description: |-
         A Timestamp represents a point in time independent of any time zone or local
@@ -595,41 +578,65 @@ components:
          ) to obtain a formatter capable of generating timestamps in this format.
     policy.Action:
       type: object
-      oneOf:
+      allOf:
         - properties:
-            custom:
+            id:
               type: string
+              title: id
+              description: Generated uuid in database
+            name:
+              type: string
+              title: name
+            namespace:
+              title: namespace
+              description: Namespace context for this action
+              $ref: '#/components/schemas/policy.Namespace'
+            metadata:
+              title: metadata
+              $ref: '#/components/schemas/common.Metadata'
+        - oneOf:
+            - type: object
+              properties:
+                custom:
+                  type: string
+                  title: custom
+                  description: Deprecated
               title: custom
-              description: Deprecated
-          title: custom
-          required:
-            - custom
-        - properties:
-            standard:
+              required:
+                - custom
+            - type: object
+              properties:
+                standard:
+                  title: standard
+                  description: Deprecated
+                  $ref: '#/components/schemas/policy.Action.StandardAction'
               title: standard
-              description: Deprecated
-              $ref: '#/components/schemas/policy.Action.StandardAction'
-          title: standard
-          required:
-            - standard
-      properties:
-        id:
-          type: string
-          title: id
-          description: Generated uuid in database
-        name:
-          type: string
-          title: name
-        namespace:
-          title: namespace
-          description: Namespace context for this action
-          $ref: '#/components/schemas/policy.Namespace'
-        metadata:
-          title: metadata
-          $ref: '#/components/schemas/common.Metadata'
+              required:
+                - standard
       title: Action
       additionalProperties: false
       description: An action an entity can take
+    policy.Action.StandardAction:
+      type: string
+      title: StandardAction
+      enum:
+        - STANDARD_ACTION_UNSPECIFIED
+        - STANDARD_ACTION_DECRYPT
+        - STANDARD_ACTION_TRANSMIT
+    policy.Algorithm:
+      type: string
+      title: Algorithm
+      enum:
+        - ALGORITHM_UNSPECIFIED
+        - ALGORITHM_RSA_2048
+        - ALGORITHM_RSA_4096
+        - ALGORITHM_EC_P256
+        - ALGORITHM_EC_P384
+        - ALGORITHM_EC_P521
+        - ALGORITHM_HPQT_XWING
+        - ALGORITHM_HPQT_SECP256R1_MLKEM768
+        - ALGORITHM_HPQT_SECP384R1_MLKEM1024
+      description: Supported key algorithms.
     policy.AsymmetricKey:
       type: object
       properties:
@@ -731,6 +738,14 @@ components:
       required:
         - rule
       additionalProperties: false
+    policy.AttributeRuleTypeEnum:
+      type: string
+      title: AttributeRuleTypeEnum
+      enum:
+        - ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED
+        - ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF
+        - ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY
     policy.Condition:
       type: object
       properties:
@@ -748,7 +763,6 @@ components:
           type: array
           items:
             type: string
-            minItems: 1
           title: subject_external_values
           minItems: 1
           description: |-
@@ -764,6 +778,13 @@ components:
         *
         A Condition defines a rule of <the value at the flattened 'selector value'
         location> <operator> <subject external values>
+    policy.ConditionBooleanTypeEnum:
+      type: string
+      title: ConditionBooleanTypeEnum
+      enum:
+        - CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED
+        - CONDITION_BOOLEAN_TYPE_ENUM_AND
+        - CONDITION_BOOLEAN_TYPE_ENUM_OR
     policy.ConditionGroup:
       type: object
       properties:
@@ -814,7 +835,7 @@ components:
         alg:
           not:
             enum:
-              - 0
+              - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
           title: alg
           description: |-
             A known algorithm type with any additional parameters encoded.
@@ -826,6 +847,19 @@ components:
       description: |-
         Deprecated
          A KAS public key and some associated metadata for further identifcation
+    policy.KasPublicKeyAlgEnum:
+      type: string
+      title: KasPublicKeyAlgEnum
+      enum:
+        - KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048
+        - KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768
+        - KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024
     policy.KasPublicKeySet:
       type: object
       properties:
@@ -848,13 +882,9 @@ components:
         uri:
           type: string
           title: uri
-          description: |+
+          description: |
             Address of a KAS instance
-            URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-            ```
-            this.matches('^https?://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(:[0-9]+)?(/.*)?$')
-            ```
-
+            uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
         publicKey:
           title: public_key
           description: 'Deprecated: KAS can have multiple key pairs'
@@ -882,6 +912,16 @@ components:
       title: KeyAccessServer
       additionalProperties: false
       description: Key Access Server Registry
+    policy.KeyMode:
+      type: string
+      title: KeyMode
+      enum:
+        - KEY_MODE_UNSPECIFIED
+        - KEY_MODE_CONFIG_ROOT_KEY
+        - KEY_MODE_PROVIDER_ROOT_KEY
+        - KEY_MODE_REMOTE
+        - KEY_MODE_PUBLIC_KEY_ONLY
+      description: Describes the management and operational mode of a cryptographic key.
     policy.KeyProviderConfig:
       type: object
       properties:
@@ -904,6 +944,14 @@ components:
           $ref: '#/components/schemas/common.Metadata'
       title: KeyProviderConfig
       additionalProperties: false
+    policy.KeyStatus:
+      type: string
+      title: KeyStatus
+      enum:
+        - KEY_STATUS_UNSPECIFIED
+        - KEY_STATUS_ACTIVE
+        - KEY_STATUS_ROTATED
+      description: The status of the key
     policy.Namespace:
       type: object
       properties:
@@ -1046,7 +1094,8 @@ components:
     policy.PublicKey:
       type: object
       oneOf:
-        - properties:
+        - type: object
+          properties:
             cached:
               title: cached
               description: public key with additional information. Current preferred version
@@ -1054,17 +1103,14 @@ components:
           title: cached
           required:
             - cached
-        - properties:
+        - type: object
+          properties:
             remote:
               type: string
               title: remote
-              description: |+
+              description: |
                 kas public key url - optional since can also be retrieved via public key
-                URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.:
-                ```
-                this.matches('^https://[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?)*(/.*)?$')
-                ```
-
+                uri_format // URI must be a valid URL (e.g., 'https://demo.com/') followed by additional segments. Each segment must start and end with an alphanumeric character, can contain hyphens, alphanumeric characters, and slashes.
           title: remote
           required:
             - remote
@@ -1182,6 +1228,17 @@ components:
           title: pem
       title: SimpleKasPublicKey
       additionalProperties: false
+    policy.SourceType:
+      type: string
+      title: SourceType
+      enum:
+        - SOURCE_TYPE_UNSPECIFIED
+        - SOURCE_TYPE_INTERNAL
+        - SOURCE_TYPE_EXTERNAL
+      description: |-
+        Describes whether this kas is managed by the organization or if they imported
+         the kas information from an external party. These two modes are necessary in order
+         to encrypt a tdf dek with an external parties kas public key.
     policy.SubjectConditionSet:
       type: object
       properties:
@@ -1247,6 +1304,14 @@ components:
       description: |-
         Subject Mapping: A Policy assigning Subject Set(s) to a permitted attribute
         value + action(s) combination
+    policy.SubjectMappingOperatorEnum:
+      type: string
+      title: SubjectMappingOperatorEnum
+      enum:
+        - SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
+        - SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
     policy.SubjectSet:
       type: object
       properties:
@@ -1525,15 +1590,11 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Optional
              WARNING!!
              Updating the name of an Attribute will retroactively alter access to existing TDFs of the old and new Attribute name.
-            Attribute name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored attribute name will be normalized to lower case.:
-            ```
-            size(this) > 0 ? this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$') : true
-            ```
-
+            attribute_name_format // Attribute name must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored attribute name will be normalized to lower case.
         rule:
           title: rule
           description: |-
@@ -1586,13 +1647,9 @@ components:
           type: string
           title: value
           maxLength: 253
-          description: |+
+          description: |
             Required
-            Attribute Value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored attribute value will be normalized to lower case.:
-            ```
-            this.matches('^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$')
-            ```
-
+            value_format // Attribute Value must be an alphanumeric string, allowing hyphens and underscores but not as the first or last character. The stored attribute value will be normalized to lower case.
       title: UnsafeUpdateAttributeValueRequest
       additionalProperties: false
       description: |-
@@ -1618,13 +1675,9 @@ components:
           type: string
           title: name
           maxLength: 253
-          description: |+
+          description: |
             Required
-            Namespace must be a valid hostname. It should include at least one dot, with each segment (label) starting and ending with an alphanumeric character. Each label must be 1 to 63 characters long, allowing hyphens but not as the first or last character. The top-level domain (the last segment after the final dot) must consist of at least two alphabetic characters. The stored namespace will be normalized to lower case.:
-            ```
-            this.matches('^([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}$')
-            ```
-
+            namespace_name_format // Namespace must be a valid hostname. It should include at least one dot, with each segment (label) starting and ending with an alphanumeric character. Each label must be 1 to 63 characters long, allowing hyphens but not as the first or last character. The top-level domain (the last segment after the final dot) must consist of at least two alphabetic characters. The stored namespace will be normalized to lower case.
       title: UnsafeUpdateNamespaceRequest
       additionalProperties: false
       description: |-
@@ -1639,63 +1692,6 @@ components:
           $ref: '#/components/schemas/policy.Namespace'
       title: UnsafeUpdateNamespaceResponse
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: policy.unsafe.UnsafeService

--- a/docs/openapi/wellknownconfiguration/wellknown_configuration.openapi.yaml
+++ b/docs/openapi/wellknownconfiguration/wellknown_configuration.openapi.yaml
@@ -39,16 +39,75 @@ paths:
                 $ref: '#/components/schemas/wellknownconfiguration.GetWellKnownConfigurationResponse'
 components:
   schemas:
-    google.protobuf.NullValue:
-      type: string
-      title: NullValue
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
       enum:
-        - NULL_VALUE
-      description: |-
-        `NullValue` is a singleton enumeration to represent the null value for the
-         `Value` type union.
-
-         The JSON representation for `NullValue` is JSON `null`.
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/connect.error_details.Any'
+          description: A list of messages that carry the error details. There is no limit on the number of messages.
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    connect.error_details.Any:
+      type: object
+      properties:
+        type:
+          type: string
+          description: 'A URL that acts as a globally unique identifier for the type of the serialized message. For example: `type.googleapis.com/google.rpc.ErrorInfo`. This is used to determine the schema of the data in the `value` field and is the discriminator for the `debug` field.'
+        value:
+          type: string
+          format: binary
+          description: The Protobuf message, serialized as bytes and base64-encoded. The specific message type is identified by the `type` field.
+        debug:
+          oneOf:
+            - type: object
+              title: Any
+              additionalProperties: true
+              description: Detailed error information.
+          discriminator:
+            propertyName: type
+          title: Debug
+          description: Deserialized error detail payload. The 'type' field indicates the schema. This field is for easier debugging and should not be relied upon for application logic.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     google.protobuf.ListValue:
       type: object
       properties:
@@ -64,6 +123,16 @@ components:
         `ListValue` is a wrapper around a repeated field of values.
 
          The JSON representation for `ListValue` is JSON array.
+    google.protobuf.NullValue:
+      type: string
+      title: NullValue
+      enum:
+        - NULL_VALUE
+      description: |-
+        `NullValue` is a singleton enumeration to represent the null value for the
+         `Value` type union.
+
+         The JSON representation for `NullValue` is JSON `null`.
     google.protobuf.Struct:
       type: object
       additionalProperties:
@@ -138,63 +207,6 @@ components:
           $ref: '#/components/schemas/google.protobuf.Struct'
       title: ConfigurationEntry
       additionalProperties: false
-    connect-protocol-version:
-      type: number
-      title: Connect-Protocol-Version
-      enum:
-        - 1
-      description: Define the version of the Connect protocol
-      const: 1
-    connect-timeout-header:
-      type: number
-      title: Connect-Timeout-Ms
-      description: Define the timeout, in ms
-    connect.error:
-      type: object
-      properties:
-        code:
-          type: string
-          examples:
-            - not_found
-          enum:
-            - canceled
-            - unknown
-            - invalid_argument
-            - deadline_exceeded
-            - not_found
-            - already_exists
-            - permission_denied
-            - resource_exhausted
-            - failed_precondition
-            - aborted
-            - out_of_range
-            - unimplemented
-            - internal
-            - unavailable
-            - data_loss
-            - unauthenticated
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        detail:
-          $ref: '#/components/schemas/google.protobuf.Any'
-      title: Connect Error
-      additionalProperties: true
-      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
-    google.protobuf.Any:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-          format: binary
-        debug:
-          type: object
-          additionalProperties: true
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 security: []
 tags:
   - name: wellknownconfiguration.WellKnownService


### PR DESCRIPTION
## Summary

- Bumps CI `protoc-gen-connect-openapi` pin **v0.18.0 → v0.25.6** (`.github/workflows/checks.yaml:620`).
- Regenerates `docs/openapi/**` against the new plugin (20 files).
- **No** `buf` version change — verified locally that v0.25.6 works fine with the currently-pinned `buf` 1.68.3. The `buf` 1.70.0 bump is a separate PR.

## Motivation

The `protoc-gen-connect-openapi` plugin pin had drifted 7 versions behind upstream (v0.18.0 → v0.25.6). Contributors who installed the plugin without an explicit version (`go install ...@latest`) were producing different `docs/openapi/**` output than CI, causing the "Protocol Buffer Lint and Gencode Up-to-date check" job to fail on their PRs.

## Notable codegen changes (v0.18.0 → v0.25.6)

- Alphabetical schema ordering within `components.schemas` (e.g. `MetadataUpdateEnum` moved later in `common.openapi.yaml`).
- New `allOf` / `oneOf` constraint encoding for proto messages that use `buf.validate` oneof rules — `IdFqnIdentifier` and `IdNameIdentifier` now explicitly express `required: id` ⊕ `required: fqn|name`.
- Timestamp examples switched from duration-style (`1s`) to RFC3339 (`2024-12-25T12:00:00Z`).
- Some field descriptions reformatted (notably `IdNameIdentifier.name`).

## Test plan

- [ ] CI `buflint` job passes (`make proto-generate` produces no diff under the new pin with the currently-pinned `buf` 1.68.3)
- [ ] CI `go` matrix passes (no consumers of `docs/openapi/**` are in the Go modules)
- [ ] Spot-check downstream OpenAPI consumers (Swagger UI, generated client SDKs) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)