### PR TITLE
feat(ci): Enable pq/t service run action option

### DIFF
--- a/test/start-additional-kas/action.yaml
+++ b/test/start-additional-kas/action.yaml
@@ -16,6 +16,10 @@ inputs:
     default: "false"
     description: 'Whether to enable ECC wrapping for TDFs'
     required: false
+  pqc-enabled:
+    default: "false"
+    description: 'Whether to enable post-quantum and hybrid PQ/T wrapping for TDFs'
+    required: false
   key-management:
     default: "false"
     description: 'Whether or not key_management is enabled for this KAS'
@@ -95,6 +99,7 @@ runs:
         KAS_NAME: ${{ inputs.kas-name }}
         KAS_PORT: ${{ inputs.kas-port }}
         EC_TDF_ENABLED: ${{ inputs.ec-tdf-enabled }}
+        PQC_ENABLED: ${{ inputs.pqc-enabled }}
         KEY_MANAGEMENT: ${{ inputs.key-management }}
         ROOT_KEY: ${{ inputs.root-key }}
         LOG_LEVEL: ${{ inputs.log-level }}
@@ -105,6 +110,7 @@ runs:
             (.server.port = env(KAS_PORT))
             | (.mode = ["kas"])
             | (.services.kas.preview.ec_tdf_enabled = env(EC_TDF_ENABLED))
+            | (.services.kas.preview.hybrid_tdf_enabled = env(PQC_ENABLED))
             | (.services.kas.preview.key_management = env(KEY_MANAGEMENT))
             | (.services.kas.registered_kas_uri = "http://localhost:" + env(KAS_PORT))
             | del(.services.kas.root_key)

--- a/test/start-additional-kas/action.yaml
+++ b/test/start-additional-kas/action.yaml
@@ -149,7 +149,11 @@ runs:
             (.server.port = env(KAS_PORT))
             | (.mode = ["kas"])
             | (.services.kas.preview.ec_tdf_enabled = env(EC_TDF_ENABLED))
