### PR TITLE
feat(policy): add search support to ListSubjectConditionSets

### DIFF
--- a/service/integration/subject_mappings_test.go
+++ b/service/integration/subject_mappings_test.go
@@ -1482,19 +1482,23 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_NoNamespaceFilter_R
 	s.True(foundUnnamespaced)
 }
 
-func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchBySelectorAndValues_Succeeds() {
+func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchByMetadataLabelValues_PaginationSort_Succeeds() {
 	suffix := time.Now().UnixNano()
 	searchToken := fmt.Sprintf("dspx-scs-search-%d", suffix)
 
-	selectorMatch := s.newSearchTestSubjectConditionSet("."+searchToken+".department", []string{"engineering"}, "")
-	valueMatch := s.newSearchTestSubjectConditionSet(fmt.Sprintf(".dspx_scs_other_%d", suffix), []string{"team-" + searchToken}, "")
-	multiConditionMatch := s.newSearchTestSubjectConditionSet("."+searchToken+".manager", []string{"group-" + searchToken}, "")
-	nonMatch := s.newSearchTestSubjectConditionSet(fmt.Sprintf(".dspx_scs_nomatch_%d", suffix), []string{"finance"}, "")
-	defer s.deleteSortTestSubjectConditionSets([]string{
-		selectorMatch.GetId(),
-		valueMatch.GetId(),
-		multiConditionMatch.GetId(),
-		nonMatch.GetId(),
+	multiLabel := map[string]string{
+		"name":    "another",
+		"display": searchToken,
+	}
+	labelValueMatch := s.newSearchTestSubjectConditionSet(fmt.Sprintf(".dspx_scs_selector_%d", suffix), []string{"engineering"}, multiLabel, "")
+	anotherLabelValueMatch := s.newSearchTestSubjectConditionSet(fmt.Sprintf(".dspx_scs_other_%d", suffix), []string{"finance"}, map[string]string{"owner": "group-" + searchToken}, "")
+	labelKeyOnlyNonMatch := s.newSearchTestSubjectConditionSet(fmt.Sprintf(".dspx_scs_key_only_%d", suffix), []string{"legal"}, map[string]string{searchToken: "not-a-matching-value"}, "")
+	conditionOnlyNonMatch := s.newSearchTestSubjectConditionSet("."+searchToken+".department", []string{"value-" + searchToken}, map[string]string{"team": "finance"}, "")
+	defer s.deleteTestSCSs([]string{
+		labelValueMatch.GetId(),
+		anotherLabelValueMatch.GetId(),
+		labelKeyOnlyNonMatch.GetId(),
+		conditionOnlyNonMatch.GetId(),
 	})
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
@@ -1504,27 +1508,55 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchBySelectorAnd
 		},
 	})
 	s.Require().NoError(err)
-	s.NotNil(listRsp)
-
-	listedIDs := make([]string, 0, len(listRsp.GetSubjectConditionSets()))
-	for _, scs := range listRsp.GetSubjectConditionSets() {
-		listedIDs = append(listedIDs, scs.GetId())
-	}
-	s.ElementsMatch([]string{selectorMatch.GetId(), valueMatch.GetId(), multiConditionMatch.GetId()}, listedIDs)
-	s.NotContains(listedIDs, nonMatch.GetId())
-	s.Equal(int32(3), listRsp.GetPagination().GetTotal())
+	s.Require().NotNil(listRsp)
+	s.Require().Len(listRsp.GetSubjectConditionSets(), 2)
+	s.Equal(labelValueMatch.GetId(), listRsp.GetSubjectConditionSets()[0].GetId())
+	s.Equal(anotherLabelValueMatch.GetId(), listRsp.GetSubjectConditionSets()[1].GetId())
+	s.Equal(int32(2), listRsp.GetPagination().GetTotal())
 
 	firstPage, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Search:     &policy.Search{Term: searchToken},
-		Pagination: &policy.PageRequest{Limit: 2},
+		Pagination: &policy.PageRequest{Limit: 1},
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
 			{Field: subjectmapping.SortSubjectConditionSetsType_SORT_SUBJECT_CONDITION_SETS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
 		},
 	})
 	s.Require().NoError(err)
