### PR TITLE
feat(policy): add search support to ListRegisteredResources

### DIFF
--- a/service/integration/registered_resources_test.go
+++ b/service/integration/registered_resources_test.go
@@ -1811,6 +1811,181 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_FilterByNamespac
 	s.True(found, "created resource should be in the filtered list")
 }
 
+func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchByName_Succeeds() {
+	suffix := time.Now().UnixNano()
+	nsID := s.getNamespaceID("example.com")
+	alphaName := fmt.Sprintf("dspx-rr-search-alpha-%d", suffix)
+	betaName := fmt.Sprintf("dspx-rr-search-beta-%d", suffix)
+
+	alpha, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
+		NamespaceId: nsID,
+		Name:        alphaName,
+	})
+	s.Require().NoError(err)
+	beta, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
+		NamespaceId: nsID,
+		Name:        betaName,
+	})
+	s.Require().NoError(err)
+	defer s.deleteSortTestRegisteredResources([]string{alpha.GetId(), beta.GetId()})
+
+	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
+		Search: &policy.Search{Term: strings.ToUpper(alphaName)},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(list.GetResources(), 1)
+	s.Equal(alpha.GetId(), list.GetResources()[0].GetId())
+	s.Equal(int32(1), list.GetPagination().GetTotal())
+}
+
+func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchEscapesLikeWildcardLiterals_Succeeds() {
+	suffix := time.Now().UnixNano()
+	nsID := s.getNamespaceID("example.com")
+	searchToken := fmt.Sprintf("dspx-rr-search-like-%d", suffix)
+
+	alpha, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
+		NamespaceId: nsID,
+		Name:        "wildcarda-" + searchToken,
+	})
+	s.Require().NoError(err)
+	beta, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
+		NamespaceId: nsID,
+		Name:        "wildcardb-" + searchToken,
+	})
+	s.Require().NoError(err)
+	defer s.deleteSortTestRegisteredResources([]string{alpha.GetId(), beta.GetId()})
+
+	for _, query := range []string{
+		"wildcard_-" + searchToken,
+		"wildcard%-" + searchToken,
+	} {
+		list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
+			Search: &policy.Search{Term: query},
+		})
+		s.Require().NoError(err)
+		s.Empty(list.GetResources())
+		s.Equal(int32(0), list.GetPagination().GetTotal())
+	}
+}
+
+func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchCombinesWithNamespaceFilters_Succeeds() {
+	suffix := time.Now().UnixNano()
+	nsID1 := s.getNamespaceID("example.com")
+	nsID2 := s.getNamespaceID("example.net")
+	nsFQN2 := s.getNamespaceFQN("example.net")
+	name := fmt.Sprintf("dspx-rr-search-filter-%d", suffix)
+
+	inFirstNamespace, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
+		NamespaceId: nsID1,
+		Name:        name,
+	})
+	s.Require().NoError(err)
+	inSecondNamespace, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
+		NamespaceId: nsID2,
+		Name:        name,
+	})
+	s.Require().NoError(err)
+	defer s.deleteSortTestRegisteredResources([]string{inFirstNamespace.GetId(), inSecondNamespace.GetId()})
+
+	byNamespaceID, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
+		NamespaceId: nsID1,
+		Search:      &policy.Search{Term: name},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(byNamespaceID.GetResources(), 1)
+	s.Equal(inFirstNamespace.GetId(), byNamespaceID.GetResources()[0].GetId())
+	s.Equal(int32(1), byNamespaceID.GetPagination().GetTotal())
+
+	byNamespaceFQN, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
+		NamespaceFqn: nsFQN2,
+		Search:       &policy.Search{Term: name},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(byNamespaceFQN.GetResources(), 1)
+	s.Equal(inSecondNamespace.GetId(), byNamespaceFQN.GetResources()[0].GetId())
+	s.Equal(int32(1), byNamespaceFQN.GetPagination().GetTotal())
+}
+
+func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchEmptyAndWhitespace_Succeeds() {
+	suffix := time.Now().UnixNano()
+	created, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
+		NamespaceId: s.getNamespaceID("example.com"),
+		Name:        fmt.Sprintf("dspx-rr-search-whitespace-%d", suffix),
+	})
+	s.Require().NoError(err)
+	defer s.deleteSortTestRegisteredResources([]string{created.GetId()})
+
+	noSearch, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{})
+	s.Require().NoError(err)
+	emptySearch, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
+		Search: &policy.Search{Term: ""},
+	})
+	s.Require().NoError(err)
+	s.Equal(noSearch.GetPagination().GetTotal(), emptySearch.GetPagination().GetTotal())
+
+	whitespaceSearch, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
+		Search: &policy.Search{Term: " " + created.GetName()},
+	})
+	s.Require().NoError(err)
+	s.Empty(whitespaceSearch.GetResources())
+	s.Equal(int32(0), whitespaceSearch.GetPagination().GetTotal())
+}
+
+func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchPaginationAppliesAfterFiltering_Succeeds() {
+	suffix := time.Now().UnixNano()
+	searchToken := fmt.Sprintf("dspx-rr-search-page-%d", suffix)
+	names := []string{
+		"a-" + searchToken,
+		"b-" + searchToken,
+		"c-" + searchToken,
+		fmt.Sprintf("dspx-rr-search-page-other-%d", suffix),
+	}
+	ids := make([]string, len(names))
+	for i, name := range names {
+		created, err := s.db.PolicyClient.CreateRegisteredResource(s.ctx, &registeredresources.CreateRegisteredResourceRequest{
+			NamespaceId: s.getNamespaceID("example.com"),
+			Name:        name,
+		})
+		s.Require().NoError(err)
+		ids[i] = created.GetId()
+	}
+	defer s.deleteSortTestRegisteredResources(ids)
+
+	firstPage, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
+		Search:     &policy.Search{Term: searchToken},
+		Pagination: &policy.PageRequest{Limit: 2},
+		Sort: []*registeredresources.RegisteredResourcesSort{
+			{
+				Field:     registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_NAME,
+				Direction: policy.SortDirection_SORT_DIRECTION_ASC,
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(firstPage.GetResources(), 2)
+	s.Equal(int32(3), firstPage.GetPagination().GetTotal())
+	s.Equal(int32(2), firstPage.GetPagination().GetNextOffset())
+	s.Equal(ids[0], firstPage.GetResources()[0].GetId())
+	s.Equal(ids[1], firstPage.GetResources()[1].GetId())
+
+	secondPage, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
+		Search:     &policy.Search{Term: searchToken},
+		Pagination: &policy.PageRequest{Limit: 2, Offset: 2},
+		Sort: []*registeredresources.RegisteredResourcesSort{
+			{
+				Field:     registeredresources.SortRegisteredResourcesType_SORT_REGISTERED_RESOURCES_TYPE_NAME,
+				Direction: policy.SortDirection_SORT_DIRECTION_ASC,
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(secondPage.GetResources(), 1)
+	s.Equal(int32(3), secondPage.GetPagination().GetTotal())
+	s.Equal(int32(2), secondPage.GetPagination().GetCurrentOffset())
+	s.Equal(int32(0), secondPage.GetPagination().GetNextOffset())
+	s.Equal(ids[2], secondPage.GetResources()[0].GetId())
+}
+
 func (s *RegisteredResourcesSuite) Test_GetRegisteredResourceValue_NamespacedFQN_Succeeds() {
 	nsID := s.getNamespaceID("example.com")
 	name := "test_get_rrv_ns_fqn"

--- a/service/integration/registered_resources_test.go
+++ b/service/integration/registered_resources_test.go
@@ -1827,7 +1827,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchByName_Suc
 		Name:        betaName,
 	})
 	s.Require().NoError(err)
-	defer s.deleteSortTestRegisteredResources([]string{alpha.GetId(), beta.GetId()})
+	defer s.deleteTestRegisteredResources([]string{alpha.GetId(), beta.GetId()})
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
 		Search: &policy.Search{Term: strings.ToUpper(alphaName)},
@@ -1853,7 +1853,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchEscapesLik
 		Name:        "wildcardb-" + searchToken,
 	})
 	s.Require().NoError(err)
-	defer s.deleteSortTestRegisteredResources([]string{alpha.GetId(), beta.GetId()})
+	defer s.deleteTestRegisteredResources([]string{alpha.GetId(), beta.GetId()})
 
 	for _, query := range []string{
 		"wildcard_-" + searchToken,
@@ -1885,7 +1885,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchCombinesWi
 		Name:        name,
 	})
 	s.Require().NoError(err)