-            | (.services.kas.preview.hybrid_tdf_enabled = env(PQC_ENABLED))
+            | (.services.kas.preview.hybrid_tdf_enabled = (env(PQC_ENABLED) == "true"))
+            | (if env(PQC_ENABLED) == "true" then
+                (.services.kas.keyring += [{"kid":"x1","alg":"hpqt:xwing"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024"}])
+                | (.server.cryptoProvider.standard.keys += [{"kid":"x1","alg":"hpqt:xwing","private":"kas-xwing-private.pem","cert":"kas-xwing-public.pem"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768","private":"kas-p256mlkem768-private.pem","cert":"kas-p256mlkem768-public.pem"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024","private":"kas-p384mlkem1024-private.pem","cert":"kas-p384mlkem1024-public.pem"}])
+              else . end)
             | (.services.kas.preview.key_management = env(KEY_MANAGEMENT))
             | (.services.kas.registered_kas_uri = "http://localhost:" + env(KAS_PORT))
             | del(.services.kas.root_key)

--- a/test/start-additional-kas/action.yaml
+++ b/test/start-additional-kas/action.yaml
@@ -148,7 +148,7 @@ runs:
           yq e '
             (.server.port = env(KAS_PORT))
             | (.mode = ["kas"])
-            | (.services.kas.preview.ec_tdf_enabled = env(EC_TDF_ENABLED))
+            | (.services.kas.preview.ec_tdf_enabled = (env(EC_TDF_ENABLED) == "true"))
             | (.services.kas.preview.hybrid_tdf_enabled = (env(PQC_ENABLED) == "true"))
             | (if env(PQC_ENABLED) == "true" then
                 (.services.kas.keyring += [{"kid":"x1","alg":"hpqt:xwing"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024"}])

--- a/test/start-additional-kas/action.yaml
+++ b/test/start-additional-kas/action.yaml
@@ -46,21 +46,60 @@ runs:
     - name: Validate inputs
       shell: bash
       env:
+        KAS_PORT: ${{ inputs.kas-port }}
+        KAS_NAME: ${{ inputs.kas-name }}
+        EC_TDF_ENABLED: ${{ inputs.ec-tdf-enabled }}
+        PQC_ENABLED: ${{ inputs.pqc-enabled }}
         KEY_MANAGEMENT: ${{ inputs.key-management }}
         ROOT_KEY: ${{ inputs.root-key }}
-        KAS_NAME: ${{ inputs.kas-name }}
         LOG_LEVEL: ${{ inputs.log-level }}
         LOG_TYPE: ${{ inputs.log-type }}
       run: |
-        # Validate key-management and root-key
-        if [[ "${KEY_MANAGEMENT}" == "true" && -z "${ROOT_KEY}" ]]; then
-          echo "Error: root-key is required when key-management is true."
+        # Validate kas-port (must be a valid port number 1-65535)
+        if [[ ! "${KAS_PORT}" =~ ^[0-9]+$ ]] || (( KAS_PORT < 1 || KAS_PORT > 65535 )); then
+          echo "Error: kas-port must be a valid port number between 1 and 65535."
           exit 1
         fi
 
         # Validate kas-name (only alphanumeric and hyphens)
         if [[ ! "${KAS_NAME}" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
           echo "Error: kas-name must contain only lowercase letters, numbers, and hyphens (e.g., 'alpha', 'kas-beta')."
+          exit 1
+        fi
+
+        # Validate ec-tdf-enabled (must be true or false)
+        case "${EC_TDF_ENABLED}" in
+          true|false)
+            ;;
+          *)
+            echo "Error: ec-tdf-enabled must be 'true' or 'false'."
+            exit 1
+            ;;
+        esac
+
+        # Validate pqc-enabled (must be true or false)
+        case "${PQC_ENABLED}" in
+          true|false)
+            ;;
+          *)
+            echo "Error: pqc-enabled must be 'true' or 'false'."
+            exit 1
+            ;;
+        esac
+
+        # Validate key-management (must be true or false)
+        case "${KEY_MANAGEMENT}" in
+          true|false)
+            ;;
+          *)
+            echo "Error: key-management must be 'true' or 'false'."
+            exit 1
+            ;;
+        esac
+
+        # Validate key-management and root-key combination
+        if [[ "${KEY_MANAGEMENT}" == "true" && -z "${ROOT_KEY}" ]]; then
+          echo "Error: root-key is required when key-management is true."
           exit 1
         fi
 

--- a/test/start-additional-kas/action.yaml
+++ b/test/start-additional-kas/action.yaml
@@ -154,7 +154,7 @@ runs:
                 (.services.kas.keyring += [{"kid":"x1","alg":"hpqt:xwing"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024"}])
                 | (.server.cryptoProvider.standard.keys += [{"kid":"x1","alg":"hpqt:xwing","private":"kas-xwing-private.pem","cert":"kas-xwing-public.pem"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768","private":"kas-p256mlkem768-private.pem","cert":"kas-p256mlkem768-public.pem"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024","private":"kas-p384mlkem1024-private.pem","cert":"kas-p384mlkem1024-public.pem"}])
               else . end)
-            | (.services.kas.preview.key_management = env(KEY_MANAGEMENT))
+            | (.services.kas.preview.key_management = (env(KEY_MANAGEMENT) == "true"))
             | (.services.kas.registered_kas_uri = "http://localhost:" + env(KAS_PORT))
             | del(.services.kas.root_key)
             | (.logger.level = env(LOG_LEVEL))

--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -43,6 +43,78 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        PLATFORM_REF: ${{ inputs.platform-ref }}
+        EXTRA_KEYS: ${{ inputs.extra-keys }}
+        EC_TDF_ENABLED: ${{ inputs.ec-tdf-enabled }}
+        PQC_ENABLED: ${{ inputs.pqc-enabled }}
+        LOG_LEVEL: ${{ inputs.log-level }}
+        LOG_TYPE: ${{ inputs.log-type }}
+        PROVISION_POLICY_FIXTURES: ${{ inputs.provision-policy-fixtures }}
+      run: |
+        # Validate platform-ref (must contain only safe characters for a git ref)
+        if [[ ! "${PLATFORM_REF}" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+          echo "Error: platform-ref must contain only alphanumeric characters, dots, underscores, hyphens, and forward slashes."
+          exit 1
+        fi
+
+        # Validate extra-keys (must be a valid JSON array)
+        if ! jq -e 'type == "array"' <<< "${EXTRA_KEYS}" > /dev/null 2>&1; then
+          echo "Error: extra-keys must be a valid JSON array."
+          exit 1
+        fi
+
+        # Validate ec-tdf-enabled (must be true or false)
+        case "${EC_TDF_ENABLED}" in
+          true|false)
+            ;;
+          *)
+            echo "Error: ec-tdf-enabled must be 'true' or 'false'."
+            exit 1
+            ;;
+        esac
+
+        # Validate pqc-enabled (must be true or false)
+        case "${PQC_ENABLED}" in
+          true|false)
+            ;;
+          *)
+            echo "Error: pqc-enabled must be 'true' or 'false'."
+            exit 1
+            ;;
+        esac
+
+        # Validate log-level (only allowed values)
+        case "${LOG_LEVEL}" in
+          audit|debug|info|warn|error)
+            ;;
+          *)
+            echo "Error: log-level must be one of: audit, debug, info, warn, error."
+            exit 1
+            ;;
+        esac
+
+        # Validate log-type (only allowed values)
+        case "${LOG_TYPE}" in
+          text|json)
+            ;;
+          *)
+            echo "Error: log-type must be one of: text, json."
+            exit 1
+            ;;
+        esac
+
+        # Validate provision-policy-fixtures (must be true or false)
+        case "${PROVISION_POLICY_FIXTURES}" in
+          true|false)
+            ;;
+          *)
+            echo "Error: provision-policy-fixtures must be 'true' or 'false'."
+            exit 1
+            ;;
+        esac
     - name: Check out platform
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
@@ -165,10 +237,12 @@ runs:
       working-directory: otdf-test-platform
     - name: Enable ECC wrapping for TDFs
       shell: bash
