### PR TITLE
feat(policy): add search support to ListKeyAccessServers

### DIFF
--- a/service/integration/kas_registry_test.go
+++ b/service/integration/kas_registry_test.go
@@ -169,6 +169,156 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_Offset_Succeeds() {
 	}
 }
 
+func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchByNameAndUri_Succeeds() {
+	suffix := time.Now().UnixNano()
+	alpha, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
+		Uri:  fmt.Sprintf("https://dspx-search-alpha-%d.example.com", suffix),
+		Name: fmt.Sprintf("dspx-search-alpha-%d", suffix),
+	})
+	s.Require().NoError(err)
+	betaURI := fmt.Sprintf("https://DSPX-Search-Beta-%d.example.com", suffix)
+	beta, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
+		Uri:  betaURI,
+		Name: fmt.Sprintf("dspx-search-beta-%d", suffix),
+	})
+	s.Require().NoError(err)
+	other, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
+		Uri:  fmt.Sprintf("https://dspx-other-%d.example.com", suffix),
+		Name: fmt.Sprintf("dspx-other-%d", suffix),
+	})
+	s.Require().NoError(err)
+	defer s.deleteSortTestKeyAccessServers([]string{alpha.GetId(), beta.GetId(), other.GetId()})
+
+	byName, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
+		Search: &policy.Search{Term: strings.ToUpper(alpha.GetName())},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(byName.GetKeyAccessServers(), 1)
+	s.Equal(alpha.GetId(), byName.GetKeyAccessServers()[0].GetId())
+	s.Equal(int32(1), byName.GetPagination().GetTotal())
+
+	byURI, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
+		Search: &policy.Search{Term: strings.ToUpper(betaURI)},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(byURI.GetKeyAccessServers(), 1)
+	s.Equal(beta.GetId(), byURI.GetKeyAccessServers()[0].GetId())
+	s.Equal(int32(1), byURI.GetPagination().GetTotal())
+}
+
+func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchEscapesLikeWildcardLiterals_Succeeds() {
+	suffix := time.Now().UnixNano()
+	searchDomain := fmt.Sprintf("dspx-search-like-%d.example.com", suffix)
+	alpha, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
+		Uri:  "https://wildcarda." + searchDomain,
+		Name: fmt.Sprintf("wildcarda-%d", suffix),
+	})
+	s.Require().NoError(err)
+	beta, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
+		Uri:  "https://wildcardb." + searchDomain,
+		Name: fmt.Sprintf("wildcardb-%d", suffix),
+	})
+	s.Require().NoError(err)
+	defer s.deleteSortTestKeyAccessServers([]string{alpha.GetId(), beta.GetId()})
+
+	for _, query := range []string{
+		"wildcard_." + searchDomain,
+		"wildcard%." + searchDomain,
+	} {
+		list, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
+			Search: &policy.Search{Term: query},
+		})
+		s.Require().NoError(err)
+		s.Empty(list.GetKeyAccessServers())
+		s.Equal(int32(0), list.GetPagination().GetTotal())
+	}
+}
+
+func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchEmptyQuery_Succeeds() {
+	suffix := time.Now().UnixNano()
+	created, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
+		Uri:  fmt.Sprintf("https://dspx-search-empty-%d.example.com", suffix),
+		Name: fmt.Sprintf("dspx-search-empty-%d", suffix),
+	})
+	s.Require().NoError(err)
+	defer s.deleteSortTestKeyAccessServers([]string{created.GetId()})
+
+	noSearch, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{})
+	s.Require().NoError(err)
+	emptySearch, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
+		Search: &policy.Search{Term: ""},
+	})
+	s.Require().NoError(err)
+	s.Equal(noSearch.GetPagination().GetTotal(), emptySearch.GetPagination().GetTotal())
+}
+
+func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchDoesNotTrimWhitespace_Succeeds() {
+	suffix := time.Now().UnixNano()
+	searchToken := fmt.Sprintf("dspx-search-whitespace-%d", suffix)
+	created, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
+		Uri:  fmt.Sprintf("https://%s.example.com", searchToken),
+		Name: searchToken,
+	})
+	s.Require().NoError(err)
+	defer s.deleteSortTestKeyAccessServers([]string{created.GetId()})
+
+	list, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
+		Search: &policy.Search{Term: " " + searchToken + " "},
+	})
+	s.Require().NoError(err)
+	s.Empty(list.GetKeyAccessServers())
+	s.Equal(int32(0), list.GetPagination().GetTotal())
+}
+
+func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchPaginationAppliesAfterFiltering_Succeeds() {
+	suffix := time.Now().UnixNano()
+	searchToken := fmt.Sprintf("dspx-search-page-%d", suffix)
+	names := []string{
+		"a-" + searchToken,
+		"b-" + searchToken,
+		"c-" + searchToken,
+		fmt.Sprintf("dspx-search-page-other-%d", suffix),
+	}
+	ids := make([]string, len(names))
+	for i, name := range names {
+		created, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
+			Uri:  fmt.Sprintf("https://%s.example.com", name),
+			Name: name,
+		})
+		s.Require().NoError(err)
+		ids[i] = created.GetId()
+	}
+	defer s.deleteSortTestKeyAccessServers(ids)
+
+	firstPage, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
+		Search:     &policy.Search{Term: searchToken},
+		Pagination: &policy.PageRequest{Limit: 2},
+		Sort: []*kasregistry.KeyAccessServersSort{
+			{Field: kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_NAME, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(firstPage.GetKeyAccessServers(), 2)
+	s.Equal(int32(3), firstPage.GetPagination().GetTotal())
+	s.Equal(int32(2), firstPage.GetPagination().GetNextOffset())
+	s.Equal(ids[0], firstPage.GetKeyAccessServers()[0].GetId())
+	s.Equal(ids[1], firstPage.GetKeyAccessServers()[1].GetId())
+
+	secondPage, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
+		Search:     &policy.Search{Term: searchToken},
+		Pagination: &policy.PageRequest{Limit: 2, Offset: 2},
+		Sort: []*kasregistry.KeyAccessServersSort{
+			{Field: kasregistry.SortKeyAccessServersType_SORT_KEY_ACCESS_SERVERS_TYPE_NAME, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(secondPage.GetKeyAccessServers(), 1)
+	s.Equal(int32(3), secondPage.GetPagination().GetTotal())
+	s.Equal(int32(2), secondPage.GetPagination().GetCurrentOffset())
+	s.Equal(int32(0), secondPage.GetPagination().GetNextOffset())
+	s.Equal(ids[2], secondPage.GetKeyAccessServers()[0].GetId())
+}
+
 func (s *KasRegistrySuite) Test_GetKeyAccessServer() {
 	remoteFixture := s.f.GetKasRegistryKey("key_access_server_1")
 	localFixture := s.f.GetKasRegistryKey("key_access_server_2")

--- a/service/integration/kas_registry_test.go
+++ b/service/integration/kas_registry_test.go
@@ -187,7 +187,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchByNameAndUri_Succeeds
 		Name: fmt.Sprintf("dspx-other-%d", suffix),
 	})
 	s.Require().NoError(err)
-	defer s.deleteSortTestKeyAccessServers([]string{alpha.GetId(), beta.GetId(), other.GetId()})
+	defer s.deleteTestKeyAccessServers([]string{alpha.GetId(), beta.GetId(), other.GetId()})
 
 	byName, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Search: &policy.Search{Term: strings.ToUpper(alpha.GetName())},
@@ -219,7 +219,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchEscapesLikeWildcardLi
 		Name: fmt.Sprintf("wildcardb-%d", suffix),
 	})
 	s.Require().NoError(err)
