### PR TITLE
feat(policy): add search support to ListKeys

### DIFF
--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -759,6 +760,156 @@ func (s *KasRegistryKeySuite) Test_ListKeys_Legacy_Success() {
 	s.False(foundLegacy)
 }
 
+func (s *KasRegistryKeySuite) Test_ListKeys_SearchByKeyID_Succeeds() {
+	searchToken := fmt.Sprintf("alpha-%x", time.Now().UnixNano())
+	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
+		{name: "matched", keyID: "DSPX-2741-" + searchToken},
+		{name: "other", keyID: fmt.Sprintf("d2741-beta-%x", time.Now().UnixNano())},
+	})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Search:    &policy.Search{Term: strings.ToLower(searchToken)},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(list.GetKasKeys(), 1)
+	s.Equal(keyIDsByName["matched"], list.GetKasKeys()[0].GetKey().GetId())
+	s.Equal(int32(1), list.GetPagination().GetTotal())
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SearchCombinesWithFilters_Succeeds() {
+	searchToken := fmt.Sprintf("combo-%x", time.Now().UnixNano())
+	legacy := true
+	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
+		{
+			name:      "matched",
+			keyID:     searchToken + "-matched",
+			algorithm: policy.Algorithm_ALGORITHM_EC_P256,
+			legacy:    true,
+		},
+		{
+			name:      "nonlegacy",
+			keyID:     searchToken + "-nonlegacy",
+			algorithm: policy.Algorithm_ALGORITHM_EC_P256,
+		},
+		{
+			name:      "rsa",
+			keyID:     searchToken + "-rsa",
+			algorithm: policy.Algorithm_ALGORITHM_RSA_2048,
+		},
+	})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter:    &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Search:       &policy.Search{Term: searchToken},
+		Legacy:       &legacy,
+		KeyAlgorithm: policy.Algorithm_ALGORITHM_EC_P256,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(list.GetKasKeys(), 1)
+	s.Equal(keyIDsByName["matched"], list.GetKasKeys()[0].GetKey().GetId())
+	s.Equal(int32(1), list.GetPagination().GetTotal())
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SearchEmptyQuery_Succeeds() {
+	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
+		{name: "matched", keyID: fmt.Sprintf("dspx-2741-empty-%d", time.Now().UnixNano())},
+	})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+
+	noSearch, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+	})
+	s.Require().NoError(err)
+	emptySearch, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Search:    &policy.Search{Term: ""},
+	})
+	s.Require().NoError(err)
+	s.Equal(noSearch.GetPagination().GetTotal(), emptySearch.GetPagination().GetTotal())
+	s.Len(emptySearch.GetKasKeys(), len(noSearch.GetKasKeys()))
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SearchDoesNotTrimWhitespace_Succeeds() {
+	keyID := fmt.Sprintf("dspx-2741-space-%d", time.Now().UnixNano())
+	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
+		{name: "matched", keyID: keyID},
+	})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Search:    &policy.Search{Term: " " + keyID},
+	})
+	s.Require().NoError(err)
+	s.Empty(list.GetKasKeys())
+	s.Equal(int32(0), list.GetPagination().GetTotal())
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SearchEscapesLikeWildcardLiterals_Succeeds() {
+	searchToken := fmt.Sprintf("like-%x", time.Now().UnixNano())
+	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
+		{name: "alpha", keyID: "wildcarda-" + searchToken},
+		{name: "beta", keyID: "wildcardb-" + searchToken},
+	})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+
+	for _, query := range []string{
+		"wildcard_-" + searchToken,
+		"wildcard%-" + searchToken,
+	} {
+		list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+			KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+			Search:    &policy.Search{Term: query},
+		})
+		s.Require().NoError(err)
+		s.Empty(list.GetKasKeys())
+		s.Equal(int32(0), list.GetPagination().GetTotal())
+	}
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SearchPaginationAppliesAfterFiltering_Succeeds() {
+	searchToken := fmt.Sprintf("page-%x", time.Now().UnixNano())
+	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
+		{name: "first", keyID: "a-" + searchToken},
+		{name: "second", keyID: "b-" + searchToken},
+		{name: "third", keyID: "c-" + searchToken},
+		{name: "other", keyID: fmt.Sprintf("other-%x", time.Now().UnixNano())},
+	})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+
+	firstPage, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter:  &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Search:     &policy.Search{Term: searchToken},
+		Pagination: &policy.PageRequest{Limit: 2},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_KEY_ID, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(firstPage.GetKasKeys(), 2)
+	s.Equal(int32(3), firstPage.GetPagination().GetTotal())
+	s.Equal(int32(2), firstPage.GetPagination().GetNextOffset())
+	s.Equal(keyIDsByName["first"], firstPage.GetKasKeys()[0].GetKey().GetId())
+	s.Equal(keyIDsByName["second"], firstPage.GetKasKeys()[1].GetKey().GetId())
+
+	secondPage, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter:  &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Search:     &policy.Search{Term: searchToken},
+		Pagination: &policy.PageRequest{Limit: 2, Offset: 2},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_KEY_ID, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(secondPage.GetKasKeys(), 1)
+	s.Equal(int32(3), secondPage.GetPagination().GetTotal())
+	s.Equal(int32(2), secondPage.GetPagination().GetCurrentOffset())
+	s.Equal(keyIDsByName["third"], secondPage.GetKasKeys()[0].GetKey().GetId())
+}
+
 func (s *KasRegistryKeySuite) Test_RotateKey_Multiple_Attributes_Values_Namespaces_Success() {
 	namespaceIDs := make([]string, 0)
 	keyIDs := make([]string, 0)
@@ -1369,7 +1520,8 @@ func (s *KasRegistryKeySuite) Test_SetBaseKey_CannotSetNonActiveKey_Fails() {
 	s.Require().Nil(baseKey)
 
 	// Update the key status to rotated
-	rotatedKeysResp, err := s.db.PolicyClient.RotateKey(s.ctx,
+	rotatedKeysResp, err := s.db.PolicyClient.RotateKey(
+		s.ctx,
 		key.GetKasKey(),
 		&kasregistry.RotateKeyRequest_NewKey{
 			KeyId:     "rotated_key_id",
@@ -2318,6 +2470,21 @@ func (s *KasRegistryKeySuite) cleanupKeys(keyIDs []string, keyAccessServerIDs []
 	}
 }
 
+type listKeysSearchKeySpec struct {
+	name      string
+	keyID     string
+	algorithm policy.Algorithm
+	legacy    bool
+}
+
+func listKeysSearchIDs(keyIDsByName map[string]string) []string {
+	keyIDs := make([]string, 0, len(keyIDsByName))
+	for _, id := range keyIDsByName {
+		keyIDs = append(keyIDs, id)
+	}
+	return keyIDs
+}
+
 func (s *KasRegistryKeySuite) getKasRegistryServerKeysFixtures() []fixtures.FixtureDataKasRegistryKey {
 	return []fixtures.FixtureDataKasRegistryKey{
 		s.f.GetKasRegistryServerKeys("kas_key_1"),
@@ -2755,4 +2922,42 @@ func (s *KasRegistryKeySuite) createSortTestKasKeys(prefixes []string) ([]string
 // deleteSortTestKasKeys cleans up kas keys and their parent KAS created by sort tests.
 func (s *KasRegistryKeySuite) deleteSortTestKasKeys(keyIDs []string, kasID string) {
 	s.cleanupKeys(keyIDs, []string{kasID})
+}
+
+func (s *KasRegistryKeySuite) createListKeysSearchTestKeys(specs []listKeysSearchKeySpec) (string, map[string]string) {
+	kasUUID := uuid.NewString()
+	kasReq := kasregistry.CreateKeyAccessServerRequest{
+		Name: "dspx-2741-search-kas-" + kasUUID,
+		Uri:  "https://dspx-2741-search-kas-" + kasUUID + ".opentdf.io",
+	}
+	kas, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasReq)
+	s.Require().NoError(err)
+	s.NotNil(kas)
+
+	keyIDsByName := make(map[string]string, len(specs))
+	for _, spec := range specs {
+		algorithm := spec.algorithm
+		if algorithm == policy.Algorithm_ALGORITHM_UNSPECIFIED {
+			algorithm = policy.Algorithm_ALGORITHM_RSA_2048
+		}
+
+		keyReq := kasregistry.CreateKeyRequest{
+			KasId:        kas.GetId(),
+			KeyId:        spec.keyID,
+			KeyAlgorithm: algorithm,
+			KeyMode:      policy.KeyMode_KEY_MODE_CONFIG_ROOT_KEY,
+			PublicKeyCtx: &policy.PublicKeyCtx{Pem: keyCtx},
+			PrivateKeyCtx: &policy.PrivateKeyCtx{
+				KeyId:      spec.keyID + "-private",
+				WrappedKey: keyCtx,
+			},
+			Legacy: spec.legacy,
+		}
+		keyResp, err := s.db.PolicyClient.CreateKey(s.ctx, &keyReq)
+		s.Require().NoError(err)
+		s.NotNil(keyResp)
+		keyIDsByName[spec.name] = keyResp.GetKasKey().GetKey().GetId()
+	}
+
+	return kas.GetId(), keyIDsByName
 }

--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -762,11 +762,10 @@ func (s *KasRegistryKeySuite) Test_ListKeys_Legacy_Success() {
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SearchByKeyID_Succeeds() {
 	searchToken := fmt.Sprintf("alpha-%x", time.Now().UnixNano())
-	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
-		{name: "matched", keyID: "DSPX-2741-" + searchToken},
-		{name: "other", keyID: fmt.Sprintf("d2741-beta-%x", time.Now().UnixNano())},
-	})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+	matchedKID := "SEARCH-KEY-" + searchToken
+	otherKID := fmt.Sprintf("other-beta-%x", time.Now().UnixNano())
+	kasID, keyIDsByKID := s.createListKeysSearchTestKeys([]string{matchedKID, otherKID})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
@@ -774,50 +773,34 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchByKeyID_Succeeds() {
 	})
 	s.Require().NoError(err)
 	s.Require().Len(list.GetKasKeys(), 1)
-	s.Equal(keyIDsByName["matched"], list.GetKasKeys()[0].GetKey().GetId())
+	s.Equal(keyIDsByKID[matchedKID], list.GetKasKeys()[0].GetKey().GetId())
 	s.Equal(int32(1), list.GetPagination().GetTotal())
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SearchCombinesWithFilters_Succeeds() {
 	searchToken := fmt.Sprintf("combo-%x", time.Now().UnixNano())
-	legacy := true
-	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
-		{
-			name:      "matched",
-			keyID:     searchToken + "-matched",
-			algorithm: policy.Algorithm_ALGORITHM_EC_P256,
-			legacy:    true,
-		},
-		{
-			name:      "nonlegacy",
-			keyID:     searchToken + "-nonlegacy",
-			algorithm: policy.Algorithm_ALGORITHM_EC_P256,
-		},
-		{
-			name:      "rsa",
-			keyID:     searchToken + "-rsa",
-			algorithm: policy.Algorithm_ALGORITHM_RSA_2048,
-		},
-	})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+	matchedKID := searchToken + "-matched"
+	otherKID := searchToken + "-other-kas"
+	kasID, keyIDsByKID := s.createListKeysSearchTestKeys([]string{matchedKID})
+	otherKasID, otherKeyIDsByKID := s.createListKeysSearchTestKeys([]string{otherKID})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	defer s.cleanupKeys(listKeysSearchIDs(otherKeyIDsByKID), []string{otherKasID})
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter:    &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Search:       &policy.Search{Term: searchToken},
-		Legacy:       &legacy,
-		KeyAlgorithm: policy.Algorithm_ALGORITHM_EC_P256,
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Search:    &policy.Search{Term: searchToken},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(list.GetKasKeys(), 1)
-	s.Equal(keyIDsByName["matched"], list.GetKasKeys()[0].GetKey().GetId())
+	s.Equal(keyIDsByKID[matchedKID], list.GetKasKeys()[0].GetKey().GetId())
 	s.Equal(int32(1), list.GetPagination().GetTotal())
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SearchEmptyQuery_Succeeds() {
-	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
-		{name: "matched", keyID: fmt.Sprintf("dspx-2741-empty-%d", time.Now().UnixNano())},
+	kasID, keyIDsByKID := s.createListKeysSearchTestKeys([]string{
+		fmt.Sprintf("search-empty-%d", time.Now().UnixNano()),
 	})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
 
 	noSearch, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
@@ -832,29 +815,28 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchEmptyQuery_Succeeds() {
 	s.Len(emptySearch.GetKasKeys(), len(noSearch.GetKasKeys()))
 }
 
-func (s *KasRegistryKeySuite) Test_ListKeys_SearchDoesNotTrimWhitespace_Succeeds() {
-	keyID := fmt.Sprintf("dspx-2741-space-%d", time.Now().UnixNano())
-	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
-		{name: "matched", keyID: keyID},
-	})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+func (s *KasRegistryKeySuite) Test_ListKeys_SearchTrimsWhitespace_Succeeds() {
+	keyID := fmt.Sprintf("search-space-%d", time.Now().UnixNano())
+	kasID, keyIDsByKID := s.createListKeysSearchTestKeys([]string{keyID})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
 		Search:    &policy.Search{Term: " " + keyID},
 	})
 	s.Require().NoError(err)
-	s.Empty(list.GetKasKeys())
-	s.Equal(int32(0), list.GetPagination().GetTotal())
+	s.Require().Len(list.GetKasKeys(), 1)
+	s.Equal(keyIDsByKID[keyID], list.GetKasKeys()[0].GetKey().GetId())
+	s.Equal(int32(1), list.GetPagination().GetTotal())
 }
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SearchEscapesLikeWildcardLiterals_Succeeds() {
 	searchToken := fmt.Sprintf("like-%x", time.Now().UnixNano())
-	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
-		{name: "alpha", keyID: "wildcarda-" + searchToken},
-		{name: "beta", keyID: "wildcardb-" + searchToken},
+	kasID, keyIDsByKID := s.createListKeysSearchTestKeys([]string{
+		"wildcarda-" + searchToken,
+		"wildcardb-" + searchToken,
 	})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
 
 	for _, query := range []string{
 		"wildcard_-" + searchToken,
@@ -872,13 +854,12 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchEscapesLikeWildcardLiterals_Su
 
 func (s *KasRegistryKeySuite) Test_ListKeys_SearchPaginationAppliesAfterFiltering_Succeeds() {
 	searchToken := fmt.Sprintf("page-%x", time.Now().UnixNano())
-	kasID, keyIDsByName := s.createListKeysSearchTestKeys([]listKeysSearchKeySpec{
-		{name: "first", keyID: "a-" + searchToken},
-		{name: "second", keyID: "b-" + searchToken},
-		{name: "third", keyID: "c-" + searchToken},
-		{name: "other", keyID: fmt.Sprintf("other-%x", time.Now().UnixNano())},
-	})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByName), []string{kasID})
+	firstKID := "a-" + searchToken
+	secondKID := "b-" + searchToken
+	thirdKID := "c-" + searchToken
+	otherKID := fmt.Sprintf("other-%x", time.Now().UnixNano())
+	kasID, keyIDsByKID := s.createListKeysSearchTestKeys([]string{firstKID, secondKID, thirdKID, otherKID})
+	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
 
 	firstPage, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
 		KasFilter:  &kasregistry.ListKeysRequest_KasId{KasId: kasID},
@@ -892,8 +873,8 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchPaginationAppliesAfterFilterin
 	s.Require().Len(firstPage.GetKasKeys(), 2)
 	s.Equal(int32(3), firstPage.GetPagination().GetTotal())
 	s.Equal(int32(2), firstPage.GetPagination().GetNextOffset())
-	s.Equal(keyIDsByName["first"], firstPage.GetKasKeys()[0].GetKey().GetId())
-	s.Equal(keyIDsByName["second"], firstPage.GetKasKeys()[1].GetKey().GetId())
+	s.Equal(keyIDsByKID[firstKID], firstPage.GetKasKeys()[0].GetKey().GetId())
+	s.Equal(keyIDsByKID[secondKID], firstPage.GetKasKeys()[1].GetKey().GetId())
 
 	secondPage, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
 		KasFilter:  &kasregistry.ListKeysRequest_KasId{KasId: kasID},
@@ -907,7 +888,8 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchPaginationAppliesAfterFilterin
 	s.Require().Len(secondPage.GetKasKeys(), 1)
 	s.Equal(int32(3), secondPage.GetPagination().GetTotal())
 	s.Equal(int32(2), secondPage.GetPagination().GetCurrentOffset())
-	s.Equal(keyIDsByName["third"], secondPage.GetKasKeys()[0].GetKey().GetId())
+	s.Equal(int32(0), secondPage.GetPagination().GetNextOffset())
+	s.Equal(keyIDsByKID[thirdKID], secondPage.GetKasKeys()[0].GetKey().GetId())
 }
 
 func (s *KasRegistryKeySuite) Test_RotateKey_Multiple_Attributes_Values_Namespaces_Success() {
@@ -2470,16 +2452,9 @@ func (s *KasRegistryKeySuite) cleanupKeys(keyIDs []string, keyAccessServerIDs []
 	}
 }
 
-type listKeysSearchKeySpec struct {
-	name      string
-	keyID     string
-	algorithm policy.Algorithm
-	legacy    bool
-}
-
-func listKeysSearchIDs(keyIDsByName map[string]string) []string {
-	keyIDs := make([]string, 0, len(keyIDsByName))
-	for _, id := range keyIDsByName {
+func listKeysSearchIDs(keyIDsByKID map[string]string) []string {
+	keyIDs := make([]string, 0, len(keyIDsByKID))
+	for _, id := range keyIDsByKID {
 		keyIDs = append(keyIDs, id)
 	}
 	return keyIDs
@@ -2924,40 +2899,34 @@ func (s *KasRegistryKeySuite) deleteSortTestKasKeys(keyIDs []string, kasID strin
 	s.cleanupKeys(keyIDs, []string{kasID})
 }
 
-func (s *KasRegistryKeySuite) createListKeysSearchTestKeys(specs []listKeysSearchKeySpec) (string, map[string]string) {
+func (s *KasRegistryKeySuite) createListKeysSearchTestKeys(kids []string) (string, map[string]string) {
 	kasUUID := uuid.NewString()
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
-		Name: "dspx-2741-search-kas-" + kasUUID,
-		Uri:  "https://dspx-2741-search-kas-" + kasUUID + ".opentdf.io",
+		Name: "list-keys-search-kas-" + kasUUID,
+		Uri:  "https://list-keys-search-kas-" + kasUUID + ".opentdf.io",
 	}
 	kas, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasReq)
 	s.Require().NoError(err)
 	s.NotNil(kas)
 
-	keyIDsByName := make(map[string]string, len(specs))
-	for _, spec := range specs {
-		algorithm := spec.algorithm
-		if algorithm == policy.Algorithm_ALGORITHM_UNSPECIFIED {
-			algorithm = policy.Algorithm_ALGORITHM_RSA_2048
-		}
-
+	keyIDsByKID := make(map[string]string, len(kids))
+	for _, kid := range kids {
 		keyReq := kasregistry.CreateKeyRequest{
 			KasId:        kas.GetId(),
-			KeyId:        spec.keyID,
-			KeyAlgorithm: algorithm,
+			KeyId:        kid,
+			KeyAlgorithm: policy.Algorithm_ALGORITHM_RSA_2048,
 			KeyMode:      policy.KeyMode_KEY_MODE_CONFIG_ROOT_KEY,
 			PublicKeyCtx: &policy.PublicKeyCtx{Pem: keyCtx},
 			PrivateKeyCtx: &policy.PrivateKeyCtx{
-				KeyId:      spec.keyID + "-private",
+				KeyId:      kid + "-private",
 				WrappedKey: keyCtx,
 			},
-			Legacy: spec.legacy,
 		}
 		keyResp, err := s.db.PolicyClient.CreateKey(s.ctx, &keyReq)
 		s.Require().NoError(err)
 		s.NotNil(keyResp)
-		keyIDsByName[spec.name] = keyResp.GetKasKey().GetKey().GetId()
+		keyIDsByKID[kid] = keyResp.GetKasKey().GetKey().GetId()
 	}
 
-	return kas.GetId(), keyIDsByName
+	return kas.GetId(), keyIDsByKID
 }

--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -811,7 +811,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchEmptyQuery_Succeeds() {
 		Search:    &policy.Search{Term: ""},
 	})
 	s.Require().NoError(err)
-	s.GreaterOrEqual(len(noSearch.GetKasKeys()), 1)
+	s.Require().Len(noSearch.GetKasKeys(), 1)
 	s.Equal(noSearch.GetPagination().GetTotal(), emptySearch.GetPagination().GetTotal())
 	s.Len(emptySearch.GetKasKeys(), len(noSearch.GetKasKeys()))
 }

--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -771,7 +771,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchByKeyID_Succeeds() {
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Search:    &policy.Search{Term: strings.ToLower(searchToken)},
+		Search:    &policy.Search{Term: strings.ToUpper(searchToken)},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(list.GetKasKeys(), 1)
@@ -2542,7 +2542,7 @@ func (s *KasRegistryKeySuite) setupKeysForRotate(kasID string) map[string]*polic
 	}
 	keyToRotate, err := s.db.PolicyClient.CreateKey(s.ctx, &keyReq)
 	s.Require().NoError(err)
-	s.NotNil(rotateKey)
+	s.NotNil(keyToRotate)
 
 	keyReq2 := kasregistry.CreateKeyRequest{
 		KasId:        kasID,

--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -811,6 +811,7 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchEmptyQuery_Succeeds() {
 		Search:    &policy.Search{Term: ""},
 	})
 	s.Require().NoError(err)
+	s.GreaterOrEqual(len(noSearch.GetKasKeys()), 1)
 	s.Equal(noSearch.GetPagination().GetTotal(), emptySearch.GetPagination().GetTotal())
 	s.Len(emptySearch.GetKasKeys(), len(noSearch.GetKasKeys()))
 }

--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -209,14 +209,14 @@ func (s *KasRegistryKeySuite) Test_CreateKasKey_Legacy_MultipleOnSameKas_Fail() 
 	s.NotNil(resp)
 	s.True(resp.GetKasKey().GetKey().GetLegacy())
 
-	defer func() {
+	s.T().Cleanup(func() {
 		_, err := s.db.PolicyClient.UnsafeDeleteKey(s.ctx, resp.GetKasKey(), &unsafe.UnsafeDeleteKasKeyRequest{
 			Id:     resp.GetKasKey().GetKey().GetId(),
 			KasUri: resp.GetKasKey().GetKasUri(),
 			Kid:    resp.GetKasKey().GetKey().GetKeyId(),
 		})
 		s.Require().NoError(err)
-	}()
+	})
 
 	req2 := kasregistry.CreateKeyRequest{
 		KasId:        s.kasKeys[0].KeyAccessServerID,
@@ -254,14 +254,14 @@ func (s *KasRegistryKeySuite) Test_CreateKasKey_Legacy_MultipleOnDifferentKas_Su
 	s.NotNil(resp)
 	s.True(resp.GetKasKey().GetKey().GetLegacy())
 
-	defer func() {
+	s.T().Cleanup(func() {
 		_, err := s.db.PolicyClient.UnsafeDeleteKey(s.ctx, resp.GetKasKey(), &unsafe.UnsafeDeleteKasKeyRequest{
 			Id:     resp.GetKasKey().GetKey().GetId(),
 			KasUri: resp.GetKasKey().GetKasUri(),
 			Kid:    resp.GetKasKey().GetKey().GetKeyId(),
 		})
 		s.Require().NoError(err)
-	}()
+	})
 
 	// Create a new KAS server
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
@@ -275,9 +275,9 @@ func (s *KasRegistryKeySuite) Test_CreateKasKey_Legacy_MultipleOnDifferentKas_Su
 	kasIDs := []string{kas.GetId()}
 	keyIDs := []string{}
 
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	req2 := kasregistry.CreateKeyRequest{
 		KasId:        kas.GetId(),
@@ -489,9 +489,9 @@ func (s *KasRegistryKeySuite) Test_ListKeys_OrdersByCreatedAt_Succeeds() {
 
 	keyIDs := make([]string, 0, 3)
 	kasIDs := []string{kas.GetId()}
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	createKey := func() string {
 		keyReq := kasregistry.CreateKeyRequest{
@@ -657,9 +657,9 @@ func (s *KasRegistryKeySuite) Test_ListKeys_Legacy_Success() {
 	kasIDs := make([]string, 0)
 	keyIDs := make([]string, 0)
 
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	kas, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasregistry.CreateKeyAccessServerRequest{
 		Uri:  "https://legacy-kas.opentdf.io",
@@ -765,7 +765,9 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchByKeyID_Succeeds() {
 	matchedKID := "SEARCH-KEY-" + searchToken
 	otherKID := fmt.Sprintf("other-beta-%x", time.Now().UnixNano())
 	kasID, keyIDsByKID := s.createListKeysSearchTestKeys([]string{matchedKID, otherKID})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	s.T().Cleanup(func() {
+		s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	})
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
@@ -783,8 +785,12 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchCombinesWithFilters_Succeeds()
 	otherKID := searchToken + "-other-kas"
 	kasID, keyIDsByKID := s.createListKeysSearchTestKeys([]string{matchedKID})
 	otherKasID, otherKeyIDsByKID := s.createListKeysSearchTestKeys([]string{otherKID})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
-	defer s.cleanupKeys(listKeysSearchIDs(otherKeyIDsByKID), []string{otherKasID})
+	s.T().Cleanup(func() {
+		s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	})
+	s.T().Cleanup(func() {
+		s.cleanupKeys(listKeysSearchIDs(otherKeyIDsByKID), []string{otherKasID})
+	})
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
@@ -800,7 +806,9 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchEmptyQuery_Succeeds() {
 	kasID, keyIDsByKID := s.createListKeysSearchTestKeys([]string{
 		fmt.Sprintf("search-empty-%d", time.Now().UnixNano()),
 	})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	s.T().Cleanup(func() {
+		s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	})
 
 	noSearch, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
@@ -819,11 +827,28 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchEmptyQuery_Succeeds() {
 func (s *KasRegistryKeySuite) Test_ListKeys_SearchTrimsWhitespace_Succeeds() {
 	keyID := fmt.Sprintf("search-space-%d", time.Now().UnixNano())
 	kasID, keyIDsByKID := s.createListKeysSearchTestKeys([]string{keyID})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	s.T().Cleanup(func() {
+		s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	})
+
+	for _, query := range []string{
+		" " + keyID,
+		keyID + " ",
+		" " + keyID + " ",
+	} {
+		list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+			KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+			Search:    &policy.Search{Term: query},
+		})
+		s.Require().NoError(err)
+		s.Require().Len(list.GetKasKeys(), 1)
+		s.Equal(keyIDsByKID[keyID], list.GetKasKeys()[0].GetKey().GetId())
+		s.Equal(int32(1), list.GetPagination().GetTotal())
+	}
 
 	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Search:    &policy.Search{Term: " " + keyID},
+		Search:    &policy.Search{Term: " "},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(list.GetKasKeys(), 1)
@@ -837,7 +862,9 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchEscapesLikeWildcardLiterals_Su
 		"wildcarda-" + searchToken,
 		"wildcardb-" + searchToken,
 	})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	s.T().Cleanup(func() {
+		s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	})
 
 	for _, query := range []string{
 		"wildcard_-" + searchToken,
@@ -860,7 +887,9 @@ func (s *KasRegistryKeySuite) Test_ListKeys_SearchPaginationAppliesAfterFilterin
 	thirdKID := "c-" + searchToken
 	otherKID := fmt.Sprintf("other-%x", time.Now().UnixNano())
 	kasID, keyIDsByKID := s.createListKeysSearchTestKeys([]string{firstKID, secondKID, thirdKID, otherKID})
-	defer s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	s.T().Cleanup(func() {
+		s.cleanupKeys(listKeysSearchIDs(keyIDsByKID), []string{kasID})
+	})
 
 	firstPage, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
 		KasFilter:  &kasregistry.ListKeysRequest_KasId{KasId: kasID},
@@ -898,10 +927,10 @@ func (s *KasRegistryKeySuite) Test_RotateKey_Multiple_Attributes_Values_Namespac
 	keyIDs := make([]string, 0)
 	kasIDs := make([]string, 0)
 
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupNamespacesAndAttrsByIDs(namespaceIDs)
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	// Create a new KAS server
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
@@ -1019,10 +1048,10 @@ func (s *KasRegistryKeySuite) Test_RotateKey_Two_Attribute_Two_Namespace_0_Attri
 	keyIDs := make([]string, 0)
 	kasIDs := make([]string, 0)
 
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupNamespacesAndAttrsByIDs(namespaceIDs)
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	// Create a new KAS server
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
@@ -1144,9 +1173,9 @@ func (s *KasRegistryKeySuite) Test_RotateKey_Two_Attribute_Two_Namespace_0_Attri
 func (s *KasRegistryKeySuite) Test_RotateKey_NoAttributeKeyMapping_Success() {
 	keyIDs := make([]string, 0)
 	kasIDs := make([]string, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
 		Name: "test_rotate_key_kas",
@@ -1209,9 +1238,9 @@ func (s *KasRegistryKeySuite) Test_RotateKey_NoAttributeKeyMapping_Success() {
 func (s *KasRegistryKeySuite) Test_RotateKey_NoBaseKeyRotated_Success() {
 	keyIDs := make([]string, 0)
 	kasIDs := make([]string, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
 		Name: "test_rotate_key_kas",
@@ -1261,9 +1290,9 @@ func (s *KasRegistryKeySuite) Test_RotateKey_NoBaseKeyRotated_Success() {
 func (s *KasRegistryKeySuite) Test_RotateKey_BaseKeyRotated_Success() {
 	keyIDs := make([]string, 0)
 	kasIDs := make([]string, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
 		Name: "test_rotate_key_kas",
@@ -1309,9 +1338,9 @@ func (s *KasRegistryKeySuite) Test_RotateKey_BaseKeyRotated_Success() {
 func (s *KasRegistryKeySuite) Test_SetBaseKey_KasKeyNotFound_Fails() {
 	keyIDs := make([]string, 0)
 	kasIDs := make([]string, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	// Create a new KAS server
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
@@ -1360,9 +1389,9 @@ func (s *KasRegistryKeySuite) Test_SetBaseKey_KasKeyNotFound_Fails() {
 func (s *KasRegistryKeySuite) Test_SetBaseKey_Insert_Success() {
 	keyIDs := make([]string, 0)
 	kasIDs := make([]string, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	// Create a new KAS server
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
@@ -1417,9 +1446,9 @@ func (s *KasRegistryKeySuite) Test_SetBaseKey_Insert_Success() {
 func (s *KasRegistryKeySuite) Test_SetBaseKey_CannotSetPublicKeyOnlyKey_Fails() {
 	keyIDs := make([]string, 0)
 	kasIDs := make([]string, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	// Create a new KAS server
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
@@ -1464,9 +1493,9 @@ func (s *KasRegistryKeySuite) Test_SetBaseKey_CannotSetPublicKeyOnlyKey_Fails() 
 func (s *KasRegistryKeySuite) Test_SetBaseKey_CannotSetNonActiveKey_Fails() {
 	keyIDs := make([]string, 0)
 	kasIDs := make([]string, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	// Create a new KAS server
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
@@ -1536,9 +1565,9 @@ func (s *KasRegistryKeySuite) Test_SetBaseKey_CannotSetNonActiveKey_Fails() {
 func (s *KasRegistryKeySuite) Test_RotateKey_MetadataUnchanged_Success() {
 	keyIDs := make([]string, 0)
 	kasIDs := make([]string, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 
 	kasReq := kasregistry.CreateKeyAccessServerRequest{
 		Name: "test_rotate_key_kas",
@@ -1612,14 +1641,14 @@ func (s *KasRegistryKeySuite) Test_ListKeyMappings_OrdersByCreatedAt_Succeeds() 
 	kasKeys := make([]*policy.KasKey, 0, 2)
 	kasIDs := make([]string, 0, 2)
 	namespaces := make([]*policy.Namespace, 0, 1)
-	defer func() {
+	s.T().Cleanup(func() {
 		keyIDs := make([]string, 0, len(kasKeys))
 		for _, key := range kasKeys {
 			keyIDs = append(keyIDs, key.GetKey().GetId())
 		}
 		s.cleanupKeys(keyIDs, kasIDs)
 		s.cleanupNamespacesAndAttrs(namespaces)
-	}()
+	})
 
 	kasKey1 := s.createKeyAndKas()
 	kasKeys = append(kasKeys, kasKey1)
@@ -1667,14 +1696,14 @@ func (s *KasRegistryKeySuite) Test_ListKeyMappings_ByID_OneAttrValue_Success() {
 	namespaces := make([]*policy.Namespace, 0)
 	attributeDefs := make([]*policy.Attribute, 0)
 	attrValues := make([]*policy.Value, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		keyIDs := make([]string, 0)
 		for _, key := range kasKeys {
 			keyIDs = append(keyIDs, key.GetKey().GetId())
 		}
 		s.cleanupKeys(keyIDs, kasIDs)
 		s.cleanupNamespacesAndAttrs(namespaces)
-	}()
+	})
 	kasKey := s.createKeyAndKas()
 	kasKeys = append(kasKeys, kasKey)
 	kasIDs = append(kasIDs, kasKey.GetKasId())
@@ -1733,14 +1762,14 @@ func (s *KasRegistryKeySuite) Test_ListKeyMappings_By_Key_Success() {
 	namespaces := make([]*policy.Namespace, 0)
 	attributeDefs := make([]*policy.Attribute, 0)
 	attrValues := make([]*policy.Value, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		keyIDs := make([]string, 0)
 		for _, key := range kasKeys {
 			keyIDs = append(keyIDs, key.GetKey().GetId())
 		}
 		s.cleanupKeys(keyIDs, kasIDs)
 		s.cleanupNamespacesAndAttrs(namespaces)
-	}()
+	})
 	kasKey := s.createKeyAndKas()
 	kasKeys = append(kasKeys, kasKey)
 	kasIDs = append(kasIDs, kasKey.GetKasId())
@@ -1832,14 +1861,14 @@ func (s *KasRegistryKeySuite) Test_ListKeyMappings_SameKeyId_DifferentKas_Succes
 	namespaces := make([]*policy.Namespace, 0)
 	attributeDefs := make([]*policy.Attribute, 0)
 	attrValues := make([]*policy.Value, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		keyIDs := make([]string, 0)
 		for _, key := range kasKeys {
 			keyIDs = append(keyIDs, key.GetKey().GetId())
 		}
 		s.cleanupKeys(keyIDs, kasIDs)
 		s.cleanupNamespacesAndAttrs(namespaces)
-	}()
+	})
 
 	kasKey := s.createKeyAndKas()
 	s.NotNil(kasKey)
@@ -1903,13 +1932,13 @@ func (s *KasRegistryKeySuite) Test_ListKeyMappings_SameKeyId_DifferentKas_Succes
 func (s *KasRegistryKeySuite) Test_ListKeyMappings_By_Key_Success_EmptyMappings() {
 	kasKeys := make([]*policy.KasKey, 0)
 	kasIDs := make([]string, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		keyIDs := make([]string, 0)
 		for _, key := range kasKeys {
 			keyIDs = append(keyIDs, key.GetKey().GetId())
 		}
 		s.cleanupKeys(keyIDs, kasIDs)
-	}()
+	})
 	kasKey := s.createKeyAndKas()
 	kasKeys = append(kasKeys, kasKey)
 	kasIDs = append(kasIDs, kasKey.GetKasId())
@@ -1935,14 +1964,14 @@ func (s *KasRegistryKeySuite) Test_ListKeyMappings_Multiple_Keys_Pagination_Succ
 	namespaces := make([]*policy.Namespace, 0)
 	attributeDefs := make([]*policy.Attribute, 0)
 	attrValues := make([]*policy.Value, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		keyIDs := make([]string, 0)
 		for _, key := range kasKeys {
 			keyIDs = append(keyIDs, key.GetKey().GetId())
 		}
 		s.cleanupKeys(keyIDs, kasIDs)
 		s.cleanupNamespacesAndAttrs(namespaces)
-	}()
+	})
 	for i := range 2 {
 		kasKey := s.createKeyAndKas()
 		kasKeys = append(kasKeys, kasKey)
@@ -2006,14 +2035,14 @@ func (s *KasRegistryKeySuite) Test_ListKeyMappings_Multiple_Mixed_Mappings() {
 	namespaces := make([]*policy.Namespace, 0)
 	attributeDefs := make([]*policy.Attribute, 0)
 	attrValues := make([]*policy.Value, 0)
-	defer func() {
+	s.T().Cleanup(func() {
 		keyIDs := make([]string, 0)
 		for _, key := range kasKeys {
 			keyIDs = append(keyIDs, key.GetKey().GetId())
 		}
 		s.cleanupKeys(keyIDs, kasIDs)
 		s.cleanupNamespacesAndAttrs(namespaces)
-	}()
+	})
 
 	for range 3 {
 		kasKey := s.createKeyAndKas()
@@ -2068,7 +2097,7 @@ func (s *KasRegistryKeySuite) Test_DeleteKey_WrongKasUriOrKid_Fail() {
 	s.Require().NoError(err)
 	s.NotNil(resp)
 
-	defer func() {
+	s.T().Cleanup(func() {
 		r := unsafe.UnsafeDeleteKasKeyRequest{
 			Id:     resp.GetKasKey().GetKey().GetId(),
 			KasUri: resp.GetKasKey().GetKasUri(),
@@ -2076,7 +2105,7 @@ func (s *KasRegistryKeySuite) Test_DeleteKey_WrongKasUriOrKid_Fail() {
 		}
 		_, err := s.db.PolicyClient.UnsafeDeleteKey(s.ctx, resp.GetKasKey(), &r)
 		s.Require().NoError(err)
-	}()
+	})
 
 	// Attempt to delete with incorrect Kid
 	deleteResp, err := s.db.PolicyClient.UnsafeDeleteKey(s.ctx, resp.GetKasKey(), &unsafe.UnsafeDeleteKasKeyRequest{Id: resp.GetKasKey().GetKey().GetId(), KasUri: resp.GetKasKey().GetKasUri(), Kid: "wrong-KID"})
@@ -2192,6 +2221,263 @@ func (s *KasRegistryKeySuite) Test_ListKeyMappings_AllParameterCombinations() {
 	})
 	s.Require().NoError(err, "Should successfully query with KAS ID and key ID")
 	s.NotNil(mappingsByKeyID)
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortByKeyId_ASC() {
+	ids, kasID := s.createSortTestKasKeys([]string{"aaa-kksort", "bbb-kksort", "ccc-kksort"})
+	s.T().Cleanup(func() {
+		s.deleteSortTestKasKeys(ids, kasID)
+	})
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_KEY_ID, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(list)
+
+	// aaa < bbb < ccc in ASC order
+	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[0], ids[1], ids[2])
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortByKeyId_DESC() {
+	ids, kasID := s.createSortTestKasKeys([]string{"aaa-kksortdesc", "bbb-kksortdesc", "ccc-kksortdesc"})
+	s.T().Cleanup(func() {
+		s.deleteSortTestKasKeys(ids, kasID)
+	})
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_KEY_ID, Direction: policy.SortDirection_SORT_DIRECTION_DESC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(list)
+
+	// ccc > bbb > aaa in DESC order
+	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[2], ids[1], ids[0])
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortByCreatedAt_ASC() {
+	ids, kasID := s.createSortTestKasKeys([]string{"createdasc-kk-0", "createdasc-kk-1", "createdasc-kk-2"})
+	s.T().Cleanup(func() {
+		s.deleteSortTestKasKeys(ids, kasID)
+	})
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(list)
+
+	// oldest first in ASC order
+	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[0], ids[1], ids[2])
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortByCreatedAt_DESC() {
+	ids, kasID := s.createSortTestKasKeys([]string{"createddesc-kk-0", "createddesc-kk-1", "createddesc-kk-2"})
+	s.T().Cleanup(func() {
+		s.deleteSortTestKasKeys(ids, kasID)
+	})
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_DESC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(list)
+
+	// newest first in DESC order
+	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[2], ids[1], ids[0])
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortByUpdatedAt_DESC() {
+	ids, kasID := s.createSortTestKasKeys([]string{"upd-sort-kk-0", "upd-sort-kk-1", "upd-sort-kk-2"})
+	s.T().Cleanup(func() {
+		s.deleteSortTestKasKeys(ids, kasID)
+	})
+
+	// Update the first key so its updated_at is the most recent
+	time.Sleep(5 * time.Millisecond)
+	_, err := s.db.PolicyClient.UpdateKey(s.ctx, &kasregistry.UpdateKeyRequest{
+		Id: ids[0],
+		Metadata: &common.MetadataMutable{
+			Labels: map[string]string{"updated": "true"},
+		},
+		MetadataUpdateBehavior: common.MetadataUpdateEnum_METADATA_UPDATE_ENUM_REPLACE,
+	})
+	s.Require().NoError(err)
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_UPDATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_DESC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(list)
+
+	// The updated key (ids[0]) should appear before the others
+	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[0], ids[2], ids[1])
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortByUpdatedAt_ASC() {
+	ids, kasID := s.createSortTestKasKeys([]string{"updasc-kk-0", "updasc-kk-1", "updasc-kk-2"})
+	s.T().Cleanup(func() {
+		s.deleteSortTestKasKeys(ids, kasID)
+	})
+
+	// Update the last key so its updated_at is the most recent
+	time.Sleep(5 * time.Millisecond)
+	_, err := s.db.PolicyClient.UpdateKey(s.ctx, &kasregistry.UpdateKeyRequest{
+		Id: ids[2],
+		Metadata: &common.MetadataMutable{
+			Labels: map[string]string{"updated": "true"},
+		},
+		MetadataUpdateBehavior: common.MetadataUpdateEnum_METADATA_UPDATE_ENUM_REPLACE,
+	})
+	s.Require().NoError(err)
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_UPDATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(list)
+
+	// The updated key (ids[2]) should appear last in ASC order
+	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[0], ids[1], ids[2])
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortTieBreaker_CreatedAtWithIDFallback() {
+	kasReq := kasregistry.CreateKeyAccessServerRequest{
+		Name: "tiebreaker-kk-kas-" + uuid.NewString(),
+		Uri:  "https://tiebreaker-kk-kas-" + uuid.NewString() + ".opentdf.io",
+	}
+	kas, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasReq)
+	s.Require().NoError(err)
+
+	suffix := time.Now().UnixNano()
+	ids := make([]string, 3)
+	for i := range 3 {
+		keyReq := kasregistry.CreateKeyRequest{
+			KasId:        kas.GetId(),
+			KeyId:        fmt.Sprintf("tiebreaker-kk-%d-%d", i, suffix),
+			KeyAlgorithm: policy.Algorithm_ALGORITHM_RSA_2048,
+			KeyMode:      policy.KeyMode_KEY_MODE_CONFIG_ROOT_KEY,
+			PublicKeyCtx: &policy.PublicKeyCtx{Pem: keyCtx},
+			PrivateKeyCtx: &policy.PrivateKeyCtx{
+				KeyId:      fmt.Sprintf("tiebreaker-kk-priv-%d-%d", i, suffix),
+				WrappedKey: keyCtx,
+			},
+		}
+		resp, err := s.db.PolicyClient.CreateKey(s.ctx, &keyReq)
+		s.Require().NoError(err)
+		ids[i] = resp.GetKasKey().GetKey().GetId()
+	}
+	s.T().Cleanup(func() {
+		s.deleteSortTestKasKeys(ids, kas.GetId())
+	})
+
+	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "key_access_server_keys", ids))
+
+	sorted := slices.Sorted(slices.Values(ids))
+
+	listRsp, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{
+			KasId: kas.GetId(),
+		},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(listRsp)
+
+	assertIDsInOrder(s.T(), listRsp.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, sorted[0], sorted[1], sorted[2])
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortByUnspecifiedField_DefaultsToCreatedAt() {
+	ids, kasID := s.createSortTestKasKeys([]string{"unsf-kk-0", "unsf-kk-1", "unsf-kk-2"})
+	s.T().Cleanup(func() {
+		s.deleteSortTestKasKeys(ids, kasID)
+	})
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_UNSPECIFIED, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(list)
+
+	// Field defaults to created_at, explicit ASC is preserved
+	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[0], ids[1], ids[2])
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortByUnspecifiedDirection_DefaultsToDESC() {
+	ids, kasID := s.createSortTestKasKeys([]string{"unsd-kk-0", "unsd-kk-1", "unsd-kk-2"})
+	s.T().Cleanup(func() {
+		s.deleteSortTestKasKeys(ids, kasID)
+	})
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_UNSPECIFIED},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(list)
+
+	// Direction defaults to DESC, explicit created_at field is preserved
+	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[2], ids[1], ids[0])
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
+	ids, kasID := s.createSortTestKasKeys([]string{"unsb-kk-0", "unsb-kk-1", "unsb-kk-2"})
+	s.T().Cleanup(func() {
+		s.deleteSortTestKasKeys(ids, kasID)
+	})
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+		Sort: []*kasregistry.KasKeysSort{
+			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_UNSPECIFIED, Direction: policy.SortDirection_SORT_DIRECTION_UNSPECIFIED},
+		},
+	})
+	s.Require().NoError(err)
+	s.NotNil(list)
+
+	// Both default: created_at DESC
+	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[2], ids[1], ids[0])
+}
+
+func (s *KasRegistryKeySuite) Test_ListKeys_SortOmitted() {
+	ids, kasID := s.createSortTestKasKeys([]string{"omit-kk-0", "omit-kk-1", "omit-kk-2"})
+	s.T().Cleanup(func() {
+		s.deleteSortTestKasKeys(ids, kasID)
+	})
+
+	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+	})
+	s.Require().NoError(err)
+	s.NotNil(list)
+
+	// No sort provided: created_at DESC
+	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[2], ids[1], ids[0])
 }
 
 func (s *KasRegistryKeySuite) validateKeyMapping(mapping *kasregistry.KeyMapping, expectedKey *policy.KasKey, expectedNamespace []*policy.Namespace, expectedAttrDef []*policy.Attribute, expectedValue []*policy.Value) {
@@ -2615,241 +2901,6 @@ func (s *KasRegistryKeySuite) createKeyAndKas() *policy.KasKey {
 	s.NotNil(keyResp)
 
 	return keyResp.GetKasKey()
-}
-
-func (s *KasRegistryKeySuite) Test_ListKeys_SortByKeyId_ASC() {
-	ids, kasID := s.createSortTestKasKeys([]string{"aaa-kksort", "bbb-kksort", "ccc-kksort"})
-	defer s.deleteSortTestKasKeys(ids, kasID)
-
-	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Sort: []*kasregistry.KasKeysSort{
-			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_KEY_ID, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
-		},
-	})
-	s.Require().NoError(err)
-	s.NotNil(list)
-
-	// aaa < bbb < ccc in ASC order
-	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[0], ids[1], ids[2])
-}
-
-func (s *KasRegistryKeySuite) Test_ListKeys_SortByKeyId_DESC() {
-	ids, kasID := s.createSortTestKasKeys([]string{"aaa-kksortdesc", "bbb-kksortdesc", "ccc-kksortdesc"})
-	defer s.deleteSortTestKasKeys(ids, kasID)
-
-	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Sort: []*kasregistry.KasKeysSort{
-			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_KEY_ID, Direction: policy.SortDirection_SORT_DIRECTION_DESC},
-		},
-	})
-	s.Require().NoError(err)
-	s.NotNil(list)
-
-	// ccc > bbb > aaa in DESC order
-	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[2], ids[1], ids[0])
-}
-
-func (s *KasRegistryKeySuite) Test_ListKeys_SortByCreatedAt_ASC() {
-	ids, kasID := s.createSortTestKasKeys([]string{"createdasc-kk-0", "createdasc-kk-1", "createdasc-kk-2"})
-	defer s.deleteSortTestKasKeys(ids, kasID)
-
-	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Sort: []*kasregistry.KasKeysSort{
-			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
-		},
-	})
-	s.Require().NoError(err)
-	s.NotNil(list)
-
-	// oldest first in ASC order
-	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[0], ids[1], ids[2])
-}
-
-func (s *KasRegistryKeySuite) Test_ListKeys_SortByCreatedAt_DESC() {
-	ids, kasID := s.createSortTestKasKeys([]string{"createddesc-kk-0", "createddesc-kk-1", "createddesc-kk-2"})
-	defer s.deleteSortTestKasKeys(ids, kasID)
-
-	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Sort: []*kasregistry.KasKeysSort{
-			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_DESC},
-		},
-	})
-	s.Require().NoError(err)
-	s.NotNil(list)
-
-	// newest first in DESC order
-	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[2], ids[1], ids[0])
-}
-
-func (s *KasRegistryKeySuite) Test_ListKeys_SortByUpdatedAt_DESC() {
-	ids, kasID := s.createSortTestKasKeys([]string{"upd-sort-kk-0", "upd-sort-kk-1", "upd-sort-kk-2"})
-	defer s.deleteSortTestKasKeys(ids, kasID)
-
-	// Update the first key so its updated_at is the most recent
-	time.Sleep(5 * time.Millisecond)
-	_, err := s.db.PolicyClient.UpdateKey(s.ctx, &kasregistry.UpdateKeyRequest{
-		Id: ids[0],
-		Metadata: &common.MetadataMutable{
-			Labels: map[string]string{"updated": "true"},
-		},
-		MetadataUpdateBehavior: common.MetadataUpdateEnum_METADATA_UPDATE_ENUM_REPLACE,
-	})
-	s.Require().NoError(err)
-
-	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Sort: []*kasregistry.KasKeysSort{
-			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_UPDATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_DESC},
-		},
-	})
-	s.Require().NoError(err)
-	s.NotNil(list)
-
-	// The updated key (ids[0]) should appear before the others
-	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[0], ids[2], ids[1])
-}
-
-func (s *KasRegistryKeySuite) Test_ListKeys_SortByUpdatedAt_ASC() {
-	ids, kasID := s.createSortTestKasKeys([]string{"updasc-kk-0", "updasc-kk-1", "updasc-kk-2"})
-	defer s.deleteSortTestKasKeys(ids, kasID)
-
-	// Update the last key so its updated_at is the most recent
-	time.Sleep(5 * time.Millisecond)
-	_, err := s.db.PolicyClient.UpdateKey(s.ctx, &kasregistry.UpdateKeyRequest{
-		Id: ids[2],
-		Metadata: &common.MetadataMutable{
-			Labels: map[string]string{"updated": "true"},
-		},
-		MetadataUpdateBehavior: common.MetadataUpdateEnum_METADATA_UPDATE_ENUM_REPLACE,
-	})
-	s.Require().NoError(err)
-
-	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Sort: []*kasregistry.KasKeysSort{
-			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_UPDATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
-		},
-	})
-	s.Require().NoError(err)
-	s.NotNil(list)
-
-	// The updated key (ids[2]) should appear last in ASC order
-	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[0], ids[1], ids[2])
-}
-
-func (s *KasRegistryKeySuite) Test_ListKeys_SortTieBreaker_CreatedAtWithIDFallback() {
-	kasReq := kasregistry.CreateKeyAccessServerRequest{
-		Name: "tiebreaker-kk-kas-" + uuid.NewString(),
-		Uri:  "https://tiebreaker-kk-kas-" + uuid.NewString() + ".opentdf.io",
-	}
-	kas, err := s.db.PolicyClient.CreateKeyAccessServer(s.ctx, &kasReq)
-	s.Require().NoError(err)
-
-	suffix := time.Now().UnixNano()
-	ids := make([]string, 3)
-	for i := range 3 {
-		keyReq := kasregistry.CreateKeyRequest{
-			KasId:        kas.GetId(),
-			KeyId:        fmt.Sprintf("tiebreaker-kk-%d-%d", i, suffix),
-			KeyAlgorithm: policy.Algorithm_ALGORITHM_RSA_2048,
-			KeyMode:      policy.KeyMode_KEY_MODE_CONFIG_ROOT_KEY,
-			PublicKeyCtx: &policy.PublicKeyCtx{Pem: keyCtx},
-			PrivateKeyCtx: &policy.PrivateKeyCtx{
-				KeyId:      fmt.Sprintf("tiebreaker-kk-priv-%d-%d", i, suffix),
-				WrappedKey: keyCtx,
-			},
-		}
-		resp, err := s.db.PolicyClient.CreateKey(s.ctx, &keyReq)
-		s.Require().NoError(err)
-		ids[i] = resp.GetKasKey().GetKey().GetId()
-	}
-	defer s.deleteSortTestKasKeys(ids, kas.GetId())
-
-	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "key_access_server_keys", ids))
-
-	sorted := slices.Sorted(slices.Values(ids))
-
-	listRsp, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter: &kasregistry.ListKeysRequest_KasId{
-			KasId: kas.GetId(),
-		},
-		Sort: []*kasregistry.KasKeysSort{
-			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
-		},
-	})
-	s.Require().NoError(err)
-	s.NotNil(listRsp)
-
-	assertIDsInOrder(s.T(), listRsp.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, sorted[0], sorted[1], sorted[2])
-}
-
-func (s *KasRegistryKeySuite) Test_ListKeys_SortByUnspecifiedField_DefaultsToCreatedAt() {
-	ids, kasID := s.createSortTestKasKeys([]string{"unsf-kk-0", "unsf-kk-1", "unsf-kk-2"})
-	defer s.deleteSortTestKasKeys(ids, kasID)
-
-	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Sort: []*kasregistry.KasKeysSort{
-			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_UNSPECIFIED, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
-		},
-	})
-	s.Require().NoError(err)
-	s.NotNil(list)
-
-	// Field defaults to created_at, explicit ASC is preserved
-	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[0], ids[1], ids[2])
-}
-
-func (s *KasRegistryKeySuite) Test_ListKeys_SortByUnspecifiedDirection_DefaultsToDESC() {
-	ids, kasID := s.createSortTestKasKeys([]string{"unsd-kk-0", "unsd-kk-1", "unsd-kk-2"})
-	defer s.deleteSortTestKasKeys(ids, kasID)
-
-	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Sort: []*kasregistry.KasKeysSort{
-			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_CREATED_AT, Direction: policy.SortDirection_SORT_DIRECTION_UNSPECIFIED},
-		},
-	})
-	s.Require().NoError(err)
-	s.NotNil(list)
-
-	// Direction defaults to DESC, explicit created_at field is preserved
-	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[2], ids[1], ids[0])
-}
-
-func (s *KasRegistryKeySuite) Test_ListKeys_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
-	ids, kasID := s.createSortTestKasKeys([]string{"unsb-kk-0", "unsb-kk-1", "unsb-kk-2"})
-	defer s.deleteSortTestKasKeys(ids, kasID)
-
-	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-		Sort: []*kasregistry.KasKeysSort{
-			{Field: kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_UNSPECIFIED, Direction: policy.SortDirection_SORT_DIRECTION_UNSPECIFIED},
-		},
-	})
-	s.Require().NoError(err)
-	s.NotNil(list)
-
-	// Both default: created_at DESC
-	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[2], ids[1], ids[0])
-}
-
-func (s *KasRegistryKeySuite) Test_ListKeys_SortOmitted() {
-	ids, kasID := s.createSortTestKasKeys([]string{"omit-kk-0", "omit-kk-1", "omit-kk-2"})
-	defer s.deleteSortTestKasKeys(ids, kasID)
-
-	list, err := s.db.PolicyClient.ListKeys(s.ctx, &kasregistry.ListKeysRequest{
-		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
-	})
-	s.Require().NoError(err)
-	s.NotNil(list)
-
-	// No sort provided: created_at DESC
-	assertIDsInOrder(s.T(), list.GetKasKeys(), func(k *policy.KasKey) string { return k.GetKey().GetId() }, ids[2], ids[1], ids[0])
 }
 
 // Sort test helpers