-	s.Len(firstPage.GetSubjectConditionSets(), 2)
-	s.Equal(int32(3), firstPage.GetPagination().GetTotal())
-	s.Equal(int32(2), firstPage.GetPagination().GetNextOffset())
+	s.Len(firstPage.GetSubjectConditionSets(), 1)
+	s.Equal(labelValueMatch.GetId(), firstPage.GetSubjectConditionSets()[0].GetId())
+	s.Equal(int32(2), firstPage.GetPagination().GetTotal())
+	s.Equal(int32(1), firstPage.GetPagination().GetNextOffset())
+}
+
+func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchEscapesLikeWildcardLiterals_Succeeds() {
+	suffix := time.Now().UnixNano()
+	conditionSetIDs := []string{
+		s.newSearchTestSubjectConditionSet(
+			fmt.Sprintf(".dspx_scs_like_a_%d", suffix),
+			[]string{"engineering"},
+			map[string]string{"team": fmt.Sprintf("wildcarda-%d", suffix)},
+			"",
+		).GetId(),
+		s.newSearchTestSubjectConditionSet(
+			fmt.Sprintf(".dspx_scs_like_b_%d", suffix),
+			[]string{"finance"},
+			map[string]string{"team": fmt.Sprintf("wildcardb-%d", suffix)},
+			"",
+		).GetId(),
+	}
+	defer s.deleteTestSCSs(conditionSetIDs)
+
+	for _, query := range []string{
+		fmt.Sprintf("wildcard_-%d", suffix),
+		fmt.Sprintf("wildcard%%-%d", suffix),
+	} {
+		listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
+			Search: &policy.Search{Term: query},
+		})
+		s.Require().NoError(err)
+		s.Empty(listRsp.GetSubjectConditionSets())
+		s.Equal(int32(0), listRsp.GetPagination().GetTotal())
+	}
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchCombinesWithNamespace_Succeeds() {
@@ -1532,14 +1564,14 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchCombinesWithN
 	netNsID := s.exampleNetNsID()
 	searchToken := fmt.Sprintf("dspx-scs-namespace-search-%d", time.Now().UnixNano())
 
-	comSCS := s.newSearchTestSubjectConditionSet("."+searchToken, []string{"com-value"}, comNsID)
-	netSCS := s.newSearchTestSubjectConditionSet("."+searchToken, []string{"net-value"}, netNsID)
-	unnamespacedSCS := s.newSearchTestSubjectConditionSet("."+searchToken, []string{"unnamespaced-value"}, "")
-	defer s.deleteSortTestSubjectConditionSets([]string{comSCS.GetId(), netSCS.GetId(), unnamespacedSCS.GetId()})
+	comSCS := s.newSearchTestSubjectConditionSet(fmt.Sprintf(".dspx_scs_com_%d", time.Now().UnixNano()), []string{"com-value"}, map[string]string{"team": "com-" + searchToken}, comNsID)
+	netSCS := s.newSearchTestSubjectConditionSet(fmt.Sprintf(".dspx_scs_net_%d", time.Now().UnixNano()), []string{"net-value"}, map[string]string{"team": "net-" + searchToken}, netNsID)
+	unnamespacedSCS := s.newSearchTestSubjectConditionSet(fmt.Sprintf(".dspx_scs_global_%d", time.Now().UnixNano()), []string{"unnamespaced-value"}, map[string]string{"team": "global-" + searchToken}, "")
+	defer s.deleteTestSCSs([]string{comSCS.GetId(), netSCS.GetId(), unnamespacedSCS.GetId()})
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		NamespaceId: comNsID,
-		Search:      &policy.Search{Term: searchToken},
+		Search:      &policy.Search{Term: "com-" + searchToken},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(listRsp.GetSubjectConditionSets(), 1)
@@ -1549,9 +1581,9 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchCombinesWithN
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchEmptyAndWhitespace_Succeeds() {
-	searchToken := fmt.Sprintf("dspx-scs-notrim-%d", time.Now().UnixNano())
-	created := s.newSearchTestSubjectConditionSet("."+searchToken, []string{"notrim-value"}, "")
-	defer s.deleteSortTestSubjectConditionSets([]string{created.GetId()})
+	searchToken := fmt.Sprintf("dspx-scs-trim-%d", time.Now().UnixNano())
+	created := s.newSearchTestSubjectConditionSet(fmt.Sprintf(".dspx_scs_trim_%d", time.Now().UnixNano()), []string{"trim-value"}, map[string]string{"team": searchToken}, "")
+	defer s.deleteTestSCSs([]string{created.GetId()})
 
 	noSearch, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{})
 	s.Require().NoError(err)
@@ -1565,13 +1597,14 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchEmptyAndWhite
 		Search: &policy.Search{Term: " " + searchToken},
 	})
 	s.Require().NoError(err)
