### PR TITLE
feat(core)!: Resolve keys.

### DIFF
--- a/service/internal/auth/authz/casbin/casbin.go
+++ b/service/internal/auth/authz/casbin/casbin.go
@@ -31,6 +31,8 @@ var builtinPolicyV2 string
 const (
 	// rolePrefix is the prefix for role subjects in casbin policies.
 	rolePrefix = "role:"
+	// clientPrefix is the prefix for client subjects in casbin policies.
+	clientPrefix = "client:"
 	// disallowedDimensionKeyChars are separators used in dimension serialization.
 	disallowedDimensionKeyChars = "=&"
 	// defaultRole is the role assigned when no roles are found.
@@ -276,8 +278,8 @@ func (a *Authorizer) authorizeV1(ctx context.Context, req *authz.Request) (*auth
 }
 
 // authorizeV2 performs RPC+dimensions authorization.
-func (a *Authorizer) authorizeV2(_ context.Context, req *authz.Request) (*authz.Decision, error) {
-	subjects := a.extractSubjects(req)
+func (a *Authorizer) authorizeV2(ctx context.Context, req *authz.Request) (*authz.Decision, error) {
+	subjects := a.extractSubjects(ctx, req)
 
 	// If no subjects found, use default role
 	if len(subjects) == 0 {
@@ -358,7 +360,7 @@ func (a *Authorizer) authorizeV2(_ context.Context, req *authz.Request) (*authz.
 }
 
 // extractSubjects extracts roles/username from JWT token and userInfo.
-func (a *Authorizer) extractSubjects(req *authz.Request) []string {
+func (a *Authorizer) extractSubjects(ctx context.Context, req *authz.Request) []string {
 	if a.v1Enforcer != nil { // ? What's the point of this
 		// Reuse v1 subject extraction logic
 		return a.v1Enforcer.BuildSubjectFromTokenAndUserInfo(req.Token, req.UserInfo)
@@ -380,6 +382,9 @@ func (a *Authorizer) extractSubjects(req *authz.Request) []string {
 		if username := a.extractUsernameFromToken(req.Token); username != "" {
 			subjects = append(subjects, username)
 		}
+		if clientID := a.extractClientIDFromToken(ctx, req.Token); clientID != "" {
+			subjects = append(subjects, clientPrefix+clientID)
+		}
 	}
 
 	// Extract roles from userInfo
@@ -393,6 +398,25 @@ func (a *Authorizer) extractSubjects(req *authz.Request) []string {
 	}
 
 	return subjects
+}
+
+// extractClientIDFromToken extracts the client ID subject from the configured token claim.
+func (a *Authorizer) extractClientIDFromToken(ctx context.Context, token jwt.Token) string {
+	if token == nil || a.baseConfig.ClientIDClaim == "" {
+		return ""
+	}
+
+	claimMap, err := token.AsMap(ctx)
+	if err != nil {
+		return ""
+	}
+	found := util.Dotnotation(claimMap, a.baseConfig.ClientIDClaim)
+	clientID, ok := found.(string)
+	if !ok || clientID == "" {
+		return ""
+	}
+
+	return clientID
 }
 
 // extractUsernameFromToken extracts and validates username subject from token.

--- a/service/internal/auth/authz/casbin/casbin_test.go
+++ b/service/internal/auth/authz/casbin/casbin_test.go
@@ -403,6 +403,39 @@ func (s *CasbinAuthorizerSuite) TestAuthorizeV2_UsernameWithRolePrefixIsIgnored(
 	s.False(decision.Allowed, "username with reserved role prefix must not match role subjects")
 }
 
+func (s *CasbinAuthorizerSuite) TestAuthorizeV2_ClientIDPolicy() {
+	cfg := authz.Config{
+		Version: "v2",
+		PolicyConfig: authz.PolicyConfig{
+			ClientIDClaim: "client_id",
+			Csv:           `p, client:test-client, /policy.attributes.AttributesService/Get*, *, allow`,
+		},
+		Logger: s.logger,
+	}
+
+	authorizer, err := NewAuthorizer(cfg)
+	s.Require().NoError(err)
+
+	token := createTestToken(s.T(), map[string]interface{}{
+		"client_id": "test-client",
+	})
+
+	req := &authz.Request{
+		Token: token,
+		RPC:   "/policy.attributes.AttributesService/GetAttribute",
+	}
+
+	decision, err := authorizer.Authorize(s.T().Context(), req)
+	s.Require().NoError(err)
+	s.True(decision.Allowed, "client policy should allow matching client ID")
+	s.Equal("client:test-client", decision.MatchedPolicy)
+
+	req.RPC = "/policy.attributes.AttributesService/CreateAttribute"
+	decision, err = authorizer.Authorize(s.T().Context(), req)
+	s.Require().NoError(err)
+	s.False(decision.Allowed, "client policy should deny unmatched RPC")
+}
+
 func (s *CasbinAuthorizerSuite) TestAuthorizeV2_KASRESTfulPathsAllowed() {
 	// v2 uses leading slashes for ALL paths (both gRPC and HTTP)
 	// This test ensures KAS RESTful paths work in v2 authorization

--- a/service/internal/auth/authz/casbin/policy.csv
+++ b/service/internal/auth/authz/casbin/policy.csv
@@ -1,7 +1,7 @@
 # Casbin Policy v2 - RPC + Dimensions Authorization
 #
 # Format: p, subject, rpc, dimensions, effect
-#   - subject: role:rolename or username
+#   - subject: role:rolename, client:client-id, or username
 #   - rpc: gRPC method path or HTTP path (supports * wildcard)
 #   - dimensions: namespace=value&attribute=value (supports * wildcard)
 #   - effect: allow or deny

--- a/service/internal/auth/casbin.go
+++ b/service/internal/auth/casbin.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	rolePrefix          = "role:"
+	clientPrefix        = "client:"
 	defaultRole         = "unknown"
 	ErrPermissionDenied = errors.New("permission denied")
 )
@@ -218,7 +219,26 @@ func (e *Enforcer) buildSubjectFromToken(ctx context.Context, t jwt.Token, req a
 			subject = ""
 		}
 	}
+	if clientID := clientIDFromToken(ctx, t, e.Config.ClientIDClaim); clientID != "" {
+		info = append(info, clientPrefix+clientID)
+	}
 	info = append(info, roles...)
 	info = append(info, subject)
 	return info, append([]string(nil), roles...), nil
+}
+
+func clientIDFromToken(ctx context.Context, t jwt.Token, claimName string) string {
+	if t == nil || claimName == "" {
+		return ""
+	}
+	claims, err := t.AsMap(ctx)
+	if err != nil {
+		return ""
+	}
+	found := dotNotation(claims, claimName)
+	clientID, ok := found.(string)
+	if !ok || clientID == "" {
+		return ""
+	}
+	return clientID
 }

--- a/service/internal/auth/casbin_policy.csv
+++ b/service/internal/auth/casbin_policy.csv
@@ -1,4 +1,6 @@
+## Subjects
 ## Roles (prefixed with role:)
+## Clients (prefixed with client:)
 # admin - admin
 # standard - standard
 # unknown - unknown role or no role

--- a/service/internal/auth/casbin_test.go
+++ b/service/internal/auth/casbin_test.go
@@ -546,6 +546,32 @@ func (s *AuthnCasbinSuite) Test_Username_Policy() {
 	s.False(allowed)
 }
 
+func (s *AuthnCasbinSuite) Test_ClientID_Policy() {
+	policyCfg := PolicyConfig{}
+	err := defaults.Set(&policyCfg)
+	s.Require().NoError(err)
+
+	policyCfg.ClientIDClaim = "client_id"
+	policyCfg.Extension = strings.Join([]string{
+		"p, client:test-client, new.service.*, read, allow",
+	}, "\n")
+
+	enforcer, err := NewCasbinEnforcer(CasbinConfig{PolicyConfig: policyCfg}, logger.CreateTestLogger())
+	s.Require().NoError(err)
+
+	tok := jwt.New()
+	err = tok.Set("client_id", "test-client")
+	s.Require().NoError(err)
+
+	allowed, err := s.enforce(enforcer, tok, "new.service.DoSomething", "read")
+	s.Require().NoError(err)
+	s.True(allowed)
+
+	allowed, err = s.enforce(enforcer, tok, "policy.attributes.List", "read")
+	s.Require().Error(err)
+	s.False(allowed)
+}
+
 type staticProvider struct {
 	roles []string
 	err   error

--- a/service/policy/attributes/attributes.go
+++ b/service/policy/attributes/attributes.go
@@ -92,18 +92,6 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 				}
 				as.cache = resolverCache
 
-				// Register authz resolvers per-method
-				// Each resolver extracts authorization dimensions from the request, performing DB lookups as needed.
-				// The resolver is called by the auth interceptor before the handler.
-				if srp.AuthzResolverRegistry != nil {
-					srp.AuthzResolverRegistry.MustRegister("CreateAttribute", as.createAttributeAuthzResolver)
-					srp.AuthzResolverRegistry.MustRegister("GetAttribute", as.getAttributeAuthzResolver)
-					srp.AuthzResolverRegistry.MustRegister("GetAttributeValuesByFqns", as.getAttributeValuesByFqnsAuthzResolver)
-					srp.AuthzResolverRegistry.MustRegister("ListAttributes", as.listAttributesAuthzResolver)
-					srp.AuthzResolverRegistry.MustRegister("UpdateAttribute", as.updateAttributeAuthzResolver)
-					srp.AuthzResolverRegistry.MustRegister("DeactivateAttribute", as.deactivateAttributeAuthzResolver)
-				}
-
 				return as, nil
 			},
 		},

--- a/service/policy/kasregistry/authz_resolver.go
+++ b/service/policy/kasregistry/authz_resolver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"github.com/opentdf/platform/protocol/go/policy"
 	kasr "github.com/opentdf/platform/protocol/go/policy/kasregistry"
 	"github.com/opentdf/platform/service/internal/auth/authz"
 )
@@ -23,7 +24,12 @@ var (
 	errKeyIDRequired                    = errors.New("key id is required")
 	errUnsupportedGetKeyIdentifier      = errors.New("unsupported GetKey identifier")
 	errResolveKasKeyForAuthz            = errors.New("failed to resolve KAS key for authz")
+	errResolvedKasKeyNil                = errors.New("resolved KAS key is nil")
 )
+
+type getKeyAuthzDBClient interface {
+	GetKey(context.Context, any) (*policy.KasKey, error)
+}
 
 func (s KeyAccessServerRegistry) getKeyAuthzResolver(ctx context.Context, req connect.AnyRequest) (authz.ResolverContext, error) {
 	resolverCtx := authz.NewResolverContext()
@@ -48,6 +54,10 @@ func (s KeyAccessServerRegistry) getKeyAuthzResolver(ctx context.Context, req co
 }
 
 func (s KeyAccessServerRegistry) resolveGetKeyKasURI(ctx context.Context, msg *kasr.GetKeyRequest, resolverCtx *authz.ResolverContext) (string, error) {
+	return resolveGetKeyKasURI(ctx, msg, resolverCtx, s.dbClient)
+}
+
+func resolveGetKeyKasURI(ctx context.Context, msg *kasr.GetKeyRequest, resolverCtx *authz.ResolverContext, dbClient getKeyAuthzDBClient) (string, error) {
 	switch identifier := msg.GetIdentifier().(type) {
 	case *kasr.GetKeyRequest_Key:
 		keyIdentifier := identifier.Key
@@ -65,9 +75,12 @@ func (s KeyAccessServerRegistry) resolveGetKeyKasURI(ctx context.Context, msg *k
 		return "", errUnsupportedGetKeyIdentifier
 	}
 
-	key, err := s.dbClient.GetKey(ctx, msg.GetIdentifier())
+	key, err := dbClient.GetKey(ctx, msg.GetIdentifier())
 	if err != nil {
 		return "", fmt.Errorf("%w: %w", errResolveKasKeyForAuthz, err)
+	}
+	if key == nil {
+		return "", fmt.Errorf("%w: %w", errResolveKasKeyForAuthz, errResolvedKasKeyNil)
 	}
 
 	resolverCtx.SetResolvedData(resolverCacheKeyKasKey, key)

--- a/service/policy/kasregistry/authz_resolver.go
+++ b/service/policy/kasregistry/authz_resolver.go
@@ -39,7 +39,7 @@ func (s KeyAccessServerRegistry) getKeyAuthzResolver(ctx context.Context, req co
 		return resolverCtx, fmt.Errorf("%w: %T", errUnexpectedGetKeyAuthzRequestType, req.Any())
 	}
 
-	kasURI, err := s.resolveGetKeyKasURI(ctx, msg, &resolverCtx)
+	kasURI, err := resolveGetKeyKasURI(ctx, msg, &resolverCtx, s.dbClient)
 	if err != nil {
 		return resolverCtx, err
 	}
@@ -51,10 +51,6 @@ func (s KeyAccessServerRegistry) getKeyAuthzResolver(ctx context.Context, req co
 	res.AddDimension(authzDimensionKasURI, kasURI)
 
 	return resolverCtx, nil
-}
-
-func (s KeyAccessServerRegistry) resolveGetKeyKasURI(ctx context.Context, msg *kasr.GetKeyRequest, resolverCtx *authz.ResolverContext) (string, error) {
-	return resolveGetKeyKasURI(ctx, msg, resolverCtx, s.dbClient)
 }
 
 func resolveGetKeyKasURI(ctx context.Context, msg *kasr.GetKeyRequest, resolverCtx *authz.ResolverContext, dbClient getKeyAuthzDBClient) (string, error) {

--- a/service/policy/kasregistry/authz_resolver.go
+++ b/service/policy/kasregistry/authz_resolver.go
@@ -1,0 +1,75 @@
+package kasregistry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"connectrpc.com/connect"
+	kasr "github.com/opentdf/platform/protocol/go/policy/kasregistry"
+	"github.com/opentdf/platform/service/internal/auth/authz"
+)
+
+const (
+	authzDimensionKasURI = "kas_uri"
+	// resolverCacheKeyKasKey is the key used to cache a resolved KAS key in the authz resolver context.
+	resolverCacheKeyKasKey = "kas_key"
+)
+
+var (
+	errUnexpectedGetKeyAuthzRequestType = errors.New("unexpected GetKey authz request type")
+	errResolvedKasURIEmpty              = errors.New("resolved KAS URI is empty")
+	errKeyIdentifierRequired            = errors.New("key identifier is required")
+	errKeyIDRequired                    = errors.New("key id is required")
+	errUnsupportedGetKeyIdentifier      = errors.New("unsupported GetKey identifier")
+	errResolveKasKeyForAuthz            = errors.New("failed to resolve KAS key for authz")
+)
+
+func (s KeyAccessServerRegistry) getKeyAuthzResolver(ctx context.Context, req connect.AnyRequest) (authz.ResolverContext, error) {
+	resolverCtx := authz.NewResolverContext()
+
+	msg, ok := req.Any().(*kasr.GetKeyRequest)
+	if !ok {
+		return resolverCtx, fmt.Errorf("%w: %T", errUnexpectedGetKeyAuthzRequestType, req.Any())
+	}
+
+	kasURI, err := s.resolveGetKeyKasURI(ctx, msg, &resolverCtx)
+	if err != nil {
+		return resolverCtx, err
+	}
+	if kasURI == "" {
+		return resolverCtx, errResolvedKasURIEmpty
+	}
+
+	res := resolverCtx.NewResource()
+	res.AddDimension(authzDimensionKasURI, kasURI)
+
+	return resolverCtx, nil
+}
+
+func (s KeyAccessServerRegistry) resolveGetKeyKasURI(ctx context.Context, msg *kasr.GetKeyRequest, resolverCtx *authz.ResolverContext) (string, error) {
+	switch identifier := msg.GetIdentifier().(type) {
+	case *kasr.GetKeyRequest_Key:
+		keyIdentifier := identifier.Key
+		if keyIdentifier == nil {
+			return "", errKeyIdentifierRequired
+		}
+		if uri := keyIdentifier.GetUri(); uri != "" {
+			return uri, nil
+		}
+	case *kasr.GetKeyRequest_Id:
+		if identifier.Id == "" {
+			return "", errKeyIDRequired
+		}
+	default:
+		return "", errUnsupportedGetKeyIdentifier
+	}
+
+	key, err := s.dbClient.GetKey(ctx, msg.GetIdentifier())
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", errResolveKasKeyForAuthz, err)
+	}
+
+	resolverCtx.SetResolvedData(resolverCacheKeyKasKey, key)
+	return key.GetKasUri(), nil
+}

--- a/service/policy/kasregistry/authz_resolver_test.go
+++ b/service/policy/kasregistry/authz_resolver_test.go
@@ -1,0 +1,81 @@
+package kasregistry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
+	"github.com/opentdf/platform/service/internal/auth/authz"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeGetKeyAuthzDBClient struct {
+	key        *policy.KasKey
+	err        error
+	identifier any
+}
+
+func (f *fakeGetKeyAuthzDBClient) GetKey(_ context.Context, identifier any) (*policy.KasKey, error) {
+	f.identifier = identifier
+	return f.key, f.err
+}
+
+func TestGetKeyAuthzResolver_UsesRequestURI(t *testing.T) {
+	const kasURI = "https://kas-a.example.com"
+	svc := KeyAccessServerRegistry{}
+
+	resolverCtx, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.GetKeyRequest{
+		Identifier: &kasregistry.GetKeyRequest_Key{
+			Key: &kasregistry.KasKeyIdentifier{
+				Identifier: &kasregistry.KasKeyIdentifier_Uri{Uri: kasURI},
+				Kid:        validKeyID,
+			},
+		},
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, resolverCtx.Resources, 1)
+	require.Equal(t, kasURI, (*resolverCtx.Resources[0])[authzDimensionKasURI])
+	require.Nil(t, resolverCtx.GetResolvedData(resolverCacheKeyKasKey))
+}
+
+func TestGetKeyAuthzResolver_UsesPolicyDBClientAndCachesResolvedKey(t *testing.T) {
+	const kasURI = "https://kas-a.example.com"
+	identifier := &kasregistry.GetKeyRequest_Id{Id: validUUID}
+	key := &policy.KasKey{
+		KasUri: kasURI,
+		Key: &policy.AsymmetricKey{
+			KeyId: validKeyID,
+		},
+	}
+	dbClient := &fakeGetKeyAuthzDBClient{key: key}
+	resolverCtx := authz.NewResolverContext()
+
+	resolvedURI, err := resolveGetKeyKasURI(t.Context(), &kasregistry.GetKeyRequest{
+		Identifier: identifier,
+	}, &resolverCtx, dbClient)
+
+	require.NoError(t, err)
+	require.Equal(t, kasURI, resolvedURI)
+	require.Same(t, identifier, dbClient.identifier)
+	require.Same(t, key, resolverCtx.GetResolvedData(resolverCacheKeyKasKey))
+}
+
+func TestGetKeyAuthzResolver_InvalidRequestType(t *testing.T) {
+	svc := KeyAccessServerRegistry{}
+
+	_, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.ListKeysRequest{}))
+
+	require.True(t, errors.Is(err, errUnexpectedGetKeyAuthzRequestType))
+}
+
+func TestGetKeyAuthzResolver_UnsupportedIdentifier(t *testing.T) {
+	svc := KeyAccessServerRegistry{}
+
+	_, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.GetKeyRequest{}))
+
+	require.True(t, errors.Is(err, errUnsupportedGetKeyIdentifier))
+}

