### PR TITLE
fix(authz): log casbin subject groups on denial

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -252,8 +252,7 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 				log.WarnContext(
 					ctx,
 					"permission denied",
-					slog.String("azp", accessTok.Subject()),
-					slog.Any("error", err),
+					permissionDeniedLogAttrs(accessTok, err)...,
 				)
 				http.Error(w, "permission denied", http.StatusForbidden)
 				return
@@ -345,8 +344,7 @@ func (a Authentication) ConnectUnaryServerInterceptor() connect.UnaryInterceptor
 					log.WarnContext(
 						ctxWithJWK,
 						"permission denied",
-						slog.String("azp", token.Subject()),
-						slog.Any("error", err),
+						permissionDeniedLogAttrs(token, err)...,
 					)
 					return nil, connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
 				}
@@ -360,6 +358,24 @@ func (a Authentication) ConnectUnaryServerInterceptor() connect.UnaryInterceptor
 		})
 	}
 	return connect.UnaryInterceptorFunc(interceptor)
+}
+
+func permissionDeniedLogAttrs(token jwt.Token, err error) []any {
+	attrs := []any{slog.String("azp", token.Subject())}
+
+	var permissionErr *permissionDeniedError
+	if errors.As(err, &permissionErr) {
+		attrs = append(attrs, slog.Group("casbin_authz",
+			slog.String("configured_groups_claim", permissionErr.ConfiguredGroupsClaim),
+			slog.Any("subject_groups", permissionErr.SubjectGroups),
+		))
+	}
+
+	if err != nil {
+		attrs = append(attrs, slog.Any("error", err))
+	}
+
+	return attrs
 }
 
 // IPCMetadataClientInterceptor transfers gRPC outgoing metadata to Connect request headers for IPC calls

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -247,23 +247,23 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 			Resource: r.URL.Path,
 			Action:   action,
 		}