-	s.Empty(leadingSpaceSearch.GetSubjectConditionSets())
-	s.Equal(int32(0), leadingSpaceSearch.GetPagination().GetTotal())
+	s.Require().Len(leadingSpaceSearch.GetSubjectConditionSets(), 1)
+	s.Equal(created.GetId(), leadingSpaceSearch.GetSubjectConditionSets()[0].GetId())
+	s.Equal(int32(1), leadingSpaceSearch.GetPagination().GetTotal())
 }
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_ASC() {
 	ids := s.createSortTestSubjectConditionSets([]string{"sort-scs-created-asc-0", "sort-scs-created-asc-1", "sort-scs-created-asc-2"})
-	defer s.deleteSortTestSubjectConditionSets(ids)
+	defer s.deleteTestSCSs(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -1587,7 +1620,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_ASC
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_DESC() {
 	ids := s.createSortTestSubjectConditionSets([]string{"sort-scs-created-desc-0", "sort-scs-created-desc-1", "sort-scs-created-desc-2"})
-	defer s.deleteSortTestSubjectConditionSets(ids)
+	defer s.deleteTestSCSs(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -1603,7 +1636,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_DES
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_DESC() {
 	ids := s.createSortTestSubjectConditionSets([]string{"sort-scs-updated-desc-0", "sort-scs-updated-desc-1", "sort-scs-updated-desc-2"})
-	defer s.deleteSortTestSubjectConditionSets(ids)
+	defer s.deleteTestSCSs(ids)
 
 	// Update the first SCS so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -1630,7 +1663,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_DES
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUpdatedAt_ASC() {
 	ids := s.createSortTestSubjectConditionSets([]string{"sort-scs-updated-asc-0", "sort-scs-updated-asc-1", "sort-scs-updated-asc-2"})
-	defer s.deleteSortTestSubjectConditionSets(ids)
+	defer s.deleteTestSCSs(ids)
 
 	// Update the last SCS so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -1681,7 +1714,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortTieBreaker_Crea
 		s.Require().NoError(err)
 		ids[i] = created.GetId()
 	}
-	defer s.deleteSortTestSubjectConditionSets(ids)
+	defer s.deleteTestSCSs(ids)
 
 	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "subject_condition_set", ids))
 
@@ -1700,7 +1733,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortTieBreaker_Crea
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedField_DefaultsToCreatedAt() {
 	ids := s.createSortTestSubjectConditionSets([]string{"unspecified-field-scs-0", "unspecified-field-scs-1", "unspecified-field-scs-2"})
-	defer s.deleteSortTestSubjectConditionSets(ids)
+	defer s.deleteTestSCSs(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -1716,7 +1749,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedFi
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedDirection_DefaultsToDESC() {
 	ids := s.createSortTestSubjectConditionSets([]string{"unspecified-dir-scs-0", "unspecified-dir-scs-1", "unspecified-dir-scs-2"})
-	defer s.deleteSortTestSubjectConditionSets(ids)
+	defer s.deleteTestSCSs(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -1732,7 +1765,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByUnspecifiedDi
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
 	ids := s.createSortTestSubjectConditionSets([]string{"both-unspecified-scs-0", "both-unspecified-scs-1", "both-unspecified-scs-2"})
-	defer s.deleteSortTestSubjectConditionSets(ids)
+	defer s.deleteTestSCSs(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
 		Sort: []*subjectmapping.SubjectConditionSetsSort{
@@ -1748,7 +1781,7 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByBothUnspecifi
 
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortOmitted() {
 	ids := s.createSortTestSubjectConditionSets([]string{"sort-omitted-scs-0", "sort-omitted-scs-1", "sort-omitted-scs-2"})
-	defer s.deleteSortTestSubjectConditionSets(ids)
+	defer s.deleteTestSCSs(ids)
 
 	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{})
 	s.Require().NoError(err)
@@ -2946,7 +2979,7 @@ func (s *SubjectMappingsSuite) newSCSInNamespace(nsID string) *policy.SubjectCon
 	return scs
 }
 
-func (s *SubjectMappingsSuite) newSearchTestSubjectConditionSet(selector string, values []string, namespaceID string) *policy.SubjectConditionSet {
+func (s *SubjectMappingsSuite) newSearchTestSubjectConditionSet(selector string, values []string, labels map[string]string, namespaceID string) *policy.SubjectConditionSet {
 	scs, err := s.db.PolicyClient.CreateSubjectConditionSet(s.ctx, &subjectmapping.SubjectConditionSetCreate{
 		SubjectSets: []*policy.SubjectSet{
 			{
@@ -2963,6 +2996,9 @@ func (s *SubjectMappingsSuite) newSearchTestSubjectConditionSet(selector string,
 					},
 				},
 			},
+		},
+		Metadata: &common.MetadataMutable{
+			Labels: labels,
 		},
 	}, namespaceID, "")
 	s.Require().NoError(err)
@@ -3047,8 +3083,8 @@ func (s *SubjectMappingsSuite) deleteSortTestSubjectMappings(ids []string) {
 	}
 }
 
-// deleteSortTestSubjectConditionSets cleans up subject condition sets created by sort tests.
-func (s *SubjectMappingsSuite) deleteSortTestSubjectConditionSets(ids []string) {
+// deleteTestSCSs cleans up subject condition sets created by sort tests.
+func (s *SubjectMappingsSuite) deleteTestSCSs(ids []string) {
 	for _, id := range ids {
 		_, err := s.db.PolicyClient.DeleteSubjectConditionSet(s.ctx, id)
 		s.Require().NoError(err)

--- a/service/integration/subject_mappings_test.go
+++ b/service/integration/subject_mappings_test.go
@@ -1482,6 +1482,93 @@ func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_NoNamespaceFilter_R
 	s.True(foundUnnamespaced)
 }
 
+func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchBySelectorAndValues_Succeeds() {
+	suffix := time.Now().UnixNano()
+	searchToken := fmt.Sprintf("dspx-scs-search-%d", suffix)
+
+	selectorMatch := s.newSearchTestSubjectConditionSet("."+searchToken+".department", []string{"engineering"}, "")
+	valueMatch := s.newSearchTestSubjectConditionSet(fmt.Sprintf(".dspx_scs_other_%d", suffix), []string{"team-" + searchToken}, "")
+	multiConditionMatch := s.newSearchTestSubjectConditionSet("."+searchToken+".manager", []string{"group-" + searchToken}, "")
+	nonMatch := s.newSearchTestSubjectConditionSet(fmt.Sprintf(".dspx_scs_nomatch_%d", suffix), []string{"finance"}, "")
+	defer s.deleteSortTestSubjectConditionSets([]string{
+		selectorMatch.GetId(),
+		valueMatch.GetId(),
+		multiConditionMatch.GetId(),
+		nonMatch.GetId(),
+	})
+
+	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
+		Search: &policy.Search{Term: strings.ToUpper(searchToken)},
+		Sort: []*subjectmapping.SubjectConditionSetsSort{
+			{Field: subjectmapping.SortSubjectConditionSetsType_SORT_SUBJECT_CONDITION_SETS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(listRsp)
+
+	listedIDs := make([]string, 0, len(listRsp.GetSubjectConditionSets()))
+	for _, scs := range listRsp.GetSubjectConditionSets() {
+		listedIDs = append(listedIDs, scs.GetId())
+	}
+	s.ElementsMatch([]string{selectorMatch.GetId(), valueMatch.GetId(), multiConditionMatch.GetId()}, listedIDs)
+	s.NotContains(listedIDs, nonMatch.GetId())
+	s.Equal(int32(3), listRsp.GetPagination().GetTotal())
+
+	firstPage, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
+		Search:     &policy.Search{Term: searchToken},
+		Pagination: &policy.PageRequest{Limit: 2},
+		Sort: []*subjectmapping.SubjectConditionSetsSort{
+			{Field: subjectmapping.SortSubjectConditionSetsType_SORT_SUBJECT_CONDITION_SETS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.Len(firstPage.GetSubjectConditionSets(), 2)
+	s.Equal(int32(3), firstPage.GetPagination().GetTotal())
+	s.Equal(int32(2), firstPage.GetPagination().GetNextOffset())
+}
+
+func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchCombinesWithNamespace_Succeeds() {
+	comNsID := s.exampleComNsID()
+	netNsID := s.exampleNetNsID()
+	searchToken := fmt.Sprintf("dspx-scs-namespace-search-%d", time.Now().UnixNano())
+
+	comSCS := s.newSearchTestSubjectConditionSet("."+searchToken, []string{"com-value"}, comNsID)
+	netSCS := s.newSearchTestSubjectConditionSet("."+searchToken, []string{"net-value"}, netNsID)
+	unnamespacedSCS := s.newSearchTestSubjectConditionSet("."+searchToken, []string{"unnamespaced-value"}, "")
+	defer s.deleteSortTestSubjectConditionSets([]string{comSCS.GetId(), netSCS.GetId(), unnamespacedSCS.GetId()})
+
+	listRsp, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
+		NamespaceId: comNsID,
+		Search:      &policy.Search{Term: searchToken},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(listRsp.GetSubjectConditionSets(), 1)
+	s.Equal(comSCS.GetId(), listRsp.GetSubjectConditionSets()[0].GetId())
+	s.Equal(comNsID, listRsp.GetSubjectConditionSets()[0].GetNamespace().GetId())
+	s.Equal(int32(1), listRsp.GetPagination().GetTotal())
+}
+
+func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SearchEmptyAndWhitespace_Succeeds() {
+	searchToken := fmt.Sprintf("dspx-scs-notrim-%d", time.Now().UnixNano())
+	created := s.newSearchTestSubjectConditionSet("."+searchToken, []string{"notrim-value"}, "")
+	defer s.deleteSortTestSubjectConditionSets([]string{created.GetId()})
+
+	noSearch, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{})
+	s.Require().NoError(err)
+	emptySearch, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
+		Search: &policy.Search{Term: ""},
+	})
+	s.Require().NoError(err)
+	s.Equal(noSearch.GetPagination().GetTotal(), emptySearch.GetPagination().GetTotal())
+
+	leadingSpaceSearch, err := s.db.PolicyClient.ListSubjectConditionSets(s.ctx, &subjectmapping.ListSubjectConditionSetsRequest{
+		Search: &policy.Search{Term: " " + searchToken},
+	})
+	s.Require().NoError(err)
+	s.Empty(leadingSpaceSearch.GetSubjectConditionSets())
+	s.Equal(int32(0), leadingSpaceSearch.GetPagination().GetTotal())
+}
+
 func (s *SubjectMappingsSuite) Test_ListSubjectConditionSets_SortByCreatedAt_ASC() {
 	ids := s.createSortTestSubjectConditionSets([]string{"sort-scs-created-asc-0", "sort-scs-created-asc-1", "sort-scs-created-asc-2"})
 	defer s.deleteSortTestSubjectConditionSets(ids)
@@ -2855,6 +2942,29 @@ func (s *SubjectMappingsSuite) newSCSInNamespace(nsID string) *policy.SubjectCon
 			},
 		},
 	}, nsID, "")
+	s.Require().NoError(err)
+	return scs
+}
+
+func (s *SubjectMappingsSuite) newSearchTestSubjectConditionSet(selector string, values []string, namespaceID string) *policy.SubjectConditionSet {
+	scs, err := s.db.PolicyClient.CreateSubjectConditionSet(s.ctx, &subjectmapping.SubjectConditionSetCreate{
+		SubjectSets: []*policy.SubjectSet{
+			{
+				ConditionGroups: []*policy.ConditionGroup{
+					{
+						BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+						Conditions: []*policy.Condition{
+							{
+								SubjectExternalSelectorValue: selector,
+								Operator:                     policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+								SubjectExternalValues:        values,
+							},
+						},
+					},
+				},
+			},
+		},
+	}, namespaceID, "")
 	s.Require().NoError(err)
 	return scs
 }

--- a/service/policy/db/queries/subject_mappings.sql
+++ b/service/policy/db/queries/subject_mappings.sql
@@ -22,9 +22,44 @@ LEFT JOIN attribute_namespaces n ON n.id = scs.namespace_id
 LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
 CROSS JOIN params p
 WHERE
-    (sqlc.narg('namespace_id')::uuid IS NULL AND sqlc.narg('namespace_fqn')::text IS NULL)
-    OR scs.namespace_id = sqlc.narg('namespace_id')::uuid
-    OR ns_fqns.fqn = sqlc.narg('namespace_fqn')::text
+    (
+        (sqlc.narg('namespace_id')::uuid IS NULL AND sqlc.narg('namespace_fqn')::text IS NULL)
+        OR scs.namespace_id = sqlc.narg('namespace_id')::uuid
+        OR ns_fqns.fqn = sqlc.narg('namespace_fqn')::text
+    )
+    AND (
+        sqlc.narg('search')::TEXT IS NULL
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValue') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_value') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValues[*]') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_values[*]') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalValues[*]') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_values[*]') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+        )
+    )
 ORDER BY
     CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'ASC' THEN scs.created_at END ASC,
     CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'DESC' THEN scs.created_at END DESC,

--- a/service/policy/db/queries/subject_mappings.sql
+++ b/service/policy/db/queries/subject_mappings.sql
@@ -31,33 +31,8 @@ WHERE
         sqlc.narg('search')::TEXT IS NULL
         OR EXISTS (
             SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValue') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_value') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValues[*]') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_values[*]') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalValues[*]') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_values[*]') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+            FROM JSONB_EACH_TEXT(COALESCE(scs.metadata -> 'labels', '{}'::JSONB)) AS label(key, value)
+            WHERE label.value ILIKE sqlc.narg('search')::TEXT ESCAPE '\'
         )
     )
 ORDER BY