--- a/service/policy/kasregistry/authz_resolver_test.go
+++ b/service/policy/kasregistry/authz_resolver_test.go
@@ -2,7 +2,6 @@ package kasregistry
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -69,7 +68,7 @@ func TestGetKeyAuthzResolver_InvalidRequestType(t *testing.T) {
 
 	_, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.ListKeysRequest{}))
 
-	require.True(t, errors.Is(err, errUnexpectedGetKeyAuthzRequestType))
+	require.ErrorIs(t, err, errUnexpectedGetKeyAuthzRequestType)
 }
 
 func TestGetKeyAuthzResolver_UnsupportedIdentifier(t *testing.T) {
@@ -77,5 +76,5 @@ func TestGetKeyAuthzResolver_UnsupportedIdentifier(t *testing.T) {
 
 	_, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.GetKeyRequest{}))
 
-	require.True(t, errors.Is(err, errUnsupportedGetKeyIdentifier))
+	require.ErrorIs(t, err, errUnsupportedGetKeyIdentifier)
 }

--- a/service/policy/kasregistry/key_access_server_registry.go
+++ b/service/policy/kasregistry/key_access_server_registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy"
 	kasr "github.com/opentdf/platform/protocol/go/policy/kasregistry"
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry/kasregistryconnect"
+	"github.com/opentdf/platform/service/internal/auth/authz"
 	"github.com/opentdf/platform/service/logger"
 	"github.com/opentdf/platform/service/logger/audit"
 	"github.com/opentdf/platform/service/pkg/config"
