### PR TITLE
fix(ci): DSPX-3499 skip PQC key config when platform lacks keygen support

### DIFF
--- a/test/start-additional-kas/action.yaml
+++ b/test/start-additional-kas/action.yaml
@@ -145,6 +145,13 @@ runs:
         LOG_TYPE: ${{ inputs.log-type }}
       with:
         run: |
+          # If PQC is requested but key files were not generated, the platform
+          # version likely does not support PQC key types. Disable PQC to avoid
+          # referencing missing key files in the config.
+          if [ "${PQC_ENABLED}" == "true" ] && [ ! -f kas-xwing-private.pem ]; then
+            echo "::warning::PQC enabled but key files not found (platform version may not support PQC). Disabling PQC key configuration for KAS ${KAS_NAME}."
+            export PQC_ENABLED="false"
+          fi
           yq e '
             (.server.port = env(KAS_PORT))
             | (.mode = ["kas"])

--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -192,7 +192,13 @@ runs:
         allowed_algorithms=(ec:secp256r1 rsa:2048)
         if echo $PLATFORM_VERSION | awk -F. '{ if ($1 > 0 || ($1 == 0 && $2 > 7) || ($1 == 0 && $2 == 7 && $3 >= 1)) exit 0; else exit 1; }'; then
           # For versions 0.7.1 and later, we allow rsa:4096 ec:secp384r1 ec:secp521r1
-          allowed_algorithms+=(rsa:4096 ec:secp384r1 ec:secp521r1 hpqt:xwing hpqt:secp256r1-mlkem768 hpqt:secp384r1-mlkem1024)
+          allowed_algorithms+=(rsa:4096 ec:secp384r1 ec:secp521r1)
+          # Only allow PQC algorithms if the platform keygen produced the key files
+          if [ -f kas-xwing-private.pem ]; then
+            allowed_algorithms+=(hpqt:xwing hpqt:secp256r1-mlkem768 hpqt:secp384r1-mlkem1024)
+          else
+            echo "::notice::PQC key files not found; hpqt algorithms will not be allowed for extra keys"
+          fi
         fi
         keyring='[{"kid":"ec1","alg":"ec:secp256r1"},{"kid":"r1","alg":"rsa:2048"}]'
         keys='[{"kid":"e1","alg":"ec:secp256r1","private":"kas-ec-private.pem","cert":"kas-ec-cert.pem"},{"kid":"ec1","alg":"ec:secp256r1","private":"kas-ec-private.pem","cert":"kas-ec-cert.pem"},{"kid":"r1","alg":"rsa:2048","private":"kas-private.pem","cert":"kas-cert.pem"}]'
@@ -245,6 +251,10 @@ runs:
       shell: bash
       if: ${{ inputs.pqc-enabled == 'true' }}
       run: |
+        if [ ! -f kas-xwing-private.pem ]; then
+          echo "::warning::PQC enabled but key files not found (platform version may not support PQC). Skipping PQC key configuration."
+          exit 0
+        fi
         yq e '
           (.services.kas.preview.hybrid_tdf_enabled = true)
           | (.services.kas.keyring += [{"kid":"x1","alg":"hpqt:xwing"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024"}])


### PR DESCRIPTION
## Summary

When `pqc-enabled: true` is passed to the test startup actions but the checked-out platform version (e.g. `v0.9.0`) does not include `service/cmd/keygen`, the PQC key files (`kas-xwing-private.pem`, etc.) are never generated. The actions previously added PQC keyring and `cryptoProvider` entries unconditionally, causing the platform to crash on startup:

```
security.NewCryptoProvider: failed to read private key file [kas-xwing-private.pem]:
open kas-xwing-private.pem: no such file or directory
```

Addresses: https://github.com/opentdf/platform/actions/runs/27224175116/job/80411765728?pr=3592

### Changes

**`test/start-up-with-containers/action.yaml`**
- "Map the config to the keys" step: only add `hpqt:*` to `allowed_algorithms` when `kas-xwing-private.pem` exists (prevents PQC extra-keys from being mapped on unsupported versions)
- "Enable PQ wrapping" step: skip PQC keyring/key config when key files are absent, with a `::warning::` annotation

**`test/start-additional-kas/action.yaml`**
- Override `PQC_ENABLED` to `false` at the top of the run script when PQC key files are missing, so the `yq` `with(select(...))` clause is skipped and no PQC entries are written to the KAS config

## Test plan

- [ ] Verify a CI run against a platform version that supports PQC (e.g. `main`) still generates and loads PQC keys correctly
- [ ] Verify a CI run against a platform version without PQC support (e.g. `v0.9.0`) no longer crashes — the warning annotation should appear and PQC config should be omitted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test action stability by implementing conditional post-quantum cryptography configuration handling. When post-quantum cryptography is enabled but required key files are unavailable, tests now emit warnings and gracefully skip cryptography-specific configuration rather than failing. Traditional algorithms remain available in all scenarios, reducing test failures and improving compatibility across different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->