--- a/service/policy/db/key_access_server_registry.go
+++ b/service/policy/db/key_access_server_registry.go
@@ -611,10 +611,15 @@ func (c PolicyDBClient) ListKeys(ctx context.Context, r *kasregistry.ListKeysReq
 	}
 
 	sortField, sortDirection := GetKasKeysSortParams(r.GetSort())
+	search := pgtype.Text{}
+	if term := r.GetSearch().GetTerm(); term != "" {
+		search = pgtypeText("%" + escapeLikePattern(strings.ToLower(term)) + "%")
+	}
 
 	params := listKeysParams{
 		Legacy:        legacy,
 		KeyAlgorithm:  algo,
+		Search:        search,
 		KasID:         kasID,
 		KasUri:        kasURI,
 		KasName:       kasName,

--- a/service/policy/db/key_access_server_registry.go
+++ b/service/policy/db/key_access_server_registry.go
@@ -611,10 +611,7 @@ func (c PolicyDBClient) ListKeys(ctx context.Context, r *kasregistry.ListKeysReq
 	}
 
 	sortField, sortDirection := GetKasKeysSortParams(r.GetSort())
-	search := pgtype.Text{}
-	if term := r.GetSearch().GetTerm(); term != "" {
-		search = pgtypeText("%" + escapeLikePattern(strings.ToLower(term)) + "%")
-	}
+	search := pgtypeSubstringSearchPattern(r.GetSearch().GetTerm())
 
 	params := listKeysParams{
 		Legacy:        legacy,

--- a/service/policy/db/key_access_server_registry.sql.go
+++ b/service/policy/db/key_access_server_registry.sql.go
@@ -1130,7 +1130,7 @@ WHERE
     AND ($2::boolean IS NULL OR kask.legacy = $2::boolean)
     AND (
         $3::TEXT IS NULL
-        OR LOWER(kask.key_id) LIKE $3::TEXT ESCAPE '\'
+        OR kask.key_id ILIKE $3::TEXT ESCAPE '\'
     )
 ORDER BY
     CASE WHEN p.resolved_field = 'key_id' AND p.resolved_direction = 'ASC' THEN kask.key_id END ASC,
@@ -1226,7 +1226,7 @@ type listKeysRow struct {
 //	    AND ($2::boolean IS NULL OR kask.legacy = $2::boolean)
 //	    AND (
 //	        $3::TEXT IS NULL
-//	        OR LOWER(kask.key_id) LIKE $3::TEXT ESCAPE '\'
+//	        OR kask.key_id ILIKE $3::TEXT ESCAPE '\'
 //	    )
 //	ORDER BY
 //	    CASE WHEN p.resolved_field = 'key_id' AND p.resolved_direction = 'ASC' THEN kask.key_id END ASC,
@@ -1239,8 +1239,7 @@ type listKeysRow struct {
 //	LIMIT $5
 //	OFFSET $4
 func (q *Queries) listKeys(ctx context.Context, arg listKeysParams) ([]listKeysRow, error) {
-	rows, err := q.db.Query(
-		ctx, listKeys,
+	rows, err := q.db.Query(ctx, listKeys,
 		arg.KeyAlgorithm,
 		arg.Legacy,
 		arg.Search,

--- a/service/policy/db/key_access_server_registry.sql.go
+++ b/service/policy/db/key_access_server_registry.sql.go
@@ -1084,17 +1084,17 @@ func (q *Queries) listKeyMappings(ctx context.Context, arg listKeyMappingsParams
 const listKeys = `-- name: listKeys :many
 WITH params AS (
     SELECT
-        COALESCE(NULLIF($5::text, ''), 'created_at') AS resolved_field,
-        COALESCE(NULLIF($6::text, ''), 'DESC') AS resolved_direction
+        COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
+        COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
 ),
 listed AS (
     SELECT
         kas.id AS kas_id,
         kas.uri AS kas_uri
     FROM key_access_servers AS kas
-    WHERE ($7::uuid IS NULL OR kas.id = $7::uuid)
-            AND ($8::text IS NULL OR kas.name = $8::text)
-            AND ($9::text IS NULL OR kas.uri = $9::text)
+    WHERE ($8::uuid IS NULL OR kas.id = $8::uuid)
+            AND ($9::text IS NULL OR kas.name = $9::text)
+            AND ($10::text IS NULL OR kas.uri = $10::text)
 )
 SELECT 
   COUNT(*) OVER () AS total,
@@ -1128,6 +1128,10 @@ LEFT JOIN
 WHERE
     ($1::integer IS NULL OR kask.key_algorithm = $1::integer)
     AND ($2::boolean IS NULL OR kask.legacy = $2::boolean)
+    AND (
+        $3::TEXT IS NULL
+        OR LOWER(kask.key_id) LIKE $3::TEXT ESCAPE '\'
+    )
 ORDER BY
     CASE WHEN p.resolved_field = 'key_id' AND p.resolved_direction = 'ASC' THEN kask.key_id END ASC,
     CASE WHEN p.resolved_field = 'key_id' AND p.resolved_direction = 'DESC' THEN kask.key_id END DESC,
@@ -1136,13 +1140,14 @@ ORDER BY
     CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'ASC' THEN kask.updated_at END ASC,
     CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'DESC' THEN kask.updated_at END DESC,
     kask.id ASC
-LIMIT $4
-OFFSET $3
+LIMIT $5
+OFFSET $4
 `
 
 type listKeysParams struct {
 	KeyAlgorithm  pgtype.Int4 `json:"key_algorithm"`
 	Legacy        pgtype.Bool `json:"legacy"`
+	Search        pgtype.Text `json:"search"`
 	Offset        int32       `json:"offset_"`
 	Limit         int32       `json:"limit_"`
 	SortField     string      `json:"sort_field"`
@@ -1175,17 +1180,17 @@ type listKeysRow struct {
 //
 //	WITH params AS (
 //	    SELECT
-//	        COALESCE(NULLIF($5::text, ''), 'created_at') AS resolved_field,
-//	        COALESCE(NULLIF($6::text, ''), 'DESC') AS resolved_direction
+//	        COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
+//	        COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
 //	),
 //	listed AS (
 //	    SELECT
 //	        kas.id AS kas_id,
 //	        kas.uri AS kas_uri
 //	    FROM key_access_servers AS kas
-//	    WHERE ($7::uuid IS NULL OR kas.id = $7::uuid)
-//	            AND ($8::text IS NULL OR kas.name = $8::text)
-//	            AND ($9::text IS NULL OR kas.uri = $9::text)
+//	    WHERE ($8::uuid IS NULL OR kas.id = $8::uuid)
+//	            AND ($9::text IS NULL OR kas.name = $9::text)
+//	            AND ($10::text IS NULL OR kas.uri = $10::text)
 //	)
 //	SELECT
 //	  COUNT(*) OVER () AS total,
@@ -1219,6 +1224,10 @@ type listKeysRow struct {
 //	WHERE
 //	    ($1::integer IS NULL OR kask.key_algorithm = $1::integer)
 //	    AND ($2::boolean IS NULL OR kask.legacy = $2::boolean)
+//	    AND (
+//	        $3::TEXT IS NULL
+//	        OR LOWER(kask.key_id) LIKE $3::TEXT ESCAPE '\'
+//	    )
 //	ORDER BY
 //	    CASE WHEN p.resolved_field = 'key_id' AND p.resolved_direction = 'ASC' THEN kask.key_id END ASC,
 //	    CASE WHEN p.resolved_field = 'key_id' AND p.resolved_direction = 'DESC' THEN kask.key_id END DESC,
@@ -1227,12 +1236,14 @@ type listKeysRow struct {
 //	    CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'ASC' THEN kask.updated_at END ASC,
 //	    CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'DESC' THEN kask.updated_at END DESC,
 //	    kask.id ASC
-//	LIMIT $4
-//	OFFSET $3
+//	LIMIT $5
+//	OFFSET $4
 func (q *Queries) listKeys(ctx context.Context, arg listKeysParams) ([]listKeysRow, error) {
-	rows, err := q.db.Query(ctx, listKeys,
+	rows, err := q.db.Query(
+		ctx, listKeys,
 		arg.KeyAlgorithm,
 		arg.Legacy,
+		arg.Search,
 		arg.Offset,
 		arg.Limit,
 		arg.SortField,

--- a/service/policy/db/queries/key_access_server_registry.sql
+++ b/service/policy/db/queries/key_access_server_registry.sql
@@ -409,7 +409,7 @@ WHERE
     AND (sqlc.narg('legacy')::boolean IS NULL OR kask.legacy = sqlc.narg('legacy')::boolean)
     AND (
         sqlc.narg('search')::TEXT IS NULL
-        OR LOWER(kask.key_id) LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+        OR kask.key_id ILIKE sqlc.narg('search')::TEXT ESCAPE '\'
     )
 ORDER BY
     CASE WHEN p.resolved_field = 'key_id' AND p.resolved_direction = 'ASC' THEN kask.key_id END ASC,

--- a/service/policy/db/queries/key_access_server_registry.sql
+++ b/service/policy/db/queries/key_access_server_registry.sql
@@ -407,6 +407,10 @@ LEFT JOIN
 WHERE
     (sqlc.narg('key_algorithm')::integer IS NULL OR kask.key_algorithm = sqlc.narg('key_algorithm')::integer)
     AND (sqlc.narg('legacy')::boolean IS NULL OR kask.legacy = sqlc.narg('legacy')::boolean)
+    AND (
+        sqlc.narg('search')::TEXT IS NULL
+        OR LOWER(kask.key_id) LIKE sqlc.narg('search')::TEXT ESCAPE '\'
+    )
 ORDER BY
     CASE WHEN p.resolved_field = 'key_id' AND p.resolved_direction = 'ASC' THEN kask.key_id END ASC,
     CASE WHEN p.resolved_field = 'key_id' AND p.resolved_direction = 'DESC' THEN kask.key_id END DESC,


### PR DESCRIPTION
## Summary
- Adds ListKeys RPC search support by wiring request search into the policy DB list query.
- Applies escaped, case-insensitive matching in the KAS key SQL path and adds integration coverage for search behavior, wildcard literals, empty search, whitespace handling, and pagination after filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search capability for KAS registry keys by key ID.
  * Search input automatically trims leading and trailing whitespace.
  * Wildcard characters in search queries are properly escaped.
  * Search results work seamlessly with existing filters and pagination.

* **Tests**
  * Added comprehensive test coverage for search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->