### PR TITLE
feat(core): Add kas registry key authz tests.

### DIFF
--- a/service/internal/auth/authz/casbin/casbin.go
+++ b/service/internal/auth/authz/casbin/casbin.go
@@ -31,6 +31,8 @@ var builtinPolicyV2 string
 const (
 	// rolePrefix is the prefix for role subjects in casbin policies.
 	rolePrefix = "role:"
+	// clientPrefix is the prefix for client subjects in casbin policies.
+	clientPrefix = "client:"
 	// disallowedDimensionKeyChars are separators used in dimension serialization.
 	disallowedDimensionKeyChars = "=&"
 	// defaultRole is the role assigned when no roles are found.
@@ -276,8 +278,8 @@ func (a *Authorizer) authorizeV1(ctx context.Context, req *authz.Request) (*auth
 }
 
 // authorizeV2 performs RPC+dimensions authorization.
-func (a *Authorizer) authorizeV2(_ context.Context, req *authz.Request) (*authz.Decision, error) {
-	subjects := a.extractSubjects(req)
+func (a *Authorizer) authorizeV2(ctx context.Context, req *authz.Request) (*authz.Decision, error) {
+	subjects := a.extractSubjects(ctx, req)
 
 	// If no subjects found, use default role
 	if len(subjects) == 0 {
@@ -358,7 +360,7 @@ func (a *Authorizer) authorizeV2(_ context.Context, req *authz.Request) (*authz.
 }
 
 // extractSubjects extracts roles/username from JWT token and userInfo.
-func (a *Authorizer) extractSubjects(req *authz.Request) []string {
+func (a *Authorizer) extractSubjects(ctx context.Context, req *authz.Request) []string {
 	if a.v1Enforcer != nil { // ? What's the point of this
 		// Reuse v1 subject extraction logic
 		return a.v1Enforcer.BuildSubjectFromTokenAndUserInfo(req.Token, req.UserInfo)
@@ -380,6 +382,9 @@ func (a *Authorizer) extractSubjects(req *authz.Request) []string {
 		if username := a.extractUsernameFromToken(req.Token); username != "" {
 			subjects = append(subjects, username)
 		}
+		if clientID := a.extractClientIDFromToken(ctx, req.Token); clientID != "" {
+			subjects = append(subjects, clientPrefix+clientID)
+		}
 	}
 
 	// Extract roles from userInfo
@@ -393,6 +398,25 @@ func (a *Authorizer) extractSubjects(req *authz.Request) []string {
 	}
 
 	return subjects
+}
+
+// extractClientIDFromToken extracts the client ID subject from the configured token claim.
+func (a *Authorizer) extractClientIDFromToken(ctx context.Context, token jwt.Token) string {
+	if token == nil || a.baseConfig.ClientIDClaim == "" {
+		return ""
+	}
+
+	claimMap, err := token.AsMap(ctx)
+	if err != nil {
+		return ""
+	}
+	found := util.Dotnotation(claimMap, a.baseConfig.ClientIDClaim)
+	clientID, ok := found.(string)
+	if !ok || clientID == "" {
+		return ""
+	}
+
+	return clientID
 }
 
 // extractUsernameFromToken extracts and validates username subject from token.

--- a/service/internal/auth/authz/casbin/casbin_test.go
+++ b/service/internal/auth/authz/casbin/casbin_test.go
@@ -403,6 +403,39 @@ func (s *CasbinAuthorizerSuite) TestAuthorizeV2_UsernameWithRolePrefixIsIgnored(
 	s.False(decision.Allowed, "username with reserved role prefix must not match role subjects")
 }
 
+func (s *CasbinAuthorizerSuite) TestAuthorizeV2_ClientIDPolicy() {
+	cfg := authz.Config{
+		Version: "v2",
+		PolicyConfig: authz.PolicyConfig{
+			ClientIDClaim: "client_id",
+			Csv:           `p, client:test-client, /policy.attributes.AttributesService/Get*, *, allow`,
+		},
+		Logger: s.logger,
+	}
+
+	authorizer, err := NewAuthorizer(cfg)
+	s.Require().NoError(err)
+
+	token := createTestToken(s.T(), map[string]interface{}{
+		"client_id": "test-client",
+	})
+
+	req := &authz.Request{
+		Token: token,
+		RPC:   "/policy.attributes.AttributesService/GetAttribute",
+	}
+
+	decision, err := authorizer.Authorize(s.T().Context(), req)
+	s.Require().NoError(err)
+	s.True(decision.Allowed, "client policy should allow matching client ID")
+	s.Equal("client:test-client", decision.MatchedPolicy)
+
+	req.RPC = "/policy.attributes.AttributesService/CreateAttribute"
+	decision, err = authorizer.Authorize(s.T().Context(), req)
+	s.Require().NoError(err)
+	s.False(decision.Allowed, "client policy should deny unmatched RPC")
+}
+
 func (s *CasbinAuthorizerSuite) TestAuthorizeV2_KASRESTfulPathsAllowed() {
 	// v2 uses leading slashes for ALL paths (both gRPC and HTTP)
 	// This test ensures KAS RESTful paths work in v2 authorization

--- a/service/internal/auth/authz/casbin/policy.csv
+++ b/service/internal/auth/authz/casbin/policy.csv
@@ -37,8 +37,6 @@ p, role:standard, /policy.subjectmapping.SubjectMappingService/List*, *, allow
 p, role:standard, /policy.subjectmapping.SubjectMappingService/Match*, *, allow
 p, role:standard, /policy.resourcemapping.ResourceMappingService/Get*, *, allow
 p, role:standard, /policy.resourcemapping.ResourceMappingService/List*, *, allow
-p, role:standard, /policy.kasregistry.KeyAccessServerRegistryService/Get*, *, allow
-p, role:standard, /policy.kasregistry.KeyAccessServerRegistryService/List*, *, allow
 
 # Authorization service
 p, role:standard, /authorization.AuthorizationService/*, *, allow

--- a/service/internal/auth/authz/casbin/policy.csv
+++ b/service/internal/auth/authz/casbin/policy.csv
@@ -1,7 +1,7 @@
 # Casbin Policy v2 - RPC + Dimensions Authorization
 #
 # Format: p, subject, rpc, dimensions, effect
-#   - subject: role:rolename or username
+#   - subject: role:rolename, client:client-id, or username
 #   - rpc: gRPC method path or HTTP path (supports * wildcard)
 #   - dimensions: namespace=value&attribute=value (supports * wildcard)
 #   - effect: allow or deny

--- a/service/internal/auth/casbin.go
+++ b/service/internal/auth/casbin.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	rolePrefix          = "role:"
+	clientPrefix        = "client:"
 	defaultRole         = "unknown"
 	ErrPermissionDenied = errors.New("permission denied")
 )
@@ -218,7 +219,26 @@ func (e *Enforcer) buildSubjectFromToken(ctx context.Context, t jwt.Token, req a
 			subject = ""
 		}
 	}
+	if clientID := clientIDFromToken(ctx, t, e.Config.ClientIDClaim); clientID != "" {
+		info = append(info, clientPrefix+clientID)
+	}
 	info = append(info, roles...)
 	info = append(info, subject)
 	return info, append([]string(nil), roles...), nil
+}
+
+func clientIDFromToken(ctx context.Context, t jwt.Token, claimName string) string {
+	if t == nil || claimName == "" {
+		return ""
+	}
+	claims, err := t.AsMap(ctx)
+	if err != nil {
+		return ""
+	}
+	found := dotNotation(claims, claimName)
+	clientID, ok := found.(string)
+	if !ok || clientID == "" {
+		return ""
+	}
+	return clientID
 }

--- a/service/internal/auth/casbin_policy.csv
+++ b/service/internal/auth/casbin_policy.csv
@@ -1,4 +1,6 @@
+## Subjects
 ## Roles (prefixed with role:)
+## Clients (prefixed with client:)
 # admin - admin
 # standard - standard
 # unknown - unknown role or no role

--- a/service/internal/auth/casbin_test.go
+++ b/service/internal/auth/casbin_test.go
@@ -546,6 +546,32 @@ func (s *AuthnCasbinSuite) Test_Username_Policy() {
 	s.False(allowed)
 }
 
+func (s *AuthnCasbinSuite) Test_ClientID_Policy() {
+	policyCfg := PolicyConfig{}
+	err := defaults.Set(&policyCfg)
+	s.Require().NoError(err)
+
+	policyCfg.ClientIDClaim = "client_id"
+	policyCfg.Extension = strings.Join([]string{
+		"p, client:test-client, new.service.*, read, allow",
+	}, "\n")
+
+	enforcer, err := NewCasbinEnforcer(CasbinConfig{PolicyConfig: policyCfg}, logger.CreateTestLogger())
+	s.Require().NoError(err)
+
+	tok := jwt.New()
+	err = tok.Set("client_id", "test-client")
+	s.Require().NoError(err)
+
+	allowed, err := s.enforce(enforcer, tok, "new.service.DoSomething", "read")
+	s.Require().NoError(err)
+	s.True(allowed)
+
+	allowed, err = s.enforce(enforcer, tok, "policy.attributes.List", "read")
+	s.Require().Error(err)
+	s.False(allowed)
+}
+
 type staticProvider struct {
 	roles []string
 	err   error

--- a/service/policy/attributes/attributes.go
+++ b/service/policy/attributes/attributes.go
@@ -92,18 +92,6 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 				}
 				as.cache = resolverCache
 
-				// Register authz resolvers per-method
-				// Each resolver extracts authorization dimensions from the request, performing DB lookups as needed.
-				// The resolver is called by the auth interceptor before the handler.
-				if srp.AuthzResolverRegistry != nil {
-					srp.AuthzResolverRegistry.MustRegister("CreateAttribute", as.createAttributeAuthzResolver)
-					srp.AuthzResolverRegistry.MustRegister("GetAttribute", as.getAttributeAuthzResolver)
-					srp.AuthzResolverRegistry.MustRegister("GetAttributeValuesByFqns", as.getAttributeValuesByFqnsAuthzResolver)
-					srp.AuthzResolverRegistry.MustRegister("ListAttributes", as.listAttributesAuthzResolver)
-					srp.AuthzResolverRegistry.MustRegister("UpdateAttribute", as.updateAttributeAuthzResolver)
-					srp.AuthzResolverRegistry.MustRegister("DeactivateAttribute", as.deactivateAttributeAuthzResolver)
-				}
-
 				return as, nil
 			},
 		},

--- a/service/policy/kasregistry/authz_resolver.go
+++ b/service/policy/kasregistry/authz_resolver.go
@@ -1,0 +1,84 @@
+package kasregistry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"github.com/opentdf/platform/protocol/go/policy"
+	kasr "github.com/opentdf/platform/protocol/go/policy/kasregistry"
+	"github.com/opentdf/platform/service/internal/auth/authz"
+)
+
+const (
+	authzDimensionKasURI = "kas_uri"
+	// resolverCacheKeyKasKey is the key used to cache a resolved KAS key in the authz resolver context.
+	resolverCacheKeyKasKey = "kas_key"
+)
+
+var (
+	errUnexpectedGetKeyAuthzRequestType = errors.New("unexpected GetKey authz request type")
+	errResolvedKasURIEmpty              = errors.New("resolved KAS URI is empty")
+	errKeyIdentifierRequired            = errors.New("key identifier is required")
+	errKeyIDRequired                    = errors.New("key id is required")
+	errUnsupportedGetKeyIdentifier      = errors.New("unsupported GetKey identifier")
+	errResolveKasKeyForAuthz            = errors.New("failed to resolve KAS key for authz")
+	errResolvedKasKeyNil                = errors.New("resolved KAS key is nil")
+)
+
+type getKeyAuthzDBClient interface {
+	GetKey(context.Context, any) (*policy.KasKey, error)
+}
+
+func (s KeyAccessServerRegistry) getKeyAuthzResolver(ctx context.Context, req connect.AnyRequest) (authz.ResolverContext, error) {
+	resolverCtx := authz.NewResolverContext()
+
+	msg, ok := req.Any().(*kasr.GetKeyRequest)
+	if !ok {
+		return resolverCtx, fmt.Errorf("%w: %T", errUnexpectedGetKeyAuthzRequestType, req.Any())
+	}
+
+	kasURI, err := resolveGetKeyKasURI(ctx, msg, &resolverCtx, s.dbClient)
+	if err != nil {
+		return resolverCtx, err
+	}
+	if kasURI == "" {
+		return resolverCtx, errResolvedKasURIEmpty
+	}
+
+	res := resolverCtx.NewResource()
+	res.AddDimension(authzDimensionKasURI, kasURI)
+
+	return resolverCtx, nil
+}
+
+func resolveGetKeyKasURI(ctx context.Context, msg *kasr.GetKeyRequest, resolverCtx *authz.ResolverContext, dbClient getKeyAuthzDBClient) (string, error) {
+	switch identifier := msg.GetIdentifier().(type) {
+	case *kasr.GetKeyRequest_Key:
+		keyIdentifier := identifier.Key
+		if keyIdentifier == nil {
+			return "", errKeyIdentifierRequired
+		}
+		if uri := keyIdentifier.GetUri(); uri != "" {
+			return uri, nil
+		}
+	case *kasr.GetKeyRequest_Id:
+		if identifier.Id == "" {
+			return "", errKeyIDRequired
+		}
+	default:
+		return "", errUnsupportedGetKeyIdentifier
+	}
+
+	key, err := dbClient.GetKey(ctx, msg.GetIdentifier())
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", errResolveKasKeyForAuthz, err)
+	}
+	if key == nil {
+		return "", fmt.Errorf("%w: %w", errResolveKasKeyForAuthz, errResolvedKasKeyNil)
+	}
+
+	resolverCtx.SetResolvedData(resolverCacheKeyKasKey, key)
+	return key.GetKasUri(), nil
+}

--- a/service/policy/kasregistry/authz_resolver_test.go
+++ b/service/policy/kasregistry/authz_resolver_test.go
@@ -1,0 +1,80 @@
+package kasregistry
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
+	"github.com/opentdf/platform/service/internal/auth/authz"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeGetKeyAuthzDBClient struct {
+	key        *policy.KasKey
+	err        error
+	identifier any
+}
+
+func (f *fakeGetKeyAuthzDBClient) GetKey(_ context.Context, identifier any) (*policy.KasKey, error) {
+	f.identifier = identifier
+	return f.key, f.err
+}
+
+func TestGetKeyAuthzResolver_UsesRequestURI(t *testing.T) {
+	const kasURI = "https://kas-a.example.com"
+	svc := KeyAccessServerRegistry{}
+
+	resolverCtx, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.GetKeyRequest{
+		Identifier: &kasregistry.GetKeyRequest_Key{
+			Key: &kasregistry.KasKeyIdentifier{
+				Identifier: &kasregistry.KasKeyIdentifier_Uri{Uri: kasURI},
+				Kid:        validKeyID,
+			},
+		},
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, resolverCtx.Resources, 1)
+	require.Equal(t, kasURI, (*resolverCtx.Resources[0])[authzDimensionKasURI])
+	require.Nil(t, resolverCtx.GetResolvedData(resolverCacheKeyKasKey))
+}
+
+func TestGetKeyAuthzResolver_UsesPolicyDBClientAndCachesResolvedKey(t *testing.T) {
+	const kasURI = "https://kas-a.example.com"
+	identifier := &kasregistry.GetKeyRequest_Id{Id: validUUID}
+	key := &policy.KasKey{
+		KasUri: kasURI,
+		Key: &policy.AsymmetricKey{
+			KeyId: validKeyID,
+		},
+	}
+	dbClient := &fakeGetKeyAuthzDBClient{key: key}
+	resolverCtx := authz.NewResolverContext()
+
+	resolvedURI, err := resolveGetKeyKasURI(t.Context(), &kasregistry.GetKeyRequest{
+		Identifier: identifier,
+	}, &resolverCtx, dbClient)
+
+	require.NoError(t, err)
+	require.Equal(t, kasURI, resolvedURI)
+	require.Same(t, identifier, dbClient.identifier)
+	require.Same(t, key, resolverCtx.GetResolvedData(resolverCacheKeyKasKey))
+}
+
+func TestGetKeyAuthzResolver_InvalidRequestType(t *testing.T) {
+	svc := KeyAccessServerRegistry{}
+
+	_, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.ListKeysRequest{}))
+
+	require.ErrorIs(t, err, errUnexpectedGetKeyAuthzRequestType)
+}
+
+func TestGetKeyAuthzResolver_UnsupportedIdentifier(t *testing.T) {
+	svc := KeyAccessServerRegistry{}
+
+	_, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.GetKeyRequest{}))
+
+	require.ErrorIs(t, err, errUnsupportedGetKeyIdentifier)
+}

--- a/service/policy/kasregistry/key_access_server_registry.go
+++ b/service/policy/kasregistry/key_access_server_registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy"
 	kasr "github.com/opentdf/platform/protocol/go/policy/kasregistry"
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry/kasregistryconnect"
+	"github.com/opentdf/platform/service/internal/auth/authz"
 	"github.com/opentdf/platform/service/logger"
 	"github.com/opentdf/platform/service/logger/audit"
 	"github.com/opentdf/platform/service/pkg/config"
@@ -76,6 +77,10 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 				if err = kasrSvc.dbClient.SetBaseKeyOnWellKnownConfig(context.TODO()); err != nil {
 					logger.Error("error setting well-known config", slog.String("error", err.Error()))
 					panic(err)
+				}
+
+				if srp.AuthzResolverRegistry != nil {
+					srp.AuthzResolverRegistry.MustRegister("GetKey", kasrSvc.getKeyAuthzResolver)
 				}
 
 				kasrSvc.config = cfg
@@ -337,10 +342,14 @@ func (s KeyAccessServerRegistry) GetKey(ctx context.Context, r *connect.Request[
 		ObjectType: audit.ObjectTypeKasRegistryKeys,
 	}
 
-	key, err := s.dbClient.GetKey(ctx, r.Msg.GetIdentifier())
-	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("key_access_server_keys", r.Msg.String()))
+	key, ok := authz.GetResolvedDataFromContext(ctx, resolverCacheKeyKasKey).(*policy.KasKey)
+	if !ok || key == nil {
+		var err error
+		key, err = s.dbClient.GetKey(ctx, r.Msg.GetIdentifier())
+		if err != nil {
+			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
+			return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("key_access_server_keys", r.Msg.String()))
+		}
 	}
 
 	auditParams.ObjectID = key.GetKey().GetKeyId()

--- a/tests-bdd/cukes/resources/keycloak_authz_v2.template
+++ b/tests-bdd/cukes/resources/keycloak_authz_v2.template
@@ -1,0 +1,91 @@
+baseUrl: &baseUrl http://{{.hostname}}:{{.kcPort}}
+serverBaseUrl: &serverBaseUrl http://{{.hostname}}:{{.platformPort}}
+customAudMapper: &customAudMapper
+  name: audience-mapper
+  protocol: openid-connect
+  protocolMapper: oidc-audience-mapper
+  config:
+    included.custom.audience: *serverBaseUrl
+    access.token.claim: "true"
+    id.token.claim: "true"
+realms:
+  - realm_repepresentation:
+      realm: {{.realm}}
+      enabled: true
+    custom_realm_roles:
+      - name: opentdf-admin
+      - name: opentdf-standard
+      - name: custom-non-admin
+      - name: kas-a
+      - name: kas-b
+    clients:
+      - client:
+          clientID: opentdf
+          enabled: true
+          name: opentdf
+          serviceAccountsEnabled: true
+          clientAuthenticatorType: client-secret
+          secret: secret
+          protocolMappers:
+            - *customAudMapper
+        sa_realm_roles:
+          - opentdf-admin
+      - client:
+          clientID: opentdf-sdk
+          enabled: true
+          name: opentdf-sdk
+          serviceAccountsEnabled: true
+          clientAuthenticatorType: client-secret
+          secret: secret
+          protocolMappers:
+            - *customAudMapper
+        sa_realm_roles:
+          - opentdf-standard
+      - client:
+          clientID: opentdf-custom
+          enabled: true
+          name: opentdf-custom
+          serviceAccountsEnabled: true
+          clientAuthenticatorType: client-secret
+          secret: secret
+          protocolMappers:
+            - *customAudMapper
+        sa_realm_roles:
+          - custom-non-admin
+      - client:
+          clientID: kas-a
+          enabled: true
+          name: kas-a
+          serviceAccountsEnabled: true
+          clientAuthenticatorType: client-secret
+          secret: secret
+          protocolMappers:
+            - *customAudMapper
+        sa_realm_roles:
+          - kas-a
+      - client:
+          clientID: kas-b
+          enabled: true
+          name: kas-b
+          serviceAccountsEnabled: true
+          clientAuthenticatorType: client-secret
+          secret: secret
+          protocolMappers:
+            - *customAudMapper
+        sa_realm_roles:
+          - kas-b
+      - client:
+          clientID: tdf-entity-resolution
+          enabled: true
+          name: tdf-entity-resolution
+          serviceAccountsEnabled: true
+          clientAuthenticatorType: client-secret
+          secret: secret
+          protocolMappers:
+            - *customAudMapper
+        sa_client_roles:
+          realm-management:
+            - view-clients
+            - query-clients
+            - view-users
+            - query-users

--- a/tests-bdd/cukes/resources/platform.authz_v2.template
+++ b/tests-bdd/cukes/resources/platform.authz_v2.template
@@ -1,0 +1,120 @@
+# Authz v2 BDD platform template using the embedded default v2 Casbin policy.
+logger:
+  level: debug
+  type: text
+  output: stderr
+mode: all
+db:
+  host: {{ .pgHost }}
+  port: {{ .pgPort }}
+  database: {{ .pgDatabase }}
+  user: postgres
+  password: changeme
+  schema: otdf
+services:
+  kas:
+    registered_kas_uri: http://{{ .hostname }}:{{ .platformPort }}
+    preview:
+      ec_tdf_enabled: false
+      key_management: false
+    root_key: a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1
+    keyring:
+      - kid: e1
+        alg: ec:secp256r1
+      - kid: e1
+        alg: ec:secp256r1
+        legacy: true
+      - kid: r1
+        alg: rsa:2048
+      - kid: r1
+        alg: rsa:2048
+        legacy: true
+  entityresolution:
+    log_level: info
+    url: http://{{ .hostname }}:{{ .kcPort }}/auth
+    clientid: "tdf-entity-resolution"
+    clientsecret: "secret"
+    realm: "{{ .authRealm }}"
+    legacykeycloak: true
+    inferid:
+      from:
+        email: true
+        username: true
+server:
+  public_hostname: {{ .hostname }}
+  tls:
+    enabled: false
+    cert: ./keys/platform.crt
+    key: ./keys/platform-key.pem
+  auth:
+    enabled: true
+    enforceDPoP: false
+    audience: "http://{{ .hostname }}:{{ .platformPort }}"
+    issuer: http://{{ .hostname }}:{{ .kcPort }}/auth/realms/{{ .authRealm }}
+    policy:
+      version: v2
+      username_claim:
+      groups_claim: realm_access.roles
+      client_id_claim:
+      csv:
+      extension: |
+        # KAS key read access for BDD-specific service-account roles.
+        g, role:kas-a, role:kas-a
+        g, role:kas-b, role:kas-b
+        p, role:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-a.example.com, allow
+        p, role:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-a.example.com, allow
+        p, role:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-b.example.com, allow
+        p, role:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-b.example.com, allow
+      model:
+  trace:
+    enabled: false
+    provider:
+      name: file
+      file:
+        path: "./traces/traces.log"
+        prettyPrint: true
+        maxSize: 50
+        maxBackups: 5
+        maxAge: 14
+        compress: true
+  cors:
+    enabled: true
+    allowedorigins:
+      - "*"
+    allowedmethods:
+      - GET
+      - POST
+      - PATCH
+      - PUT
+      - DELETE
+      - OPTIONS
+    allowedheaders:
+      - Accept
+      - Accept-Encoding
+      - Authorization
+      - Connect-Protocol-Version
+      - Content-Length
+      - Content-Type
+      - Dpop
+      - X-CSRF-Token
+      - X-Requested-With
+      - X-Rewrap-Additional-Context
+    exposedheaders:
+      - Link
+    allowcredentials: true
+    maxage: 3600
+  grpc:
+    reflectionEnabled: true
+  cryptoProvider:
+    type: standard
+    standard:
+      keys:
+        - kid: r1
+          alg: rsa:2048
+          private: {{ .platformKeysDir }}/kas-private.pem
+          cert: {{ .platformKeysDir }}/kas-cert.pem
+        - kid: e1
+          alg: ec:secp256r1
+          private: {{ .platformKeysDir }}/kas-ec-private.pem
+          cert: {{ .platformKeysDir }}/kas-ec-cert.pem
+  port: {{ .platformPort }}

--- a/tests-bdd/cukes/resources/platform.authz_v2.template
+++ b/tests-bdd/cukes/resources/platform.authz_v2.template
@@ -55,16 +55,12 @@ server:
       version: v2
       username_claim:
       groups_claim: realm_access.roles
-      client_id_claim:
+      client_id_claim: client_id
       csv:
       extension: |
         # KAS key read access for BDD-specific service-account roles.
-        g, role:kas-a, role:kas-a
-        g, role:kas-b, role:kas-b
-        p, role:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-a.example.com, allow
-        p, role:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-a.example.com, allow
-        p, role:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-b.example.com, allow
-        p, role:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-b.example.com, allow
+        p, client:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-a.example.com, allow
+        p, client:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-b.example.com, allow
       model:
   trace:
     enabled: false

--- a/tests-bdd/cukes/steps_kasregistry.go
+++ b/tests-bdd/cukes/steps_kasregistry.go
@@ -1,0 +1,112 @@
+package cukes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cucumber/godog"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
+)
+
+const bddKasPublicKeyCtx = `YS1wZW0K`
+
+type KasRegistryStepDefinitions struct{}
+
+func (s *KasRegistryStepDefinitions) iCreateKASKeys(ctx context.Context, tbl *godog.Table) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	scenarioContext.ClearError()
+
+	for i, row := range tbl.Rows {
+		if i == 0 {
+			continue
+		}
+		if len(row.Cells) < 2 {
+			return ctx, fmt.Errorf("expected kas_uri and key_id columns")
+		}
+
+		kasURI := normalizeKASURI(row.Cells[0].Value)
+		keyID := row.Cells[1].Value
+
+		kasResp, err := scenarioContext.SDK.KeyAccessServerRegistry.CreateKeyAccessServer(ctx, &kasregistry.CreateKeyAccessServerRequest{
+			Uri:        kasURI,
+			Name:       keyID,
+			SourceType: policy.SourceType_SOURCE_TYPE_EXTERNAL,
+		})
+		scenarioContext.SetError(err)
+		if err != nil {
+			return ctx, err
+		}
+		if kasResp == nil || kasResp.GetKeyAccessServer() == nil {
+			return ctx, fmt.Errorf("create KAS response was nil for %q", keyID)
+		}
+
+		keyResp, err := scenarioContext.SDK.KeyAccessServerRegistry.CreateKey(ctx, &kasregistry.CreateKeyRequest{
+			KasId:        kasResp.GetKeyAccessServer().GetId(),
+			KeyId:        keyID,
+			KeyAlgorithm: policy.Algorithm_ALGORITHM_EC_P256,
+			KeyMode:      policy.KeyMode_KEY_MODE_PUBLIC_KEY_ONLY,
+			PublicKeyCtx: &policy.PublicKeyCtx{
+				Pem: bddKasPublicKeyCtx,
+			},
+		})
+		scenarioContext.SetError(err)
+		if err != nil {
+			return ctx, err
+		}
+		if keyResp == nil || keyResp.GetKasKey() == nil || keyResp.GetKasKey().GetKey() == nil {
+			return ctx, fmt.Errorf("create KAS key response was nil for %q", keyID)
+		}
+
+		scenarioContext.RecordObject(keyID, keyResp.GetKasKey().GetKey().GetId())
+		scenarioContext.RecordObject(keyID+"_kas_uri", kasURI)
+		scenarioContext.RecordObject(keyID+"_kas_id", kasResp.GetKeyAccessServer().GetId())
+	}
+
+	return ctx, nil
+}
+
+func (s *KasRegistryStepDefinitions) iGetKASKey(ctx context.Context, keyID string) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	kasURI, ok := scenarioContext.GetObject(keyID + "_kas_uri").(string)
+	if !ok {
+		return ctx, fmt.Errorf("unable to extract KAS URI for %q", keyID)
+	}
+
+	scenarioContext.ClearError()
+	_, err := scenarioContext.SDK.KeyAccessServerRegistry.GetKey(ctx, &kasregistry.GetKeyRequest{
+		Identifier: &kasregistry.GetKeyRequest_Key{
+			Key: &kasregistry.KasKeyIdentifier{
+				Identifier: &kasregistry.KasKeyIdentifier_Uri{Uri: kasURI},
+				Kid:        keyID,
+			},
+		},
+	})
+	scenarioContext.SetError(err)
+	return ctx, nil
+}
+
+func (s *KasRegistryStepDefinitions) iListKASKeysForURI(ctx context.Context, kasURI string) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	scenarioContext.ClearError()
+	_, err := scenarioContext.SDK.KeyAccessServerRegistry.ListKeys(ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasUri{KasUri: normalizeKASURI(kasURI)},
+	})
+	scenarioContext.SetError(err)
+	return ctx, nil
+}
+
+func normalizeKASURI(uri string) string {
+	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
+		return uri
+	}
+	return "https://" + uri
+}
+
+func RegisterKasRegistryStepDefinitions(ctx *godog.ScenarioContext) {
+	stepDefinitions := KasRegistryStepDefinitions{}
+	ctx.Step(`^I create KAS keys:$`, stepDefinitions.iCreateKASKeys)
+	ctx.Step(`^I send a request to get KAS key "([^"]*)"$`, stepDefinitions.iGetKASKey)
+	ctx.Step(`^I send a request to list KAS keys for URI "([^"]*)"$`, stepDefinitions.iListKASKeysForURI)
+}

--- a/tests-bdd/cukes/steps_kasregistry.go
+++ b/tests-bdd/cukes/steps_kasregistry.go
@@ -2,6 +2,7 @@ package cukes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,10 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
 )
 
-const bddKasPublicKeyCtx = `YS1wZW0K`
+const (
+	bddKasPublicKeyCtx    = `YS1wZW0K`
+	expectedKASKeyColumns = 2
+)
 
 type KasRegistryStepDefinitions struct{}
 
@@ -22,8 +26,8 @@ func (s *KasRegistryStepDefinitions) iCreateKASKeys(ctx context.Context, tbl *go
 		if i == 0 {
 			continue
 		}
-		if len(row.Cells) < 2 {
-			return ctx, fmt.Errorf("expected kas_uri and key_id columns")
+		if len(row.Cells) < expectedKASKeyColumns {
+			return ctx, errors.New("expected kas_uri and key_id columns")
 		}
 
 		kasURI := normalizeKASURI(row.Cells[0].Value)

--- a/tests-bdd/cukes/steps_localplatform.go
+++ b/tests-bdd/cukes/steps_localplatform.go
@@ -296,6 +296,33 @@ func (s *LocalPlatformStepDefinitions) aDefaultLocalPlatform(ctx context.Context
 	})
 }
 
+func (s *LocalPlatformStepDefinitions) iUseThePlatformAs(ctx context.Context, role string) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	clientIDByRole := map[string]string{
+		"opentdf-admin":    "opentdf",
+		"opentdf-standard": "opentdf-sdk",
+		"custom-non-admin": "opentdf-custom",
+		"kas-a":            "kas-a",
+		"kas-b":            "kas-b",
+	}
+
+	clientID, ok := clientIDByRole[role]
+	if !ok {
+		return ctx, fmt.Errorf("unknown platform role %q", role)
+	}
+
+	platformSDK, err := otdf.New(
+		scenarioContext.ScenarioOptions.PlatformEndpoint,
+		otdf.WithInsecureSkipVerifyConn(),
+		otdf.WithClientCredentials(clientID, "secret", nil),
+	)
+	if err != nil {
+		return ctx, err
+	}
+	scenarioContext.SDK = platformSDK
+	return ctx, nil
+}
+
 func (s *LocalPlatformStepDefinitions) aLocalPlatformWithTemplates(ctx context.Context, platformTemplate string, kcTemplate string) (context.Context, error) {
 	kcTemplateBytes, err := os.ReadFile(kcTemplate)
 	if err != nil {
@@ -548,6 +575,7 @@ func RegisterLocalPlatformStepDefinitions(ctx *godog.ScenarioContext, x *Platfor
 	}
 	ctx.Step(`^an empty local platform$`, platformStepDefinitions.aEmptyLocalPlatform)
 	ctx.Step(`^a default local platform$`, platformStepDefinitions.aDefaultLocalPlatform)
+	ctx.Step(`^I use the platform as "([^"]*)"$`, platformStepDefinitions.iUseThePlatformAs)
 	ctx.Step(`^a user exists with username "([^"]*)" and email "([^"]*)" and the following attributes:$`, platformStepDefinitions.aUser)
 	ctx.Step(`^a local platform with platform template "([^"]*)" and keycloak template "([^"]*)"$`, platformStepDefinitions.aLocalPlatformWithTemplates)
 }

--- a/tests-bdd/cukes/steps_namespaces.go
+++ b/tests-bdd/cukes/steps_namespaces.go
@@ -3,7 +3,9 @@ package cukes
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"connectrpc.com/connect"
 	"github.com/cucumber/godog"
 	"github.com/opentdf/platform/protocol/go/policy/namespaces"
 )
@@ -32,12 +34,27 @@ func (ns *NamespacesStepDefinitions) thereIsNoError(ctx context.Context) (contex
 	return ctx, nil
 }
 
+func (ns *NamespacesStepDefinitions) thereIsAPermissionDeniedError(ctx context.Context) (context.Context, error) {
+	err := GetPlatformScenarioContext(ctx).GetError()
+	if err == nil {
+		return ctx, errors.New("expected permission denied error, got nil")
+	}
+	if connect.CodeOf(err) != connect.CodePermissionDenied {
+		return ctx, fmt.Errorf("expected permission denied error, got %v: %w", connect.CodeOf(err), err)
+	}
+	return ctx, nil
+}
+
 func (ns *NamespacesStepDefinitions) aNamespace(ctx context.Context, namespaceName string, referenceID string) (context.Context, error) {
 	scenarioContext := GetPlatformScenarioContext(ctx)
+	scenarioContext.ClearError()
 	resp, err := scenarioContext.SDK.Namespaces.CreateNamespace(ctx, &namespaces.CreateNamespaceRequest{Name: namespaceName})
 	scenarioContext.SetError(err)
 	scenarioContext.RecordObject(createNamespaceResponseKey, &resp)
-	scenarioContext.RecordObject(referenceID, resp.GetNamespace().GetId())
+	if err == nil {
+		scenarioContext.RecordObject(referenceID, resp.GetNamespace().GetId())
+		scenarioContext.RecordObject(referenceID+"_fqn", resp.GetNamespace().GetFqn())
+	}
 	return ctx, nil
 }
 
@@ -46,4 +63,5 @@ func RegisterNamespaceStepDefinitions(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I submit a request to create a namespace with name "([^"]*)" and reference id "([^"]*)"$`, stepDefinitions.aNamespace)
 	ctx.Step(`the response should be successful$`, stepDefinitions.thereIsNoError)
 	ctx.Step(`the response should be unsuccessful$`, stepDefinitions.thereIsAnError)
+	ctx.Step(`the response should be permission denied$`, stepDefinitions.thereIsAPermissionDeniedError)
 }

--- a/tests-bdd/features/authz-v2.feature
+++ b/tests-bdd/features/authz-v2.feature
@@ -1,0 +1,60 @@
+@authz-v2 @stateless
+Feature: Authz v2 default policy authorization
+
+  Background:
+    # The platform template leaves policy.csv empty so the platform loads the
+    # embedded default v2 policy from service/internal/auth/authz/casbin/policy.csv,
+    # then appends only the BDD-specific KAS key roles via policy.extension.
+    Given a local platform with platform template "cukes/resources/platform.authz_v2.template" and keycloak template "cukes/resources/keycloak_authz_v2.template"
+
+  Rule: KAS registry key access
+
+    # TODO: Register authz resolvers for /policy.kasregistry.KeyAccessServerRegistryService/GetKey
+    # and /policy.kasregistry.KeyAccessServerRegistryService/ListKeys that resolve kas_uri.
+    # The kas-a/kas-b cases are expected to fail until those RPCs authorize with
+    # kas_uri=https://kas-a.example.com or kas_uri=https://kas-b.example.com instead of dims=*.
+    Scenario: opentdf-admin can read KAS keys by default
+      Given I use the platform as "opentdf-admin"
+      And I create KAS keys:
+        | kas_uri                      | key_id    |
+        | https://kas-admin.example.com | admin-kid |
+      When I send a request to get KAS key "admin-kid"
+      Then the response should be successful
+      When I send a request to list KAS keys for URI "https://kas-admin.example.com"
+      Then the response should be successful
+
+    Scenario: opentdf-standard cannot read KAS keys by default
+      Given I use the platform as "opentdf-admin"
+      And I create KAS keys:
+        | kas_uri                         | key_id       |
+        | https://kas-standard.example.com | standard-kid |
+      Given I use the platform as "opentdf-standard"
+      When I send a request to get KAS key "standard-kid"
+      Then the response should be permission denied
+      When I send a request to list KAS keys for URI "https://kas-standard.example.com"
+      Then the response should be permission denied
+
+    Scenario: URI-specific KAS roles cannot read each other's keys
+      Given I use the platform as "opentdf-admin"
+      And I create KAS keys:
+        | kas_uri                   | key_id    |
+        | https://kas-a.example.com | kas-a-kid |
+        | https://kas-b.example.com | kas-b-kid |
+      Given I use the platform as "kas-a"
+      When I send a request to get KAS key "kas-a-kid"
+      Then the response should be successful
+      When I send a request to list KAS keys for URI "https://kas-a.example.com"
+      Then the response should be successful
+      When I send a request to get KAS key "kas-b-kid"
+      Then the response should be permission denied
+      When I send a request to list KAS keys for URI "https://kas-b.example.com"
+      Then the response should be permission denied
+      Given I use the platform as "kas-b"
+      When I send a request to get KAS key "kas-b-kid"
+      Then the response should be successful
+      When I send a request to list KAS keys for URI "https://kas-b.example.com"
+      Then the response should be successful
+      When I send a request to get KAS key "kas-a-kid"
+      Then the response should be permission denied
+      When I send a request to list KAS keys for URI "https://kas-a.example.com"
+      Then the response should be permission denied

--- a/tests-bdd/features/authz-v2.feature
+++ b/tests-bdd/features/authz-v2.feature
@@ -9,10 +9,8 @@ Feature: Authz v2 default policy authorization
 
   Rule: KAS registry key access
 
-    # TODO: Register authz resolvers for /policy.kasregistry.KeyAccessServerRegistryService/GetKey
-    # and /policy.kasregistry.KeyAccessServerRegistryService/ListKeys that resolve kas_uri.
-    # The kas-a/kas-b cases are expected to fail until those RPCs authorize with
-    # kas_uri=https://kas-a.example.com or kas_uri=https://kas-b.example.com instead of dims=*.
+    # KAS GetKey resolves kas_uri for v2 authz. Granular ListKeys authorization is
+    # intentionally deferred, so URI-scoped KAS roles are denied ListKeys.
     Scenario: opentdf-admin can read KAS keys by default
       Given I use the platform as "opentdf-admin"
       And I create KAS keys:
@@ -44,7 +42,7 @@ Feature: Authz v2 default policy authorization
       When I send a request to get KAS key "kas-a-kid"
       Then the response should be successful
       When I send a request to list KAS keys for URI "https://kas-a.example.com"
-      Then the response should be successful
+      Then the response should be permission denied
       When I send a request to get KAS key "kas-b-kid"
       Then the response should be permission denied
       When I send a request to list KAS keys for URI "https://kas-b.example.com"
@@ -53,7 +51,7 @@ Feature: Authz v2 default policy authorization
       When I send a request to get KAS key "kas-b-kid"
       Then the response should be successful
       When I send a request to list KAS keys for URI "https://kas-b.example.com"
-      Then the response should be successful
+      Then the response should be permission denied
       When I send a request to get KAS key "kas-a-kid"
       Then the response should be permission denied
       When I send a request to list KAS keys for URI "https://kas-a.example.com"

--- a/tests-bdd/go.mod
+++ b/tests-bdd/go.mod
@@ -3,6 +3,7 @@ module github.com/opentdf/platform/tests-bdd
 go 1.25.5
 
 require (
+	connectrpc.com/connect v1.20.0
 	github.com/cucumber/godog v0.15.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
@@ -24,7 +25,6 @@ require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250613105001-9f2d3c737feb.1 // indirect
 	buf.build/go/protovalidate v0.13.1 // indirect
 	cel.dev/expr v0.25.1 // indirect
-	connectrpc.com/connect v1.20.0 // indirect
 	connectrpc.com/grpchealth v1.4.0 // indirect
 	connectrpc.com/grpcreflect v1.3.0 // indirect
 	connectrpc.com/validate v0.3.0 // indirect

--- a/tests-bdd/platform_test.go
+++ b/tests-bdd/platform_test.go
@@ -110,6 +110,7 @@ func runTests() int {
 			cukes.RegisterSubjectMappingsStepsDefinitions(ctx)
 			cukes.RegisterRegisteredResourcesStepDefinitions(ctx)
 			cukes.RegisterObligationsStepDefinitions(ctx, platformCukesContext)
+			cukes.RegisterKasRegistryStepDefinitions(ctx)
 			cukes.RegisterEncryptionStepDefinitions(ctx)
 			platformCukesContext.InitializeScenario(ctx)
 		},


### PR DESCRIPTION
## Summary

  Adds BDD coverage for authz v2 KAS key access behavior.

  This introduces an authz-v2-specific platform template and Keycloak template, reusing the embedded default Casbin v2 policy from:

  `service/internal/auth/authz/casbin/policy.csv`

  The tests currently cover:

  - `opentdf-admin` can get and list KAS keys by default.
  - `opentdf-standard` cannot get or list KAS keys by default.
  - URI-scoped KAS roles can be expressed in policy extension rules for `kas-a` and `kas-b`.

  ## Policy Changes

  Removes default `opentdf-standard` access to KAS registry key read RPCs from the embedded v2 policy:

  - `/policy.kasregistry.KeyAccessServerRegistryService/Get*`
  - `/policy.kasregistry.KeyAccessServerRegistryService/List*`

  ## Test Coverage

  Adds `tests-bdd/features/authz-v2.feature` with focused KAS registry authorization scenarios.

  Adds BDD glue for:

  - Creating KAS keys
  - Getting KAS keys by key ID
  - Listing KAS keys by URI
  - Switching platform client role context

  ## Known Gap

  The URI-specific `kas-a` / `kas-b` scenario is expected to fail until KAS registry authz resolvers are registered for:

  - `/policy.kasregistry.KeyAccessServerRegistryService/GetKey`
  - `/policy.kasregistry.KeyAccessServerRegistryService/ListKeys`

  Current behavior authorizes those RPCs with `dims=*`, so URI-specific policy clauses cannot match yet.

  ## Verification

  Ran focused Go tests successfully:

  ```sh
  go test ./tests-bdd/cukes ./service/internal/auth/authz/casbin

  Ran local BDD authz-v2 tests:

  PLATFORM_IMAGE=DEBUG go test ./tests-bdd -v --tags=cukes --godog.random --godog.format=pretty --godog.tags='@authz-v2' ./features

  Result:

  - 2 scenarios passing
  - 1 scenario failing as expected for missing KAS URI authz resolver registration