### PR TITLE
feat(authz): Mux handler uses new authorizer

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -353,6 +353,14 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
+		if a.authorizer == nil {
+			log.ErrorContext(ctx, "authorizer not initialized") //nolint:contextcheck // checkToken derives ctx from r.Context.
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		// Extra HTTP handlers do not use Connect resolvers, so v2 authorizers receive no
+		// resource dimensions here. Dimension-scoped v2 policy therefore fails closed
+		// unless the policy explicitly allows wildcard dimensions for this path.
 		decision, err := a.authorizer.Authorize(ctx, &internalauthz.Request{ //nolint:contextcheck // checkToken derives ctx from r.Context.
 			Token:  accessTok,
 			RPC:    r.URL.Path,

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -93,8 +93,8 @@ type Authentication struct {
 	authorizer internalauthz.Authorizer
 	// authzResolverRegistry holds per-method resolvers for extracting authorization dimensions
 	authzResolverRegistry *internalauthz.ResolverRegistry
-	// roleProvider extracts configured authorization subjects from request tokens.
-	roleProvider authz.RoleProvider
+	// subjectExtractor extracts configured authorization subjects from request tokens.
+	subjectExtractor internalauthz.SubjectExtractor
 	// Public Routes HTTP & gRPC
 	publicRoutes []string
 	// IPC Reauthorization Routes
@@ -139,7 +139,12 @@ func NewAuthenticator(ctx context.Context, cfg Config, logger *logger.Logger, we
 	if err != nil {
 		return nil, err
 	}
-	a.roleProvider = roleProvider
+	a.subjectExtractor = internalauthz.SubjectExtractor{
+		UserNameClaim: cfg.Policy.UserNameClaim,
+		ClientIDClaim: cfg.Policy.ClientIDClaim,
+		RoleProvider:  roleProvider,
+		Logger:        logger,
+	}
 	casbinConfig := CasbinConfig{
 		PolicyConfig: cfg.Policy,
 		RoleProvider: roleProvider,
@@ -154,6 +159,7 @@ func NewAuthenticator(ctx context.Context, cfg Config, logger *logger.Logger, we
 		Engine:  cfg.Policy.Engine,
 		Version: cfg.Policy.Version,
 		PolicyConfig: internalauthz.PolicyConfig{
+			Issuer:        cfg.Issuer,
 			Engine:        cfg.Policy.Engine,
 			Version:       cfg.Policy.Version,
 			UserNameClaim: cfg.Policy.UserNameClaim,
@@ -305,7 +311,7 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 			return
 		}
 
-		clientID, err := a.subjectExtractor().ClientIDFromToken(r.Context(), accessTok) //nolint:contextcheck // r.Context includes public route state.
+		clientID, err := a.subjectExtractor.ClientIDFromToken(r.Context(), accessTok) //nolint:contextcheck // r.Context includes public route state.
 		if err != nil {
 			log.WarnContext( //nolint:contextcheck // r.Context was enriched with public route state.
 				r.Context(),
@@ -337,7 +343,7 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 			Resource: r.URL.Path,
 			Action:   action,
 		}
-		ctx, err = a.subjectExtractor().ContextWithClaims(ctx, accessTok, roleReq)
+		ctx, err = a.subjectExtractor.ContextWithClaims(ctx, accessTok, roleReq)
 		if err != nil {
 			log.WarnContext(r.Context(), "role provider error", slog.Any("error", err)) //nolint:contextcheck // request context is already derived with public route state above.
 			if errors.Is(err, ErrPermissionDenied) {
@@ -347,23 +353,23 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
-		if allowed, metadata, err := a.enforcer.Enforce(ctx, accessTok, roleReq); err != nil { //nolint:contextcheck // checkToken derives ctx from r.Context.
-			if errors.Is(err, ErrPermissionDenied) {
-				log.WarnContext( //nolint:contextcheck // checkToken derives ctx from r.Context.
-					ctx,
-					"permission denied",
-					permissionDeniedLogAttrs(accessTok, metadata, err)...,
-				)
-				http.Error(w, "permission denied", http.StatusForbidden)
-				return
-			}
+		decision, err := a.authorizer.Authorize(ctx, &internalauthz.Request{ //nolint:contextcheck // checkToken derives ctx from r.Context.
+			Token:  accessTok,
+			RPC:    r.URL.Path,
+			Action: roleReq.Action,
+		})
+		if err != nil {
+			log.ErrorContext(ctx, "authorization error", slog.Any("error", err)) //nolint:contextcheck // checkToken derives ctx from r.Context.
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
-		} else if !allowed {
+		}
+		if !decision.Allowed {
 			log.WarnContext( //nolint:contextcheck // checkToken derives ctx from r.Context.
 				ctx,
 				"permission denied",
-				permissionDeniedLogAttrs(accessTok, metadata, nil)...,
+				slog.String("azp", accessTok.Subject()),
+				slog.String("mode", string(decision.Mode)),
+				slog.String("reason", decision.Reason),
 			)
 			http.Error(w, "permission denied", http.StatusForbidden)
 			return
@@ -410,7 +416,7 @@ func (a Authentication) ConnectAuthNInterceptor() connect.UnaryInterceptorFunc {
 				return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
 			}
 
-			clientID, err := a.subjectExtractor().ClientIDFromToken(ctxWithJWK, token)
+			clientID, err := a.subjectExtractor.ClientIDFromToken(ctxWithJWK, token)
 			if err != nil {
 				log.WarnContext(
 					ctxWithJWK,
@@ -429,7 +435,7 @@ func (a Authentication) ConnectAuthNInterceptor() connect.UnaryInterceptorFunc {
 			if err != nil {
 				return nil, connect.NewError(connect.CodeInvalidArgument, err)
 			}
-			ctxWithJWK, err = a.subjectExtractor().ContextWithClaims(ctxWithJWK, token, roleReq)
+			ctxWithJWK, err = a.subjectExtractor.ContextWithClaims(ctxWithJWK, token, roleReq)
 			if err != nil {
 				log.WarnContext(ctxWithJWK, "role provider error", slog.Any("error", err))
 				if errors.Is(err, ErrPermissionDenied) {
@@ -599,15 +605,6 @@ func (a Authentication) IPCUnaryServerInterceptor() connect.UnaryInterceptorFunc
 		})
 	}
 	return connect.UnaryInterceptorFunc(interceptor)
-}
-
-func (a Authentication) subjectExtractor() internalauthz.SubjectExtractor {
-	return internalauthz.SubjectExtractor{
-		UserNameClaim: a.oidcConfiguration.Policy.UserNameClaim,
-		ClientIDClaim: a.oidcConfiguration.Policy.ClientIDClaim,
-		RoleProvider:  a.roleProvider,
-		Logger:        a.logger,
-	}
 }
 
 // authzResult holds the result of an authorization check
@@ -939,7 +936,7 @@ func (a Authentication) ipcReauthCheck(ctx context.Context, path string, header 
 			}
 
 			// Return the next context with the token
-			clientID, err := a.subjectExtractor().ClientIDFromToken(ctxWithJWK, token)
+			clientID, err := a.subjectExtractor.ClientIDFromToken(ctxWithJWK, token)
 			if err != nil {
 				return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
 			}

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -531,6 +531,85 @@ func (s *AuthSuite) Test_MuxHandler_UsesAuthorizer() {
 	s.NotNil(authorizer.req.Token)
 }
 
+func (s *AuthSuite) Test_MuxHandler_NilAuthorizerReturnsInternalServerError() {
+	tok := jwt.New()
+	s.Require().NoError(tok.Set(jwt.ExpirationKey, time.Now().Add(time.Hour)))
+	s.Require().NoError(tok.Set("iss", s.server.URL))
+	s.Require().NoError(tok.Set("aud", "test"))
+	s.Require().NoError(tok.Set("cid", "client-123"))
+	signedTok, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, s.key))
+	s.Require().NoError(err)
+
+	policyCfg := PolicyConfig{ClientIDClaim: "cid"}
+	s.Require().NoError(defaults.Set(&policyCfg))
+	auth, err := NewAuthenticator(s.T().Context(), Config{
+		AuthNConfig: AuthNConfig{
+			EnforceDPoP: false,
+			Issuer:      s.server.URL,
+			Audience:    "test",
+			Policy:      policyCfg,
+		},
+	}, logger.CreateTestLogger(), func(_ string, _ any) error { return nil })
+	s.Require().NoError(err)
+	auth.authorizer = nil
+
+	called := false
+	handler := auth.MuxHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/attributes/example/value", nil)
+	req.Header.Set("Authorization", "Bearer "+string(signedTok))
+
+	handler.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusInternalServerError, rec.Code)
+	s.False(called)
+}
+
+func (s *AuthSuite) Test_MuxHandler_V2WithoutResourceContextFailsClosedForDimensionPolicy() {
+	tok := jwt.New()
+	s.Require().NoError(tok.Set(jwt.ExpirationKey, time.Now().Add(time.Hour)))
+	s.Require().NoError(tok.Set("iss", s.server.URL))
+	s.Require().NoError(tok.Set("aud", "test"))
+	s.Require().NoError(tok.Set("cid", "client-123"))
+	s.Require().NoError(tok.Set("realm_access", map[string]any{
+		"roles": []string{"standard"},
+	}))
+	signedTok, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, s.key))
+	s.Require().NoError(err)
+
+	policyCfg := PolicyConfig{
+		Version:       "v2",
+		ClientIDClaim: "cid",
+		GroupsClaim:   "realm_access.roles",
+		Csv:           `p, role:standard, /attributes/example/value, namespace=finance, allow`,
+	}
+	s.Require().NoError(defaults.Set(&policyCfg))
+	auth, err := NewAuthenticator(s.T().Context(), Config{
+		AuthNConfig: AuthNConfig{
+			EnforceDPoP: false,
+			Issuer:      s.server.URL,
+			Audience:    "test",
+			Policy:      policyCfg,
+		},
+	}, logger.CreateTestLogger(), func(_ string, _ any) error { return nil })
+	s.Require().NoError(err)
+
+	called := false
+	handler := auth.MuxHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/attributes/example/value", nil)
+	req.Header.Set("Authorization", "Bearer "+string(signedTok))
+
+	handler.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusForbidden, rec.Code)
+	s.False(called)
+}
+
 func (s *AuthSuite) Test_ConnectAuthNInterceptor_RoleProviderErrorReturnsInternal() {
 	tok := jwt.New()
 	s.Require().NoError(tok.Set(jwt.ExpirationKey, time.Now().Add(time.Hour)))

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -56,6 +56,28 @@ type FakeAccessTokenSource struct {
 	accessToken string
 }
 
+type recordingAuthorizer struct {
+	req      *internalauthz.Request
+	decision *internalauthz.Decision
+	err      error
+}
+
+func (a *recordingAuthorizer) Authorize(_ context.Context, req *internalauthz.Request) (*internalauthz.Decision, error) {
+	a.req = req
+	if a.decision != nil || a.err != nil {
+		return a.decision, a.err
+	}
+	return &internalauthz.Decision{Allowed: true, Mode: internalauthz.ModeV1}, nil
+}
+
+func (a *recordingAuthorizer) Version() string {
+	return "test"
+}
+
+func (a *recordingAuthorizer) SupportsResourceAuthorization() bool {
+	return false
+}
+
 type FakeAccessServiceServer struct {
 	clientID       string
 	authzClientID  string
@@ -464,6 +486,49 @@ func (s *AuthSuite) Test_MuxHandler_RoleProviderErrorReturnsInternalServerError(
 
 	s.Equal(http.StatusInternalServerError, rec.Code)
 	s.False(called)
+}
+
+func (s *AuthSuite) Test_MuxHandler_UsesAuthorizer() {
+	tok := jwt.New()
+	s.Require().NoError(tok.Set(jwt.ExpirationKey, time.Now().Add(time.Hour)))
+	s.Require().NoError(tok.Set("iss", s.server.URL))
+	s.Require().NoError(tok.Set("aud", "test"))
+	s.Require().NoError(tok.Set("cid", "client-123"))
+	signedTok, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, s.key))
+	s.Require().NoError(err)
+
+	policyCfg := PolicyConfig{ClientIDClaim: "cid"}
+	s.Require().NoError(defaults.Set(&policyCfg))
+	auth, err := NewAuthenticator(s.T().Context(), Config{
+		AuthNConfig: AuthNConfig{
+			EnforceDPoP: false,
+			Issuer:      s.server.URL,
+			Audience:    "test",
+			Policy:      policyCfg,
+		},
+	}, logger.CreateTestLogger(), func(_ string, _ any) error { return nil })
+	s.Require().NoError(err)
+
+	authorizer := &recordingAuthorizer{}
+	auth.authorizer = authorizer
+
+	called := false
+	handler := auth.MuxHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/attributes/example/value", nil)
+	req.Header.Set("Authorization", "Bearer "+string(signedTok))
+
+	handler.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusNoContent, rec.Code)
+	s.True(called)
+	s.Require().NotNil(authorizer.req)
+	s.Equal("/attributes/example/value", authorizer.req.RPC)
+	s.Equal(ActionDelete, authorizer.req.Action)
+	s.NotNil(authorizer.req.Token)
 }
 
 func (s *AuthSuite) Test_ConnectAuthNInterceptor_RoleProviderErrorReturnsInternal() {
@@ -1130,10 +1195,8 @@ func Test_GetClientIDFromToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			auth := &Authentication{
-				oidcConfiguration: AuthNConfig{
-					Policy: PolicyConfig{
-						ClientIDClaim: tt.clientIDClaim,
-					},
+				subjectExtractor: internalauthz.SubjectExtractor{
+					ClientIDClaim: tt.clientIDClaim,
 				},
 			}
 
@@ -1143,7 +1206,7 @@ func Test_GetClientIDFromToken(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			clientID, err := auth.subjectExtractor().ClientIDFromToken(t.Context(), tok)
+			clientID, err := auth.subjectExtractor.ClientIDFromToken(t.Context(), tok)
 
 			assert.Equal(t, tt.expectedClientID, clientID)
 

--- a/service/internal/auth/authz/adapter_config.go
+++ b/service/internal/auth/authz/adapter_config.go
@@ -20,6 +20,9 @@ const (
 // BaseAdapterConfig contains configuration common to all authorization adapters.
 // This provides a consistent interface for subject extraction across engines.
 type BaseAdapterConfig struct {
+	// Issuer is the configured token issuer for role provider requests.
+	Issuer string
+
 	// UserNameClaim is the JWT claim containing the username.
 	UserNameClaim string
 
@@ -142,6 +145,7 @@ type OPAConfig struct {
 //   - "opa": Returns OPAConfig (future)
 func AdapterConfigFromExternal(cfg Config) any {
 	base := BaseAdapterConfig{
+		Issuer:        cfg.Issuer,
 		UserNameClaim: cfg.UserNameClaim,
 		GroupsClaim:   cfg.GroupsClaim,
 		ClientIDClaim: cfg.ClientIDClaim,

--- a/service/internal/auth/authz/adapter_config_test.go
+++ b/service/internal/auth/authz/adapter_config_test.go
@@ -14,11 +14,13 @@ func TestEngineTypeConstants(t *testing.T) {
 
 func TestBaseAdapterConfig(t *testing.T) {
 	cfg := BaseAdapterConfig{
+		Issuer:        "https://issuer.example",
 		UserNameClaim: "preferred_username",
 		GroupsClaim:   "realm_access.roles",
 		ClientIDClaim: "azp",
 	}
 
+	assert.Equal(t, "https://issuer.example", cfg.Issuer)
 	assert.Equal(t, "preferred_username", cfg.UserNameClaim)
 	assert.Equal(t, "realm_access.roles", cfg.GroupsClaim)
 	assert.Equal(t, "azp", cfg.ClientIDClaim)
@@ -30,6 +32,7 @@ func TestAdapterConfigFromExternal_CasbinV1(t *testing.T) {
 		Engine:  "casbin",
 		Version: "v1",
 		PolicyConfig: PolicyConfig{
+			Issuer:        "https://issuer.example",
 			UserNameClaim: "sub",
 			GroupsClaim:   "roles",
 			ClientIDClaim: "client_id",
@@ -44,6 +47,7 @@ func TestAdapterConfigFromExternal_CasbinV1(t *testing.T) {
 
 	v1Config, ok := result.(CasbinV1Config)
 	assert.True(t, ok, "Expected CasbinV1Config")
+	assert.Equal(t, "https://issuer.example", v1Config.Issuer)
 	assert.Equal(t, "sub", v1Config.UserNameClaim)
 	assert.Equal(t, "roles", v1Config.GroupsClaim)
 	assert.Equal(t, "client_id", v1Config.ClientIDClaim)
@@ -60,6 +64,7 @@ func TestAdapterConfigFromExternal_CasbinV2(t *testing.T) {
 		Engine:  "casbin",
 		Version: "v2",
 		PolicyConfig: PolicyConfig{
+			Issuer:        "https://issuer.example",
 			UserNameClaim: "sub",
 			GroupsClaim:   "roles",
 			ClientIDClaim: "client_id",
@@ -74,6 +79,7 @@ func TestAdapterConfigFromExternal_CasbinV2(t *testing.T) {
 
 	v2Config, ok := result.(CasbinV2Config)
 	assert.True(t, ok, "Expected CasbinV2Config")
+	assert.Equal(t, "https://issuer.example", v2Config.Issuer)
 	assert.Equal(t, "sub", v2Config.UserNameClaim)
 	assert.Equal(t, "roles", v2Config.GroupsClaim)
 	assert.Equal(t, "client_id", v2Config.ClientIDClaim)

--- a/service/internal/auth/authz/casbin/casbin.go
+++ b/service/internal/auth/authz/casbin/casbin.go
@@ -56,6 +56,9 @@ type Authorizer struct {
 	// version indicates which model is active ("v1" or "v2")
 	version string
 
+	// issuer is the configured token issuer for role provider requests.
+	issuer string
+
 	// v1Enforcer handles legacy path-based authorization
 	// Used when version == "v1"
 	v1Enforcer authz.V1Enforcer
@@ -99,6 +102,7 @@ func newCasbinV1Authorizer(cfg authz.CasbinV1Config, log *logger.Logger) (*Autho
 
 	authorizer := &Authorizer{
 		version:    "v1",
+		issuer:     cfg.Issuer,
 		logger:     log,
 		v1Enforcer: cfg.Enforcer,
 	}
@@ -126,13 +130,13 @@ func newCasbinV2Authorizer(cfg authz.CasbinV2Config, log *logger.Logger) (*Autho
 
 	authorizer := &Authorizer{
 		version:    "v2",
+		issuer:     cfg.Issuer,
 		logger:     log,
 		v2Enforcer: enforcer,
 		subjectExtractor: authz.SubjectExtractor{
 			UserNameClaim: cfg.UserNameClaim,
 			ClientIDClaim: cfg.ClientIDClaim,
 			RoleProvider:  roleProvider,
-			UsePrefix:     true,
 			Logger:        log,
 		},
 	}
@@ -253,6 +257,7 @@ func (a *Authorizer) authorizeV1(ctx context.Context, req *authz.Request) (*auth
 	// Example: /kas/v2/rewrap -> /kas/v2/rewrap
 
 	allowed, _, err := a.v1Enforcer.Enforce(ctx, req.Token, platformauthz.RoleRequest{
+		Issuer:   a.issuer,
 		Resource: resource,
 		Action:   req.Action,
 	})
@@ -276,7 +281,12 @@ func (a *Authorizer) authorizeV1(ctx context.Context, req *authz.Request) (*auth
 
 // authorizeV2 performs RPC+dimensions authorization.
 func (a *Authorizer) authorizeV2(ctx context.Context, req *authz.Request) (*authz.Decision, error) {
-	subjects, _, err := a.subjectExtractor.BuildSubjectFromToken(ctx, req.Token, platformauthz.RoleRequest{})
+	roleReq := platformauthz.RoleRequest{
+		Issuer:   a.issuer,
+		Resource: req.RPC,
+		Action:   req.Action,
+	}
+	subjects, _, err := a.subjectExtractor.BuildSubjectFromToken(ctx, req.Token, roleReq, true)
 	if err != nil {
 		return nil, fmt.Errorf("v2 authorization subject extraction error: %w", err)
 	}

--- a/service/internal/auth/authz/casbin/casbin.go
+++ b/service/internal/auth/authz/casbin/casbin.go
@@ -214,6 +214,13 @@ func buildV2PolicyFromConfig(cfg authz.CasbinV2Config) string {
 
 // Authorize implements authz.Authorizer.Authorize.
 func (a *Authorizer) Authorize(ctx context.Context, req *authz.Request) (*authz.Decision, error) {
+	if req == nil {
+		return nil, errors.New("authorization request is required")
+	}
+	if req.Token == nil {
+		return nil, errors.New("authorization token is required")
+	}
+
 	switch a.version {
 	case "v1":
 		return a.authorizeV1(ctx, req)

--- a/service/internal/auth/authz/casbin/casbin_test.go
+++ b/service/internal/auth/authz/casbin/casbin_test.go
@@ -98,6 +98,29 @@ func (s *CasbinAuthorizerSuite) TestNewCasbinAuthorizer_V2() {
 	s.True(authorizer.SupportsResourceAuthorization())
 }
 
+func (s *CasbinAuthorizerSuite) TestAuthorizeRequiresRequestAndToken() {
+	cfg := authz.Config{
+		Version: "v2",
+		PolicyConfig: authz.PolicyConfig{
+			Csv: "p, role:admin, *, *, allow",
+		},
+		Logger: s.logger,
+	}
+
+	authorizer, err := NewAuthorizer(cfg)
+	s.Require().NoError(err)
+
+	decision, err := authorizer.Authorize(s.T().Context(), nil)
+	s.Require().Error(err)
+	s.Nil(decision)
+	s.Contains(err.Error(), "authorization request is required")
+
+	decision, err = authorizer.Authorize(s.T().Context(), &authz.Request{})
+	s.Require().Error(err)
+	s.Nil(decision)
+	s.Contains(err.Error(), "authorization token is required")
+}
+
 func (s *CasbinAuthorizerSuite) TestNewCasbinAuthorizer_UnknownVersionFallsBackToV1() {
 	// Unknown versions default to v1, which requires a v1 enforcer.
 	// This maintains backwards compatibility while providing a clear error.
@@ -389,6 +412,35 @@ func (s *CasbinAuthorizerSuite) TestAuthorizeV2_NoDimensions() {
 	decision, err := authorizer.Authorize(context.Background(), req)
 	s.Require().NoError(err)
 	s.True(decision.Allowed, "should be allowed with nil resource context when policy has wildcard")
+}
+
+func (s *CasbinAuthorizerSuite) TestAuthorizeV2_NoDimensionsDeniedWhenPolicyRequiresDimension() {
+	cfg := authz.Config{
+		Version: "v2",
+		PolicyConfig: authz.PolicyConfig{
+			GroupsClaim: "realm_access.roles",
+			Csv:         `p, role:standard, /policy.attributes.AttributesService/Get*, namespace=finance, allow`,
+		},
+		Logger: s.logger,
+	}
+
+	authorizer, err := NewAuthorizer(cfg)
+	s.Require().NoError(err)
+
+	token := createTestToken(s.T(), map[string]interface{}{
+		"realm_access": map[string]interface{}{
+			"roles": []interface{}{"standard"},
+		},
+	})
+
+	decision, err := authorizer.Authorize(context.Background(), &authz.Request{
+		Token:           token,
+		RPC:             "/policy.attributes.AttributesService/GetAttribute",
+		Action:          "read",
+		ResourceContext: nil,
+	})
+	s.Require().NoError(err)
+	s.False(decision.Allowed, "should deny nil resource context when policy requires dimensions")
 }
 
 func (s *CasbinAuthorizerSuite) TestAuthorizeV2_UsernameWithRolePrefixIsIgnored() {

--- a/service/internal/auth/authz/casbin/casbin_test.go
+++ b/service/internal/auth/authz/casbin/casbin_test.go
@@ -38,6 +38,16 @@ func (p staticRoleProvider) Roles(_ context.Context, _ jwt.Token, _ platformauth
 	return p.roles, nil
 }
 
+type recordingRoleProvider struct {
+	roles []string
+	req   platformauthz.RoleRequest
+}
+
+func (p *recordingRoleProvider) Roles(_ context.Context, _ jwt.Token, req platformauthz.RoleRequest) ([]string, error) {
+	p.req = req
+	return p.roles, nil
+}
+
 type CasbinAuthorizerSuite struct {
 	suite.Suite
 	logger *logger.Logger
@@ -473,6 +483,7 @@ p, alice, /policy.attributes.AttributesService/Get*, *, allow`,
 		s.T().Context(),
 		token,
 		platformauthz.RoleRequest{},
+		true,
 	)
 	s.Require().NoError(err)
 	s.Equal([]string{"client:test-client", "role:admin", "alice"}, subjects)
@@ -514,6 +525,34 @@ func (s *CasbinAuthorizerSuite) TestAuthorizeV2_UsesConfiguredRoleProvider() {
 	s.Require().NoError(err)
 	s.True(decision.Allowed)
 	s.Equal("role:external-admin", decision.MatchedPolicy)
+}
+
+func (s *CasbinAuthorizerSuite) TestAuthorizeV2_PassesRoleRequestToRoleProvider() {
+	roleProvider := &recordingRoleProvider{roles: []string{"external-admin"}}
+	cfg := authz.Config{
+		Version: "v2",
+		PolicyConfig: authz.PolicyConfig{
+			Issuer: "https://issuer.example",
+			Csv:    "p, role:external-admin, /policy.attributes.AttributesService/Get*, *, allow",
+		},
+		Logger:  s.logger,
+		Options: []authz.Option{authz.WithRoleProvider(roleProvider)},
+	}
+
+	authorizer, err := NewAuthorizer(cfg)
+	s.Require().NoError(err)
+
+	_, err = authorizer.Authorize(s.T().Context(), &authz.Request{
+		Token:  jwt.New(),
+		RPC:    "/policy.attributes.AttributesService/GetAttribute",
+		Action: "read",
+	})
+	s.Require().NoError(err)
+	s.Equal(platformauthz.RoleRequest{
+		Issuer:   "https://issuer.example",
+		Resource: "/policy.attributes.AttributesService/GetAttribute",
+		Action:   "read",
+	}, roleProvider.req)
 }
 
 func (s *CasbinAuthorizerSuite) TestAuthorizeV2_ReturnsSubjectExtractionError() {
@@ -1065,9 +1104,11 @@ func (s *CasbinAuthorizerSuite) TestAuthorizeV1_GRPCPathStripsLeadingSlash() {
 	// v1 policy: gRPC paths have NO leading slash
 	// Create a mock enforcer that validates the resource path
 	var receivedResource string
+	var receivedIssuer string
 	mockEnforcer := &mockV1Enforcer{
 		enforceFunc: func(_ context.Context, _ jwt.Token, req platformauthz.RoleRequest) (bool, map[string]any, error) {
 			receivedResource = req.Resource
+			receivedIssuer = req.Issuer
 			// Allow if resource matches expected stripped path
 			return req.Resource == "kas.AccessService/Rewrap", nil, nil
 		},
@@ -1076,6 +1117,7 @@ func (s *CasbinAuthorizerSuite) TestAuthorizeV1_GRPCPathStripsLeadingSlash() {
 	cfg := authz.Config{
 		Version: "v1",
 		PolicyConfig: authz.PolicyConfig{
+			Issuer:      "https://issuer.example",
 			GroupsClaim: "realm_access.roles",
 		},
 		Logger:  s.logger,
@@ -1104,6 +1146,7 @@ func (s *CasbinAuthorizerSuite) TestAuthorizeV1_GRPCPathStripsLeadingSlash() {
 	s.True(decision.Allowed, "gRPC path should be allowed after stripping leading slash")
 	s.Equal(authz.ModeV1, decision.Mode)
 	s.Equal("kas.AccessService/Rewrap", receivedResource, "resource should have leading slash stripped")
+	s.Equal("https://issuer.example", receivedIssuer)
 }
 
 func (s *CasbinAuthorizerSuite) TestAuthorizeV1_HTTPPathKeepsLeadingSlash() {

--- a/service/internal/auth/authz/policy.go
+++ b/service/internal/auth/authz/policy.go
@@ -4,6 +4,9 @@ package authz
 // This mirrors auth.PolicyConfig to avoid circular imports while maintaining
 // the same field structure for consistent configuration.
 type PolicyConfig struct {
+	// Issuer is the configured token issuer for role provider requests.
+	Issuer string
+
 	// Engine specifies the authorization engine to use.
 	// - "casbin" (default): Casbin policy engine
 	// - "cedar": AWS Cedar policy engine (future)

--- a/service/internal/auth/authz/subject_extractor.go
+++ b/service/internal/auth/authz/subject_extractor.go
@@ -22,6 +22,7 @@ var (
 	ErrClientIDClaimNotConfigured = errors.New("no client ID claim configured")
 	ErrClientIDClaimNotFound      = errors.New("client ID claim not found")
 	ErrClientIDClaimNotString     = errors.New("client ID claim is not a string")
+	ErrTokenRequired              = errors.New("token is required")
 )
 
 type SubjectExtractor struct {
@@ -68,6 +69,9 @@ func (e SubjectExtractor) ClaimsForRequest(ctx context.Context, token jwt.Token,
 		if claims.Subject != "" || len(claims.Groups) > 0 {
 			return claims, nil
 		}
+	}
+	if token == nil {
+		return platformauthz.RequestClaims{}, ErrTokenRequired
 	}
 
 	var roles []string

--- a/service/internal/auth/authz/subject_extractor.go
+++ b/service/internal/auth/authz/subject_extractor.go
@@ -28,11 +28,10 @@ type SubjectExtractor struct {
 	UserNameClaim string
 	ClientIDClaim string
 	RoleProvider  platformauthz.RoleProvider
-	UsePrefix     bool
 	Logger        *logger.Logger
 }
 
-func (e SubjectExtractor) BuildSubjectFromToken(ctx context.Context, token jwt.Token, req platformauthz.RoleRequest) ([]string, []string, error) {
+func (e SubjectExtractor) BuildSubjectFromToken(ctx context.Context, token jwt.Token, req platformauthz.RoleRequest, usePrefix bool) ([]string, []string, error) {
 	subjects := []string{}
 
 	if e.Logger != nil {
@@ -43,10 +42,10 @@ func (e SubjectExtractor) BuildSubjectFromToken(ctx context.Context, token jwt.T
 	if err != nil {
 		return nil, nil, err
 	}
-	roles := e.normalizeRoles(claims.Groups)
+	roles := normalizeRoles(claims.Groups, usePrefix)
 
 	if clientID := claims.ClientID; clientID != "" {
-		subjects = append(subjects, e.subjectWithPrefix(clientID, SubjectClientPrefix))
+		subjects = append(subjects, subjectWithPrefix(clientID, SubjectClientPrefix, usePrefix))
 	}
 	subjects = append(subjects, roles...)
 	if claims.Subject != "" {
@@ -110,8 +109,8 @@ func (e SubjectExtractor) ClientIDFromToken(ctx context.Context, token jwt.Token
 	return clientID, nil
 }
 
-func (e SubjectExtractor) normalizeRoles(roles []string) []string {
-	if !e.UsePrefix {
+func normalizeRoles(roles []string, usePrefix bool) []string {
+	if !usePrefix {
 		return roles
 	}
 	prefixed := make([]string, 0, len(roles))
@@ -119,13 +118,13 @@ func (e SubjectExtractor) normalizeRoles(roles []string) []string {
 		if role == "" {
 			continue
 		}
-		prefixed = append(prefixed, e.subjectWithPrefix(role, SubjectRolePrefix))
+		prefixed = append(prefixed, subjectWithPrefix(role, SubjectRolePrefix, usePrefix))
 	}
 	return prefixed
 }
 
-func (e SubjectExtractor) subjectWithPrefix(subject, prefix string) string {
-	if !e.UsePrefix || strings.HasPrefix(subject, prefix) {
+func subjectWithPrefix(subject, prefix string, usePrefix bool) string {
+	if !usePrefix || strings.HasPrefix(subject, prefix) {
 		return subject
 	}
 	return prefix + subject

--- a/service/internal/auth/authz/subject_extractor_test.go
+++ b/service/internal/auth/authz/subject_extractor_test.go
@@ -31,7 +31,7 @@ func TestSubjectExtractorGroupsClaimSupportsStringSlices(t *testing.T) {
 		RoleProvider:  NewJWTClaimsRoleProvider("realm_access.roles", nil),
 	}
 
-	subjects, roles, err := extractor.BuildSubjectFromToken(t.Context(), token, platformauthz.RoleRequest{})
+	subjects, roles, err := extractor.BuildSubjectFromToken(t.Context(), token, platformauthz.RoleRequest{}, false)
 	require.NoError(t, err)
 	require.Equal(t, []string{"test-client", "opentdf-admin", "opentdf-standard", "alice"}, subjects)
 	require.Equal(t, []string{"opentdf-admin", "opentdf-standard"}, roles)
@@ -46,10 +46,9 @@ func TestSubjectExtractorCanPrefixSubjects(t *testing.T) {
 		UserNameClaim: "preferred_username",
 		ClientIDClaim: "azp",
 		RoleProvider:  staticRoleProvider{roles: []string{"admin", ""}},
-		UsePrefix:     true,
 	}
 
-	subjects, roles, err := extractor.BuildSubjectFromToken(t.Context(), token, platformauthz.RoleRequest{})
+	subjects, roles, err := extractor.BuildSubjectFromToken(t.Context(), token, platformauthz.RoleRequest{}, true)
 	require.NoError(t, err)
 	require.Equal(t, []string{"client:test-client", "role:admin", "alice"}, subjects)
 	require.Equal(t, []string{"role:admin"}, roles)
@@ -129,7 +128,7 @@ func TestSubjectExtractorDoesNotAppendEmptyUsername(t *testing.T) {
 		RoleProvider:  staticRoleProvider{roles: []string{"role:admin"}},
 	}
 
-	subjects, roles, err := extractor.BuildSubjectFromToken(t.Context(), token, platformauthz.RoleRequest{})
+	subjects, roles, err := extractor.BuildSubjectFromToken(t.Context(), token, platformauthz.RoleRequest{}, false)
 	require.NoError(t, err)
 	require.Equal(t, []string{"role:admin"}, subjects)
 	require.Equal(t, []string{"role:admin"}, roles)
@@ -144,7 +143,7 @@ func TestSubjectExtractorIgnoresUsernameWithReservedRolePrefix(t *testing.T) {
 		RoleProvider:  staticRoleProvider{roles: []string{"role:admin"}},
 	}
 
-	subjects, roles, err := extractor.BuildSubjectFromToken(t.Context(), token, platformauthz.RoleRequest{})
+	subjects, roles, err := extractor.BuildSubjectFromToken(t.Context(), token, platformauthz.RoleRequest{}, false)
 	require.NoError(t, err)
 	require.Equal(t, []string{"role:admin"}, subjects)
 	require.Equal(t, []string{"role:admin"}, roles)

--- a/service/internal/auth/authz/subject_extractor_test.go
+++ b/service/internal/auth/authz/subject_extractor_test.go
@@ -54,6 +54,20 @@ func TestSubjectExtractorCanPrefixSubjects(t *testing.T) {
 	require.Equal(t, []string{"role:admin"}, roles)
 }
 
+func TestSubjectExtractorRequiresTokenWhenClaimsAreNotCached(t *testing.T) {
+	extractor := SubjectExtractor{
+		UserNameClaim: "preferred_username",
+		ClientIDClaim: "azp",
+		RoleProvider:  staticRoleProvider{roles: []string{"admin"}},
+	}
+
+	subjects, roles, err := extractor.BuildSubjectFromToken(t.Context(), nil, platformauthz.RoleRequest{}, true)
+
+	require.ErrorIs(t, err, ErrTokenRequired)
+	require.Nil(t, subjects)
+	require.Nil(t, roles)
+}
+
 func TestSubjectExtractorClientIDFromToken(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/service/internal/auth/casbin.go
+++ b/service/internal/auth/casbin.go
@@ -189,7 +189,7 @@ func (e *Enforcer) Enforce(ctx context.Context, token jwt.Token, req authz.RoleR
 }
 
 func (e *Enforcer) buildSubjectFromToken(ctx context.Context, t jwt.Token, req authz.RoleRequest) (casbinSubject, []string, error) {
-	subjects, roles, err := e.subjectExtractor().BuildSubjectFromToken(ctx, t, req)
+	subjects, roles, err := e.subjectExtractor().BuildSubjectFromToken(ctx, t, req, false)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Summary

  Updates the HTTP mux authentication path to use the configured pluggable authorizer instead of directly invoking the legacy Casbin enforcer.

  ## Changes

  - Routes `MuxHandler` authorization through `Authentication.authorizer.Authorize`.
  - Stores a configured `SubjectExtractor` on `Authentication` instead of storing the role provider and rebuilding the extractor.
  - Makes subject prefixing an explicit `BuildSubjectFromToken(..., usePrefix)` argument instead of `SubjectExtractor` state.
  - Threads issuer into internal authz/Casbin config so authorizers can populate `RoleRequest`.
  - Updates v1/v2 Casbin authorization to pass populated `RoleRequest` values to role providers/enforcers.
  - Adds tests covering mux authorizer usage, subject prefix behavior, adapter issuer mapping, and v1/v2 issuer propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring token issuer in authorization policies.

* **Bug Fixes**
  * Improved error handling and messaging for missing or invalid tokens during authorization.
  * Enhanced authorization decision logging to include issuer and policy mode information.
  * Fixed enforcement of resource dimension requirements in authorization policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->