@@ -76,6 +77,10 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 				if err = kasrSvc.dbClient.SetBaseKeyOnWellKnownConfig(context.TODO()); err != nil {
 					logger.Error("error setting well-known config", slog.String("error", err.Error()))
 					panic(err)
+				}
+
+				if srp.AuthzResolverRegistry != nil {
+					srp.AuthzResolverRegistry.MustRegister("GetKey", kasrSvc.getKeyAuthzResolver)
 				}
 
 				kasrSvc.config = cfg
@@ -337,10 +342,14 @@ func (s KeyAccessServerRegistry) GetKey(ctx context.Context, r *connect.Request[
 		ObjectType: audit.ObjectTypeKasRegistryKeys,
 	}
 
-	key, err := s.dbClient.GetKey(ctx, r.Msg.GetIdentifier())
-	if err != nil {
-		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("key_access_server_keys", r.Msg.String()))
+	key, ok := authz.GetResolvedDataFromContext(ctx, resolverCacheKeyKasKey).(*policy.KasKey)
+	if !ok || key == nil {
+		var err error
+		key, err = s.dbClient.GetKey(ctx, r.Msg.GetIdentifier())
+		if err != nil {
+			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
+			return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("key_access_server_keys", r.Msg.String()))
+		}
 	}
 
 	auditParams.ObjectID = key.GetKey().GetKeyId()