-      if: ${{ inputs.ec-tdf-enabled }}
+      if: ${{ inputs.ec-tdf-enabled == 'true' }}
       run: |
         yq e '.services.kas.ec_tdf_enabled = true' -i opentdf.yaml
       working-directory: otdf-test-platform
+    - name: Enable PQ (mlkem, xwing, and hybrid) wrapping for TDFs
+      shell: bash
       if: ${{ inputs.pqc-enabled == 'true' }}
       run: |
         yq e '
@@ -177,78 +251,6 @@ runs:
           | (.server.cryptoProvider.standard.keys += [{"kid":"x1","alg":"hpqt:xwing","private":"kas-xwing-private.pem","cert":"kas-xwing-public.pem"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768","private":"kas-p256mlkem768-private.pem","cert":"kas-p256mlkem768-public.pem"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024","private":"kas-p384mlkem1024-private.pem","cert":"kas-p384mlkem1024-public.pem"}])
         ' -i opentdf.yaml
       working-directory: otdf-test-platform
-    - name: Validate inputs
-      shell: bash
-      env:
-        PLATFORM_REF: ${{ inputs.platform-ref }}
-        EXTRA_KEYS: ${{ inputs.extra-keys }}
-        EC_TDF_ENABLED: ${{ inputs.ec-tdf-enabled }}
-        PQC_ENABLED: ${{ inputs.pqc-enabled }}
-        LOG_LEVEL: ${{ inputs.log-level }}
-        LOG_TYPE: ${{ inputs.log-type }}
-        PROVISION_POLICY_FIXTURES: ${{ inputs.provision-policy-fixtures }}
-      run: |
-        # Validate platform-ref (safe characters only — prevents path/command injection)
-        if [[ ! "${PLATFORM_REF}" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
-          echo "Error: platform-ref must contain only alphanumeric characters, dots, underscores, hyphens, and forward slashes."
-          exit 1
-        fi
-
-        # Validate extra-keys (must be a valid JSON array)
-        if ! jq -e 'type == "array"' <<< "${EXTRA_KEYS}" > /dev/null 2>&1; then
-          echo "Error: extra-keys must be a valid JSON array."
-          exit 1
-        fi
-
-        # Validate ec-tdf-enabled (must be true or false)
-        case "${EC_TDF_ENABLED}" in
-          true|false)
-            ;;
-          *)
-            echo "Error: ec-tdf-enabled must be 'true' or 'false'."
-            exit 1
-            ;;
-        esac
-
-        # Validate pqc-enabled (must be true or false)
-        case "${PQC_ENABLED}" in
-          true|false)
-            ;;
-          *)
-            echo "Error: pqc-enabled must be 'true' or 'false'."
-            exit 1
-            ;;
-        esac
-
-        # Validate log-level (only allowed values)
-        case "${LOG_LEVEL}" in
-          audit|debug|info|warn|error)
-            ;;
-          *)
-            echo "Error: log-level must be one of: audit, debug, info, warn, error."
-            exit 1
-            ;;
-        esac
-
-        # Validate log-type (only allowed values)
-        case "${LOG_TYPE}" in
-          text|json)
-            ;;
-          *)
-            echo "Error: log-type must be one of: text, json."
-            exit 1
-            ;;
-        esac
-
-        # Validate provision-policy-fixtures (must be true or false)
-        case "${PROVISION_POLICY_FIXTURES}" in
-          true|false)
-            ;;
-          *)
-            echo "Error: provision-policy-fixtures must be 'true' or 'false'."
-            exit 1
-            ;;
-        esac
     - name: Configure logging
       shell: bash
       env:

--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -175,12 +175,49 @@ runs:
       run: |
         yq e '.services.kas.hybrid_tdf_enabled = true' -i opentdf.yaml
       working-directory: otdf-test-platform
-    - name: Validate logging inputs
+    - name: Validate inputs
       shell: bash
       env:
+        PLATFORM_REF: ${{ inputs.platform-ref }}
+        EXTRA_KEYS: ${{ inputs.extra-keys }}
+        EC_TDF_ENABLED: ${{ inputs.ec-tdf-enabled }}
+        PQC_ENABLED: ${{ inputs.pqc-enabled }}
         LOG_LEVEL: ${{ inputs.log-level }}
         LOG_TYPE: ${{ inputs.log-type }}
