### PR TITLE
fix(cli): fix the get key command.

### DIFF
--- a/otdfctl/cmd/policy/kasKeys.go
+++ b/otdfctl/cmd/policy/kasKeys.go
@@ -312,7 +312,8 @@ func policyImportKasKey(cmd *cobra.Command, args []string) {
 		resolvedKasID = kasEntry.GetId()
 	}
 
-	importedKey, err := h.CreateKasKey(c.Context(),
+	importedKey, err := h.CreateKasKey(
+		c.Context(),
 		resolvedKasID,
 		keyIdentifier,
 		alg,
@@ -348,11 +349,13 @@ func policyGetKasKey(cmd *cobra.Command, args []string) {
 	var identifier *kasregistry.KasKeyIdentifier
 	var err error
 
-	if utils.ClassifyString(id) != utils.StringTypeUUID {
+	kasIdentifier := c.Flags.GetOptionalString("kas")
+	if kasIdentifier != "" || utils.ClassifyString(id) != utils.StringTypeUUID {
 		identifier, err = getKasKeyIdentifier(c)
 		if err != nil {
 			cli.ExitWithError("Invalid key identifier", err)
 		}
+		id = ""
 	}
 	kasKey, err := h.GetKasKey(c.Context(), id, identifier)
 	if err != nil {
@@ -379,7 +382,8 @@ func policyUpdateKasKey(cmd *cobra.Command, args []string) {
 		c.Context(),
 		id,
 		getMetadataMutable(metadataLabels),
-		getMetadataUpdateBehavior())
+		getMetadataUpdateBehavior(),
+	)
 	if err != nil {
 		cli.ExitWithError("Failed to update kas key", err)
 	}
@@ -826,7 +830,8 @@ func getLegacyFlag(c *cli.Cli) (*bool, error) {
 
 func initKASKeysCommands() {
 	// Create Kas Key
-	createDoc := man.Docs.GetCommand("policy/kas-registry/key/create",
+	createDoc := man.Docs.GetCommand(
+		"policy/kas-registry/key/create",
 		man.WithRun(policyCreateKasKey),
 	)
 	createDoc.Flags().StringP(
@@ -887,7 +892,8 @@ func initKASKeysCommands() {
 	createDoc.MarkSensitiveFlags()
 
 	// Get Kas Key
-	getDoc := man.Docs.GetCommand("policy/kas-registry/key/get",
+	getDoc := man.Docs.GetCommand(
+		"policy/kas-registry/key/get",
 		man.WithRun(policyGetKasKey),
 	)
 	getDoc.Flags().StringP(
@@ -903,7 +909,8 @@ func initKASKeysCommands() {
 		getDoc.GetDocFlag("kas").Description,
 	)
 	// Update Kas Key
-	updateDoc := man.Docs.GetCommand("policy/kas-registry/key/update",
+	updateDoc := man.Docs.GetCommand(
+		"policy/kas-registry/key/update",
 		man.WithRun(policyUpdateKasKey),
 	)
 	updateDoc.Flags().StringP(
@@ -915,7 +922,8 @@ func initKASKeysCommands() {
 	injectLabelFlags(&updateDoc.Command, true)
 
 	// List Kas Keys
-	listDoc := man.Docs.GetCommand("policy/kas-registry/key/list",
+	listDoc := man.Docs.GetCommand(
+		"policy/kas-registry/key/list",
 		man.WithRun(policyListKasKeys),
 	)
 	listDoc.Flags().StringP(
@@ -940,7 +948,8 @@ func initKASKeysCommands() {
 	injectListSortFlags(listDoc)
 
 	// Rotate Kas Key
-	rotateDoc := man.Docs.GetCommand("policy/kas-registry/key/rotate",
+	rotateDoc := man.Docs.GetCommand(
+		"policy/kas-registry/key/rotate",
 		man.WithRun(policyRotateKasKey),
 	)
 	rotateDoc.Flags().StringP(
@@ -1007,7 +1016,8 @@ func initKASKeysCommands() {
 	rotateDoc.MarkSensitiveFlags()
 
 	// Import Kas Key
-	importDoc := man.Docs.GetCommand("policy/kas-registry/key/import",
+	importDoc := man.Docs.GetCommand(
+		"policy/kas-registry/key/import",
 		man.WithRun(policyImportKasKey),
 	)
 	importDoc.Flags().StringP(
@@ -1061,7 +1071,8 @@ func initKASKeysCommands() {
 	injectLabelFlags(&importDoc.Command, false)
 	importDoc.MarkSensitiveFlags()
 
-	mappingsDoc := man.Docs.GetCommand("policy/kas-registry/key/list-mappings",
+	mappingsDoc := man.Docs.GetCommand(
+		"policy/kas-registry/key/list-mappings",
 		man.WithRun(policyListKeyMappings),
 	)
 	mappingsDoc.Flags().StringP(
@@ -1095,7 +1106,8 @@ func initKASKeysCommands() {
 		unsafeCmd.GetDocFlag("force").Description,
 	)
 
-	unsafeDeleteDoc := man.Docs.GetCommand("policy/kas-registry/key/unsafe/delete",
+	unsafeDeleteDoc := man.Docs.GetCommand(
+		"policy/kas-registry/key/unsafe/delete",
 		man.WithRun(policyUnsafeDeleteKasKey),
 	)
 	unsafeDeleteDoc.Flags().StringP(

--- a/otdfctl/cmd/policy/kasKeys.go
+++ b/otdfctl/cmd/policy/kasKeys.go
@@ -595,11 +595,13 @@ func policyRotateKasKey(cmd *cobra.Command, args []string) {
 	}
 
 	var identifier *kasregistry.KasKeyIdentifier
-	if utils.ClassifyString(oldKey) != utils.StringTypeUUID {
+	kasIdentifier := c.Flags.GetOptionalString("kas")
+	if kasIdentifier != "" || utils.ClassifyString(oldKey) != utils.StringTypeUUID {
 		identifier, err = getKasKeyIdentifier(c)
 		if err != nil {
 			cli.ExitWithError("Invalid key identifier", err)
 		}
+		oldKey = ""
 	}
 
 	// Call the rotate key function

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -435,6 +435,23 @@ format_kas_name_as_uri() {
   assert_not_equal "$(echo "$output" | jq -r .key.metadata.updated_at)" "null"
 }
 
+@test "kas-keys: get key by UUID-form user key-id and kasId" {
+  KEY_ID_GET_USER_UUID=$(uuidgen)
+  run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${KEY_ID_GET_USER_UUID}" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64}" --json
+  assert_success
+  local created_key_system_id_for_get=$(echo "$output" | jq -r .key.id)
+
+  run_otdfctl_key get --key "${KEY_ID_GET_USER_UUID}" --kas "${KAS_REGISTRY_ID}" --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r .kas_id)" "${KAS_REGISTRY_ID}"
+  assert_equal "$(echo "$output" | jq -r .key.id)" "${created_key_system_id_for_get}"
+  assert_equal "$(echo "$output" | jq -r .key.key_id)" "${KEY_ID_GET_USER_UUID}"
+  assert_equal "$(echo "$output" | jq -r .key.key_algorithm)" "1" # rsa:2048
+  assert_equal "$(echo "$output" | jq -r .key.key_mode)" "4"      # public_key
+  assert_equal "$(echo "$output" | jq -r .key.key_status)" "1"    # active
+  assert_equal "$(echo "$output" | jq -r .key.public_key_ctx.pem)" "${PEM_B64}"
+}
+
 @test "kas-keys: get key by user key-id and kasName" {
   KEY_ID_GET_USER_kas=$(generate_key_id)
   run_otdfctl_key create --kas "kas-registry-for-keys-test" --key-id "${KEY_ID_GET_USER_kas}" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64}"  --json

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -966,6 +966,31 @@ format_kas_name_as_uri() {
   assert_equal "$(echo "$output" | jq -r .rotated_resources.rotated_out_key.key.key_status)" "2" # rotated (old key should be marked as rotated)
 }
 
+@test "kas-keys: rotate key by UUID-form user key-id and kasId" {
+  # Create a key with a user-defined key ID that is formatted as a UUID.
+  OLD_KEY_ID=$(uuidgen)
+  run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${OLD_KEY_ID}" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64}" --json
+  assert_success
+  OLD_KEY_SYSTEM_ID=$(echo "$output" | jq -r .key.id)
+
+  # Rotate by user-defined key ID with KAS filter. The UUID-form key ID should not be treated as the system ID.
+  NEW_KEY_ID=$(generate_key_id)
+  run_otdfctl_key rotate --key "${OLD_KEY_ID}" --kas "${KAS_REGISTRY_ID}" --key-id "${NEW_KEY_ID}" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64}" --json
+  assert_success
+
+  NEW_KEY_SYSTEM_ID=$(echo "$output" | jq -r .kas_key.key.id)
+  assert_not_equal "${OLD_KEY_SYSTEM_ID}" "${NEW_KEY_SYSTEM_ID}"
+  assert_equal "$(echo "$output" | jq -r .kas_key.kas_id)" "${KAS_REGISTRY_ID}"
+  assert_equal "$(echo "$output" | jq -r .kas_key.key.key_id)" "${NEW_KEY_ID}"
+  assert_equal "$(echo "$output" | jq -r .kas_key.key.key_algorithm)" "1" # rsa:2048
+  assert_equal "$(echo "$output" | jq -r .kas_key.key.key_mode)" "4"      # public_key
+  assert_equal "$(echo "$output" | jq -r .kas_key.key.key_status)" "1"    # active
+  assert_equal "$(echo "$output" | jq -r .kas_key.key.public_key_ctx.pem)" "${PEM_B64}"
+  assert_equal "$(echo "$output" | jq -r .rotated_resources.rotated_out_key.key.id)" "${OLD_KEY_SYSTEM_ID}"
+  assert_equal "$(echo "$output" | jq -r .rotated_resources.rotated_out_key.key.key_id)" "${OLD_KEY_ID}"
+  assert_equal "$(echo "$output" | jq -r .rotated_resources.rotated_out_key.key.key_status)" "2" # rotated
+}
+
 @test "kas-keys: rotate key (missing key)" {
   run_otdfctl_key rotate --key-id "new-key-id" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64}"
   assert_failure


### PR DESCRIPTION
### Proposed Changes

1.) Fix issue where a `kid` created as a UUID was not respecting the kas flag, and being treated as an ID.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KAS key handling when using `--kas` together with user-provided key IDs (ensures correct identifier selection for get and rotate operations).

* **Tests**
  * Added end-to-end tests for retrieving and rotating KAS keys when the user key ID is a UUID and a KAS registry is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->