### PR TITLE
fix(core): Fix malicious escaping of dimensions.

### DIFF
--- a/service/internal/auth/authz/casbin/casbin.go
+++ b/service/internal/auth/authz/casbin/casbin.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -555,10 +556,11 @@ func serializeDimensions(ctx *authz.ResolverContext) (string, error) {
 	}
 	sort.Strings(keys)
 
-	// Build canonical string
+	// Build canonical string, URL-encoding values to prevent injection via
+	// special characters like '&' and '=' that are used as separators.
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
-		parts = append(parts, fmt.Sprintf("%s=%s", k, allDims[k]))
+		parts = append(parts, fmt.Sprintf("%s=%s", k, url.QueryEscape(allDims[k])))
 	}
 
 	return strings.Join(parts, "&"), nil
@@ -671,7 +673,11 @@ func parseDimensions(dims string) (map[string]string, bool) {
 		if !isValidDimensionKey(kv[0]) {
 			return nil, false
 		}
-		result[kv[0]] = kv[1]
+		unescapedVal, err := url.QueryUnescape(kv[1])
+		if err != nil {
+			return nil, false
+		}
+		result[kv[0]] = unescapedVal
 	}
 	return result, true
 }

--- a/service/internal/auth/authz/casbin/casbin.go
+++ b/service/internal/auth/authz/casbin/casbin.go
@@ -638,6 +638,14 @@ func dimensionMatch(reqDims, policyDims string) bool {
 		if !isValidDimensionKey(key) {
 			return false
 		}
+		policyWildcard := policyVal == "*"
+		if !policyWildcard {
+			unescapedVal, err := url.QueryUnescape(policyVal)
+			if err != nil {
+				return false
+			}
+			policyVal = unescapedVal
+		}
 
 		reqVal, exists := reqMap[key]
 		if !exists {
@@ -646,7 +654,7 @@ func dimensionMatch(reqDims, policyDims string) bool {
 		}
 
 		// Wildcard matches any value
-		if policyVal != "*" && policyVal != reqVal {
+		if !policyWildcard && policyVal != reqVal {
 			return false
 		}
 	}

--- a/service/internal/auth/authz/casbin/casbin.go
+++ b/service/internal/auth/authz/casbin/casbin.go
@@ -46,6 +46,12 @@ const (
 	kvPairParts = 2
 )
 
+var dimensionValueEscaper = strings.NewReplacer(
+	"%", "%25",
+	"&", "%26",
+	"*", "%2A",
+)
+
 func init() {
 	// Register the Casbin authorizer factory
 	authz.RegisterFactory("casbin", NewAuthorizer)
@@ -556,14 +562,25 @@ func serializeDimensions(ctx *authz.ResolverContext) (string, error) {
 	}
 	sort.Strings(keys)
 
-	// Build canonical string, URL-encoding values to prevent injection via
-	// special characters like '&' and '=' that are used as separators.
+	// Build canonical string, percent-encoding only the characters that conflict
+	// with dimension parsing. '%' must be escaped first because it introduces an
+	// escape sequence, and '&' must be escaped because it separates key-value
+	// pairs. '*' is escaped because raw '*' is the policy wildcard. '=' can remain
+	// readable because pair parsing splits on the first '='.
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
-		parts = append(parts, fmt.Sprintf("%s=%s", k, url.QueryEscape(allDims[k])))
+		parts = append(parts, fmt.Sprintf("%s=%s", k, escapeDimensionValue(allDims[k])))
 	}
 
 	return strings.Join(parts, "&"), nil
+}
+
+func escapeDimensionValue(value string) string {
+	return dimensionValueEscaper.Replace(value)
+}
+
+func unescapeDimensionValue(value string) (string, error) {
+	return url.PathUnescape(value)
 }
 
 // isValidDimensionKey reports whether a dimension key can be safely serialized.
@@ -640,7 +657,7 @@ func dimensionMatch(reqDims, policyDims string) bool {
 		}
 		policyWildcard := policyVal == "*"
 		if !policyWildcard {
-			unescapedVal, err := url.QueryUnescape(policyVal)
+			unescapedVal, err := unescapeDimensionValue(policyVal)
 			if err != nil {
 				return false
 			}
@@ -681,7 +698,7 @@ func parseDimensions(dims string) (map[string]string, bool) {
 		if !isValidDimensionKey(kv[0]) {
 			return nil, false
 		}
-		unescapedVal, err := url.QueryUnescape(kv[1])
+		unescapedVal, err := unescapeDimensionValue(kv[1])
 		if err != nil {
 			return nil, false
 		}

--- a/service/internal/auth/authz/casbin/casbin_test.go
+++ b/service/internal/auth/authz/casbin/casbin_test.go
@@ -2,7 +2,6 @@ package casbin
 
 import (
 	"context"
-	"net/url"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -680,27 +679,45 @@ func TestSerializeDimensions_InjectionPrevention(t *testing.T) {
 					{"kas_uri": "https://kas.example.com?foo=bar&second_dim=injected"},
 				},
 			},
-			// The '&' and '=' in the value must be percent-encoded so parseDimensions
+			// The '&' in the value must be percent-encoded so parseDimensions
 			// sees only one key-value pair, not two.
-			expected: "kas_uri=https%3A%2F%2Fkas.example.com%3Ffoo%3Dbar%26second_dim%3Dinjected",
+			expected: "kas_uri=https://kas.example.com?foo=bar%26second_dim=injected",
 		},
 		{
-			name: "value with equals sign is safely encoded",
+			name: "value with equals sign is unchanged",
 			ctx: &authz.ResolverContext{
 				Resources: []*authz.ResolverResource{
 					{"kas_uri": "https://kas.example.com?key=value"},
 				},
 			},
-			expected: "kas_uri=https%3A%2F%2Fkas.example.com%3Fkey%3Dvalue",
+			expected: "kas_uri=https://kas.example.com?key=value",
 		},
 		{
-			name: "plain URI with colon and slashes is encoded",
+			name: "plain URI with colon and slashes is unchanged",
 			ctx: &authz.ResolverContext{
 				Resources: []*authz.ResolverResource{
 					{"kas_uri": "https://kas.example.com"},
 				},
 			},
-			expected: "kas_uri=https%3A%2F%2Fkas.example.com",
+			expected: "kas_uri=https://kas.example.com",
+		},
+		{
+			name: "value with percent sign is safely encoded",
+			ctx: &authz.ResolverContext{
+				Resources: []*authz.ResolverResource{
+					{"label": "done%complete"},
+				},
+			},
+			expected: "label=done%25complete",
+		},
+		{
+			name: "wildcard token value is safely encoded",
+			ctx: &authz.ResolverContext{
+				Resources: []*authz.ResolverResource{
+					{"label": "*"},
+				},
+			},
+			expected: "label=%2A",
 		},
 		{
 			name: "plain value without special chars is unchanged",
@@ -740,6 +757,22 @@ func TestParseDimensions_RoundTrip(t *testing.T) {
 		{
 			name:  "full URI with query string round-trips correctly",
 			input: map[string]string{"kas_uri": "https://kas.example.com?foo=bar&baz=qux"},
+		},
+		{
+			name:  "value with literal plus round-trips correctly",
+			input: map[string]string{"kas_uri": "https://kas.example.com/path+plus?token=a+b"},
+		},
+		{
+			name:  "value with space round-trips correctly",
+			input: map[string]string{"display_name": "first last"},
+		},
+		{
+			name:  "value with percent round-trips correctly",
+			input: map[string]string{"label": "done%complete"},
+		},
+		{
+			name:  "wildcard token value round-trips correctly",
+			input: map[string]string{"label": "*"},
 		},
 		{
 			name:  "plain value round-trips correctly",
@@ -787,7 +820,13 @@ func TestDimensionMatch_WithURIValues(t *testing.T) {
 		{
 			name:       "serialized URI with query string matches escaped policy URI",
 			input:      map[string]string{"kas_uri": "https://kas.example.com?foo=bar&baz=qux"},
-			policyDims: "kas_uri=" + url.QueryEscape("https://kas.example.com?foo=bar&baz=qux"),
+			policyDims: "kas_uri=" + escapeDimensionValue("https://kas.example.com?foo=bar&baz=qux"),
+			expected:   true,
+		},
+		{
+			name:       "serialized URI with literal plus matches escaped policy URI",
+			input:      map[string]string{"kas_uri": "https://kas.example.com/path+plus?token=a+b"},
+			policyDims: "kas_uri=" + escapeDimensionValue("https://kas.example.com/path+plus?token=a+b"),
 			expected:   true,
 		},
 		{
@@ -800,8 +839,20 @@ func TestDimensionMatch_WithURIValues(t *testing.T) {
 		{
 			name:       "escaped literal star policy value does not act as wildcard",
 			input:      map[string]string{"kas_uri": "https://kas.example.com"},
-			policyDims: "kas_uri=" + url.QueryEscape("*"),
+			policyDims: "kas_uri=" + escapeDimensionValue("*"),
 			expected:   false,
+		},
+		{
+			name:       "serialized literal star matches escaped policy value",
+			input:      map[string]string{"label": "*"},
+			policyDims: "label=" + escapeDimensionValue("*"),
+			expected:   true,
+		},
+		{
+			name:       "serialized literal star matches raw wildcard policy value",
+			input:      map[string]string{"label": "*"},
+			policyDims: "label=*",
+			expected:   true,
 		},
 		{
 			name:       "injected extra dimension does not satisfy a different policy key",

--- a/service/internal/auth/authz/casbin/casbin_test.go
+++ b/service/internal/auth/authz/casbin/casbin_test.go
@@ -2,6 +2,7 @@ package casbin
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -784,11 +785,23 @@ func TestDimensionMatch_WithURIValues(t *testing.T) {
 			expected:   true,
 		},
 		{
+			name:       "serialized URI with query string matches escaped policy URI",
+			input:      map[string]string{"kas_uri": "https://kas.example.com?foo=bar&baz=qux"},
+			policyDims: "kas_uri=" + url.QueryEscape("https://kas.example.com?foo=bar&baz=qux"),
+			expected:   true,
+		},
+		{
 			name:       "URI value with query string does not match policy for base URI only",
 			input:      map[string]string{"kas_uri": "https://kas.example.com?foo=bar"},
 			policyDims: "kas_uri=https://kas.example.com",
 			// The query string makes the URIs different; policy requires exact match.
 			expected: false,
+		},
+		{
+			name:       "escaped literal star policy value does not act as wildcard",
+			input:      map[string]string{"kas_uri": "https://kas.example.com"},
+			policyDims: "kas_uri=" + url.QueryEscape("*"),
+			expected:   false,
 		},
 		{
 			name:       "injected extra dimension does not satisfy a different policy key",

--- a/service/internal/auth/authz/casbin/casbin_test.go
+++ b/service/internal/auth/authz/casbin/casbin_test.go
@@ -665,6 +665,162 @@ func TestSerializeDimensions(t *testing.T) {
 	}
 }
 
+// Test dimension value injection prevention via URL-encoding
+func TestSerializeDimensions_InjectionPrevention(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctx      *authz.ResolverContext
+		expected string
+	}{
+		{
+			name: "value with ampersand is safely encoded",
+			ctx: &authz.ResolverContext{
+				Resources: []*authz.ResolverResource{
+					{"kas_uri": "https://kas.example.com?foo=bar&second_dim=injected"},
+				},
+			},
+			// The '&' and '=' in the value must be percent-encoded so parseDimensions
+			// sees only one key-value pair, not two.
+			expected: "kas_uri=https%3A%2F%2Fkas.example.com%3Ffoo%3Dbar%26second_dim%3Dinjected",
+		},
+		{
+			name: "value with equals sign is safely encoded",
+			ctx: &authz.ResolverContext{
+				Resources: []*authz.ResolverResource{
+					{"kas_uri": "https://kas.example.com?key=value"},
+				},
+			},
+			expected: "kas_uri=https%3A%2F%2Fkas.example.com%3Fkey%3Dvalue",
+		},
+		{
+			name: "plain URI with colon and slashes is encoded",
+			ctx: &authz.ResolverContext{
+				Resources: []*authz.ResolverResource{
+					{"kas_uri": "https://kas.example.com"},
+				},
+			},
+			expected: "kas_uri=https%3A%2F%2Fkas.example.com",
+		},
+		{
+			name: "plain value without special chars is unchanged",
+			ctx: &authz.ResolverContext{
+				Resources: []*authz.ResolverResource{
+					{"namespace": "hr"},
+				},
+			},
+			expected: "namespace=hr",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := serializeDimensions(tc.ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestParseDimensions_RoundTrip verifies that values containing special characters
+// survive a serialize→parse round-trip without being misinterpreted.
+func TestParseDimensions_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]string
+	}{
+		{
+			name:  "value with ampersand round-trips correctly",
+			input: map[string]string{"kas_uri": "https://kas.example.com?foo=bar&second_dim=injected"},
+		},
+		{
+			name:  "value with equals sign round-trips correctly",
+			input: map[string]string{"kas_uri": "https://kas.example.com?key=value"},
+		},
+		{
+			name:  "full URI with query string round-trips correctly",
+			input: map[string]string{"kas_uri": "https://kas.example.com?foo=bar&baz=qux"},
+		},
+		{
+			name:  "plain value round-trips correctly",
+			input: map[string]string{"namespace": "hr"},
+		},
+		{
+			name:  "multiple dimensions including URI round-trip correctly",
+			input: map[string]string{"kas_uri": "https://kas.example.com?x=1&y=2", "namespace": "hr"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build a ResolverContext from the input map
+			res := authz.ResolverResource(tc.input)
+			ctx := &authz.ResolverContext{
+				Resources: []*authz.ResolverResource{&res},
+			}
+
+			serialized, err := serializeDimensions(ctx)
+			require.NoError(t, err)
+
+			parsed, ok := parseDimensions(serialized)
+			require.True(t, ok, "parseDimensions must succeed on serialized output")
+			assert.Equal(t, tc.input, parsed, "round-trip must preserve original values exactly")
+		})
+	}
+}
+
+// TestDimensionMatch_WithURIValues verifies that dimensionMatch works correctly
+// when dimension values are URIs (which get URL-encoded by serializeDimensions).
+func TestDimensionMatch_WithURIValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      map[string]string
+		policyDims string
+		expected   bool
+	}{
+		{
+			name:       "serialized URI matches policy with same URI",
+			input:      map[string]string{"kas_uri": "https://kas.example.com"},
+			policyDims: "kas_uri=https://kas.example.com",
+			expected:   true,
+		},
+		{
+			name:       "URI value with query string does not match policy for base URI only",
+			input:      map[string]string{"kas_uri": "https://kas.example.com?foo=bar"},
+			policyDims: "kas_uri=https://kas.example.com",
+			// The query string makes the URIs different; policy requires exact match.
+			expected: false,
+		},
+		{
+			name:       "injected extra dimension does not satisfy a different policy key",
+			input:      map[string]string{"kas_uri": "https://kas.example.com?foo=bar&second_dim=injected"},
+			policyDims: "second_dim=injected",
+			// The injected 'second_dim' must NOT appear as a separate dimension.
+			expected: false,
+		},
+		{
+			name:       "wildcard policy matches URI dimension",
+			input:      map[string]string{"kas_uri": "https://kas.example.com"},
+			policyDims: "*",
+			expected:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Serialize the input dimensions as the authorizer would
+			res := authz.ResolverResource(tc.input)
+			ctx := &authz.ResolverContext{
+				Resources: []*authz.ResolverResource{&res},
+			}
+			serialized, err := serializeDimensions(ctx)
+			require.NoError(t, err)
+
+			result := dimensionMatch(serialized, tc.policyDims)
+			assert.Equal(t, tc.expected, result, "dimensionMatch(%q, %q)", serialized, tc.policyDims)
+		})
+	}
+}
+
 // Test NewAuthorizer factory function via authz.New
 func TestNewAuthorizer(t *testing.T) {
 	log := logger.CreateTestLogger()

--- a/tests-bdd/features/authz-v2.feature
+++ b/tests-bdd/features/authz-v2.feature
@@ -56,3 +56,18 @@ Feature: Authz v2 default policy authorization
       Then the response should be permission denied
       When I send a request to list KAS keys for URI "https://kas-a.example.com"
       Then the response should be permission denied
+
+    # Security: URL values containing '&' and '=' must not be mis-parsed as
+    # extra dimensions. A kas-a scoped role must not gain access to a different
+    # KAS key whose URI injects a trailing "kas_uri=https://kas-a.example.com".
+    Scenario: KAS URI with injected dimension characters is rejected
+      Given I use the platform as "opentdf-admin"
+      And I create KAS keys:
+        | kas_uri                                                             | key_id           |
+        | https://kas-b.example.com?foo=bar&kas_uri=https://kas-a.example.com | inject-query-kid |
+        | https://kas-b.example.com/a?x=y&kas_uri=https://kas-a.example.com   | inject-path-kid  |
+      Given I use the platform as "kas-a"
+      When I send a request to get KAS key "inject-query-kid"
+      Then the response should be permission denied
+      When I send a request to get KAS key "inject-path-kid"
+      Then the response should be permission denied


### PR DESCRIPTION
## Summary

Fixes KAS URI dimension injection in authz v2 by escaping dimension values before Casbin matching, then decoding them during dimension parsing. This prevents harmful values containing dimension parser tokens from being interpreted as additional authorization dimensions.

## Changes

- Escape only dimension grammar conflicts during serialization:
  - `%` as `%25`
  - `&` as `%26`
  - literal `*` as `%2A`
- Decode escaped request and policy dimension values with percent-decoding before comparison.
- Keep values readable where possible: `=`, `+`, URI schemes, paths, and query keys remain unchanged.
- Add unit coverage for:
  - URI values containing `&` and `=`
  - literal `+`, spaces, `%`, and `*`
  - serialize/parse round trips
  - `dimensionMatch` behavior with escaped policy dimensions and wildcard values
- Update authz-v2 cukes to verify a `kas-a` scoped client cannot access KAS keys whose URI injects a trailing `kas_uri=https://kas-a.example.com`.

## Security Impact

Previously, a malicious KAS URI like:

```text
https://kas-b.example.com?foo=bar&kas_uri=https://kas-a.example.com
```

could be serialized into dimensions in a way that allowed the trailing `kas_uri` pair to overwrite the original value during parsing. The fix keeps the full URL as one dimension value, so policy matching compares against the actual KAS URI.

## Policy Authoring Note

Raw policy dimensions remain readable. Authors only need percent-encoding for values containing characters that conflict with the dimension grammar, especially literal `&` inside a value:

```text
kas_uri=https://kas.example.com?foo=bar%26baz=qux
```

Raw `*` remains the wildcard policy value; use `%2A` for a literal `*`.

## 💡 Follow-up Recommendation: Structured Policy Dimensions

> 🚧 **Recommendation:** Consider moving policy dimensions to a structured representation before matching, such as `map[string][]string` per RPC/path. This would avoid delimiter ambiguity in raw Casbin dimension strings and reduce the need for authors to percent-encode parser tokens.