-	defer s.deleteSortTestKeyAccessServers([]string{alpha.GetId(), beta.GetId()})
+	defer s.deleteTestKeyAccessServers([]string{alpha.GetId(), beta.GetId()})
 
 	for _, query := range []string{
 		"wildcard_." + searchDomain,
@@ -241,7 +241,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchEmptyQuery_Succeeds()
 		Name: fmt.Sprintf("dspx-search-empty-%d", suffix),
 	})
 	s.Require().NoError(err)
-	defer s.deleteSortTestKeyAccessServers([]string{created.GetId()})
+	defer s.deleteTestKeyAccessServers([]string{created.GetId()})
 
 	noSearch, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{})
 	s.Require().NoError(err)
@@ -252,7 +252,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchEmptyQuery_Succeeds()
 	s.Equal(noSearch.GetPagination().GetTotal(), emptySearch.GetPagination().GetTotal())
 }
 
-func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchDoesNotTrimWhitespace_Succeeds() {
+func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchDoesTrimWhitespace_Succeeds() {
 	suffix := time.Now().UnixNano()
 	searchToken := fmt.Sprintf("dspx-search-whitespace-%d", suffix)
 	created, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
@@ -260,14 +260,15 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchDoesNotTrimWhitespace
 		Name: searchToken,
 	})
 	s.Require().NoError(err)