+        PROVISION_POLICY_FIXTURES: ${{ inputs.provision-policy-fixtures }}
       run: |
+        # Validate platform-ref (safe characters only — prevents path/command injection)
+        if [[ ! "${PLATFORM_REF}" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+          echo "Error: platform-ref must contain only alphanumeric characters, dots, underscores, hyphens, and forward slashes."
+          exit 1
+        fi
+
+        # Validate extra-keys (must be a valid JSON array)
+        if ! jq -e 'type == "array"' <<< "${EXTRA_KEYS}" > /dev/null 2>&1; then
+          echo "Error: extra-keys must be a valid JSON array."
+          exit 1
+        fi
+
+        # Validate ec-tdf-enabled (must be true or false)
+        case "${EC_TDF_ENABLED}" in
+          true|false)
+            ;;
+          *)
+            echo "Error: ec-tdf-enabled must be 'true' or 'false'."
+            exit 1
+            ;;
+        esac
+
+        # Validate pqc-enabled (must be true or false)
+        case "${PQC_ENABLED}" in
+          true|false)
+            ;;
+          *)
+            echo "Error: pqc-enabled must be 'true' or 'false'."
+            exit 1
+            ;;
+        esac
+
         # Validate log-level (only allowed values)
         case "${LOG_LEVEL}" in
           audit|debug|info|warn|error)
@@ -197,6 +234,16 @@ runs:
             ;;
           *)
             echo "Error: log-type must be one of: text, json."
+            exit 1
+            ;;
+        esac
+
+        # Validate provision-policy-fixtures (must be true or false)
+        case "${PROVISION_POLICY_FIXTURES}" in
+          true|false)
+            ;;
+          *)
+            echo "Error: provision-policy-fixtures must be 'true' or 'false'."
             exit 1
             ;;
         esac

--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -15,6 +15,10 @@ inputs:
     default: "false"
     description: 'Whether to enable ECC wrapping for TDFs'
     required: false
+  pqc-enabled:
+    default: "false"
+    description: 'Whether to enable post-quantum and hybrid PQ/T wrapping for TDFs'
+    required: false
   log-level:
     default: "debug"
     description: 'Log level for the platform (audit, debug, info, warn, error)'
@@ -164,6 +168,12 @@ runs:
       if: ${{ inputs.ec-tdf-enabled }}
       run: |
         yq e '.services.kas.ec_tdf_enabled = true' -i opentdf.yaml
+      working-directory: otdf-test-platform
+    - name: Enable PQ (mlkem, xwing, and hybrid) wrapping for TDFs
+      shell: bash
+      if: ${{ inputs.pqc-enabled }}
+      run: |
+        yq e '.services.kas.hybrid_tdf_enabled = true' -i opentdf.yaml
       working-directory: otdf-test-platform
     - name: Validate logging inputs
       shell: bash

--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -169,11 +169,13 @@ runs:
       run: |
         yq e '.services.kas.ec_tdf_enabled = true' -i opentdf.yaml
       working-directory: otdf-test-platform
-    - name: Enable PQ (mlkem, xwing, and hybrid) wrapping for TDFs
-      shell: bash
-      if: ${{ inputs.pqc-enabled }}
+      if: ${{ inputs.pqc-enabled == 'true' }}
       run: |
-        yq e '.services.kas.hybrid_tdf_enabled = true' -i opentdf.yaml
+        yq e '
+          (.services.kas.preview.hybrid_tdf_enabled = true)
+          | (.services.kas.keyring += [{"kid":"x1","alg":"hpqt:xwing"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024"}])
+          | (.server.cryptoProvider.standard.keys += [{"kid":"x1","alg":"hpqt:xwing","private":"kas-xwing-private.pem","cert":"kas-xwing-public.pem"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768","private":"kas-p256mlkem768-private.pem","cert":"kas-p256mlkem768-public.pem"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024","private":"kas-p384mlkem1024-private.pem","cert":"kas-p384mlkem1024-public.pem"}])
+        ' -i opentdf.yaml
       working-directory: otdf-test-platform
     - name: Validate inputs
       shell: bash


### PR DESCRIPTION

### Proposed Changes

* Adds `pqc-enabled` boolean parameter to `start-up-with-containers`
and `start-additional-kas` actions, which when set to true will enable
the post-quantum and hybrid PQ/T wrapping option for TDFs
in the KAS service.


### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added support for post-quantum cryptography (PQC) configuration in KAS startup actions with a new `pqc-enabled` input option (default: `false`).
* Enhanced input validation for cryptographic settings including the new PQC option.
* KAS instances can now be configured to enable hybrid post-quantum/TDF wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->