-	defer s.deleteSortTestRegisteredResources([]string{inFirstNamespace.GetId(), inSecondNamespace.GetId()})
+	defer s.deleteTestRegisteredResources([]string{inFirstNamespace.GetId(), inSecondNamespace.GetId()})
 
 	byNamespaceID, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
 		NamespaceId: nsID1,
@@ -1913,7 +1913,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchEmptyAndWh
 		Name:        fmt.Sprintf("dspx-rr-search-whitespace-%d", suffix),
 	})
 	s.Require().NoError(err)
-	defer s.deleteSortTestRegisteredResources([]string{created.GetId()})
+	defer s.deleteTestRegisteredResources([]string{created.GetId()})
 
 	noSearch, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{})
 	s.Require().NoError(err)
@@ -1927,8 +1927,9 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchEmptyAndWh
 		Search: &policy.Search{Term: " " + created.GetName()},
 	})
 	s.Require().NoError(err)
-	s.Empty(whitespaceSearch.GetResources())
-	s.Equal(int32(0), whitespaceSearch.GetPagination().GetTotal())
+	s.Require().Len(whitespaceSearch.GetResources(), 1)
+	s.Equal(created.GetId(), whitespaceSearch.GetResources()[0].GetId())
+	s.Equal(int32(1), whitespaceSearch.GetPagination().GetTotal())
 }
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchPaginationAppliesAfterFiltering_Succeeds() {
@@ -1949,7 +1950,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SearchPagination
 		s.Require().NoError(err)
 		ids[i] = created.GetId()
 	}
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	firstPage, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
 		Search:     &policy.Search{Term: searchToken},
