### PR TITLE
feat(policy): add search support to ListObligations

### DIFF
--- a/service/integration/obligations_test.go
+++ b/service/integration/obligations_test.go
@@ -553,6 +553,28 @@ func (s *ObligationsSuite) Test_ListObligations_SearchByNameAndFqn_Succeeds() {
 	s.Equal(int32(1), page.GetTotal())
 }
 
+func (s *ObligationsSuite) Test_ListObligations_SearchEscapesLikeWildcardLiterals_Succeeds() {
+	namespaceID, _, _ := s.getNamespaceData(nsExampleCom)
+	suffix := time.Now().UnixNano()
+
+	alpha := s.createObligation(namespaceID, fmt.Sprintf("wildcarda-%d", suffix), nil)
+	beta := s.createObligation(namespaceID, fmt.Sprintf("wildcardb-%d", suffix), nil)
+	defer s.deleteObligations([]string{alpha.GetId(), beta.GetId()})
+
+	for _, query := range []string{
+		fmt.Sprintf("wildcard_-%d", suffix),
+		fmt.Sprintf("wildcard%%-%d", suffix),
+	} {
+		list, page, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+			NamespaceId: namespaceID,
+			Search:      &policy.Search{Term: query},
+		})
+		s.Require().NoError(err)
+		s.Empty(list)
+		s.Equal(int32(0), page.GetTotal())
+	}
+}
+
 func (s *ObligationsSuite) Test_ListObligations_SearchCombinesWithNamespaceFilters_Succeeds() {
 	comID, comFQN, _ := s.getNamespaceData(nsExampleCom)
 	netID, netFQN, _ := s.getNamespaceData(nsExampleNet)

--- a/service/integration/obligations_test.go
+++ b/service/integration/obligations_test.go
@@ -610,13 +610,21 @@ func (s *ObligationsSuite) Test_ListObligations_SearchEmptyAndWhitespace_Succeed
 	s.Require().NoError(err)
 	s.Equal(noSearchPage.GetTotal(), emptySearchPage.GetTotal())
 
-	whitespaceSearch, whitespaceSearchPage, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+	_, whitespaceSearchPage, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		NamespaceId: namespaceID,
+		Search:      &policy.Search{Term: " "},
+	})
+	s.Require().NoError(err)
+	s.Equal(whitespaceSearchPage.GetTotal(), emptySearchPage.GetTotal())
+
+	trimAdditional, trimAdditionalPage, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
 		NamespaceId: namespaceID,
 		Search:      &policy.Search{Term: " " + name + " "},
 	})
 	s.Require().NoError(err)