--- a/service/policy/db/queries/subject_mappings.sql
+++ b/service/policy/db/queries/subject_mappings.sql
@@ -27,14 +27,14 @@ WHERE
         OR scs.namespace_id = sqlc.narg('namespace_id')::uuid
         OR ns_fqns.fqn = sqlc.narg('namespace_fqn')::text
     )
-    AND (
-        sqlc.narg('search')::TEXT IS NULL
-        OR EXISTS (
+    AND CASE
+        WHEN sqlc.narg('search')::TEXT IS NULL THEN TRUE
+        ELSE EXISTS (
             SELECT 1
             FROM JSONB_EACH_TEXT(COALESCE(scs.metadata -> 'labels', '{}'::JSONB)) AS label(key, value)
             WHERE label.value ILIKE sqlc.narg('search')::TEXT ESCAPE '\'
         )
-    )
+    END
 ORDER BY
     CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'ASC' THEN scs.created_at END ASC,
     CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'DESC' THEN scs.created_at END DESC,

--- a/service/policy/db/subject_mappings.go
+++ b/service/policy/db/subject_mappings.go
@@ -124,7 +124,7 @@ func (c PolicyDBClient) ListSubjectConditionSets(ctx context.Context, r *subject
 	}
 
 	sortField, sortDirection := GetSubjectConditionSetsSortParams(r.GetSort())
-	search := pgtypeSubstringSearchPatternNoTrim(r.GetSearch().GetTerm())
+	search := pgtypeSubstringSearchPattern(r.GetSearch().GetTerm())
 
 	list, err := c.queries.listSubjectConditionSets(ctx, listSubjectConditionSetsParams{
 		NamespaceID:   pgtypeUUID(r.GetNamespaceId()),

--- a/service/policy/db/subject_mappings.go
+++ b/service/policy/db/subject_mappings.go
@@ -124,10 +124,12 @@ func (c PolicyDBClient) ListSubjectConditionSets(ctx context.Context, r *subject
 	}
 
 	sortField, sortDirection := GetSubjectConditionSetsSortParams(r.GetSort())
+	search := pgtypeSubstringSearchPatternNoTrim(r.GetSearch().GetTerm())
 
 	list, err := c.queries.listSubjectConditionSets(ctx, listSubjectConditionSetsParams{
 		NamespaceID:   pgtypeUUID(r.GetNamespaceId()),
 		NamespaceFqn:  pgtypeText(r.GetNamespaceFqn()),
+		Search:        search,
 		Limit:         limit,
 		Offset:        offset,
 		SortField:     sortField,

--- a/service/policy/db/subject_mappings.sql.go
+++ b/service/policy/db/subject_mappings.sql.go
@@ -378,14 +378,14 @@ WHERE
         OR scs.namespace_id = $1::uuid
         OR ns_fqns.fqn = $2::text
     )
-    AND (
-        $3::TEXT IS NULL
-        OR EXISTS (
+    AND CASE
+        WHEN $3::TEXT IS NULL THEN TRUE
+        ELSE EXISTS (
             SELECT 1
             FROM JSONB_EACH_TEXT(COALESCE(scs.metadata -> 'labels', '{}'::JSONB)) AS label(key, value)
             WHERE label.value ILIKE $3::TEXT ESCAPE '\'
         )
-    )
+    END
 ORDER BY
     CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'ASC' THEN scs.created_at END ASC,
     CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'DESC' THEN scs.created_at END DESC,
@@ -442,14 +442,14 @@ type listSubjectConditionSetsRow struct {
 //	        OR scs.namespace_id = $1::uuid
 //	        OR ns_fqns.fqn = $2::text
 //	    )
-//	    AND (
-//	        $3::TEXT IS NULL
-//	        OR EXISTS (
+//	    AND CASE
+//	        WHEN $3::TEXT IS NULL THEN TRUE
+//	        ELSE EXISTS (
 //	            SELECT 1
 //	            FROM JSONB_EACH_TEXT(COALESCE(scs.metadata -> 'labels', '{}'::JSONB)) AS label(key, value)
 //	            WHERE label.value ILIKE $3::TEXT ESCAPE '\'
 //	        )
-//	    )
+//	    END
 //	ORDER BY
 //	    CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'ASC' THEN scs.created_at END ASC,
 //	    CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'DESC' THEN scs.created_at END DESC,

--- a/service/policy/db/subject_mappings.sql.go
+++ b/service/policy/db/subject_mappings.sql.go
@@ -101,7 +101,8 @@ type createSubjectMappingParams struct {
 //	)
 //	SELECT id FROM inserted_mapping
 func (q *Queries) createSubjectMapping(ctx context.Context, arg createSubjectMappingParams) (string, error) {
-	row := q.db.QueryRow(ctx, createSubjectMapping,
+	row := q.db.QueryRow(
+		ctx, createSubjectMapping,
 		arg.AttributeValueID,
 		arg.Metadata,
 		arg.SubjectConditionSetID,
@@ -356,8 +357,8 @@ const listSubjectConditionSets = `-- name: listSubjectConditionSets :many
 
 WITH params AS (
     SELECT
-        COALESCE(NULLIF($5::text, ''), 'created_at') AS resolved_field,
-        COALESCE(NULLIF($6::text, ''), 'DESC') AS resolved_direction
+        COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
+        COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
 )
 SELECT
     scs.id,
@@ -373,22 +374,58 @@ LEFT JOIN attribute_namespaces n ON n.id = scs.namespace_id
 LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
 CROSS JOIN params p
 WHERE
-    ($1::uuid IS NULL AND $2::text IS NULL)
-    OR scs.namespace_id = $1::uuid
-    OR ns_fqns.fqn = $2::text
+    (
+        ($1::uuid IS NULL AND $2::text IS NULL)
+        OR scs.namespace_id = $1::uuid
+        OR ns_fqns.fqn = $2::text
+    )
+    AND (
+        $3::TEXT IS NULL
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValue') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_value') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValues[*]') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_values[*]') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalValues[*]') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_values[*]') AS selector_value(value)
+            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+        )
+    )
 ORDER BY
     CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'ASC' THEN scs.created_at END ASC,
     CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'DESC' THEN scs.created_at END DESC,
     CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'ASC' THEN scs.updated_at END ASC,
     CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'DESC' THEN scs.updated_at END DESC,
     scs.id ASC
-LIMIT $4
-OFFSET $3
+LIMIT $5
+OFFSET $4
 `
 
 type listSubjectConditionSetsParams struct {
 	NamespaceID   pgtype.UUID `json:"namespace_id"`
 	NamespaceFqn  pgtype.Text `json:"namespace_fqn"`
+	Search        pgtype.Text `json:"search"`
 	Offset        int32       `json:"offset_"`
 	Limit         int32       `json:"limit_"`
 	SortField     string      `json:"sort_field"`
@@ -409,8 +446,8 @@ type listSubjectConditionSetsRow struct {
 //
 //	WITH params AS (
 //	    SELECT
-//	        COALESCE(NULLIF($5::text, ''), 'created_at') AS resolved_field,
-//	        COALESCE(NULLIF($6::text, ''), 'DESC') AS resolved_direction
+//	        COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
+//	        COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
 //	)
 //	SELECT
 //	    scs.id,
@@ -426,21 +463,58 @@ type listSubjectConditionSetsRow struct {
 //	LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
 //	CROSS JOIN params p
 //	WHERE
-//	    ($1::uuid IS NULL AND $2::text IS NULL)
-//	    OR scs.namespace_id = $1::uuid
-//	    OR ns_fqns.fqn = $2::text
+//	    (
+//	        ($1::uuid IS NULL AND $2::text IS NULL)
+//	        OR scs.namespace_id = $1::uuid
+//	        OR ns_fqns.fqn = $2::text
+//	    )
+//	    AND (
+//	        $3::TEXT IS NULL
+//	        OR EXISTS (
+//	            SELECT 1
+//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValue') AS selector_value(value)
+//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+//	        )
+//	        OR EXISTS (
+//	            SELECT 1
+//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_value') AS selector_value(value)
+//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+//	        )
+//	        OR EXISTS (
+//	            SELECT 1
+//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValues[*]') AS selector_value(value)
+//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+//	        )
+//	        OR EXISTS (
+//	            SELECT 1
+//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_values[*]') AS selector_value(value)
+//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+//	        )
+//	        OR EXISTS (
+//	            SELECT 1
+//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalValues[*]') AS selector_value(value)
+//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+//	        )
+//	        OR EXISTS (
+//	            SELECT 1
+//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_values[*]') AS selector_value(value)
+//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+//	        )
+//	    )
 //	ORDER BY
 //	    CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'ASC' THEN scs.created_at END ASC,
 //	    CASE WHEN p.resolved_field = 'created_at' AND p.resolved_direction = 'DESC' THEN scs.created_at END DESC,
 //	    CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'ASC' THEN scs.updated_at END ASC,
 //	    CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'DESC' THEN scs.updated_at END DESC,
 //	    scs.id ASC
-//	LIMIT $4
-//	OFFSET $3
+//	LIMIT $5
+//	OFFSET $4
 func (q *Queries) listSubjectConditionSets(ctx context.Context, arg listSubjectConditionSetsParams) ([]listSubjectConditionSetsRow, error) {
-	rows, err := q.db.Query(ctx, listSubjectConditionSets,
+	rows, err := q.db.Query(
+		ctx, listSubjectConditionSets,
 		arg.NamespaceID,
 		arg.NamespaceFqn,
+		arg.Search,
 		arg.Offset,
 		arg.Limit,
 		arg.SortField,
@@ -697,7 +771,8 @@ type listSubjectMappingsRow struct {
 //	LIMIT $4
 //	OFFSET $3
 func (q *Queries) listSubjectMappings(ctx context.Context, arg listSubjectMappingsParams) ([]listSubjectMappingsRow, error) {
-	rows, err := q.db.Query(ctx, listSubjectMappings,
+	rows, err := q.db.Query(
+		ctx, listSubjectMappings,
 		arg.NamespaceID,
 		arg.NamespaceFqn,
 		arg.Offset,
@@ -1005,7 +1080,8 @@ type updateSubjectMappingParams struct {
 //	SELECT cnt
 //	FROM update_count
 func (q *Queries) updateSubjectMapping(ctx context.Context, arg updateSubjectMappingParams) (int64, error) {
-	result, err := q.db.Exec(ctx, updateSubjectMapping,
+	result, err := q.db.Exec(
+		ctx, updateSubjectMapping,
 		arg.Metadata,
 		arg.SubjectConditionSetID,
 		arg.ID,

--- a/service/policy/db/subject_mappings.sql.go
+++ b/service/policy/db/subject_mappings.sql.go
@@ -101,8 +101,7 @@ type createSubjectMappingParams struct {
 //	)
 //	SELECT id FROM inserted_mapping
 func (q *Queries) createSubjectMapping(ctx context.Context, arg createSubjectMappingParams) (string, error) {
-	row := q.db.QueryRow(
-		ctx, createSubjectMapping,
+	row := q.db.QueryRow(ctx, createSubjectMapping,
 		arg.AttributeValueID,
 		arg.Metadata,
 		arg.SubjectConditionSetID,
@@ -383,33 +382,8 @@ WHERE
         $3::TEXT IS NULL
         OR EXISTS (
             SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValue') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_value') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValues[*]') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_values[*]') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalValues[*]') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
-        )
-        OR EXISTS (
-            SELECT 1
-            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_values[*]') AS selector_value(value)
-            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+            FROM JSONB_EACH_TEXT(COALESCE(scs.metadata -> 'labels', '{}'::JSONB)) AS label(key, value)
+            WHERE label.value ILIKE $3::TEXT ESCAPE '\'
         )
     )
 ORDER BY
@@ -472,33 +446,8 @@ type listSubjectConditionSetsRow struct {
 //	        $3::TEXT IS NULL
 //	        OR EXISTS (
 //	            SELECT 1
-//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValue') AS selector_value(value)
-//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
-//	        )
-//	        OR EXISTS (
-//	            SELECT 1
-//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_value') AS selector_value(value)
-//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
-//	        )
-//	        OR EXISTS (
-//	            SELECT 1
-//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalSelectorValues[*]') AS selector_value(value)
-//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
-//	        )
-//	        OR EXISTS (
-//	            SELECT 1
-//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_selector_values[*]') AS selector_value(value)
-//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
-//	        )
-//	        OR EXISTS (
-//	            SELECT 1
-//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subjectExternalValues[*]') AS selector_value(value)
-//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
-//	        )
-//	        OR EXISTS (
-//	            SELECT 1
-//	            FROM JSONB_PATH_QUERY(scs.condition, '$.**.subject_external_values[*]') AS selector_value(value)
-//	            WHERE LOWER(selector_value.value #>> '{}') LIKE $3::TEXT ESCAPE '\'
+//	            FROM JSONB_EACH_TEXT(COALESCE(scs.metadata -> 'labels', '{}'::JSONB)) AS label(key, value)
+//	            WHERE label.value ILIKE $3::TEXT ESCAPE '\'
 //	        )
 //	    )
 //	ORDER BY
@@ -510,8 +459,7 @@ type listSubjectConditionSetsRow struct {
 //	LIMIT $5
 //	OFFSET $4
 func (q *Queries) listSubjectConditionSets(ctx context.Context, arg listSubjectConditionSetsParams) ([]listSubjectConditionSetsRow, error) {
-	rows, err := q.db.Query(
-		ctx, listSubjectConditionSets,
+	rows, err := q.db.Query(ctx, listSubjectConditionSets,
 		arg.NamespaceID,
 		arg.NamespaceFqn,
 		arg.Search,
@@ -771,8 +719,7 @@ type listSubjectMappingsRow struct {
 //	LIMIT $4
 //	OFFSET $3
 func (q *Queries) listSubjectMappings(ctx context.Context, arg listSubjectMappingsParams) ([]listSubjectMappingsRow, error) {
-	rows, err := q.db.Query(
-		ctx, listSubjectMappings,
+	rows, err := q.db.Query(ctx, listSubjectMappings,
 		arg.NamespaceID,
 		arg.NamespaceFqn,
 		arg.Offset,
@@ -1080,8 +1027,7 @@ type updateSubjectMappingParams struct {
 //	SELECT cnt
 //	FROM update_count
 func (q *Queries) updateSubjectMapping(ctx context.Context, arg updateSubjectMappingParams) (int64, error) {
-	result, err := q.db.Exec(
-		ctx, updateSubjectMapping,
+	result, err := q.db.Exec(ctx, updateSubjectMapping,
 		arg.Metadata,
 		arg.SubjectConditionSetID,
 		arg.ID,

--- a/service/policy/db/utils.go
+++ b/service/policy/db/utils.go
@@ -175,13 +175,6 @@ func pgtypeSubstringSearchPattern(query string) pgtype.Text {
 	return pgtypeText("%" + escapeLikePattern(strings.ToLower(query)) + "%")
 }
 
-func pgtypeSubstringSearchPatternNoTrim(query string) pgtype.Text {
-	if query == "" {
-		return pgtype.Text{}
-	}
-	return pgtypeText("%" + escapeLikePattern(strings.ToLower(query)) + "%")
-}
-
 func escapeLikePattern(query string) string {
 	return strings.NewReplacer(
 		`\`, `\\`,

--- a/service/policy/db/utils.go
+++ b/service/policy/db/utils.go
@@ -175,6 +175,13 @@ func pgtypeSubstringSearchPattern(query string) pgtype.Text {
 	return pgtypeText("%" + escapeLikePattern(strings.ToLower(query)) + "%")
 }
 
+func pgtypeSubstringSearchPatternNoTrim(query string) pgtype.Text {
+	if query == "" {
+		return pgtype.Text{}
+	}
+	return pgtypeText("%" + escapeLikePattern(strings.ToLower(query)) + "%")
+}
+
 func escapeLikePattern(query string) string {
 	return strings.NewReplacer(
 		`\`, `\\`,
@@ -430,7 +437,8 @@ func UUIDToString(uuid pgtype.UUID) string {
 		return ""
 	}
 
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+	return fmt.Sprintf(
+		"%08x-%04x-%04x-%04x-%012x",
 		uuid.Bytes[0:4],
 		uuid.Bytes[4:6],
 		uuid.Bytes[6:8],


### PR DESCRIPTION
## Summary
- Adds ListSubjectConditionSets RPC search support by wiring request search into the policy DB list query.
- Applies escaped, case-insensitive matching in the subject condition set SQL path and adds integration coverage for search behavior, wildcard literals, empty search, and pagination after filtering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality for subject condition sets filtered by metadata labels.
  * Search supports pagination, sorting, and combines with namespace filtering.
  * Search properly handles whitespace and special character escaping.

* **Tests**
  * Expanded integration test coverage for search behavior with metadata labels.
  * Updated existing sorting tests with improved cleanup utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->