### PR TITLE
feat(core): Fix some authz issues.

### DIFF
--- a/service/internal/auth/authz/casbin/casbin_test.go
+++ b/service/internal/auth/authz/casbin/casbin_test.go
@@ -192,7 +192,7 @@ func (s *CasbinAuthorizerSuite) TestAuthorizeV2_DefaultPolicyIncludesDefaultRole
 		Action: "write",
 	}
 
-	decision, err := authorizer.Authorize(context.Background(), req)
+	decision, err := authorizer.Authorize(s.T().Context(), req)
 	s.Require().NoError(err)
 	s.Require().NotNil(decision)
 	s.True(decision.Allowed, "default v2 policy should map opentdf-admin to role:admin")

--- a/service/internal/auth/authz/casbin/casbin_test.go
+++ b/service/internal/auth/authz/casbin/casbin_test.go
@@ -169,6 +169,35 @@ func (s *CasbinAuthorizerSuite) TestAuthorizeV2_AdminWildcard() {
 	s.Equal(authz.ModeV2, decision.Mode)
 }
 
+func (s *CasbinAuthorizerSuite) TestAuthorizeV2_DefaultPolicyIncludesDefaultRoleGroupings() {
+	cfg := authz.Config{
+		Version: "v2",
+		PolicyConfig: authz.PolicyConfig{
+			GroupsClaim: "realm_access.roles",
+		},
+		Logger: s.logger,
+	}
+
+	authorizer, err := NewAuthorizer(cfg)
+	s.Require().NoError(err)
+
+	token := createTestToken(s.T(), map[string]interface{}{
+		"realm_access": map[string]interface{}{
+			"roles": []interface{}{"opentdf-admin"},
+		},
+	})
+	req := &authz.Request{
+		Token:  token,
+		RPC:    "/policy.attributes.AttributesService/UpdateAttribute",
+		Action: "write",
+	}
+
+	decision, err := authorizer.Authorize(context.Background(), req)
+	s.Require().NoError(err)
+	s.Require().NotNil(decision)
+	s.True(decision.Allowed, "default v2 policy should map opentdf-admin to role:admin")
+}
+
 func (s *CasbinAuthorizerSuite) TestAuthorizeV2_NamespaceScopedAccess() {
 	// Policy: hr-admin can only access HR namespace
 	cfg := authz.Config{

--- a/service/internal/auth/authz/casbin/policy.csv
+++ b/service/internal/auth/authz/casbin/policy.csv
@@ -13,10 +13,12 @@
 # Admin Role - Full Access
 # ============================================================================
 p, role:admin, *, *, allow
+g, role:opentdf-admin, role:admin
 
 # ============================================================================
 # Standard Role - Authenticated Users
 # ============================================================================
+g, role:opentdf-standard, role:standard
 
 # Discovery and health endpoints
 p, role:standard, /wellknownconfiguration.WellKnownService/*, *, allow

--- a/service/internal/auth/interceptor_authz_test.go
+++ b/service/internal/auth/interceptor_authz_test.go
@@ -5,12 +5,15 @@ import (
 	"strings"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/creasty/defaults"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/opentdf/platform/protocol/go/policy/attributes"
 	"github.com/opentdf/platform/service/internal/auth/authz"
 	_ "github.com/opentdf/platform/service/internal/auth/authz/casbin" // Register casbin authorizer
 	"github.com/opentdf/platform/service/logger"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
 )
 
 // InterceptorAuthzSuite tests the authorization flow through the interceptor
@@ -456,6 +459,47 @@ p, role:finance-admin, /policy.attributes.AttributesService/*, namespace=finance
 	s.True(decision.Allowed, "finance-admin should be allowed with namespace=finance dimension")
 }
 
+func (s *InterceptorAuthzSuite) TestAuthorizeV2_InvokesRegisteredResolver() {
+	csvPolicy := "p, role:hr-admin, /policy.attributes.AttributesService/*, namespace=hr, allow"
+	registry := authz.NewResolverRegistry()
+	scopedRegistry := registry.ScopedForService(&grpc.ServiceDesc{
+		ServiceName: "policy.attributes.AttributesService",
+		Methods: []grpc.MethodDesc{
+			{MethodName: "UpdateAttribute"},
+		},
+	})
+
+	resolverCalled := false
+	scopedRegistry.MustRegister("UpdateAttribute", func(_ context.Context, _ connect.AnyRequest) (authz.ResolverContext, error) {
+		resolverCalled = true
+		resolverCtx := authz.NewResolverContext()
+		res := resolverCtx.NewResource()
+		res.AddDimension("namespace", "hr")
+		resolverCtx.SetResolvedData("attribute", "resolved")
+		return resolverCtx, nil
+	})
+
+	authn := &Authentication{
+		logger:                s.logger,
+		authorizer:            s.createV2Authorizer(csvPolicy),
+		authzResolverRegistry: registry,
+	}
+
+	req := &authzTestRequest{
+		Request:   connect.NewRequest(&attributes.GetAttributeRequest{}),
+		procedure: "/policy.attributes.AttributesService/UpdateAttribute",
+	}
+
+	result := authn.authorize(s.T().Context(), s.logger, s.newTokenWithRoles("hr-admin"), req, ActionWrite)
+
+	s.Require().NoError(result.err)
+	s.Require().NotNil(result.decision)
+	s.True(result.decision.Allowed)
+	s.True(resolverCalled, "registered resolver should be invoked")
+	s.Require().NotNil(result.resourceContext)
+	s.Equal("resolved", result.resourceContext.GetResolvedData("attribute"))
+}
+
 func (s *InterceptorAuthzSuite) TestV2_EmptyToken() {
 	csvPolicy := "p, role:admin, *, *, allow"
 	authorizer := s.createV2Authorizer(csvPolicy)
@@ -473,6 +517,15 @@ func (s *InterceptorAuthzSuite) TestV2_EmptyToken() {
 	s.Require().NotNil(decision)
 	// Should be denied because no matching role (defaults to unknown)
 	s.False(decision.Allowed, "empty token should be denied")
+}
+
+type authzTestRequest struct {
+	*connect.Request[attributes.GetAttributeRequest]
+	procedure string
+}
+
+func (r *authzTestRequest) Spec() connect.Spec {
+	return connect.Spec{Procedure: r.procedure}
 }
 
 // =============================================================================

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opentdf/platform/sdk"
 	sdkAudit "github.com/opentdf/platform/sdk/audit"
 	"github.com/opentdf/platform/service/internal/auth"
+	"github.com/opentdf/platform/service/internal/auth/authz"
 	"github.com/opentdf/platform/service/internal/security"
 	"github.com/opentdf/platform/service/internal/server/memhttp"
 	"github.com/opentdf/platform/service/logger"
@@ -70,6 +71,9 @@ type Config struct {
 	EnablePprof bool `mapstructure:"enable_pprof" json:"enable_pprof" default:"false"`
 	// Trace is for configuring open telemetry based tracing.
 	Trace tracing.Config `mapstructure:"trace" json:"trace"`
+
+	// AuthzResolverRegistry contains service-registered resolvers used by the auth interceptor.
+	AuthzResolverRegistry *authz.ResolverRegistry `mapstructure:"-" json:"-"`
 }
 
 func (c Config) LogValue() slog.Value {
@@ -265,6 +269,7 @@ func NewOpenTDFServer(config Config, logger *logger.Logger, cacheManager *cache.
 			config.Auth,
 			logger,
 			config.WellKnownConfigRegister,
+			auth.WithAuthzResolverRegistry(config.AuthzResolverRegistry),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create authentication interceptor: %w", err)
@@ -352,7 +357,8 @@ func newHTTPServer(c Config, connectRPC http.Handler, extraHTTP http.Handler, a 
 		effectiveExposed := c.CORS.EffectiveExposedHeaders()
 
 		// Log effective CORS config for operator visibility
-		l.Info("CORS middleware enabled",
+		l.Info(
+			"CORS middleware enabled",
 			slog.Any("allowed_origins", c.CORS.AllowedOrigins),
 			slog.Any("effective_methods", effectiveMethods),
 			slog.Any("effective_headers", effectiveHeaders),

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -189,6 +189,11 @@ func Start(f ...StartOptions) error {
 		cfg.Server.CORS.AdditionalExposedHeaders = append(cfg.Server.CORS.AdditionalExposedHeaders, startConfig.additionalCORSExposedHeaders...)
 	}
 
+	// Create the global authz resolver registry before the server/authenticator.
+	// Services receive scoped views of this same registry during startup.
+	authzResolverRegistry := authz.NewResolverRegistry()
+	cfg.Server.AuthzResolverRegistry = authzResolverRegistry
+
 	// Create new server for grpc & http. Also will support in process grpc potentially too
 	logger.Debug("initializing opentdf server")
 	cfg.Server.WellKnownConfigRegister = wellknown.RegisterConfiguration
@@ -282,10 +287,6 @@ func Start(f ...StartOptions) error {
 	}
 
 	defer client.Close()
-
-	// Create the global authz resolver registry
-	// Services will receive scoped registries that can only register resolvers for their own methods
-	authzResolverRegistry := authz.NewResolverRegistry()
 
 	logger.Info("starting services")
 	err = startServices(ctx, startServicesParams{


### PR DESCRIPTION
 ## Summary

  Step 1 production-readiness security changes for PR #2999.

  This wires the authz resolver registry into the server authenticator path so v2 authorization can resolve request-specific resource dimensions during interceptor authorization. It also adds default
  Casbin v2 grouping statements for the built-in admin and standard roles, without reintroducing deprecated `RoleMap` behavior.

  ## Changes

  - Pass `AuthzResolverRegistry` from server startup into `auth.NewAuthenticator`
  - Share the same resolver registry between service registration and auth enforcement
  - Add built-in v2 Casbin grouping statements:
    - `role:opentdf-admin -> role:admin`
    - `role:opentdf-standard -> role:standard`
  - Add unit coverage proving:
    - registered authz resolvers are invoked by v2 authorization
    - resolved resource context is passed into authorization
    - default v2 policy allows `opentdf-admin` through grouping statements

  ## Verification

  Ran:

  ```sh
  go test ./service/internal/auth/... ./service/internal/server/... ./service/pkg/server/...
```
  Also ran targeted tests for resolver invocation and default role grouping behavior.

  ## Notes

  Customer policy override behavior is preserved. A customer can still replace the built-in Casbin policy with server.auth.policy.csv and omit the default opentdf-admin role mapping if they do not want
  that role.