@@ -2530,7 +2531,7 @@ func (s *RegisteredResourcesSuite) Test_GetRegisteredResource_ByName_Ambiguous_R
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByName_ASC() {
 	ids := s.createSortTestRegisteredResources([]string{"aaa-rrsort", "bbb-rrsort", "ccc-rrsort"})
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
 		Sort: []*registeredresources.RegisteredResourcesSort{
@@ -2546,7 +2547,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByName_ASC()
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByName_DESC() {
 	ids := s.createSortTestRegisteredResources([]string{"aaa-rrsortdesc", "bbb-rrsortdesc", "ccc-rrsortdesc"})
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
 		Sort: []*registeredresources.RegisteredResourcesSort{
@@ -2562,7 +2563,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByName_DESC(
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByCreatedAt_ASC() {
 	ids := s.createSortTestRegisteredResources([]string{"createdasc-rr-0", "createdasc-rr-1", "createdasc-rr-2"})
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
 		Sort: []*registeredresources.RegisteredResourcesSort{
@@ -2578,7 +2579,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByCreatedAt_
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByCreatedAt_DESC() {
 	ids := s.createSortTestRegisteredResources([]string{"createddesc-rr-0", "createddesc-rr-1", "createddesc-rr-2"})
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
 		Sort: []*registeredresources.RegisteredResourcesSort{
@@ -2594,7 +2595,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByCreatedAt_
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUpdatedAt_DESC() {
 	ids := s.createSortTestRegisteredResources([]string{"upd-sort-rr-0", "upd-sort-rr-1", "upd-sort-rr-2"})
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	// Update the first resource so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -2621,7 +2622,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUpdatedAt_
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUpdatedAt_ASC() {
 	ids := s.createSortTestRegisteredResources([]string{"upd-sort-asc-rr-0", "upd-sort-asc-rr-1", "upd-sort-asc-rr-2"})
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	// Update the last resource so its updated_at is the most recent
 	time.Sleep(5 * time.Millisecond)
@@ -2658,7 +2659,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortTieBreaker_C
 		s.Require().NoError(err)
 		ids[i] = created.GetId()
 	}
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	s.Require().NoError(forceCreatedAtTie(s.ctx, s.db, "registered_resources", ids))
 
@@ -2677,7 +2678,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortTieBreaker_C
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUnspecifiedField_DefaultsToCreatedAt() {
 	ids := s.createSortTestRegisteredResources([]string{"unspecified-field-rr-0", "unspecified-field-rr-1", "unspecified-field-rr-2"})
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
 		Sort: []*registeredresources.RegisteredResourcesSort{
@@ -2693,7 +2694,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUnspecifie
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUnspecifiedDirection_DefaultsToDESC() {
 	ids := s.createSortTestRegisteredResources([]string{"unspecified-dir-rr-0", "unspecified-dir-rr-1", "unspecified-dir-rr-2"})
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
 		Sort: []*registeredresources.RegisteredResourcesSort{
@@ -2709,7 +2710,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByUnspecifie
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByBothUnspecified_DefaultsToCreatedAtDESC() {
 	ids := s.createSortTestRegisteredResources([]string{"both-unspecified-rr-0", "both-unspecified-rr-1", "both-unspecified-rr-2"})
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{
 		Sort: []*registeredresources.RegisteredResourcesSort{
@@ -2725,7 +2726,7 @@ func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortByBothUnspec
 
 func (s *RegisteredResourcesSuite) Test_ListRegisteredResources_SortOmitted() {
 	ids := s.createSortTestRegisteredResources([]string{"sort-omitted-rr-0", "sort-omitted-rr-1", "sort-omitted-rr-2"})
-	defer s.deleteSortTestRegisteredResources(ids)
+	defer s.deleteTestRegisteredResources(ids)
 
 	list, err := s.db.PolicyClient.ListRegisteredResources(s.ctx, &registeredresources.ListRegisteredResourcesRequest{})
 	s.Require().NoError(err)
@@ -2756,8 +2757,7 @@ func (s *RegisteredResourcesSuite) createSortTestRegisteredResources(prefixes []
 	return ids
 }
 
-// deleteSortTestRegisteredResources cleans up registered resources created by sort tests.
-func (s *RegisteredResourcesSuite) deleteSortTestRegisteredResources(ids []string) {
+func (s *RegisteredResourcesSuite) deleteTestRegisteredResources(ids []string) {
 	for _, id := range ids {
 		_, err := s.db.PolicyClient.DeleteRegisteredResource(s.ctx, id)
 		s.Require().NoError(err)

--- a/service/policy/db/queries/registered_resources.sql
+++ b/service/policy/db/queries/registered_resources.sql
@@ -104,16 +104,6 @@ WITH params AS (
     SELECT
         COALESCE(NULLIF(@sort_field::text, ''), 'created_at') AS resolved_field,
         COALESCE(NULLIF(@sort_direction::text, ''), 'DESC') AS resolved_direction
-),
-counted AS (
-    SELECT COUNT(r.id) AS total
-    FROM registered_resources r
-    LEFT JOIN attribute_namespaces n ON r.namespace_id = n.id
-    LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-    WHERE
-        (sqlc.narg('namespace_id')::uuid IS NULL OR r.namespace_id = sqlc.narg('namespace_id')::uuid) AND
-        (sqlc.narg('namespace_fqn')::text IS NULL OR ns_fqns.fqn = sqlc.narg('namespace_fqn')::text) AND
-        (sqlc.narg('search')::text IS NULL OR LOWER(r.name) LIKE sqlc.narg('search')::text ESCAPE '\')
 )
 SELECT
     r.id,
@@ -134,11 +124,10 @@ SELECT
             'action_attribute_values', action_attrs.values
         )
     ) FILTER (WHERE v.id IS NOT NULL) as values,
-    counted.total
+    COUNT(*) OVER() AS total
 FROM registered_resources r
 LEFT JOIN attribute_namespaces n ON r.namespace_id = n.id
 LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-CROSS JOIN counted
 CROSS JOIN params p
 LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
 -- Build a JSON array of action/attribute pairs for each resource value
@@ -175,8 +164,8 @@ LEFT JOIN LATERAL (
 WHERE
     (sqlc.narg('namespace_id')::uuid IS NULL OR r.namespace_id = sqlc.narg('namespace_id')::uuid) AND
     (sqlc.narg('namespace_fqn')::text IS NULL OR ns_fqns.fqn = sqlc.narg('namespace_fqn')::text) AND
-    (sqlc.narg('search')::text IS NULL OR LOWER(r.name) LIKE sqlc.narg('search')::text ESCAPE '\')
-GROUP BY r.id, n.id, ns_fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
+    (sqlc.narg('search')::text IS NULL OR r.name LIKE sqlc.narg('search')::text ESCAPE '\')
+GROUP BY r.id, n.id, ns_fqns.fqn, p.resolved_field, p.resolved_direction
 ORDER BY
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN r.name END ASC,
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'DESC' THEN r.name END DESC,

--- a/service/policy/db/queries/registered_resources.sql
+++ b/service/policy/db/queries/registered_resources.sql
@@ -112,7 +112,8 @@ counted AS (
     LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
     WHERE
         (sqlc.narg('namespace_id')::uuid IS NULL OR r.namespace_id = sqlc.narg('namespace_id')::uuid) AND
-        (sqlc.narg('namespace_fqn')::text IS NULL OR ns_fqns.fqn = sqlc.narg('namespace_fqn')::text)
+        (sqlc.narg('namespace_fqn')::text IS NULL OR ns_fqns.fqn = sqlc.narg('namespace_fqn')::text) AND
+        (sqlc.narg('search')::text IS NULL OR LOWER(r.name) LIKE sqlc.narg('search')::text ESCAPE '\')
 )
 SELECT
     r.id,
@@ -173,7 +174,8 @@ LEFT JOIN LATERAL (
 ) action_attrs ON true  -- required syntax for LATERAL joins
 WHERE
     (sqlc.narg('namespace_id')::uuid IS NULL OR r.namespace_id = sqlc.narg('namespace_id')::uuid) AND
-    (sqlc.narg('namespace_fqn')::text IS NULL OR ns_fqns.fqn = sqlc.narg('namespace_fqn')::text)
+    (sqlc.narg('namespace_fqn')::text IS NULL OR ns_fqns.fqn = sqlc.narg('namespace_fqn')::text) AND
+    (sqlc.narg('search')::text IS NULL OR LOWER(r.name) LIKE sqlc.narg('search')::text ESCAPE '\')
 GROUP BY r.id, n.id, ns_fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
 ORDER BY
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN r.name END ASC,

--- a/service/policy/db/registered_resources.go
+++ b/service/policy/db/registered_resources.go
@@ -109,6 +109,13 @@ func hydrateRegisteredResourceValueFQNs(values []*policy.RegisteredResourceValue
 	}
 }
 
+func pgtypeRegisteredResourceSearchPattern(query string) pgtype.Text {
+	if query == "" {
+		return pgtype.Text{}
+	}
+	return pgtypeText("%" + escapeLikePattern(strings.ToLower(query)) + "%")
+}
+
 ///
 /// Registered Resources
 ///
@@ -230,10 +237,12 @@ func (c PolicyDBClient) ListRegisteredResources(ctx context.Context, r *register
 	}
 
 	sortField, sortDirection := GetRegisteredResourcesSortParams(r.GetSort())
+	search := pgtypeRegisteredResourceSearchPattern(r.GetSearch().GetTerm())
 
 	list, err := c.queries.listRegisteredResources(ctx, listRegisteredResourcesParams{
 		NamespaceID:   parsedID,
 		NamespaceFqn:  pgtypeText(r.GetNamespaceFqn()),
+		Search:        search,
 		Limit:         limit,
 		Offset:        offset,
 		SortField:     sortField,
@@ -441,7 +450,8 @@ func (c PolicyDBClient) GetRegisteredResourceValuesByFQNs(ctx context.Context, r
 			},
 		})
 		if err != nil {
-			c.logger.ErrorContext(ctx,
+			c.logger.ErrorContext(
+				ctx,
 				"registered resource value for FQN not found",
 				slog.String("fqn", fqn),
 				slog.Any("err", err),

--- a/service/policy/db/registered_resources.go
+++ b/service/policy/db/registered_resources.go
@@ -109,13 +109,6 @@ func hydrateRegisteredResourceValueFQNs(values []*policy.RegisteredResourceValue
 	}
 }
 
-func pgtypeRegisteredResourceSearchPattern(query string) pgtype.Text {
-	if query == "" {
-		return pgtype.Text{}
-	}
-	return pgtypeText("%" + escapeLikePattern(strings.ToLower(query)) + "%")
-}
-
 ///
 /// Registered Resources
 ///
@@ -237,7 +230,7 @@ func (c PolicyDBClient) ListRegisteredResources(ctx context.Context, r *register
 	}
 
 	sortField, sortDirection := GetRegisteredResourcesSortParams(r.GetSort())
-	search := pgtypeRegisteredResourceSearchPattern(r.GetSearch().GetTerm())
+	search := pgtypeSubstringSearchPattern(r.GetSearch().GetTerm())
 
 	list, err := c.queries.listRegisteredResources(ctx, listRegisteredResourcesParams{
 		NamespaceID:   parsedID,

--- a/service/policy/db/registered_resources.sql.go
+++ b/service/policy/db/registered_resources.sql.go
@@ -646,16 +646,6 @@ WITH params AS (
     SELECT
         COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
         COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
-),
-counted AS (
-    SELECT COUNT(r.id) AS total
-    FROM registered_resources r
-    LEFT JOIN attribute_namespaces n ON r.namespace_id = n.id
-    LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-    WHERE
-        ($1::uuid IS NULL OR r.namespace_id = $1::uuid) AND
-        ($2::text IS NULL OR ns_fqns.fqn = $2::text) AND
-        ($3::text IS NULL OR LOWER(r.name) LIKE $3::text ESCAPE '\')
 )
 SELECT
     r.id,
@@ -676,11 +666,10 @@ SELECT
             'action_attribute_values', action_attrs.values
         )
     ) FILTER (WHERE v.id IS NOT NULL) as values,
-    counted.total
+    COUNT(*) OVER() AS total
 FROM registered_resources r
 LEFT JOIN attribute_namespaces n ON r.namespace_id = n.id
 LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-CROSS JOIN counted
 CROSS JOIN params p
 LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
 LEFT JOIN LATERAL (
@@ -716,8 +705,8 @@ LEFT JOIN LATERAL (
 WHERE
     ($1::uuid IS NULL OR r.namespace_id = $1::uuid) AND
     ($2::text IS NULL OR ns_fqns.fqn = $2::text) AND
-    ($3::text IS NULL OR LOWER(r.name) LIKE $3::text ESCAPE '\')
-GROUP BY r.id, n.id, ns_fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
+    ($3::text IS NULL OR r.name LIKE $3::text ESCAPE '\')
+GROUP BY r.id, n.id, ns_fqns.fqn, p.resolved_field, p.resolved_direction
 ORDER BY
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN r.name END ASC,
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'DESC' THEN r.name END DESC,
@@ -755,16 +744,6 @@ type listRegisteredResourcesRow struct {
 //	    SELECT
 //	        COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
 //	        COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
-//	),
-//	counted AS (
-//	    SELECT COUNT(r.id) AS total
-//	    FROM registered_resources r
-//	    LEFT JOIN attribute_namespaces n ON r.namespace_id = n.id
-//	    LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-//	    WHERE
-//	        ($1::uuid IS NULL OR r.namespace_id = $1::uuid) AND
-//	        ($2::text IS NULL OR ns_fqns.fqn = $2::text) AND
-//	        ($3::text IS NULL OR LOWER(r.name) LIKE $3::text ESCAPE '\')
 //	)
 //	SELECT
 //	    r.id,
@@ -785,11 +764,10 @@ type listRegisteredResourcesRow struct {
 //	            'action_attribute_values', action_attrs.values
 //	        )
 //	    ) FILTER (WHERE v.id IS NOT NULL) as values,
-//	    counted.total
+//	    COUNT(*) OVER() AS total
 //	FROM registered_resources r
 //	LEFT JOIN attribute_namespaces n ON r.namespace_id = n.id
 //	LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-//	CROSS JOIN counted
 //	CROSS JOIN params p
 //	LEFT JOIN registered_resource_values v ON v.registered_resource_id = r.id
 //	LEFT JOIN LATERAL (
@@ -825,8 +803,8 @@ type listRegisteredResourcesRow struct {
 //	WHERE
 //	    ($1::uuid IS NULL OR r.namespace_id = $1::uuid) AND
 //	    ($2::text IS NULL OR ns_fqns.fqn = $2::text) AND
-//	    ($3::text IS NULL OR LOWER(r.name) LIKE $3::text ESCAPE '\')
-//	GROUP BY r.id, n.id, ns_fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
+//	    ($3::text IS NULL OR r.name LIKE $3::text ESCAPE '\')
+//	GROUP BY r.id, n.id, ns_fqns.fqn, p.resolved_field, p.resolved_direction
 //	ORDER BY
 //	    CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN r.name END ASC,
 //	    CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'DESC' THEN r.name END DESC,

--- a/service/policy/db/registered_resources.sql.go
+++ b/service/policy/db/registered_resources.sql.go
@@ -644,8 +644,8 @@ func (q *Queries) listRegisteredResourceValues(ctx context.Context, arg listRegi
 const listRegisteredResources = `-- name: listRegisteredResources :many
 WITH params AS (
     SELECT
-        COALESCE(NULLIF($5::text, ''), 'created_at') AS resolved_field,
-        COALESCE(NULLIF($6::text, ''), 'DESC') AS resolved_direction
+        COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
+        COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
 ),
 counted AS (
     SELECT COUNT(r.id) AS total
@@ -654,7 +654,8 @@ counted AS (
     LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
     WHERE
         ($1::uuid IS NULL OR r.namespace_id = $1::uuid) AND
-        ($2::text IS NULL OR ns_fqns.fqn = $2::text)
+        ($2::text IS NULL OR ns_fqns.fqn = $2::text) AND
+        ($3::text IS NULL OR LOWER(r.name) LIKE $3::text ESCAPE '\')
 )
 SELECT
     r.id,
@@ -714,7 +715,8 @@ LEFT JOIN LATERAL (
 ) action_attrs ON true  -- required syntax for LATERAL joins
 WHERE
     ($1::uuid IS NULL OR r.namespace_id = $1::uuid) AND
-    ($2::text IS NULL OR ns_fqns.fqn = $2::text)
+    ($2::text IS NULL OR ns_fqns.fqn = $2::text) AND
+    ($3::text IS NULL OR LOWER(r.name) LIKE $3::text ESCAPE '\')
 GROUP BY r.id, n.id, ns_fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
 ORDER BY
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN r.name END ASC,
@@ -724,13 +726,14 @@ ORDER BY
     CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'ASC' THEN r.updated_at END ASC,
     CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'DESC' THEN r.updated_at END DESC,
     r.id ASC
-LIMIT $4
-OFFSET $3
+LIMIT $5
+OFFSET $4
 `
 
 type listRegisteredResourcesParams struct {
 	NamespaceID   pgtype.UUID `json:"namespace_id"`
 	NamespaceFqn  pgtype.Text `json:"namespace_fqn"`
+	Search        pgtype.Text `json:"search"`
 	Offset        int32       `json:"offset_"`
 	Limit         int32       `json:"limit_"`
 	SortField     string      `json:"sort_field"`
@@ -750,8 +753,8 @@ type listRegisteredResourcesRow struct {
 //
 //	WITH params AS (
 //	    SELECT
-//	        COALESCE(NULLIF($5::text, ''), 'created_at') AS resolved_field,
-//	        COALESCE(NULLIF($6::text, ''), 'DESC') AS resolved_direction
+//	        COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
+//	        COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
 //	),
 //	counted AS (
 //	    SELECT COUNT(r.id) AS total
@@ -760,7 +763,8 @@ type listRegisteredResourcesRow struct {
 //	    LEFT JOIN attribute_fqns ns_fqns ON ns_fqns.namespace_id = n.id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
 //	    WHERE
 //	        ($1::uuid IS NULL OR r.namespace_id = $1::uuid) AND
-//	        ($2::text IS NULL OR ns_fqns.fqn = $2::text)
+//	        ($2::text IS NULL OR ns_fqns.fqn = $2::text) AND
+//	        ($3::text IS NULL OR LOWER(r.name) LIKE $3::text ESCAPE '\')
 //	)
 //	SELECT
 //	    r.id,
@@ -820,7 +824,8 @@ type listRegisteredResourcesRow struct {
 //	) action_attrs ON true  -- required syntax for LATERAL joins
 //	WHERE
 //	    ($1::uuid IS NULL OR r.namespace_id = $1::uuid) AND
-//	    ($2::text IS NULL OR ns_fqns.fqn = $2::text)
+//	    ($2::text IS NULL OR ns_fqns.fqn = $2::text) AND
+//	    ($3::text IS NULL OR LOWER(r.name) LIKE $3::text ESCAPE '\')
 //	GROUP BY r.id, n.id, ns_fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
 //	ORDER BY
 //	    CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN r.name END ASC,
@@ -830,12 +835,13 @@ type listRegisteredResourcesRow struct {
 //	    CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'ASC' THEN r.updated_at END ASC,
 //	    CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'DESC' THEN r.updated_at END DESC,
 //	    r.id ASC
-//	LIMIT $4
-//	OFFSET $3
+//	LIMIT $5
+//	OFFSET $4
 func (q *Queries) listRegisteredResources(ctx context.Context, arg listRegisteredResourcesParams) ([]listRegisteredResourcesRow, error) {
 	rows, err := q.db.Query(ctx, listRegisteredResources,
 		arg.NamespaceID,
 		arg.NamespaceFqn,
+		arg.Search,
 		arg.Offset,
 		arg.Limit,
 		arg.SortField,


### PR DESCRIPTION
## Summary
- Adds ListRegisteredResources RPC search support by wiring request search into the policy DB list query.
- Applies escaped, case-insensitive matching in the registered resources SQL path and adds integration coverage for search behavior, wildcard literals, namespace filters, empty/whitespace search, and pagination after filtering.