### PR TITLE
chore(ci): bump buf to 1.70.0

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -598,7 +598,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ github.token }}
-          version: "1.68.3"
+          version: "1.70.0"
       - uses: bufbuild/buf-lint-action@06f9dd823d873146471cfaaf108a993fe00e5325 # v1.1.1
         with:
           input: service

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 MODS=protocol/go lib/ocrypto lib/fixtures lib/flattening lib/identifier sdk service examples otdfctl tests-bdd
 HAND_MODS=lib/ocrypto lib/fixtures lib/flattening lib/identifier sdk service examples otdfctl tests-bdd
-REQUIRED_BUF_VERSION=1.68.2
+REQUIRED_BUF_VERSION=1.70.0
 REQUIRED_SQLC_VERSION=1.31.0
 
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))

--- a/protocol/go/authorization/authorization.pb.go
+++ b/protocol/go/authorization/authorization.pb.go
@@ -453,6 +453,7 @@ func (x *EntityChain) GetEntities() []*Entity {
 // Example Request Get Decisions to answer the question -  Do Bob (represented by entity chain ec1)
 // and Alice (represented by entity chain ec2) have TRANSMIT authorization for
 // 2 resources; resource1 (attr-set-1) defined by attributes foo:bar  resource2 (attr-set-2) defined by attribute foo:bar, color:red ?
+//
 // {
 // "actions": [
 // {
@@ -559,11 +560,13 @@ func (x *DecisionRequest) GetResourceAttributes() []*ResourceAttribute {
 // Example response for a Decision Request -  Do Bob (represented by entity chain ec1)
 // and Alice (represented by entity chain ec2) have TRANSMIT authorization for
 // 2 resources; resource1 (attr-set-1) defined by attributes foo:bar  resource2 (attr-set-2) defined by attribute foo:bar, color:red ?
+//
 // Results:
 // - bob has permitted authorization to transmit for a resource defined by attr-set-1 attributes and has a watermark obligation
 // - bob has denied authorization to transmit a for a resource defined by attr-set-2 attributes
 // - alice has permitted authorization to transmit for a resource defined by attr-set-1 attributes
 // - alice has denied authorization to transmit a for a resource defined by attr-set-2 attributes
+//
 // {
 // "entityChainId":  "ec1",
 // "resourceAttributesId":  "attr-set-1",
@@ -761,7 +764,9 @@ func (x *GetDecisionsResponse) GetDecisionResponses() []*DecisionResponse {
 }
 
 // Request to get entitlements for one or more entities for an optional attribute scope
+//
 // Example: Get entitlements for bob and alice (both represented using an email address
+//
 // {
 // "entities": [
 // {
@@ -958,6 +963,7 @@ func (x *ResourceAttribute) GetAttributeValueFqns() []string {
 }
 
 // Example Response for a request of : Get entitlements for bob and alice (both represented using an email address
+//
 // {
 // "entitlements":  [
 // {
@@ -1028,6 +1034,7 @@ func (x *GetEntitlementsResponse) GetEntitlements() []*EntityEntitlements {
 // Example Request Get Decisions by Token to answer the question -  Do Bob and client1 (represented by token tok1)
 // and Alice and client2 (represented by token tok2) have TRANSMIT authorization for
 // 2 resources; resource1 (attr-set-1) defined by attributes foo:bar  resource2 (attr-set-2) defined by attribute foo:bar, color:red ?
+//
 // {
 // "actions": [
 // {

--- a/protocol/go/policy/objects.pb.go
+++ b/protocol/go/policy/objects.pb.go
@@ -1593,6 +1593,7 @@ func (x *SubjectConditionSet) GetMetadata() *common.Metadata {
 // authoritative source such as an IDP (Identity Provider) or User Store.
 // Examples include such ADFS/LDAP, OKTA, etc. For now, a valid property must
 // contain both a selector expression & a resulting value.
+//
 // The external_selector_value is a specifier to select a value from a flattened
 // external representation of an Entity (such as from idP/LDAP), and the
 // external_value is the value selected by the external_selector_value on that


### PR DESCRIPTION
## Summary

- `Makefile` minimum `REQUIRED_BUF_VERSION` **1.68.2 → 1.70.0**.
- CI `buf` pin **1.68.3 → 1.70.0** (`.github/workflows/checks.yaml:601`).
- 2 regenerated `.pb.go` files reflecting godoc comment-block formatting from the newer `protocolbuffers/go` remote plugin that ships with buf 1.70.0.

## Motivation

Most contributors are now on `buf` 1.70.0 (or later) via Homebrew. Their `make proto-generate` runs produce slightly different `.pb.go` output than CI's pinned 1.68.3, causing the "Protocol Buffer Lint and Gencode Up-to-date check" job to fail. Bumping the CI pin eliminates that drift class.

The remote Go plugins in `buf.gen.yaml` are already version-pinned; the diff is limited to comment formatting (blank line insertions before indented example blocks in godoc comments) — no semantic protobuf changes.

## Scope

Intentionally narrow. The `protoc-gen-connect-openapi` bump and resulting `docs/openapi/**` changes are handled separately in #3545.

## Test plan

- [ ] CI `buflint` job passes (`make proto-generate` produces no further diff under the new pins)
- [ ] CI `go` matrix passes (comment-only `.pb.go` changes should not affect any consumer)
- [ ] All other CI jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)