-	defer s.deleteSortTestKeyAccessServers([]string{created.GetId()})
+	defer s.deleteTestKeyAccessServers([]string{created.GetId()})
 
 	list, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Search: &policy.Search{Term: " " + searchToken + " "},
 	})
 	s.Require().NoError(err)
-	s.Empty(list.GetKeyAccessServers())
-	s.Equal(int32(0), list.GetPagination().GetTotal())
+	s.Require().Len(list.GetKeyAccessServers(), 1)
+	s.Equal(int32(1), list.GetPagination().GetTotal())
+	s.Equal(created.GetId(), list.GetKeyAccessServers()[0].GetId())
 }
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchPaginationAppliesAfterFiltering_Succeeds() {
@@ -288,7 +289,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SearchPaginationAppliesAfte
 		s.Require().NoError(err)
 		ids[i] = created.GetId()
 	}
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	firstPage, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Search:     &policy.Search{Term: searchToken},
@@ -1030,7 +1031,7 @@ func (s *KasRegistrySuite) Test_GetKeyAccessServer_ByIdNameUri_ReturnSameResult(
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_ASC() {
 	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-created-asc-0", "sort-kas-created-asc-1", "sort-kas-created-asc-2"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1045,7 +1046,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_ASC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_DESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-created-desc-0", "sort-kas-created-desc-1", "sort-kas-created-desc-2"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1060,7 +1061,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByCreatedAt_DESC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_DESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-updated-desc-0", "sort-kas-updated-desc-1", "sort-kas-updated-desc-2"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	time.Sleep(5 * time.Millisecond)
 	_, err := s.db.PolicyClient.UpdateKeyAccessServer(s.ctx, ids[0], &kasregistry.UpdateKeyAccessServerRequest{
@@ -1085,7 +1086,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_DESC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_ASC() {
 	ids := s.createSortTestKeyAccessServers([]string{"sort-kas-updated-asc-0", "sort-kas-updated-asc-1", "sort-kas-updated-asc-2"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	time.Sleep(5 * time.Millisecond)
 	_, err := s.db.PolicyClient.UpdateKeyAccessServer(s.ctx, ids[2], &kasregistry.UpdateKeyAccessServerRequest{
@@ -1110,7 +1111,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUpdatedAt_ASC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_ASC() {
 	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-sort", "bbb-kas-sort", "ccc-kas-sort"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1125,7 +1126,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_ASC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_DESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-sortdesc", "bbb-kas-sortdesc", "ccc-kas-sortdesc"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1140,7 +1141,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByName_DESC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_ASC() {
 	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-uri", "bbb-kas-uri", "ccc-kas-uri"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1155,7 +1156,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_ASC() {
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUri_DESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"aaa-kas-uridesc", "bbb-kas-uridesc", "ccc-kas-uridesc"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1180,7 +1181,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortTieBreaker_CreatedAtWit
 		s.Require().NoError(err)
 		ids[i] = created.GetId()
 	}
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "key_access_servers", ids))
 
@@ -1199,7 +1200,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortTieBreaker_CreatedAtWit
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedField_DefaultsToCreatedAt() {
 	ids := s.createSortTestKeyAccessServers([]string{"unspecified-field-kas-0", "unspecified-field-kas-1", "unspecified-field-kas-2"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1215,7 +1216,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedField_Defa
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedDirection_DefaultsToDESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"unspecified-dir-kas-0", "unspecified-dir-kas-1", "unspecified-dir-kas-2"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1231,7 +1232,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByUnspecifiedDirection_
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
 	ids := s.createSortTestKeyAccessServers([]string{"both-unspecified-kas-0", "both-unspecified-kas-1", "both-unspecified-kas-2"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{
 		Sort: []*kasregistry.KeyAccessServersSort{
@@ -1247,7 +1248,7 @@ func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortByBothUnspecified_Defau
 
 func (s *KasRegistrySuite) Test_ListKeyAccessServers_SortOmitted() {
 	ids := s.createSortTestKeyAccessServers([]string{"sort-omitted-kas-0", "sort-omitted-kas-1", "sort-omitted-kas-2"})
-	defer s.deleteSortTestKeyAccessServers(ids)
+	defer s.deleteTestKeyAccessServers(ids)
 
 	listRsp, err := s.db.PolicyClient.ListKeyAccessServers(s.ctx, &kasregistry.ListKeyAccessServersRequest{})
 	s.Require().NoError(err)
@@ -1322,8 +1323,8 @@ func (s *KasRegistrySuite) createSortTestKeyAccessServers(prefixes []string) []s
 	return ids
 }
 
-// deleteSortTestKeyAccessServers cleans up KAS entries created by sort tests.
-func (s *KasRegistrySuite) deleteSortTestKeyAccessServers(ids []string) {
+// deleteTestKeyAccessServers cleans up KAS entries created by sort tests.
+func (s *KasRegistrySuite) deleteTestKeyAccessServers(ids []string) {
 	for _, id := range ids {
 		_, err := s.db.PolicyClient.DeleteKeyAccessServer(s.ctx, id)
 		s.Require().NoError(err)

--- a/service/policy/db/key_access_server_registry.go
+++ b/service/policy/db/key_access_server_registry.go
@@ -43,7 +43,7 @@ func (c PolicyDBClient) ListKeyAccessServers(ctx context.Context, r *kasregistry
 	}
 
 	sortField, sortDirection := GetKeyAccessServersSortParams(r.GetSort())
-	search := pgtypeKASSubstringSearchPattern(r.GetSearch().GetTerm())
+	search := pgtypeSubstringSearchPattern(r.GetSearch().GetTerm())
 
 	list, err := c.queries.listKeyAccessServers(ctx, listKeyAccessServersParams{
 		Offset:        offset,
@@ -105,13 +105,6 @@ func (c PolicyDBClient) ListKeyAccessServers(ctx context.Context, r *kasregistry
 			NextOffset:    nextOffset,
 		},
 	}, nil
-}
-
-func pgtypeKASSubstringSearchPattern(query string) pgtype.Text {
-	if query == "" {
-		return pgtype.Text{}
-	}
-	return pgtypeText("%" + escapeLikePattern(strings.ToLower(query)) + "%")
 }
 
 func (c PolicyDBClient) GetKeyAccessServer(ctx context.Context, identifier any) (*policy.KeyAccessServer, error) {

--- a/service/policy/db/key_access_server_registry.go
+++ b/service/policy/db/key_access_server_registry.go
@@ -43,10 +43,12 @@ func (c PolicyDBClient) ListKeyAccessServers(ctx context.Context, r *kasregistry
 	}
 
 	sortField, sortDirection := GetKeyAccessServersSortParams(r.GetSort())
+	search := pgtypeKASSubstringSearchPattern(r.GetSearch().GetTerm())
 
 	list, err := c.queries.listKeyAccessServers(ctx, listKeyAccessServersParams{
 		Offset:        offset,
 		Limit:         limit,
+		Search:        search,
 		SortField:     sortField,
 		SortDirection: sortDirection,
 	})
@@ -103,6 +105,13 @@ func (c PolicyDBClient) ListKeyAccessServers(ctx context.Context, r *kasregistry
 			NextOffset:    nextOffset,
 		},
 	}, nil
+}
+
+func pgtypeKASSubstringSearchPattern(query string) pgtype.Text {
+	if query == "" {
+		return pgtype.Text{}
+	}
+	return pgtypeText("%" + escapeLikePattern(strings.ToLower(query)) + "%")
 }
 
 func (c PolicyDBClient) GetKeyAccessServer(ctx context.Context, identifier any) (*policy.KeyAccessServer, error) {

--- a/service/policy/db/key_access_server_registry.sql.go
+++ b/service/policy/db/key_access_server_registry.sql.go
@@ -40,8 +40,7 @@ type createKeyParams struct {
 //	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 //	RETURNING id
 func (q *Queries) createKey(ctx context.Context, arg createKeyParams) (string, error) {
-	row := q.db.QueryRow(
-		ctx, createKey,
+	row := q.db.QueryRow(ctx, createKey,
 		arg.KeyAccessServerID,
 		arg.KeyAlgorithm,
 		arg.KeyID,
@@ -78,8 +77,7 @@ type createKeyAccessServerParams struct {
 //	VALUES ($1, $2, $3, $4, $5)
 //	RETURNING id
 func (q *Queries) createKeyAccessServer(ctx context.Context, arg createKeyAccessServerParams) (string, error) {
-	row := q.db.QueryRow(
-		ctx, createKeyAccessServer,
+	row := q.db.QueryRow(ctx, createKeyAccessServer,
 		arg.Uri,
 		arg.PublicKey,
 		arg.Name,
@@ -277,8 +275,7 @@ type getKeyRow struct {
 //	  AND ($4::text IS NULL OR kas.uri = $4::text)
 //	  AND ($5::text IS NULL OR kas.name = $5::text)
 func (q *Queries) getKey(ctx context.Context, arg getKeyParams) (getKeyRow, error) {
-	row := q.db.QueryRow(
-		ctx, getKey,
+	row := q.db.QueryRow(ctx, getKey,
 		arg.ID,
 		arg.KeyID,
 		arg.KasID,
@@ -603,8 +600,7 @@ type listKeyAccessServerGrantsRow struct {
 //	LIMIT $2
 //	OFFSET $1
 func (q *Queries) listKeyAccessServerGrants(ctx context.Context, arg listKeyAccessServerGrantsParams) ([]listKeyAccessServerGrantsRow, error) {
-	rows, err := q.db.Query(
-		ctx, listKeyAccessServerGrants,
+	rows, err := q.db.Query(ctx, listKeyAccessServerGrants,
 		arg.Offset,
 		arg.Limit,
 		arg.KasID,
@@ -650,8 +646,8 @@ filtered AS (
     FROM key_access_servers AS kas
     WHERE (
         $5::TEXT IS NULL
-        OR LOWER(kas.name) LIKE $5::TEXT ESCAPE '\'
-        OR LOWER(kas.uri) LIKE $5::TEXT ESCAPE '\'
+        OR kas.name LIKE $5::TEXT ESCAPE '\'
+        OR kas.uri ILIKE $5::TEXT ESCAPE '\' -- Use slower case-insensitive matching, URIs can be registered with variable casing.
     )
 ),
 counted AS (
@@ -732,8 +728,8 @@ type listKeyAccessServersRow struct {
 //	    FROM key_access_servers AS kas
 //	    WHERE (
 //	        $5::TEXT IS NULL
-//	        OR LOWER(kas.name) LIKE $5::TEXT ESCAPE '\'
-//	        OR LOWER(kas.uri) LIKE $5::TEXT ESCAPE '\'
+//	        OR kas.name LIKE $5::TEXT ESCAPE '\'
+//	        OR kas.uri ILIKE $5::TEXT ESCAPE '\' -- Use slower case-insensitive matching, URIs can be registered with variable casing.
 //	    )
 //	),
 //	counted AS (
@@ -782,8 +778,7 @@ type listKeyAccessServersRow struct {
 //	LIMIT $2
 //	OFFSET $1
 func (q *Queries) listKeyAccessServers(ctx context.Context, arg listKeyAccessServersParams) ([]listKeyAccessServersRow, error) {
-	rows, err := q.db.Query(
-		ctx, listKeyAccessServers,
+	rows, err := q.db.Query(ctx, listKeyAccessServers,
 		arg.Offset,
 		arg.Limit,
 		arg.SortField,
@@ -1052,8 +1047,7 @@ type listKeyMappingsRow struct {
 //	LIMIT $2
 //	OFFSET $1
 func (q *Queries) listKeyMappings(ctx context.Context, arg listKeyMappingsParams) ([]listKeyMappingsRow, error) {
-	rows, err := q.db.Query(
-		ctx, listKeyMappings,
+	rows, err := q.db.Query(ctx, listKeyMappings,
 		arg.Offset,
 		arg.Limit,
 		arg.ID,
@@ -1236,8 +1230,7 @@ type listKeysRow struct {
 //	LIMIT $4
 //	OFFSET $3
 func (q *Queries) listKeys(ctx context.Context, arg listKeysParams) ([]listKeysRow, error) {
-	rows, err := q.db.Query(
-		ctx, listKeys,
+	rows, err := q.db.Query(ctx, listKeys,
 		arg.KeyAlgorithm,
 		arg.Legacy,
 		arg.Offset,
@@ -1360,8 +1353,7 @@ type updateKeyAccessServerParams struct {
 //	    source_type = COALESCE($6, source_type)
 //	WHERE id = $1
 func (q *Queries) updateKeyAccessServer(ctx context.Context, arg updateKeyAccessServerParams) (int64, error) {
-	result, err := q.db.Exec(
-		ctx, updateKeyAccessServer,
+	result, err := q.db.Exec(ctx, updateKeyAccessServer,
 		arg.ID,
 		arg.Uri,
 		arg.PublicKey,

--- a/service/policy/db/key_access_server_registry.sql.go
+++ b/service/policy/db/key_access_server_registry.sql.go
@@ -40,7 +40,8 @@ type createKeyParams struct {
 //	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 //	RETURNING id
 func (q *Queries) createKey(ctx context.Context, arg createKeyParams) (string, error) {
-	row := q.db.QueryRow(ctx, createKey,
+	row := q.db.QueryRow(
+		ctx, createKey,
 		arg.KeyAccessServerID,
 		arg.KeyAlgorithm,
 		arg.KeyID,
@@ -77,7 +78,8 @@ type createKeyAccessServerParams struct {
 //	VALUES ($1, $2, $3, $4, $5)
 //	RETURNING id
 func (q *Queries) createKeyAccessServer(ctx context.Context, arg createKeyAccessServerParams) (string, error) {
-	row := q.db.QueryRow(ctx, createKeyAccessServer,
+	row := q.db.QueryRow(
+		ctx, createKeyAccessServer,
 		arg.Uri,
 		arg.PublicKey,
 		arg.Name,
@@ -275,7 +277,8 @@ type getKeyRow struct {
 //	  AND ($4::text IS NULL OR kas.uri = $4::text)
 //	  AND ($5::text IS NULL OR kas.name = $5::text)
 func (q *Queries) getKey(ctx context.Context, arg getKeyParams) (getKeyRow, error) {
-	row := q.db.QueryRow(ctx, getKey,
+	row := q.db.QueryRow(
+		ctx, getKey,
 		arg.ID,
 		arg.KeyID,
 		arg.KasID,
@@ -600,7 +603,8 @@ type listKeyAccessServerGrantsRow struct {
 //	LIMIT $2
 //	OFFSET $1
 func (q *Queries) listKeyAccessServerGrants(ctx context.Context, arg listKeyAccessServerGrantsParams) ([]listKeyAccessServerGrantsRow, error) {
-	rows, err := q.db.Query(ctx, listKeyAccessServerGrants,
+	rows, err := q.db.Query(
+		ctx, listKeyAccessServerGrants,
 		arg.Offset,
 		arg.Limit,
 		arg.KasID,
@@ -641,9 +645,18 @@ WITH params AS (
         COALESCE(NULLIF($3::text, ''), 'created_at') AS resolved_field,
         COALESCE(NULLIF($4::text, ''), 'DESC') AS resolved_direction
 ),
+filtered AS (
+    SELECT kas.id, kas.uri, kas.public_key, kas.metadata, kas.created_at, kas.updated_at, kas.name, kas.source_type
+    FROM key_access_servers AS kas
+    WHERE (
+        $5::TEXT IS NULL
+        OR LOWER(kas.name) LIKE $5::TEXT ESCAPE '\'
+        OR LOWER(kas.uri) LIKE $5::TEXT ESCAPE '\'
+    )
+),
 counted AS (
     SELECT COUNT(kas.id) AS total
-    FROM key_access_servers AS kas
+    FROM filtered AS kas
 )
 SELECT kas.id,
     kas.uri,
@@ -653,7 +666,7 @@ SELECT kas.id,
     JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', kas.metadata -> 'labels', 'created_at', kas.created_at, 'updated_at', kas.updated_at)) AS metadata,
     kask_keys.keys,
     counted.total
-FROM key_access_servers AS kas
+FROM filtered AS kas
 CROSS JOIN counted
 CROSS JOIN params p
 LEFT JOIN (
@@ -689,10 +702,11 @@ OFFSET $1
 `
 
 type listKeyAccessServersParams struct {
-	Offset        int32  `json:"offset_"`
-	Limit         int32  `json:"limit_"`
-	SortField     string `json:"sort_field"`
-	SortDirection string `json:"sort_direction"`
+	Offset        int32       `json:"offset_"`
+	Limit         int32       `json:"limit_"`
+	SortField     string      `json:"sort_field"`
+	SortDirection string      `json:"sort_direction"`
+	Search        pgtype.Text `json:"search"`
 }
 
 type listKeyAccessServersRow struct {
@@ -713,9 +727,18 @@ type listKeyAccessServersRow struct {
 //	        COALESCE(NULLIF($3::text, ''), 'created_at') AS resolved_field,
 //	        COALESCE(NULLIF($4::text, ''), 'DESC') AS resolved_direction
 //	),
+//	filtered AS (
+//	    SELECT kas.id, kas.uri, kas.public_key, kas.metadata, kas.created_at, kas.updated_at, kas.name, kas.source_type
+//	    FROM key_access_servers AS kas
+//	    WHERE (
+//	        $5::TEXT IS NULL
+//	        OR LOWER(kas.name) LIKE $5::TEXT ESCAPE '\'
+//	        OR LOWER(kas.uri) LIKE $5::TEXT ESCAPE '\'
+//	    )
+//	),
 //	counted AS (
 //	    SELECT COUNT(kas.id) AS total
-//	    FROM key_access_servers AS kas
+//	    FROM filtered AS kas
 //	)
 //	SELECT kas.id,
 //	    kas.uri,
@@ -725,7 +748,7 @@ type listKeyAccessServersRow struct {
 //	    JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', kas.metadata -> 'labels', 'created_at', kas.created_at, 'updated_at', kas.updated_at)) AS metadata,
 //	    kask_keys.keys,
 //	    counted.total
-//	FROM key_access_servers AS kas
+//	FROM filtered AS kas
 //	CROSS JOIN counted
 //	CROSS JOIN params p
 //	LEFT JOIN (
@@ -759,11 +782,13 @@ type listKeyAccessServersRow struct {
 //	LIMIT $2
 //	OFFSET $1
 func (q *Queries) listKeyAccessServers(ctx context.Context, arg listKeyAccessServersParams) ([]listKeyAccessServersRow, error) {
-	rows, err := q.db.Query(ctx, listKeyAccessServers,
+	rows, err := q.db.Query(
+		ctx, listKeyAccessServers,
 		arg.Offset,
 		arg.Limit,
 		arg.SortField,
 		arg.SortDirection,
+		arg.Search,
 	)
 	if err != nil {
 		return nil, err
@@ -1027,7 +1052,8 @@ type listKeyMappingsRow struct {
 //	LIMIT $2
 //	OFFSET $1
 func (q *Queries) listKeyMappings(ctx context.Context, arg listKeyMappingsParams) ([]listKeyMappingsRow, error) {
-	rows, err := q.db.Query(ctx, listKeyMappings,
+	rows, err := q.db.Query(
+		ctx, listKeyMappings,
 		arg.Offset,
 		arg.Limit,
 		arg.ID,
@@ -1210,7 +1236,8 @@ type listKeysRow struct {
 //	LIMIT $4
 //	OFFSET $3
 func (q *Queries) listKeys(ctx context.Context, arg listKeysParams) ([]listKeysRow, error) {
-	rows, err := q.db.Query(ctx, listKeys,
+	rows, err := q.db.Query(
+		ctx, listKeys,
 		arg.KeyAlgorithm,
 		arg.Legacy,
 		arg.Offset,
@@ -1333,7 +1360,8 @@ type updateKeyAccessServerParams struct {
 //	    source_type = COALESCE($6, source_type)
 //	WHERE id = $1
 func (q *Queries) updateKeyAccessServer(ctx context.Context, arg updateKeyAccessServerParams) (int64, error) {
-	result, err := q.db.Exec(ctx, updateKeyAccessServer,
+	result, err := q.db.Exec(
+		ctx, updateKeyAccessServer,
 		arg.ID,
 		arg.Uri,
 		arg.PublicKey,

--- a/service/policy/db/queries/key_access_server_registry.sql
+++ b/service/policy/db/queries/key_access_server_registry.sql
@@ -78,8 +78,8 @@ filtered AS (
     FROM key_access_servers AS kas
     WHERE (
         sqlc.narg('search')::TEXT IS NULL
-        OR LOWER(kas.name) LIKE sqlc.narg('search')::TEXT ESCAPE '\'
-        OR LOWER(kas.uri) LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+        OR kas.name LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+        OR kas.uri ILIKE sqlc.narg('search')::TEXT ESCAPE '\' -- Use slower case-insensitive matching, URIs can be registered with variable casing.
     )
 ),
 counted AS (

--- a/service/policy/db/queries/key_access_server_registry.sql
+++ b/service/policy/db/queries/key_access_server_registry.sql
@@ -73,9 +73,18 @@ WITH params AS (
         COALESCE(NULLIF(@sort_field::text, ''), 'created_at') AS resolved_field,
         COALESCE(NULLIF(@sort_direction::text, ''), 'DESC') AS resolved_direction
 ),
+filtered AS (
+    SELECT kas.*
+    FROM key_access_servers AS kas
+    WHERE (
+        sqlc.narg('search')::TEXT IS NULL
+        OR LOWER(kas.name) LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+        OR LOWER(kas.uri) LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+    )
+),
 counted AS (
     SELECT COUNT(kas.id) AS total
-    FROM key_access_servers AS kas
+    FROM filtered AS kas
 )
 SELECT kas.id,
     kas.uri,
@@ -85,7 +94,7 @@ SELECT kas.id,
     JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', kas.metadata -> 'labels', 'created_at', kas.created_at, 'updated_at', kas.updated_at)) AS metadata,
     kask_keys.keys,
     counted.total
-FROM key_access_servers AS kas
+FROM filtered AS kas
 CROSS JOIN counted
 CROSS JOIN params p
 LEFT JOIN (


### PR DESCRIPTION
## Summary
- Adds ListKeyAccessServers RPC search support by wiring request search into the policy DB list query.
- Applies escaped, case-insensitive matching in the KAS registry SQL path and adds integration coverage for search behavior, wildcard literals, empty search, and pagination after filtering.