-	s.Empty(whitespaceSearch)
-	s.Equal(int32(0), whitespaceSearchPage.GetTotal())
+	s.Require().Len(trimAdditional, 1)
+	s.Equal(trimAdditional[0].GetId(), created.GetId())
+	s.Equal(int32(1), trimAdditionalPage.GetTotal())
 }
 
 func (s *ObligationsSuite) Test_ListObligations_SearchPaginationAppliesAfterFiltering_Succeeds() {

--- a/service/integration/obligations_test.go
+++ b/service/integration/obligations_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"slices"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -524,6 +525,146 @@ func (s *ObligationsSuite) Test_ListObligations_OrdersByCreatedAt_Succeeds() {
 	s.NotNil(oblList)
 
 	assertIDsInOrder(s.T(), oblList, func(obl *policy.Obligation) string { return obl.GetId() }, third.GetId(), second.GetId(), first.GetId())
+}
+
+func (s *ObligationsSuite) Test_ListObligations_SearchByNameAndFqn_Succeeds() {
+	namespaceID, _, _ := s.getNamespaceData(nsExampleCom)
+	suffix := time.Now().UnixNano()
+
+	alpha := s.createObligation(namespaceID, fmt.Sprintf("dspx-search-alpha-%d", suffix), nil)
+	beta := s.createObligation(namespaceID, fmt.Sprintf("dspx-search-beta-%d", suffix), nil)
+	other := s.createObligation(namespaceID, fmt.Sprintf("dspx-other-%d", suffix), nil)
+	defer s.deleteObligations([]string{alpha.GetId(), beta.GetId(), other.GetId()})
+
+	byName, page, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		Search: &policy.Search{Term: strings.ToUpper(alpha.GetName())},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(byName, 1)
+	s.Equal(alpha.GetId(), byName[0].GetId())
+	s.Equal(int32(1), page.GetTotal())
+
+	byFqn, page, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		Search: &policy.Search{Term: strings.ToUpper(beta.GetFqn())},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(byFqn, 1)
+	s.Equal(beta.GetId(), byFqn[0].GetId())
+	s.Equal(int32(1), page.GetTotal())
+}
+
+func (s *ObligationsSuite) Test_ListObligations_SearchCombinesWithNamespaceFilters_Succeeds() {
+	comID, comFQN, _ := s.getNamespaceData(nsExampleCom)
+	netID, netFQN, _ := s.getNamespaceData(nsExampleNet)
+	suffix := time.Now().UnixNano()
+	searchToken := fmt.Sprintf("dspx-search-filter-%d", suffix)
+
+	comMatch := s.createObligation(comID, "com-"+searchToken, nil)
+	netMatch := s.createObligation(netID, "net-"+searchToken, nil)
+	comOther := s.createObligation(comID, fmt.Sprintf("dspx-search-filter-other-%d", suffix), nil)
+	defer s.deleteObligations([]string{comMatch.GetId(), netMatch.GetId(), comOther.GetId()})
+
+	byNamespaceID, page, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		NamespaceId: comID,
+		Search:      &policy.Search{Term: searchToken},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(byNamespaceID, 1)
+	s.Equal(comMatch.GetId(), byNamespaceID[0].GetId())
+	s.Equal(int32(1), page.GetTotal())
+
+	byNamespaceFQN, page, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		NamespaceFqn: netFQN,
+		Search:       &policy.Search{Term: strings.ToUpper(searchToken)},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(byNamespaceFQN, 1)
+	s.Equal(netMatch.GetId(), byNamespaceFQN[0].GetId())
+	s.Equal(int32(1), page.GetTotal())
+
+	noMatch, page, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		NamespaceFqn: comFQN,
+		Search:       &policy.Search{Term: "missing-" + searchToken},
+	})
+	s.Require().NoError(err)
+	s.Empty(noMatch)
+	s.Equal(int32(0), page.GetTotal())
+}
+
+func (s *ObligationsSuite) Test_ListObligations_SearchEmptyAndWhitespace_Succeeds() {
+	namespaceID, _, _ := s.getNamespaceData(nsExampleCom)
+	name := fmt.Sprintf("dspx-search-whitespace-%d", time.Now().UnixNano())
+	created := s.createObligation(namespaceID, name, nil)
+	defer s.deleteObligations([]string{created.GetId()})
+
+	noSearch, noSearchPage, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		NamespaceId: namespaceID,
+	})
+	s.Require().NoError(err)
+	s.NotEmpty(noSearch)
+
+	_, emptySearchPage, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		NamespaceId: namespaceID,
+		Search:      &policy.Search{Term: ""},
+	})
+	s.Require().NoError(err)
+	s.Equal(noSearchPage.GetTotal(), emptySearchPage.GetTotal())
+
+	whitespaceSearch, whitespaceSearchPage, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		NamespaceId: namespaceID,
+		Search:      &policy.Search{Term: " " + name + " "},
+	})
+	s.Require().NoError(err)
+	s.Empty(whitespaceSearch)
+	s.Equal(int32(0), whitespaceSearchPage.GetTotal())
+}
+
+func (s *ObligationsSuite) Test_ListObligations_SearchPaginationAppliesAfterFiltering_Succeeds() {
+	namespaceID, _, _ := s.getNamespaceData(nsExampleCom)
+	suffix := time.Now().UnixNano()
+	searchToken := fmt.Sprintf("dspx-search-page-%d", suffix)
+	names := []string{
+		"a-" + searchToken,
+		"b-" + searchToken,
+		"c-" + searchToken,
+		fmt.Sprintf("dspx-search-page-other-%d", suffix),
+	}
+	ids := make([]string, len(names))
+	for i, name := range names {
+		created := s.createObligation(namespaceID, name, nil)
+		ids[i] = created.GetId()
+	}
+	defer s.deleteObligations(ids)
+
+	firstPage, firstPagePagination, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		NamespaceId: namespaceID,
+		Search:      &policy.Search{Term: searchToken},
+		Pagination:  &policy.PageRequest{Limit: 2},
+		Sort: []*obligations.ObligationsSort{
+			{Field: obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_NAME, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(firstPage, 2)
+	s.Equal(int32(3), firstPagePagination.GetTotal())
+	s.Equal(int32(2), firstPagePagination.GetNextOffset())
+	s.Equal(ids[0], firstPage[0].GetId())
+	s.Equal(ids[1], firstPage[1].GetId())
+
+	secondPage, secondPagePagination, err := s.db.PolicyClient.ListObligations(s.ctx, &obligations.ListObligationsRequest{
+		NamespaceId: namespaceID,
+		Search:      &policy.Search{Term: searchToken},
+		Pagination:  &policy.PageRequest{Limit: 2, Offset: 2},
+		Sort: []*obligations.ObligationsSort{
+			{Field: obligations.SortObligationsType_SORT_OBLIGATIONS_TYPE_NAME, Direction: policy.SortDirection_SORT_DIRECTION_ASC},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(secondPage, 1)
+	s.Equal(int32(3), secondPagePagination.GetTotal())
+	s.Equal(int32(2), secondPagePagination.GetCurrentOffset())
+	s.Equal(int32(0), secondPagePagination.GetNextOffset())
+	s.Equal(ids[2], secondPage[0].GetId())
 }
 
 func (s *ObligationsSuite) Test_ListObligations_Fails() {

--- a/service/policy/db/obligations.go
+++ b/service/policy/db/obligations.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/opentdf/platform/lib/identifier"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/protocol/go/policy"
@@ -228,11 +227,7 @@ func (c PolicyDBClient) ListObligations(ctx context.Context, r *obligations.List
 	idIsValid := parsedID.Valid
 
 	sortField, sortDirection := GetObligationsSortParams(r.GetSort())
-	searchTerm := r.GetSearch().GetTerm()
-	search := pgtype.Text{}
-	if searchTerm != "" {
-		search = pgtypeText("%" + escapeLikePattern(strings.ToLower(searchTerm)) + "%")
-	}
+	searchTerm := pgtypeSubstringSearchPattern(r.GetSearch().GetTerm())
 
 	if useID && !idIsValid {
 		return nil, nil, db.ErrUUIDInvalid
@@ -248,7 +243,7 @@ func (c PolicyDBClient) ListObligations(ctx context.Context, r *obligations.List
 	rows, err := c.queries.listObligations(ctx, listObligationsParams{
 		NamespaceID:   parsedID,
 		NamespaceFqn:  pgtypeText(r.GetNamespaceFqn()),
-		Search:        search,
+		Search:        searchTerm,
 		Limit:         limit,
 		Offset:        offset,
 		SortField:     sortField,

--- a/service/policy/db/obligations.go
+++ b/service/policy/db/obligations.go
@@ -226,13 +226,12 @@ func (c PolicyDBClient) ListObligations(ctx context.Context, r *obligations.List
 	parsedID := pgtypeUUID(namespaceID)
 	idIsValid := parsedID.Valid
 
-	sortField, sortDirection := GetObligationsSortParams(r.GetSort())
-	searchTerm := pgtypeSubstringSearchPattern(r.GetSearch().GetTerm())
-
 	if useID && !idIsValid {
 		return nil, nil, db.ErrUUIDInvalid
 	}
 
+	sortField, sortDirection := GetObligationsSortParams(r.GetSort())
+	searchTerm := pgtypeSubstringSearchPattern(r.GetSearch().GetTerm())
 	limit, offset := c.getRequestedLimitOffset(r.GetPagination())
 
 	maxLimit := c.listCfg.limitMax

--- a/service/policy/db/obligations.go
+++ b/service/policy/db/obligations.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/opentdf/platform/lib/identifier"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/protocol/go/policy"
@@ -227,6 +228,11 @@ func (c PolicyDBClient) ListObligations(ctx context.Context, r *obligations.List
 	idIsValid := parsedID.Valid
 
 	sortField, sortDirection := GetObligationsSortParams(r.GetSort())
+	searchTerm := r.GetSearch().GetTerm()
+	search := pgtype.Text{}
+	if searchTerm != "" {
+		search = pgtypeText("%" + escapeLikePattern(strings.ToLower(searchTerm)) + "%")
+	}
 
 	if useID && !idIsValid {
 		return nil, nil, db.ErrUUIDInvalid
@@ -242,6 +248,7 @@ func (c PolicyDBClient) ListObligations(ctx context.Context, r *obligations.List
 	rows, err := c.queries.listObligations(ctx, listObligationsParams{
 		NamespaceID:   parsedID,
 		NamespaceFqn:  pgtypeText(r.GetNamespaceFqn()),
+		Search:        search,
 		Limit:         limit,
 		Offset:        offset,
 		SortField:     sortField,

--- a/service/policy/db/obligations.sql.go
+++ b/service/policy/db/obligations.sql.go
@@ -1678,22 +1678,6 @@ WITH params AS (
         COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
         COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
 ),
-counted AS (
-    SELECT COUNT(od.id) AS total
-    FROM obligation_definitions od
-    LEFT JOIN attribute_namespaces n ON od.namespace_id = n.id
-    LEFT JOIN attribute_fqns fqns ON fqns.namespace_id = n.id AND fqns.attribute_id IS NULL AND fqns.value_id IS NULL
-    WHERE
-        ($1::uuid IS NULL OR od.namespace_id = $1::uuid) AND
-        ($2::text IS NULL OR fqns.fqn = $2::text) AND
-        -- No search-specific optimization is added here. If needed, consider
-        -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
-        (
-            $3::text IS NULL
-            OR LOWER(od.name) LIKE $3::text ESCAPE '\'
-            OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE $3::text ESCAPE '\'
-        )
-),
 obligation_triggers_agg AS (
     SELECT
         ot.obligation_value_id,
@@ -1750,11 +1734,10 @@ SELECT
             'triggers', COALESCE(ota.triggers, '[]'::JSON)
         )
     ) FILTER (WHERE ov.id IS NOT NULL) as values,
-    counted.total
+    COUNT(*) OVER () AS total
 FROM obligation_definitions od
 JOIN attribute_namespaces n on od.namespace_id = n.id
 LEFT JOIN attribute_fqns fqns ON fqns.namespace_id = n.id AND fqns.attribute_id IS NULL AND fqns.value_id IS NULL
-CROSS JOIN counted
 CROSS JOIN params p
 LEFT JOIN obligation_values_standard ov on od.id = ov.obligation_definition_id
 LEFT JOIN obligation_triggers_agg ota on ov.id = ota.obligation_value_id
@@ -1765,10 +1748,9 @@ WHERE
     -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
     (
         $3::text IS NULL
-        OR LOWER(od.name) LIKE $3::text ESCAPE '\'
-        OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE $3::text ESCAPE '\'
+        OR CONCAT_WS('/', fqns.fqn, 'obl', od.name) LIKE $3::text ESCAPE '\'
     )
-GROUP BY od.id, n.id, fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
+GROUP BY od.id, n.id, fqns.fqn, p.resolved_field, p.resolved_direction
 ORDER BY
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN od.name END ASC,
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'DESC' THEN od.name END DESC,
@@ -1808,22 +1790,6 @@ type listObligationsRow struct {
 //	    SELECT
 //	        COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
 //	        COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
-//	),
-//	counted AS (
-//	    SELECT COUNT(od.id) AS total
-//	    FROM obligation_definitions od
-//	    LEFT JOIN attribute_namespaces n ON od.namespace_id = n.id
-//	    LEFT JOIN attribute_fqns fqns ON fqns.namespace_id = n.id AND fqns.attribute_id IS NULL AND fqns.value_id IS NULL
-//	    WHERE
-//	        ($1::uuid IS NULL OR od.namespace_id = $1::uuid) AND
-//	        ($2::text IS NULL OR fqns.fqn = $2::text) AND
-//	        -- No search-specific optimization is added here. If needed, consider
-//	        -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
-//	        (
-//	            $3::text IS NULL
-//	            OR LOWER(od.name) LIKE $3::text ESCAPE '\'
-//	            OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE $3::text ESCAPE '\'
-//	        )
 //	),
 //	obligation_triggers_agg AS (
 //	    SELECT
@@ -1881,11 +1847,10 @@ type listObligationsRow struct {
 //	            'triggers', COALESCE(ota.triggers, '[]'::JSON)
 //	        )
 //	    ) FILTER (WHERE ov.id IS NOT NULL) as values,
-//	    counted.total
+//	    COUNT(*) OVER () AS total
 //	FROM obligation_definitions od
 //	JOIN attribute_namespaces n on od.namespace_id = n.id
 //	LEFT JOIN attribute_fqns fqns ON fqns.namespace_id = n.id AND fqns.attribute_id IS NULL AND fqns.value_id IS NULL
-//	CROSS JOIN counted
 //	CROSS JOIN params p
 //	LEFT JOIN obligation_values_standard ov on od.id = ov.obligation_definition_id
 //	LEFT JOIN obligation_triggers_agg ota on ov.id = ota.obligation_value_id
@@ -1896,10 +1861,9 @@ type listObligationsRow struct {
 //	    -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
 //	    (
 //	        $3::text IS NULL
-//	        OR LOWER(od.name) LIKE $3::text ESCAPE '\'
-//	        OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE $3::text ESCAPE '\'
+//	        OR CONCAT_WS('/', fqns.fqn, 'obl', od.name) LIKE $3::text ESCAPE '\'
 //	    )
-//	GROUP BY od.id, n.id, fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
+//	GROUP BY od.id, n.id, fqns.fqn, p.resolved_field, p.resolved_direction
 //	ORDER BY
 //	    CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN od.name END ASC,
 //	    CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'DESC' THEN od.name END DESC,

--- a/service/policy/db/obligations.sql.go
+++ b/service/policy/db/obligations.sql.go
@@ -1675,8 +1675,8 @@ func (q *Queries) listObligationTriggers(ctx context.Context, arg listObligation
 const listObligations = `-- name: listObligations :many
 WITH params AS (
     SELECT
-        COALESCE(NULLIF($5::text, ''), 'created_at') AS resolved_field,
-        COALESCE(NULLIF($6::text, ''), 'DESC') AS resolved_direction
+        COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
+        COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
 ),
 counted AS (
     SELECT COUNT(od.id) AS total
@@ -1685,7 +1685,14 @@ counted AS (
     LEFT JOIN attribute_fqns fqns ON fqns.namespace_id = n.id AND fqns.attribute_id IS NULL AND fqns.value_id IS NULL
     WHERE
         ($1::uuid IS NULL OR od.namespace_id = $1::uuid) AND
-        ($2::text IS NULL OR fqns.fqn = $2::text)
+        ($2::text IS NULL OR fqns.fqn = $2::text) AND
+        -- No search-specific optimization is added here. If needed, consider
+        -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
+        (
+            $3::text IS NULL
+            OR LOWER(od.name) LIKE $3::text ESCAPE '\'
+            OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE $3::text ESCAPE '\'
+        )
 ),
 obligation_triggers_agg AS (
     SELECT
@@ -1753,7 +1760,14 @@ LEFT JOIN obligation_values_standard ov on od.id = ov.obligation_definition_id
 LEFT JOIN obligation_triggers_agg ota on ov.id = ota.obligation_value_id
 WHERE
     ($1::uuid IS NULL OR od.namespace_id = $1::uuid) AND
-    ($2::text IS NULL OR fqns.fqn = $2::text)
+    ($2::text IS NULL OR fqns.fqn = $2::text) AND
+    -- No search-specific optimization is added here. If needed, consider
+    -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
+    (
+        $3::text IS NULL
+        OR LOWER(od.name) LIKE $3::text ESCAPE '\'
+        OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE $3::text ESCAPE '\'
+    )
 GROUP BY od.id, n.id, fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
 ORDER BY
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN od.name END ASC,
@@ -1765,13 +1779,14 @@ ORDER BY
     CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'ASC' THEN od.updated_at END ASC,
     CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'DESC' THEN od.updated_at END DESC,
     od.id ASC
-LIMIT $4
-OFFSET $3
+LIMIT $5
+OFFSET $4
 `
 
 type listObligationsParams struct {
 	NamespaceID   pgtype.UUID `json:"namespace_id"`
 	NamespaceFqn  pgtype.Text `json:"namespace_fqn"`
+	Search        pgtype.Text `json:"search"`
 	Offset        int32       `json:"offset_"`
 	Limit         int32       `json:"limit_"`
 	SortField     string      `json:"sort_field"`
@@ -1791,8 +1806,8 @@ type listObligationsRow struct {
 //
 //	WITH params AS (
 //	    SELECT
-//	        COALESCE(NULLIF($5::text, ''), 'created_at') AS resolved_field,
-//	        COALESCE(NULLIF($6::text, ''), 'DESC') AS resolved_direction
+//	        COALESCE(NULLIF($6::text, ''), 'created_at') AS resolved_field,
+//	        COALESCE(NULLIF($7::text, ''), 'DESC') AS resolved_direction
 //	),
 //	counted AS (
 //	    SELECT COUNT(od.id) AS total
@@ -1801,7 +1816,14 @@ type listObligationsRow struct {
 //	    LEFT JOIN attribute_fqns fqns ON fqns.namespace_id = n.id AND fqns.attribute_id IS NULL AND fqns.value_id IS NULL
 //	    WHERE
 //	        ($1::uuid IS NULL OR od.namespace_id = $1::uuid) AND
-//	        ($2::text IS NULL OR fqns.fqn = $2::text)
+//	        ($2::text IS NULL OR fqns.fqn = $2::text) AND
+//	        -- No search-specific optimization is added here. If needed, consider
+//	        -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
+//	        (
+//	            $3::text IS NULL
+//	            OR LOWER(od.name) LIKE $3::text ESCAPE '\'
+//	            OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE $3::text ESCAPE '\'
+//	        )
 //	),
 //	obligation_triggers_agg AS (
 //	    SELECT
@@ -1869,7 +1891,14 @@ type listObligationsRow struct {
 //	LEFT JOIN obligation_triggers_agg ota on ov.id = ota.obligation_value_id
 //	WHERE
 //	    ($1::uuid IS NULL OR od.namespace_id = $1::uuid) AND
-//	    ($2::text IS NULL OR fqns.fqn = $2::text)
+//	    ($2::text IS NULL OR fqns.fqn = $2::text) AND
+//	    -- No search-specific optimization is added here. If needed, consider
+//	    -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
+//	    (
+//	        $3::text IS NULL
+//	        OR LOWER(od.name) LIKE $3::text ESCAPE '\'
+//	        OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE $3::text ESCAPE '\'
+//	    )
 //	GROUP BY od.id, n.id, fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
 //	ORDER BY
 //	    CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN od.name END ASC,
@@ -1881,12 +1910,13 @@ type listObligationsRow struct {
 //	    CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'ASC' THEN od.updated_at END ASC,
 //	    CASE WHEN p.resolved_field = 'updated_at' AND p.resolved_direction = 'DESC' THEN od.updated_at END DESC,
 //	    od.id ASC
-//	LIMIT $4
-//	OFFSET $3
+//	LIMIT $5
+//	OFFSET $4
 func (q *Queries) listObligations(ctx context.Context, arg listObligationsParams) ([]listObligationsRow, error) {
 	rows, err := q.db.Query(ctx, listObligations,
 		arg.NamespaceID,
 		arg.NamespaceFqn,
+		arg.Search,
 		arg.Offset,
 		arg.Limit,
 		arg.SortField,

--- a/service/policy/db/queries/obligations.sql
+++ b/service/policy/db/queries/obligations.sql
@@ -130,22 +130,6 @@ WITH params AS (
         COALESCE(NULLIF(@sort_field::text, ''), 'created_at') AS resolved_field,
         COALESCE(NULLIF(@sort_direction::text, ''), 'DESC') AS resolved_direction
 ),
-counted AS (
-    SELECT COUNT(od.id) AS total
-    FROM obligation_definitions od
-    LEFT JOIN attribute_namespaces n ON od.namespace_id = n.id
-    LEFT JOIN attribute_fqns fqns ON fqns.namespace_id = n.id AND fqns.attribute_id IS NULL AND fqns.value_id IS NULL
-    WHERE
-        (sqlc.narg('namespace_id')::uuid IS NULL OR od.namespace_id = sqlc.narg('namespace_id')::uuid) AND
-        (sqlc.narg('namespace_fqn')::text IS NULL OR fqns.fqn = sqlc.narg('namespace_fqn')::text) AND
-        -- No search-specific optimization is added here. If needed, consider
-        -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
-        (
-            sqlc.narg('search')::text IS NULL
-            OR LOWER(od.name) LIKE sqlc.narg('search')::text ESCAPE '\'
-            OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE sqlc.narg('search')::text ESCAPE '\'
-        )
-),
 obligation_triggers_agg AS (
     SELECT
         ot.obligation_value_id,
@@ -202,11 +186,10 @@ SELECT
             'triggers', COALESCE(ota.triggers, '[]'::JSON)
         )
     ) FILTER (WHERE ov.id IS NOT NULL) as values,
-    counted.total
+    COUNT(*) OVER () AS total
 FROM obligation_definitions od
 JOIN attribute_namespaces n on od.namespace_id = n.id
 LEFT JOIN attribute_fqns fqns ON fqns.namespace_id = n.id AND fqns.attribute_id IS NULL AND fqns.value_id IS NULL
-CROSS JOIN counted
 CROSS JOIN params p
 LEFT JOIN obligation_values_standard ov on od.id = ov.obligation_definition_id
 LEFT JOIN obligation_triggers_agg ota on ov.id = ota.obligation_value_id
@@ -217,10 +200,9 @@ WHERE
     -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
     (
         sqlc.narg('search')::text IS NULL
-        OR LOWER(od.name) LIKE sqlc.narg('search')::text ESCAPE '\'
-        OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE sqlc.narg('search')::text ESCAPE '\'
+        OR CONCAT_WS('/', fqns.fqn, 'obl', od.name) LIKE sqlc.narg('search')::text ESCAPE '\'
     )
-GROUP BY od.id, n.id, fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
+GROUP BY od.id, n.id, fqns.fqn, p.resolved_field, p.resolved_direction
 ORDER BY
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN od.name END ASC,
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'DESC' THEN od.name END DESC,

--- a/service/policy/db/queries/obligations.sql
+++ b/service/policy/db/queries/obligations.sql
@@ -137,7 +137,14 @@ counted AS (
     LEFT JOIN attribute_fqns fqns ON fqns.namespace_id = n.id AND fqns.attribute_id IS NULL AND fqns.value_id IS NULL
     WHERE
         (sqlc.narg('namespace_id')::uuid IS NULL OR od.namespace_id = sqlc.narg('namespace_id')::uuid) AND
-        (sqlc.narg('namespace_fqn')::text IS NULL OR fqns.fqn = sqlc.narg('namespace_fqn')::text)
+        (sqlc.narg('namespace_fqn')::text IS NULL OR fqns.fqn = sqlc.narg('namespace_fqn')::text) AND
+        -- No search-specific optimization is added here. If needed, consider
+        -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
+        (
+            sqlc.narg('search')::text IS NULL
+            OR LOWER(od.name) LIKE sqlc.narg('search')::text ESCAPE '\'
+            OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE sqlc.narg('search')::text ESCAPE '\'
+        )
 ),
 obligation_triggers_agg AS (
     SELECT
@@ -205,7 +212,14 @@ LEFT JOIN obligation_values_standard ov on od.id = ov.obligation_definition_id
 LEFT JOIN obligation_triggers_agg ota on ov.id = ota.obligation_value_id
 WHERE
     (sqlc.narg('namespace_id')::uuid IS NULL OR od.namespace_id = sqlc.narg('namespace_id')::uuid) AND
-    (sqlc.narg('namespace_fqn')::text IS NULL OR fqns.fqn = sqlc.narg('namespace_fqn')::text)
+    (sqlc.narg('namespace_fqn')::text IS NULL OR fqns.fqn = sqlc.narg('namespace_fqn')::text) AND
+    -- No search-specific optimization is added here. If needed, consider
+    -- a pg_trgm-backed GIN index on obligation name/FQN expressions.
+    (
+        sqlc.narg('search')::text IS NULL
+        OR LOWER(od.name) LIKE sqlc.narg('search')::text ESCAPE '\'
+        OR LOWER(fqns.fqn || '/obl/' || od.name) LIKE sqlc.narg('search')::text ESCAPE '\'
+    )
 GROUP BY od.id, n.id, fqns.fqn, counted.total, p.resolved_field, p.resolved_direction
 ORDER BY
     CASE WHEN p.resolved_field = 'name' AND p.resolved_direction = 'ASC' THEN od.name END ASC,


### PR DESCRIPTION
## Summary
- Adds ListObligations RPC search support by wiring request search into the policy DB list query.
- Applies escaped, case-insensitive matching in the obligations SQL path and adds integration coverage for search behavior, wildcard literals, empty search, and pagination after filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search capability to obligation listings, supporting search by name and fully qualified name with case-insensitive matching.
  * Search integrates seamlessly with namespace filters and pagination.

* **Tests**
  * Added comprehensive integration tests for search functionality, including combined filtering, whitespace handling, and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->