--- a/service/policy/kasregistry/key_access_server_registry_keys_test.go
+++ b/service/policy/kasregistry/key_access_server_registry_keys_test.go
@@ -1,10 +1,8 @@
 package kasregistry
 
 import (
-	"errors"
 	"testing"
 
-	"connectrpc.com/connect"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
@@ -92,41 +90,6 @@ var (
 	legacyTrue  = true
 	legacyFalse = false
 )
-
-func TestGetKeyAuthzResolver_UsesRequestURI(t *testing.T) {
-	const kasURI = "https://kas-a.example.com"
-	svc := KeyAccessServerRegistry{}
-
-	resolverCtx, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.GetKeyRequest{
-		Identifier: &kasregistry.GetKeyRequest_Key{
-			Key: &kasregistry.KasKeyIdentifier{
-				Identifier: &kasregistry.KasKeyIdentifier_Uri{Uri: kasURI},
-				Kid:        validKeyID,
-			},
-		},
-	}))
-
-	require.NoError(t, err)
-	require.Len(t, resolverCtx.Resources, 1)
-	require.Equal(t, kasURI, (*resolverCtx.Resources[0])[authzDimensionKasURI])
-	require.Nil(t, resolverCtx.GetResolvedData(resolverCacheKeyKasKey))
-}
-
-func TestGetKeyAuthzResolver_InvalidRequestType(t *testing.T) {
-	svc := KeyAccessServerRegistry{}
-
-	_, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.ListKeysRequest{}))
-
-	require.True(t, errors.Is(err, errUnexpectedGetKeyAuthzRequestType))
-}
-
-func TestGetKeyAuthzResolver_UnsupportedIdentifier(t *testing.T) {
-	svc := KeyAccessServerRegistry{}
-
-	_, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.GetKeyRequest{}))
-
-	require.True(t, errors.Is(err, errUnsupportedGetKeyIdentifier))
-}
 
 func Test_GetKeyAccessServer_Keys(t *testing.T) {
 	testCases := []struct {

--- a/service/policy/kasregistry/key_access_server_registry_keys_test.go
+++ b/service/policy/kasregistry/key_access_server_registry_keys_test.go
@@ -1,8 +1,10 @@
 package kasregistry
 
 import (
+	"errors"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
@@ -90,6 +92,41 @@ var (
 	legacyTrue  = true
 	legacyFalse = false
 )
+
+func TestGetKeyAuthzResolver_UsesRequestURI(t *testing.T) {
+	const kasURI = "https://kas-a.example.com"
+	svc := KeyAccessServerRegistry{}
+
+	resolverCtx, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.GetKeyRequest{
+		Identifier: &kasregistry.GetKeyRequest_Key{
+			Key: &kasregistry.KasKeyIdentifier{
+				Identifier: &kasregistry.KasKeyIdentifier_Uri{Uri: kasURI},
+				Kid:        validKeyID,
+			},
+		},
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, resolverCtx.Resources, 1)
+	require.Equal(t, kasURI, (*resolverCtx.Resources[0])[authzDimensionKasURI])
+	require.Nil(t, resolverCtx.GetResolvedData(resolverCacheKeyKasKey))
+}
+
+func TestGetKeyAuthzResolver_InvalidRequestType(t *testing.T) {
+	svc := KeyAccessServerRegistry{}
+
+	_, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.ListKeysRequest{}))
+
+	require.True(t, errors.Is(err, errUnexpectedGetKeyAuthzRequestType))
+}
+
+func TestGetKeyAuthzResolver_UnsupportedIdentifier(t *testing.T) {
+	svc := KeyAccessServerRegistry{}
+
+	_, err := svc.getKeyAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.GetKeyRequest{}))
+
+	require.True(t, errors.Is(err, errUnsupportedGetKeyIdentifier))
+}
 
 func Test_GetKeyAccessServer_Keys(t *testing.T) {
 	testCases := []struct {

--- a/tests-bdd/cukes/resources/platform.authz_v2.template
+++ b/tests-bdd/cukes/resources/platform.authz_v2.template
@@ -55,14 +55,12 @@ server:
       version: v2
       username_claim:
       groups_claim: realm_access.roles
-      client_id_claim:
+      client_id_claim: client_id
       csv:
       extension: |
         # KAS key read access for BDD-specific service-account roles.
-        g, role:kas-a, role:kas-a
-        g, role:kas-b, role:kas-b
-        p, role:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-a.example.com, allow
-        p, role:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-b.example.com, allow
+        p, client:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-a.example.com, allow
+        p, client:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-b.example.com, allow
       model:
   trace:
     enabled: false

--- a/tests-bdd/cukes/resources/platform.authz_v2.template
+++ b/tests-bdd/cukes/resources/platform.authz_v2.template
@@ -62,9 +62,7 @@ server:
         g, role:kas-a, role:kas-a
         g, role:kas-b, role:kas-b
         p, role:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-a.example.com, allow
-        p, role:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-a.example.com, allow
         p, role:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-b.example.com, allow
-        p, role:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-b.example.com, allow
       model:
   trace:
     enabled: false

--- a/tests-bdd/features/authz-v2.feature
+++ b/tests-bdd/features/authz-v2.feature
@@ -9,10 +9,8 @@ Feature: Authz v2 default policy authorization
 
   Rule: KAS registry key access
 
-    # TODO: Register authz resolvers for /policy.kasregistry.KeyAccessServerRegistryService/GetKey
-    # and /policy.kasregistry.KeyAccessServerRegistryService/ListKeys that resolve kas_uri.
-    # The kas-a/kas-b cases are expected to fail until those RPCs authorize with
-    # kas_uri=https://kas-a.example.com or kas_uri=https://kas-b.example.com instead of dims=*.
+    # KAS GetKey resolves kas_uri for v2 authz. Granular ListKeys authorization is
+    # intentionally deferred, so URI-scoped KAS roles are denied ListKeys.
     Scenario: opentdf-admin can read KAS keys by default
       Given I use the platform as "opentdf-admin"
       And I create KAS keys:
@@ -44,7 +42,7 @@ Feature: Authz v2 default policy authorization
       When I send a request to get KAS key "kas-a-kid"
       Then the response should be successful
       When I send a request to list KAS keys for URI "https://kas-a.example.com"
-      Then the response should be successful
+      Then the response should be permission denied
       When I send a request to get KAS key "kas-b-kid"
       Then the response should be permission denied
       When I send a request to list KAS keys for URI "https://kas-b.example.com"
@@ -53,7 +51,7 @@ Feature: Authz v2 default policy authorization
       When I send a request to get KAS key "kas-b-kid"
       Then the response should be successful
       When I send a request to list KAS keys for URI "https://kas-b.example.com"
-      Then the response should be successful
+      Then the response should be permission denied
       When I send a request to get KAS key "kas-a-kid"
       Then the response should be permission denied
       When I send a request to list KAS keys for URI "https://kas-a.example.com"

--- a/tests-bdd/go.mod
+++ b/tests-bdd/go.mod
@@ -3,6 +3,7 @@ module github.com/opentdf/platform/tests-bdd
 go 1.25.5
 
 require (
+	connectrpc.com/connect v1.20.0
 	github.com/cucumber/godog v0.15.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
@@ -24,7 +25,6 @@ require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250613105001-9f2d3c737feb.1 // indirect
 	buf.build/go/protovalidate v0.13.1 // indirect
 	cel.dev/expr v0.25.1 // indirect
-	connectrpc.com/connect v1.20.0 // indirect
 	connectrpc.com/grpchealth v1.4.0 // indirect
 	connectrpc.com/grpcreflect v1.3.0 // indirect
 	connectrpc.com/validate v0.3.0 // indirect


### PR DESCRIPTION
## Summary

  Adds authz v2 support for URI-scoped KAS `GetKey` authorization.

  ## Changes

  - Register a KAS registry authz resolver for `GetKey`
  - Resolve `kas_uri` for KAS key requests
  - Cache the resolved KAS key in resolver context so `GetKey` can reuse it
  - Leave `ListKeys` without granular URI resolution for now
  - Keep attribute resolver registration disabled for this KAS-only scope
  - Update authz v2 BDD coverage for KAS key access
  - Update the authz v2 BDD template to grant URI-specific access only for `GetKey`
  - Add `client:` prefix to client_ids

  ## Behavior Covered

  - `opentdf-admin` can `GetKey` and `ListKeys`
  - `opentdf-standard` cannot `GetKey` or `ListKeys`
  - `kas-a` can `GetKey` only for `https://kas-a.example.com`
  - `kas-b` can `GetKey` only for `https://kas-b.example.com`
  - `kas-a` and `kas-b` cannot access each other’s keys
  - URI-scoped `kas-a` / `kas-b` roles are denied `ListKeys`

  ## Verification

  ```sh
  go test ./internal/auth/...
  go test ./policy/kasregistry/...
  go test ./policy/attributes/...
  PLATFORM_IMAGE=DEBUG go test ./tests-bdd -v --tags=cukes --godog.random --godog.format=pretty --godog.tags='@authz-v2' ./features
```


>[!WARNING]
>The breaking change is that I set the `client:` prefix for client_ids.
>
>For current policy, customers will need to change their custom policy to include the `client:` prefix.