-		if allow, err := a.enforcer.Enforce(ctx, accessTok, roleReq); err != nil {
+		if result, err := a.enforcer.Enforce(ctx, accessTok, roleReq); err != nil {
 			if errors.Is(err, ErrPermissionDenied) {
 				log.WarnContext(
 					ctx,
 					"permission denied",
-					permissionDeniedLogAttrs(accessTok, err)...,
+					permissionDeniedLogAttrs(accessTok, result.CasbinAuthz, err)...,
 				)
 				http.Error(w, "permission denied", http.StatusForbidden)
 				return
 			}
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
-		} else if !allow {
+		} else if !result.Allowed {
 			log.WarnContext(
 				ctx,
 				"permission denied",
-				slog.String("azp", accessTok.Subject()),
+				permissionDeniedLogAttrs(accessTok, result.CasbinAuthz, nil)...,
 			)
 			http.Error(w, "permission denied", http.StatusForbidden)
 			return
@@ -339,18 +339,18 @@ func (a Authentication) ConnectUnaryServerInterceptor() connect.UnaryInterceptor
 				Resource: resource,
 				Action:   action,
 			}
-			if allowed, err := a.enforcer.Enforce(ctxWithJWK, token, roleReq); err != nil {
+			if result, err := a.enforcer.Enforce(ctxWithJWK, token, roleReq); err != nil {
 				if errors.Is(err, ErrPermissionDenied) {
 					log.WarnContext(
 						ctxWithJWK,
 						"permission denied",
-						permissionDeniedLogAttrs(token, err)...,
+						permissionDeniedLogAttrs(token, result.CasbinAuthz, err)...,
 					)
 					return nil, connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
 				}
 				return nil, err
-			} else if !allowed {
-				log.WarnContext(ctxWithJWK, "permission denied", slog.String("azp", token.Subject()))
+			} else if !result.Allowed {
+				log.WarnContext(ctxWithJWK, "permission denied", permissionDeniedLogAttrs(token, result.CasbinAuthz, nil)...)
 				return nil, connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
 			}
 
@@ -360,14 +360,13 @@ func (a Authentication) ConnectUnaryServerInterceptor() connect.UnaryInterceptor
 	return connect.UnaryInterceptorFunc(interceptor)
 }
 
-func permissionDeniedLogAttrs(token jwt.Token, err error) []any {
+func permissionDeniedLogAttrs(token jwt.Token, casbinAuthz CasbinAuthzLog, err error) []any {
 	attrs := []any{slog.String("azp", token.Subject())}
 
-	var permissionErr *permissionDeniedError
-	if errors.As(err, &permissionErr) {
+	if casbinAuthz.ConfiguredGroupsClaim != "" || casbinAuthz.SubjectGroups != nil {
 		attrs = append(attrs, slog.Group("casbin_authz",
-			slog.String("configured_groups_claim", permissionErr.ConfiguredGroupsClaim),
-			slog.Any("subject_groups", permissionErr.SubjectGroups),
+			slog.String("configured_groups_claim", casbinAuthz.ConfiguredGroupsClaim),
+			slog.Any("subject_groups", casbinAuthz.SubjectGroups),
 		))
 	}
 

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -215,6 +215,57 @@ func TestNormalizeUrl(t *testing.T) {
 	}
 }
 
+func TestPermissionDeniedLogAttrs(t *testing.T) {
+	tok := jwt.New()
+	require.NoError(t, tok.Set(jwt.SubjectKey, "client-subject"))
+
+	attrs := permissionDeniedLogAttrs(tok, &permissionDeniedError{
+		ConfiguredGroupsClaim: "custom.groups",
+		SubjectGroups:         []string{"opentdf-standard"},
+	})
+
+	require.Len(t, attrs, 3)
+	assert.Equal(t, slog.String("azp", "client-subject"), attrs[0])
+
+	casbinAuthzAttr, ok := attrs[1].(slog.Attr)
+	require.True(t, ok)
+	assert.Equal(t, "casbin_authz", casbinAuthzAttr.Key)
+
+	casbinAuthzAttrs := casbinAuthzAttr.Value.Group()
+	require.Len(t, casbinAuthzAttrs, 2)
+	assert.Equal(t, slog.String("configured_groups_claim", "custom.groups"), casbinAuthzAttrs[0])
+	assert.Equal(t, "subject_groups", casbinAuthzAttrs[1].Key)
+	assert.Equal(t, []string{"opentdf-standard"}, casbinAuthzAttrs[1].Value.Any())
+
+	errorAttr, ok := attrs[2].(slog.Attr)
+	require.True(t, ok)
+	assert.Equal(t, "error", errorAttr.Key)
+	loggedErr, ok := errorAttr.Value.Any().(error)
+	require.True(t, ok)
+	if !errors.Is(loggedErr, ErrPermissionDenied) {
+		t.Fatalf("expected error to wrap %v", ErrPermissionDenied)
+	}
+}
+
+func TestPermissionDeniedLogAttrsWithoutSubjectInfo(t *testing.T) {
+	tok := jwt.New()
+	require.NoError(t, tok.Set(jwt.SubjectKey, "client-subject"))
+
+	attrs := permissionDeniedLogAttrs(tok, ErrPermissionDenied)
+
+	require.Len(t, attrs, 2)
+	assert.Equal(t, slog.String("azp", "client-subject"), attrs[0])
+
+	errorAttr, ok := attrs[1].(slog.Attr)
+	require.True(t, ok)
+	assert.Equal(t, "error", errorAttr.Key)
+	loggedErr, ok := errorAttr.Value.Any().(error)
+	require.True(t, ok)
+	if !errors.Is(loggedErr, ErrPermissionDenied) {
+		t.Fatalf("expected error to wrap %v", ErrPermissionDenied)
+	}
+}
+
 func (s *AuthSuite) Test_IPCUnaryServerInterceptor() {
 	// Mock the checkToken method to return a valid token and context
 	mockToken := jwt.New()

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -219,10 +219,10 @@ func TestPermissionDeniedLogAttrs(t *testing.T) {
 	tok := jwt.New()
 	require.NoError(t, tok.Set(jwt.SubjectKey, "client-subject"))
 
-	attrs := permissionDeniedLogAttrs(tok, &permissionDeniedError{
+	attrs := permissionDeniedLogAttrs(tok, CasbinAuthzLog{
 		ConfiguredGroupsClaim: "custom.groups",
 		SubjectGroups:         []string{"opentdf-standard"},
-	})
+	}, ErrPermissionDenied)
 
 	require.Len(t, attrs, 3)
 	assert.Equal(t, slog.String("azp", "client-subject"), attrs[0])
@@ -251,7 +251,7 @@ func TestPermissionDeniedLogAttrsWithoutSubjectInfo(t *testing.T) {
 	tok := jwt.New()
 	require.NoError(t, tok.Set(jwt.SubjectKey, "client-subject"))
 
-	attrs := permissionDeniedLogAttrs(tok, ErrPermissionDenied)
+	attrs := permissionDeniedLogAttrs(tok, CasbinAuthzLog{}, ErrPermissionDenied)
 
 	require.Len(t, attrs, 2)
 	assert.Equal(t, slog.String("azp", "client-subject"), attrs[0])

--- a/service/internal/auth/casbin.go
+++ b/service/internal/auth/casbin.go
@@ -23,17 +23,14 @@ var (
 	ErrPermissionDenied = errors.New("permission denied")
 )
 
-type permissionDeniedError struct {
+type EnforcementResult struct {
+	Allowed     bool
+	CasbinAuthz CasbinAuthzLog
+}
+
+type CasbinAuthzLog struct {
 	ConfiguredGroupsClaim string
 	SubjectGroups         []string
-}
-
-func (e *permissionDeniedError) Error() string {
-	return ErrPermissionDenied.Error()
-}
-
-func (e *permissionDeniedError) Unwrap() error {
-	return ErrPermissionDenied
 }
 
 //go:embed casbin_policy.csv
@@ -148,12 +145,18 @@ func NewCasbinEnforcer(c CasbinConfig, logger *logger.Logger) (*Enforcer, error)
 
 // casbinEnforce is a helper function to enforce the policy with casbin
 // TODO implement a common type so this can be used for both http and grpc
-func (e *Enforcer) Enforce(ctx context.Context, token jwt.Token, req authz.RoleRequest) (bool, error) {
+func (e *Enforcer) Enforce(ctx context.Context, token jwt.Token, req authz.RoleRequest) (EnforcementResult, error) {
 	// extract the role claim from the token
 	s, subjectGroups, err := e.buildSubjectFromToken(ctx, token, req)
+	result := EnforcementResult{
+		CasbinAuthz: CasbinAuthzLog{
+			ConfiguredGroupsClaim: e.Config.GroupsClaim,
+			SubjectGroups:         subjectGroups,
+		},
+	}
 	if err != nil {
 		e.logger.Warn("role provider error", slog.Any("error", err))
-		return false, ErrPermissionDenied
+		return result, ErrPermissionDenied
 	}
 	s = append(s, rolePrefix+defaultRole)
 
@@ -175,7 +178,8 @@ func (e *Enforcer) Enforce(ctx context.Context, token jwt.Token, req authz.RoleR
 				slog.String("action", action),
 				slog.String("resource", resource),
 			)
-			return true, nil
+			result.Allowed = true
+			return result, nil
 		}
 	}
 	e.logger.Debug("permission denied by policy",
@@ -183,10 +187,7 @@ func (e *Enforcer) Enforce(ctx context.Context, token jwt.Token, req authz.RoleR
 		slog.String("action", action),
 		slog.String("resource", resource),
 	)
-	return false, &permissionDeniedError{
-		ConfiguredGroupsClaim: e.Config.GroupsClaim,
-		SubjectGroups:         subjectGroups,
-	}
+	return result, ErrPermissionDenied
 }
 
 func (e *Enforcer) buildSubjectFromToken(ctx context.Context, t jwt.Token, req authz.RoleRequest) (casbinSubject, []string, error) {

--- a/service/internal/auth/casbin.go
+++ b/service/internal/auth/casbin.go
@@ -23,6 +23,19 @@ var (
 	ErrPermissionDenied = errors.New("permission denied")
 )
 
+type permissionDeniedError struct {
+	ConfiguredGroupsClaim string
+	SubjectGroups         []string
+}
+
+func (e *permissionDeniedError) Error() string {
+	return ErrPermissionDenied.Error()
+}
+
+func (e *permissionDeniedError) Unwrap() error {
+	return ErrPermissionDenied
+}
+
 //go:embed casbin_policy.csv
 var builtinPolicy string
 
@@ -137,7 +150,7 @@ func NewCasbinEnforcer(c CasbinConfig, logger *logger.Logger) (*Enforcer, error)
 // TODO implement a common type so this can be used for both http and grpc
 func (e *Enforcer) Enforce(ctx context.Context, token jwt.Token, req authz.RoleRequest) (bool, error) {
 	// extract the role claim from the token
-	s, err := e.buildSubjectFromToken(ctx, token, req)
+	s, subjectGroups, err := e.buildSubjectFromToken(ctx, token, req)
 	if err != nil {
 		e.logger.Warn("role provider error", slog.Any("error", err))
 		return false, ErrPermissionDenied
@@ -170,17 +183,20 @@ func (e *Enforcer) Enforce(ctx context.Context, token jwt.Token, req authz.RoleR
 		slog.String("action", action),
 		slog.String("resource", resource),
 	)
-	return false, ErrPermissionDenied
+	return false, &permissionDeniedError{
+		ConfiguredGroupsClaim: e.Config.GroupsClaim,
+		SubjectGroups:         subjectGroups,
+	}
 }
 
-func (e *Enforcer) buildSubjectFromToken(ctx context.Context, t jwt.Token, req authz.RoleRequest) (casbinSubject, error) {
+func (e *Enforcer) buildSubjectFromToken(ctx context.Context, t jwt.Token, req authz.RoleRequest) (casbinSubject, []string, error) {
 	var subject string
 	info := casbinSubject{}
 
 	e.logger.Debug("building subject from token")
 	roles, err := e.roleProvider.Roles(ctx, t, req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if claim, found := t.Get(e.Config.UserNameClaim); found {
@@ -196,5 +212,5 @@ func (e *Enforcer) buildSubjectFromToken(ctx context.Context, t jwt.Token, req a
 	}
 	info = append(info, roles...)
 	info = append(info, subject)
-	return info, nil
+	return info, append([]string(nil), roles...), nil
 }

--- a/service/internal/auth/casbin_test.go
+++ b/service/internal/auth/casbin_test.go
@@ -538,7 +538,7 @@ func (s *AuthnCasbinSuite) Test_Override_Of_Groups_Claim() {
 }
 
 func (s *AuthnCasbinSuite) enforce(enforcer *Enforcer, tok jwt.Token, resource, action string) (bool, error) {
-	return enforcer.Enforce(
+	result, err := enforcer.Enforce(
 		context.Background(),
 		tok,
 		authz.RoleRequest{
@@ -546,6 +546,7 @@ func (s *AuthnCasbinSuite) enforce(enforcer *Enforcer, tok jwt.Token, resource, 
 			Action:   action,
 		},
 	)
+	return result.Allowed, err
 }
 
 func (s *AuthnCasbinSuite) buildTokenRoles(admin bool, standard bool, roleMaps []string) []interface{} {


### PR DESCRIPTION
Adds Casbin authorization context to permission denied warning logs, including the configured groups claim and extracted subject groups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved authorization handling consistency across different request interceptors with centralized permission-denied logic.
  * Enhanced structured logging for authorization denials to provide more detailed diagnostic information.

* **Tests**
  * Added tests verifying structured logging attributes for permission-denied scenarios with and without authorization group data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->