### PR TITLE
feat(cli): Add search to cli

### DIFF
--- a/otdfctl/cmd/policy/attributes.go
+++ b/otdfctl/cmd/policy/attributes.go
@@ -90,9 +90,10 @@ func listAttributes(cmd *cobra.Command, args []string) {
 	state := cli.GetState(cmd)
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
+	search := c.Flags.GetOptionalString("search")
 	sort := getSortOption(c)
 
-	resp, err := h.ListAttributes(cmd.Context(), state, limit, offset, sort)
+	resp, err := h.ListAttributes(cmd.Context(), state, limit, offset, search, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list attributes", err)
 	}
@@ -355,7 +356,8 @@ func policyRemoveKeyFromAttribute(cmd *cobra.Command, args []string) {
 
 func initAttributesCommands() {
 	// Create an attribute
-	createDoc := man.Docs.GetCommand("policy/attributes/create",
+	createDoc := man.Docs.GetCommand(
+		"policy/attributes/create",
 		man.WithRun(createAttribute),
 	)
 	createDoc.Flags().StringP(
@@ -391,7 +393,8 @@ func initAttributesCommands() {
 	injectLabelFlags(&createDoc.Command, false)
 
 	// Get an attribute
-	getDoc := man.Docs.GetCommand("policy/attributes/get",
+	getDoc := man.Docs.GetCommand(
+		"policy/attributes/get",
 		man.WithRun(getAttribute),
 	)
 	getDoc.Flags().StringP(
@@ -402,7 +405,8 @@ func initAttributesCommands() {
 	)
 
 	// List attributes
-	listDoc := man.Docs.GetCommand("policy/attributes/list",
+	listDoc := man.Docs.GetCommand(
+		"policy/attributes/list",
 		man.WithRun(listAttributes),
 	)
 	listDoc.Flags().StringP(
@@ -412,10 +416,12 @@ func initAttributesCommands() {
 		listDoc.GetDocFlag("state").Description,
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSearchFlag(listDoc)
 	injectListSortFlags(listDoc)
 
 	// Update an attribute
-	updateDoc := man.Docs.GetCommand("policy/attributes/update",
+	updateDoc := man.Docs.GetCommand(
+		"policy/attributes/update",
 		man.WithRun(updateAttribute),
 	)
 	updateDoc.Flags().StringP(
@@ -427,7 +433,8 @@ func initAttributesCommands() {
 	injectLabelFlags(&updateDoc.Command, true)
 
 	// Deactivate an attribute
-	deactivateDoc := man.Docs.GetCommand("policy/attributes/deactivate",
+	deactivateDoc := man.Docs.GetCommand(
+		"policy/attributes/deactivate",
 		man.WithRun(deactivateAttribute),
 	)
 	deactivateDoc.Flags().StringP(
@@ -444,13 +451,15 @@ func initAttributesCommands() {
 
 	// unsafe actions on attributes
 	unsafeCmd := man.Docs.GetCommand("policy/attributes/unsafe")
-	unsafeCmd.PersistentFlags().BoolVar(&forceUnsafe,
+	unsafeCmd.PersistentFlags().BoolVar(
+		&forceUnsafe,
 		unsafeCmd.GetDocFlag("force").Name,
 		false,
 		unsafeCmd.GetDocFlag("force").Description,
 	)
 
-	reactivateCmd := man.Docs.GetCommand("policy/attributes/unsafe/reactivate",
+	reactivateCmd := man.Docs.GetCommand(
+		"policy/attributes/unsafe/reactivate",
 		man.WithRun(unsafeReactivateAttribute),
 	)
 	reactivateCmd.Flags().StringP(
@@ -459,7 +468,8 @@ func initAttributesCommands() {
 		reactivateCmd.GetDocFlag("id").Default,
 		reactivateCmd.GetDocFlag("id").Description,
 	)
-	deleteCmd := man.Docs.GetCommand("policy/attributes/unsafe/delete",
+	deleteCmd := man.Docs.GetCommand(
+		"policy/attributes/unsafe/delete",
 		man.WithRun(unsafeDeleteAttribute),
 	)
 	deleteCmd.Flags().StringP(
@@ -468,7 +478,8 @@ func initAttributesCommands() {
 		deleteCmd.GetDocFlag("id").Default,
 		deleteCmd.GetDocFlag("id").Description,
 	)
-	unsafeUpdateCmd := man.Docs.GetCommand("policy/attributes/unsafe/update",
+	unsafeUpdateCmd := man.Docs.GetCommand(
+		"policy/attributes/unsafe/update",
 		man.WithRun(unsafeUpdateAttribute),
 	)
 	unsafeUpdateCmd.Flags().StringP(
@@ -505,7 +516,8 @@ func initAttributesCommands() {
 	keyCmd := man.Docs.GetCommand("policy/attributes/key")
 
 	// Assign KAS key to attribute
-	assignKasKeyCmd := man.Docs.GetCommand("policy/attributes/key/assign",
+	assignKasKeyCmd := man.Docs.GetCommand(
+		"policy/attributes/key/assign",
 		man.WithRun(policyAssignKeyToAttribute),
 	)
 	assignKasKeyCmd.Flags().StringP(
@@ -521,7 +533,8 @@ func initAttributesCommands() {
 		assignKasKeyCmd.GetDocFlag("key-id").Description,
 	)
 
-	removeKasKeyCmd := man.Docs.GetCommand("policy/attributes/key/remove",
+	removeKasKeyCmd := man.Docs.GetCommand(
+		"policy/attributes/key/remove",
 		man.WithRun(policyRemoveKeyFromAttribute),
 	)
 	removeKasKeyCmd.Flags().StringP(

--- a/otdfctl/cmd/policy/kasKeys.go
+++ b/otdfctl/cmd/policy/kasKeys.go
@@ -423,6 +423,7 @@ func policyListKasKeys(cmd *cobra.Command, args []string) {
 	if err != nil {
 		cli.ExitWithError("Invalid legacy flag", err)
 	}
+	search := c.Flags.GetOptionalString("search")
 	sort := getSortOption(c)
 
 	kasLookup, err := resolveKasIdentifier(kasIdentifier)
@@ -431,7 +432,7 @@ func policyListKasKeys(cmd *cobra.Command, args []string) {
 	}
 
 	// Get the list of keys.
-	resp, err := h.ListKasKeys(c.Context(), limit, offset, alg, kasLookup, legacy, sort)
+	resp, err := h.ListKasKeys(c.Context(), limit, offset, alg, kasLookup, legacy, search, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list kas keys", err)
 	}
@@ -947,6 +948,7 @@ func initKASKeysCommands() {
 		listDoc.GetDocFlag("legacy").Description,
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSearchFlag(listDoc)
 	injectListSortFlags(listDoc)
 
 	// Rotate Kas Key

--- a/otdfctl/cmd/policy/kasRegistry.go
+++ b/otdfctl/cmd/policy/kasRegistry.go
@@ -61,9 +61,10 @@ func listKeyAccessRegistries(cmd *cobra.Command, args []string) {
 
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
+	search := c.Flags.GetOptionalString("search")
 	sort := getSortOption(c)
 
-	resp, err := h.ListKasRegistryEntries(cmd.Context(), limit, offset, sort)
+	resp, err := h.ListKasRegistryEntries(cmd.Context(), limit, offset, search, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list Registered KAS entries", err)
 	}
@@ -213,7 +214,8 @@ func deleteKeyAccessRegistry(cmd *cobra.Command, args []string) {
 }
 
 func initKASRegistryCommands() {
-	getDoc := man.Docs.GetCommand("policy/kas-registry/get",
+	getDoc := man.Docs.GetCommand(
+		"policy/kas-registry/get",
 		man.WithRun(getKeyAccessRegistry),
 	)
 	getDoc.Flags().StringP(
@@ -223,13 +225,16 @@ func initKASRegistryCommands() {
 		getDoc.GetDocFlag("id").Description,
 	)
 
-	listDoc := man.Docs.GetCommand("policy/kas-registry/list",
+	listDoc := man.Docs.GetCommand(
+		"policy/kas-registry/list",
 		man.WithRun(listKeyAccessRegistries),
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSearchFlag(listDoc)
 	injectListSortFlags(listDoc)
 
-	createDoc := man.Docs.GetCommand("policy/kas-registry/create",
+	createDoc := man.Docs.GetCommand(
+		"policy/kas-registry/create",
 		man.WithRun(createKeyAccessRegistry),
 	)
 	createDoc.Flags().StringP(
@@ -258,7 +263,8 @@ func initKASRegistryCommands() {
 	)
 	injectLabelFlags(&createDoc.Command, false)
 
-	updateDoc := man.Docs.GetCommand("policy/kas-registry/update",
+	updateDoc := man.Docs.GetCommand(
+		"policy/kas-registry/update",
 		man.WithRun(updateKeyAccessRegistry),
 	)
 	updateDoc.Flags().StringP(
@@ -293,7 +299,8 @@ func initKASRegistryCommands() {
 	)
 	injectLabelFlags(&updateDoc.Command, true)
 
-	deleteDoc := man.Docs.GetCommand("policy/kas-registry/delete",
+	deleteDoc := man.Docs.GetCommand(
+		"policy/kas-registry/delete",
 		man.WithRun(deleteKeyAccessRegistry),
 	)
 	deleteDoc.Flags().StringP(

--- a/otdfctl/cmd/policy/namespaces.go
+++ b/otdfctl/cmd/policy/namespaces.go
@@ -45,9 +45,10 @@ func listAttributeNamespaces(cmd *cobra.Command, args []string) {
 	state := cli.GetState(cmd)
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
+	search := c.Flags.GetOptionalString("search")
 	sort := getSortOption(c)
 
-	resp, err := h.ListNamespaces(cmd.Context(), state, limit, offset, sort)
+	resp, err := h.ListNamespaces(cmd.Context(), state, limit, offset, search, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list namespaces", err)
 	}
@@ -62,7 +63,8 @@ func listAttributeNamespaces(cmd *cobra.Command, args []string) {
 	rows := []table.Row{}
 	for _, ns := range resp.GetNamespaces() {
 		metadata := cli.ConstructMetadata(ns.GetMetadata())
-		rows = append(rows,
+		rows = append(
+			rows,
 			table.NewRow(table.RowData{
 				"id":         ns.GetId(),
 				"name":       ns.GetName(),
@@ -320,7 +322,8 @@ func policyRemoveKeyFromNamespace(cmd *cobra.Command, args []string) {
 func initNamespacesCommands() {
 	nsDoc := man.Docs.GetCommand("policy/namespaces")
 
-	getDoc := man.Docs.GetCommand("policy/namespaces/get",
+	getDoc := man.Docs.GetCommand(
+		"policy/namespaces/get",
 		man.WithRun(getAttributeNamespace),
 	)
 	getDoc.Flags().StringP(
@@ -330,7 +333,8 @@ func initNamespacesCommands() {
 		getDoc.GetDocFlag("id").Description,
 	)
 
-	listDoc := man.Docs.GetCommand("policy/namespaces/list",
+	listDoc := man.Docs.GetCommand(
+		"policy/namespaces/list",
 		man.WithRun(listAttributeNamespaces),
 	)
 	listDoc.Flags().StringP(
@@ -340,9 +344,11 @@ func initNamespacesCommands() {
 		listDoc.GetDocFlag("state").Description,
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSearchFlag(listDoc)
 	injectListSortFlags(listDoc)
 
-	createDoc := man.Docs.GetCommand("policy/namespaces/create",
+	createDoc := man.Docs.GetCommand(
+		"policy/namespaces/create",
 		man.WithRun(createAttributeNamespace),
 	)
 	createDoc.Flags().StringP(
@@ -353,7 +359,8 @@ func initNamespacesCommands() {
 	)
 	injectLabelFlags(&createDoc.Command, false)
 
-	updateDoc := man.Docs.GetCommand("policy/namespaces/update",
+	updateDoc := man.Docs.GetCommand(
+		"policy/namespaces/update",
 		man.WithRun(updateAttributeNamespace),
 	)
 	updateDoc.Flags().StringP(
@@ -364,7 +371,8 @@ func initNamespacesCommands() {
 	)
 	injectLabelFlags(&updateDoc.Command, true)
 
-	deactivateDoc := man.Docs.GetCommand("policy/namespaces/deactivate",
+	deactivateDoc := man.Docs.GetCommand(
+		"policy/namespaces/deactivate",
 		man.WithRun(deactivateAttributeNamespace),
 	)
 	deactivateDoc.Flags().StringP(
@@ -388,7 +396,8 @@ func initNamespacesCommands() {
 		unsafeDoc.GetDocFlag("force").Description,
 	)
 
-	deleteDoc := man.Docs.GetCommand("policy/namespaces/unsafe/delete",
+	deleteDoc := man.Docs.GetCommand(
+		"policy/namespaces/unsafe/delete",
 		man.WithRun(unsafeDeleteAttributeNamespace),
 	)
 	deleteDoc.Flags().StringP(
@@ -398,7 +407,8 @@ func initNamespacesCommands() {
 		deleteDoc.GetDocFlag("id").Description,
 	)
 
-	reactivateDoc := man.Docs.GetCommand("policy/namespaces/unsafe/reactivate",
+	reactivateDoc := man.Docs.GetCommand(
+		"policy/namespaces/unsafe/reactivate",
 		man.WithRun(unsafeReactivateAttributeNamespace),
 	)
 	reactivateDoc.Flags().StringP(
@@ -408,7 +418,8 @@ func initNamespacesCommands() {
 		reactivateDoc.GetDocFlag("id").Description,
 	)
 
-	unsafeUpdateDoc := man.Docs.GetCommand("policy/namespaces/unsafe/update",
+	unsafeUpdateDoc := man.Docs.GetCommand(
+		"policy/namespaces/unsafe/update",
 		man.WithRun(unsafeUpdateAttributeNamespace),
 	)
 	unsafeUpdateDoc.Flags().StringP(
@@ -427,7 +438,8 @@ func initNamespacesCommands() {
 	// key
 	keyDoc := man.Docs.GetCommand("policy/namespaces/key")
 
-	assignDoc := man.Docs.GetCommand("policy/namespaces/key/assign",
+	assignDoc := man.Docs.GetCommand(
+		"policy/namespaces/key/assign",
 		man.WithRun(policyAssignKeyToNamespace),
 	)
 	assignDoc.Flags().StringP(
@@ -443,7 +455,8 @@ func initNamespacesCommands() {
 		assignDoc.GetDocFlag("key-id").Description,
 	)
 
-	removeDoc := man.Docs.GetCommand("policy/namespaces/key/remove",
+	removeDoc := man.Docs.GetCommand(
+		"policy/namespaces/key/remove",
 		man.WithRun(policyRemoveKeyFromNamespace),
 	)
 	removeDoc.Flags().StringP(

--- a/otdfctl/cmd/policy/obligations.go
+++ b/otdfctl/cmd/policy/obligations.go
@@ -99,9 +99,10 @@ func policyListObligations(cmd *cobra.Command, args []string) {
 	namespace := c.Flags.GetOptionalString("namespace")
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
+	search := c.Flags.GetOptionalString("search")
 	sort := getSortOption(c)
 
-	resp, err := h.ListObligations(cmd.Context(), limit, offset, namespace, sort)
+	resp, err := h.ListObligations(cmd.Context(), limit, offset, namespace, search, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list obligations", err)
 	}
@@ -498,7 +499,8 @@ func parseTriggers(triggerInput string) ([]*obligations.ValueTriggerRequest, err
 
 func initObligationsCommands() {
 	// Obligations commands
-	getDoc := man.Docs.GetCommand("policy/obligations/get",
+	getDoc := man.Docs.GetCommand(
+		"policy/obligations/get",
 		man.WithRun(policyGetObligation),
 	)
 	getDoc.Flags().StringP(
@@ -516,7 +518,8 @@ func initObligationsCommands() {
 	getDoc.MarkFlagsMutuallyExclusive("id", "fqn")
 	getDoc.MarkFlagsOneRequired("id", "fqn")
 
-	listDoc := man.Docs.GetCommand("policy/obligations/list",
+	listDoc := man.Docs.GetCommand(
+		"policy/obligations/list",
 		man.WithRun(policyListObligations),
 	)
 	listDoc.Flags().StringP(
@@ -526,9 +529,11 @@ func initObligationsCommands() {
 		listDoc.GetDocFlag("namespace").Description,
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSearchFlag(listDoc)
 	injectListSortFlags(listDoc)
 
-	createDoc := man.Docs.GetCommand("policy/obligations/create",
+	createDoc := man.Docs.GetCommand(
+		"policy/obligations/create",
 		man.WithRun(policyCreateObligation),
 	)
 	createDoc.Flags().StringP(
@@ -552,7 +557,8 @@ func initObligationsCommands() {
 	)
 	injectLabelFlags(&createDoc.Command, false)
 
-	updateDoc := man.Docs.GetCommand("policy/obligations/update",
+	updateDoc := man.Docs.GetCommand(
+		"policy/obligations/update",
 		man.WithRun(policyUpdateObligation),
 	)
 	updateDoc.Flags().StringP(
@@ -569,7 +575,8 @@ func initObligationsCommands() {
 	)
 	injectLabelFlags(&updateDoc.Command, true)
 
-	deleteDoc := man.Docs.GetCommand("policy/obligations/delete",
+	deleteDoc := man.Docs.GetCommand(
+		"policy/obligations/delete",
 		man.WithRun(policyDeleteObligation),
 	)
 	deleteDoc.Flags().StringP(
@@ -594,7 +601,8 @@ func initObligationsCommands() {
 
 	// Obligation Values commands
 
-	getValueDoc := man.Docs.GetCommand("policy/obligations/values/get",
+	getValueDoc := man.Docs.GetCommand(
+		"policy/obligations/values/get",
 		man.WithRun(policyGetObligationValue),
 	)
 	getValueDoc.Flags().StringP(
@@ -612,7 +620,8 @@ func initObligationsCommands() {
 	getValueDoc.MarkFlagsMutuallyExclusive("id", "fqn")
 	getValueDoc.MarkFlagsOneRequired("id", "fqn")
 
-	createValueDoc := man.Docs.GetCommand("policy/obligations/values/create",
+	createValueDoc := man.Docs.GetCommand(
+		"policy/obligations/values/create",
 		man.WithRun(policyCreateObligationValue),
 	)
 	createValueDoc.Flags().StringP(
@@ -635,7 +644,8 @@ func initObligationsCommands() {
 	)
 	injectLabelFlags(&createValueDoc.Command, false)
 
-	updateValueDoc := man.Docs.GetCommand("policy/obligations/values/update",
+	updateValueDoc := man.Docs.GetCommand(
+		"policy/obligations/values/update",
 		man.WithRun(policyUpdateObligationValue),
 	)
 	updateValueDoc.Flags().StringP(
@@ -657,7 +667,8 @@ func initObligationsCommands() {
 		updateValueDoc.GetDocFlag("triggers").Description,
 	)
 	injectLabelFlags(&updateValueDoc.Command, true)
-	deleteValueDoc := man.Docs.GetCommand("policy/obligations/values/delete",
+	deleteValueDoc := man.Docs.GetCommand(
+		"policy/obligations/values/delete",
 		man.WithRun(policyDeleteObligationValue),
 	)
 	deleteValueDoc.Flags().StringP(
@@ -681,7 +692,8 @@ func initObligationsCommands() {
 	deleteValueDoc.MarkFlagsOneRequired("id", "fqn")
 
 	// Obligation Triggers commands
-	createTriggerDoc := man.Docs.GetCommand("policy/obligations/triggers/create",
+	createTriggerDoc := man.Docs.GetCommand(
+		"policy/obligations/triggers/create",
 		man.WithRun(policyCreateObligationTrigger),
 	)
 	createTriggerDoc.Flags().StringP(
@@ -710,7 +722,8 @@ func initObligationsCommands() {
 	)
 	injectLabelFlags(&createTriggerDoc.Command, false)
 
-	deleteTriggerDoc := man.Docs.GetCommand("policy/obligations/triggers/delete",
+	deleteTriggerDoc := man.Docs.GetCommand(
+		"policy/obligations/triggers/delete",
 		man.WithRun(policyDeleteObligationTrigger),
 	)
 	deleteTriggerDoc.Flags().StringP(
@@ -725,7 +738,8 @@ func initObligationsCommands() {
 		deleteTriggerDoc.GetDocFlag("force").Description,
 	)
 
-	listTriggerDoc := man.Docs.GetCommand("policy/obligations/triggers/list",
+	listTriggerDoc := man.Docs.GetCommand(
+		"policy/obligations/triggers/list",
 		man.WithRun(policyListObligationTriggers),
 	)
 	listTriggerDoc.Flags().StringP(
@@ -738,7 +752,8 @@ func initObligationsCommands() {
 
 	// Add commands to the policy command
 
-	policyObligationsDoc := man.Docs.GetCommand("policy/obligations",
+	policyObligationsDoc := man.Docs.GetCommand(
+		"policy/obligations",
 		man.WithSubcommands(
 			getDoc,
 			listDoc,
@@ -748,7 +763,8 @@ func initObligationsCommands() {
 		),
 	)
 
-	policyObligationValuesDoc := man.Docs.GetCommand("policy/obligations/values",
+	policyObligationValuesDoc := man.Docs.GetCommand(
+		"policy/obligations/values",
 		man.WithSubcommands(
 			getValueDoc,
 			createValueDoc,
@@ -757,7 +773,8 @@ func initObligationsCommands() {
 		),
 	)
 
-	policyObligationTriggersDoc := man.Docs.GetCommand("policy/obligations/triggers",
+	policyObligationTriggersDoc := man.Docs.GetCommand(
+		"policy/obligations/triggers",
 		man.WithSubcommands(
 			createTriggerDoc,
 			deleteTriggerDoc,

--- a/otdfctl/cmd/policy/policy.go
+++ b/otdfctl/cmd/policy/policy.go
@@ -94,6 +94,11 @@ func injectListSortFlags(listDoc *man.Doc) {
 	listDoc.Flags().String(orderFlag.Name, orderFlag.Default, orderFlag.Description)
 }
 
+func injectListSearchFlag(listDoc *man.Doc) {
+	searchFlag := listDoc.GetDocFlag("search")
+	listDoc.Flags().String(searchFlag.Name, searchFlag.Default, searchFlag.Description)
+}
+
 func getSortOption(c *cli.Cli) handlers.SortOption {
 	sort, err := handlers.NewSortOption(c.Flags.GetOptionalString("sort"), c.Flags.GetOptionalString("order"))
 	if err != nil {

--- a/otdfctl/cmd/policy/registeredResources.go
+++ b/otdfctl/cmd/policy/registeredResources.go
@@ -103,9 +103,10 @@ func policyListRegisteredResources(cmd *cobra.Command, args []string) {
 	namespace := c.Flags.GetOptionalString("namespace")
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
+	search := c.Flags.GetOptionalString("search")
 	sort := getSortOption(c)
 
-	resp, err := h.ListRegisteredResources(cmd.Context(), limit, offset, namespace, sort)
+	resp, err := h.ListRegisteredResources(cmd.Context(), limit, offset, namespace, search, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list registered resources", err)
 	}
@@ -461,7 +462,8 @@ func parseActionAttributeValueArgs(args []string) []*registeredresources.ActionA
 func initRegisteredResourcesCommands() {
 	// Registered Resources commands
 
-	getDoc := man.Docs.GetCommand("policy/registered-resources/get",
+	getDoc := man.Docs.GetCommand(
+		"policy/registered-resources/get",
 		man.WithRun(policyGetRegisteredResource),
 	)
 	getDoc.Flags().StringP(
@@ -483,7 +485,8 @@ func initRegisteredResourcesCommands() {
 		getDoc.GetDocFlag("namespace").Description,
 	)
 
-	listDoc := man.Docs.GetCommand("policy/registered-resources/list",
+	listDoc := man.Docs.GetCommand(
+		"policy/registered-resources/list",
 		man.WithRun(policyListRegisteredResources),
 	)
 	listDoc.Flags().StringP(
@@ -493,9 +496,11 @@ func initRegisteredResourcesCommands() {
 		listDoc.GetDocFlag("namespace").Description,
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSearchFlag(listDoc)
 	injectListSortFlags(listDoc)
 
-	createDoc := man.Docs.GetCommand("policy/registered-resources/create",
+	createDoc := man.Docs.GetCommand(
+		"policy/registered-resources/create",
 		man.WithRun(policyCreateRegisteredResource),
 	)
 	createDoc.Flags().StringP(
@@ -519,7 +524,8 @@ func initRegisteredResourcesCommands() {
 	)
 	injectLabelFlags(&createDoc.Command, false)
 
-	updateDoc := man.Docs.GetCommand("policy/registered-resources/update",
+	updateDoc := man.Docs.GetCommand(
+		"policy/registered-resources/update",
 		man.WithRun(policyUpdateRegisteredResource),
 	)
 	updateDoc.Flags().StringP(
@@ -536,7 +542,8 @@ func initRegisteredResourcesCommands() {
 	)
 	injectLabelFlags(&updateDoc.Command, true)
 
-	deleteDoc := man.Docs.GetCommand("policy/registered-resources/delete",
+	deleteDoc := man.Docs.GetCommand(
+		"policy/registered-resources/delete",
 		man.WithRun(policyDeleteRegisteredResource),
 	)
 	deleteDoc.Flags().StringP(
@@ -553,7 +560,8 @@ func initRegisteredResourcesCommands() {
 
 	// Registered Resource Values commands
 
-	getValueDoc := man.Docs.GetCommand("policy/registered-resources/values/get",
+	getValueDoc := man.Docs.GetCommand(
+		"policy/registered-resources/values/get",
 		man.WithRun(policyGetRegisteredResourceValue),
 	)
 	getValueDoc.Flags().StringP(
@@ -569,7 +577,8 @@ func initRegisteredResourcesCommands() {
 		getValueDoc.GetDocFlag("fqn").Description,
 	)
 
-	listValuesDoc := man.Docs.GetCommand("policy/registered-resources/values/list",
+	listValuesDoc := man.Docs.GetCommand(
+		"policy/registered-resources/values/list",
 		man.WithRun(policyListRegisteredResourceValues),
 	)
 	listValuesDoc.Flags().StringP(
@@ -586,7 +595,8 @@ func initRegisteredResourcesCommands() {
 	)
 	injectListPaginationFlags(listValuesDoc)
 
-	createValueDoc := man.Docs.GetCommand("policy/registered-resources/values/create",
+	createValueDoc := man.Docs.GetCommand(
+		"policy/registered-resources/values/create",
 		man.WithRun(policyCreateRegisteredResourceValue),
 	)
 	createValueDoc.Flags().StringP(
@@ -616,7 +626,8 @@ func initRegisteredResourcesCommands() {
 	)
 	injectLabelFlags(&createValueDoc.Command, false)
 
-	updateValueDoc := man.Docs.GetCommand("policy/registered-resources/values/update",
+	updateValueDoc := man.Docs.GetCommand(
+		"policy/registered-resources/values/update",
 		man.WithRun(policyUpdateRegisteredResourceValue),
 	)
 	updateValueDoc.Flags().StringP(
@@ -645,7 +656,8 @@ func initRegisteredResourcesCommands() {
 		updateValueDoc.GetDocFlag("force").Description,
 	)
 
-	deleteValueDoc := man.Docs.GetCommand("policy/registered-resources/values/delete",
+	deleteValueDoc := man.Docs.GetCommand(
+		"policy/registered-resources/values/delete",
 		man.WithRun(policyDeleteRegisteredResourceValue),
 	)
 	deleteValueDoc.Flags().StringP(
@@ -662,7 +674,8 @@ func initRegisteredResourcesCommands() {
 
 	// Add commands to the policy command
 
-	policyRegisteredResourcesDoc := man.Docs.GetCommand("policy/registered-resources",
+	policyRegisteredResourcesDoc := man.Docs.GetCommand(
+		"policy/registered-resources",
 		man.WithSubcommands(
 			getDoc,
 			listDoc,
@@ -672,7 +685,8 @@ func initRegisteredResourcesCommands() {
 		),
 	)
 
-	policyRegisteredResourceValuesDoc := man.Docs.GetCommand("policy/registered-resources/values",
+	policyRegisteredResourceValuesDoc := man.Docs.GetCommand(
+		"policy/registered-resources/values",
 		man.WithSubcommands(
 			getValueDoc,
 			listValuesDoc,

--- a/otdfctl/cmd/policy/subjectConditionSets.go
+++ b/otdfctl/cmd/policy/subjectConditionSets.go
@@ -150,9 +150,10 @@ func listSubjectConditionSets(cmd *cobra.Command, args []string) {
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
 	namespace := c.Flags.GetOptionalString("namespace")
+	search := c.Flags.GetOptionalString("search")
 	sort := getSortOption(c)
 
-	resp, err := h.ListSubjectConditionSets(cmd.Context(), limit, offset, namespace, sort)
+	resp, err := h.ListSubjectConditionSets(cmd.Context(), limit, offset, namespace, search, sort)
 	if err != nil {
 		cli.ExitWithError("Error listing subject condition sets", err)
 	}
@@ -324,7 +325,8 @@ func pruneSubjectConditionSet(cmd *cobra.Command, args []string) {
 var subjectConditionSetsCmd *cobra.Command
 
 func initSubjectConditionSetsCommands() {
-	createDoc := man.Docs.GetCommand("policy/subject-condition-sets/create",
+	createDoc := man.Docs.GetCommand(
+		"policy/subject-condition-sets/create",
 		man.WithRun(createSubjectConditionSet),
 	)
 	injectLabelFlags(&createDoc.Command, false)
@@ -347,7 +349,8 @@ func initSubjectConditionSetsCommands() {
 		createDoc.GetDocFlag("namespace").Description,
 	)
 
-	getDoc := man.Docs.GetCommand("policy/subject-condition-sets/get",
+	getDoc := man.Docs.GetCommand(
+		"policy/subject-condition-sets/get",
 		man.WithRun(getSubjectConditionSet),
 	)
 	getDoc.Flags().StringP(
@@ -357,10 +360,12 @@ func initSubjectConditionSetsCommands() {
 		getDoc.GetDocFlag("id").Description,
 	)
 
-	listDoc := man.Docs.GetCommand("policy/subject-condition-sets/list",
+	listDoc := man.Docs.GetCommand(
+		"policy/subject-condition-sets/list",
 		man.WithRun(listSubjectConditionSets),
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSearchFlag(listDoc)
 	injectListSortFlags(listDoc)
 	listDoc.Flags().StringP(
 		listDoc.GetDocFlag("namespace").Name,
@@ -369,7 +374,8 @@ func initSubjectConditionSetsCommands() {
 		listDoc.GetDocFlag("namespace").Description,
 	)
 
-	updateDoc := man.Docs.GetCommand("policy/subject-condition-sets/update",
+	updateDoc := man.Docs.GetCommand(
+		"policy/subject-condition-sets/update",
 		man.WithRun(updateSubjectConditionSet),
 	)
 	updateDoc.Flags().StringP(
@@ -418,7 +424,8 @@ func initSubjectConditionSetsCommands() {
 		pruneDoc.GetDocFlag("force").Description,
 	)
 
-	doc := man.Docs.GetCommand("policy/subject-condition-sets",
+	doc := man.Docs.GetCommand(
+		"policy/subject-condition-sets",
 		man.WithSubcommands(
 			createDoc,
 			getDoc,

--- a/otdfctl/cmd/policy/subjectMappings.go
+++ b/otdfctl/cmd/policy/subjectMappings.go
@@ -67,9 +67,10 @@ func policyListSubjectMappings(cmd *cobra.Command, args []string) {
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
 	namespace := c.Flags.GetOptionalString("namespace")
+	search := c.Flags.GetOptionalString("search")
 	sort := getSortOption(c)
 
-	resp, err := h.ListSubjectMappings(cmd.Context(), limit, offset, namespace, sort)
+	resp, err := h.ListSubjectMappings(cmd.Context(), limit, offset, namespace, search, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to get subject mappings", err)
 	}
@@ -327,7 +328,8 @@ func policyMatchSubjectMappings(cmd *cobra.Command, args []string) {
 }
 
 func initSubjectMappingsCommands() {
-	getDoc := man.Docs.GetCommand("policy/subject-mappings/get",
+	getDoc := man.Docs.GetCommand(
+		"policy/subject-mappings/get",
 		man.WithRun(policyGetSubjectMapping),
 	)
 	getDoc.Flags().StringP(
@@ -337,10 +339,12 @@ func initSubjectMappingsCommands() {
 		getDoc.GetDocFlag("id").Description,
 	)
 
-	listDoc := man.Docs.GetCommand("policy/subject-mappings/list",
+	listDoc := man.Docs.GetCommand(
+		"policy/subject-mappings/list",
 		man.WithRun(policyListSubjectMappings),
 	)
 	injectListPaginationFlags(listDoc)
+	injectListSearchFlag(listDoc)
 	injectListSortFlags(listDoc)
 	listDoc.Flags().StringP(
 		listDoc.GetDocFlag("namespace").Name,
@@ -349,7 +353,8 @@ func initSubjectMappingsCommands() {
 		listDoc.GetDocFlag("namespace").Description,
 	)
 
-	createDoc := man.Docs.GetCommand("policy/subject-mappings/create",
+	createDoc := man.Docs.GetCommand(
+		"policy/subject-mappings/create",
 		man.WithRun(policyCreateSubjectMapping),
 	)
 	createDoc.Flags().StringP(
@@ -399,7 +404,8 @@ func initSubjectMappingsCommands() {
 	)
 	injectLabelFlags(&createDoc.Command, false)
 
-	updateDoc := man.Docs.GetCommand("policy/subject-mappings/update",
+	updateDoc := man.Docs.GetCommand(
+		"policy/subject-mappings/update",
 		man.WithRun(policyUpdateSubjectMapping),
 	)
 	updateDoc.Flags().StringP(
@@ -437,7 +443,8 @@ func initSubjectMappingsCommands() {
 	)
 	injectLabelFlags(&updateDoc.Command, true)
 
-	deleteDoc := man.Docs.GetCommand("policy/subject-mappings/delete",
+	deleteDoc := man.Docs.GetCommand(
+		"policy/subject-mappings/delete",
 		man.WithRun(policyDeleteSubjectMapping),
 	)
 	deleteDoc.Flags().StringP(
@@ -452,7 +459,8 @@ func initSubjectMappingsCommands() {
 		deleteDoc.GetDocFlag("force").Description,
 	)
 
-	matchDoc := man.Docs.GetCommand("policy/subject-mappings/match",
+	matchDoc := man.Docs.GetCommand(
+		"policy/subject-mappings/match",
 		man.WithRun(policyMatchSubjectMappings),
 	)
 	matchDoc.Flags().StringP(
@@ -469,7 +477,8 @@ func initSubjectMappingsCommands() {
 		matchDoc.GetDocFlag("selector").Description,
 	)
 
-	doc := man.Docs.GetCommand("policy/subject-mappings",
+	doc := man.Docs.GetCommand(
+		"policy/subject-mappings",
 		man.WithSubcommands(
 			createDoc,
 			getDoc,

--- a/otdfctl/docs/man/policy/attributes/list.md
+++ b/otdfctl/docs/man/policy/attributes/list.md
@@ -19,6 +19,8 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: search
+      description: Search term to filter results
     - name: sort
       description: Sort list results by field
     - name: order
@@ -28,6 +30,14 @@ command:
 By default, the list will only provide `active` attributes if unspecified, but the filter can be controlled with the `--state` flag.
 
 For more general information about attributes, see the `attributes` subcommand.
+
+## Search Fields
+
+The `--search` term is trimmed and matched as a substring against these values:
+
+| Value | Description |
+| --- | --- |
+| Attribute FQN | Fully qualified attribute definition name, such as `https://example.com/attr/classification` |
 
 ## Sort Options
 
@@ -60,6 +70,12 @@ otdfctl policy attributes list --order asc
 
 ```shell
 otdfctl policy attributes list
+```
+
+Search attributes by FQN:
+
+```shell
+otdfctl policy attributes list --search classification
 ```
 
 Sort attributes by name ascending:

--- a/otdfctl/docs/man/policy/kas-registry/key/list.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/list.md
@@ -21,6 +21,8 @@ command:
     - name: legacy
       description: Filter keys by legacy status.
       required: false
+    - name: search
+      description: Search term to filter results
     - name: sort
       description: Sort list results by field
     - name: order
@@ -30,6 +32,14 @@ command:
 This command lists keys registered within a specified Key Access Server (KAS). You must specify the KAS using its ID, URI, or Name.
 
 The list can be filtered by key algorithm. Pagination is supported using `limit` and `offset` flags to manage the number of results returned.
+
+## Search Fields
+
+The `--search` term is trimmed and matched as a substring against these values:
+
+| Value | Description |
+| --- | --- |
+| Key ID | Registered key identifier |
 
 ## Sort Options
 
@@ -64,6 +74,12 @@ List the first 10 keys from a KAS specified by its URI:
 
 ```shell
 otdfctl policy kas-registry key list --kas "https://kas.example.com/kas" --limit 10 --offset 0
+```
+
+Search keys by key ID:
+
+```shell
+otdfctl policy kas-registry key list --kas "https://kas.example.com/kas" --search r1
 ```
 
 List keys from a KAS named "Primary KAS", filtering for keys using the "RSA:2048" algorithm, and output in JSON format:

--- a/otdfctl/docs/man/policy/kas-registry/list.md
+++ b/otdfctl/docs/man/policy/kas-registry/list.md
@@ -11,6 +11,8 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: search
+      description: Search term to filter results
     - name: sort
       description: Sort list results by field
     - name: order
@@ -18,6 +20,15 @@ command:
 ---
 
 For more information about registration of Key Access Servers, see the manual for `kas-registry`.
+
+## Search Fields
+
+The `--search` term is trimmed and matched as a substring against these values:
+
+| Value | Description |
+| --- | --- |
+| KAS registration name | Registered Key Access Server name |
+| KAS URI | Registered Key Access Server URI |
 
 ## Sort Options
 
@@ -51,6 +62,12 @@ otdfctl policy kas-registry list --order asc
 
 ```shell
 otdfctl policy kas-registry list
+```
+
+Search KAS registrations by name or URI:
+
+```shell
+otdfctl policy kas-registry list --search kas.example.com
 ```
 
 Sort KAS registrations by URI descending:

--- a/otdfctl/docs/man/policy/namespaces/list.md
+++ b/otdfctl/docs/man/policy/namespaces/list.md
@@ -15,6 +15,8 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: search
+      description: Search term to filter results
     - name: sort
       description: Sort list results by field
     - name: order
@@ -22,6 +24,14 @@ command:
 ---
 
 For more general information, see the `namespaces` subcommand.
+
+## Search Fields
+
+The `--search` term is trimmed and matched as a substring against these values:
+
+| Value | Description |
+| --- | --- |
+| Namespace FQN | Fully qualified namespace name, such as `https://example.com` |
 
 ## Sort Options
 
@@ -55,6 +65,12 @@ otdfctl policy namespaces list --order asc
 
 ```shell
 otdfctl policy namespaces list
+```
+
+Search namespaces by FQN:
+
+```shell
+otdfctl policy namespaces list --search example.com
 ```
 
 Sort namespaces by name ascending:

--- a/otdfctl/docs/man/policy/obligations/list.md
+++ b/otdfctl/docs/man/policy/obligations/list.md
@@ -14,6 +14,8 @@ command:
     - name: namespace
       shorthand: n
       description: Namespace ID or FQN by which to filter results
+    - name: search
+      description: Search term to filter results
     - name: sort
       description: Sort list results by field
     - name: order
@@ -23,6 +25,14 @@ command:
 List obligations definitions (optionally by namespace).
 
 For more information about obligations, see the `obligations` subcommand.
+
+## Search Fields
+
+The `--search` term is trimmed and matched as a substring against these values:
+
+| Value | Description |
+| --- | --- |
+| Obligation FQN | Fully qualified obligation name, built as `<namespace-fqn>/obl/<obligation-name>` |
 
 ## Sort Options
 
@@ -56,6 +66,12 @@ otdfctl policy obligations list --order asc
 
 ```shell
 otdfctl policy obligations list --limit 10 --offset 0
+```
+
+Search obligations by FQN:
+
+```shell
+otdfctl policy obligations list --search retention
 ```
 
 Sort obligations by name ascending:

--- a/otdfctl/docs/man/policy/registered-resources/list.md
+++ b/otdfctl/docs/man/policy/registered-resources/list.md
@@ -14,6 +14,8 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: search
+      description: Search term to filter results
     - name: sort
       description: Sort list results by field
     - name: order
@@ -21,6 +23,14 @@ command:
 ---
 
 For more information about Registered Resources, see the `registered-resources` subcommand.
+
+## Search Fields
+
+The `--search` term is trimmed and matched as a substring against these values:
+
+| Value | Description |
+| --- | --- |
+| Registered resource name | Resource name |
 
 ## Sort Options
 
@@ -53,6 +63,12 @@ otdfctl policy registered-resources list --order asc
 
 ```shell
 otdfctl policy registered-resources list
+```
+
+Search registered resources by name:
+
+```shell
+otdfctl policy registered-resources list --search document
 ```
 
 Sort registered resources by name ascending:

--- a/otdfctl/docs/man/policy/subject-condition-sets/list.md
+++ b/otdfctl/docs/man/policy/subject-condition-sets/list.md
@@ -15,6 +15,8 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: search
+      description: Search term to filter results
     - name: sort
       description: Sort list results by field
     - name: order
@@ -22,6 +24,14 @@ command:
 ---
 
 For more information about subject condition sets, see the `subject-condition-sets` subcommand.
+
+## Search Fields
+
+The `--search` term is trimmed and matched as a substring against these values:
+
+| Value | Description |
+| --- | --- |
+| Metadata label values | Values under subject condition set metadata `labels` |
 
 ## Sort Options
 
@@ -55,6 +65,12 @@ otdfctl policy subject-condition-sets list --order asc
 otdfctl policy subject-condition-sets list
 
 otdfctl policy subject-condition-sets list --namespace https://example.com
+```
+
+Search subject condition sets by metadata label value:
+
+```shell
+otdfctl policy subject-condition-sets list --search engineering
 ```
 
 Sort subject condition sets by creation time ascending:

--- a/otdfctl/docs/man/policy/subject-mappings/list.md
+++ b/otdfctl/docs/man/policy/subject-mappings/list.md
@@ -14,6 +14,8 @@ command:
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
+    - name: search
+      description: Search term to filter results
     - name: sort
       description: Sort list results by field
     - name: order
@@ -21,6 +23,15 @@ command:
 ---
 
 For more information about subject mappings, see the `subject-mappings` subcommand.
+
+## Search Fields
+
+The `--search` term is trimmed and matched as a substring against these values:
+
+| Value | Description |
+| --- | --- |
+| Attribute value FQN | Fully qualified mapped attribute value, such as `https://example.com/attr/classification/value/public` |
+| Metadata label values | Values under subject mapping metadata `labels` |
 
 ## Sort Options
 
@@ -54,6 +65,12 @@ otdfctl policy subject-mappings list --order asc
 otdfctl policy subject-mappings list
 
 otdfctl policy subject-mappings list --namespace "https://example.com"
+```
+
+Search subject mappings by mapped attribute value FQN or metadata label value:
+
+```shell
+otdfctl policy subject-mappings list --search public
 ```
 
 Sort subject mappings by creation time ascending:

--- a/otdfctl/e2e/attributes.bats
+++ b/otdfctl/e2e/attributes.bats
@@ -188,6 +188,20 @@ teardown_file() {
   run_otdfctl_attr unsafe delete --force --id "$attr_c_id"
 }
 
+@test "List attribute definitions supports search flag" {
+  search_prefix="search_attr_${BATS_TEST_NUMBER}_$RANDOM"
+  match_id=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "${search_prefix}_match" --rule ANY_OF --json | jq -r '.id')
+  other_id=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "${search_prefix}_other" --rule ANY_OF --json | jq -r '.id')
+
+  run_otdfctl_attr list --search "${search_prefix}_match" --limit 500 --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg id "$match_id" '[.attributes[] | select(.id == $id)] | length')" "1"
+  assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.attributes[] | select(.id == $id)] | length')" "0"
+
+  run_otdfctl_attr unsafe delete --force --id "$match_id"
+  run_otdfctl_attr unsafe delete --force --id "$other_id"
+}
+
 @test "List - comprehensive pagination tests" {
   # create 10 random attributes so we have confidence there are >= 10 attribute definitions
   for i in {1..10}; do
@@ -278,7 +292,7 @@ teardown_file() {
   # ensure non-JSON output reflects reordered values immediately
   run_otdfctl_attr unsafe update --id "$CREATED_ID" --values-order "$VAL1_ID" --values-order "$VAL2_ID" --force
   assert_success
-  assert_line --regexp "Value IDs\\s+│\\[$VAL1_ID, $VAL2_ID\\]"
+  assert_line --regexp "Value IDs[[:space:]]+│\\[$VAL1_ID, $VAL2_ID\\]"
 
   run_otdfctl_attr unsafe update --id "$CREATED_ID" --allow-traversal --json --force
   assert_success

--- a/otdfctl/e2e/attributes.bats
+++ b/otdfctl/e2e/attributes.bats
@@ -199,7 +199,9 @@ teardown_file() {
   assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.attributes[] | select(.id == $id)] | length')" "0"
 
   run_otdfctl_attr unsafe delete --force --id "$match_id"
+  assert_success
   run_otdfctl_attr unsafe delete --force --id "$other_id"
+  assert_success
 }
 
 @test "List - comprehensive pagination tests" {

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -681,6 +681,27 @@ format_kas_name_as_uri() {
   assert_equal "$(echo "$output" | jq -r --arg a "$key_a_id" --arg b "$key_b_id" --arg c "$key_c_id" '[.kas_keys[] | select(.key.id == $a or .key.id == $b or .key.id == $c) | .key.id] | join(",")')" "$key_a_id,$key_b_id,$key_c_id"
 }
 
+@test "kas-keys: list keys supports search flag" {
+  search_prefix="search-key-${BATS_TEST_NUMBER}-${RANDOM}"
+  match_kid="${search_prefix}-match"
+  other_kid="${search_prefix}-other"
+
+  run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "$match_kid" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64_RSA}" --json
+  assert_success
+  match_id=$(echo "$output" | jq -r .key.id)
+  run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "$other_kid" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64_RSA}" --json
+  assert_success
+  other_id=$(echo "$output" | jq -r .key.id)
+
+  run_otdfctl_key list --kas "${KAS_REGISTRY_ID}" --search "$match_kid" --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg id "$match_id" '[.kas_keys[] | select(.key.id == $id)] | length')" "1"
+  assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.kas_keys[] | select(.key.id == $id)] | length')" "0"
+
+  run_otdfctl_key unsafe delete --id "$match_id" --kas-uri "$KAS_URI" --key-id "$match_kid" --force
+  run_otdfctl_key unsafe delete --id "$other_id" --kas-uri "$KAS_URI" --key-id "$other_kid" --force
+}
+
 @test "kas-keys: list keys (pagination with limit and offset)" {
   KAS_NAME_LIST=$(generate_kas_name)
   KAS_URI_LIST=$(format_kas_name_as_uri "${KAS_NAME_LIST}")

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -699,7 +699,9 @@ format_kas_name_as_uri() {
   assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.kas_keys[] | select(.key.id == $id)] | length')" "0"
 
   run_otdfctl_key unsafe delete --id "$match_id" --kas-uri "$KAS_URI" --key-id "$match_kid" --force
+  assert_success
   run_otdfctl_key unsafe delete --id "$other_id" --kas-uri "$KAS_URI" --key-id "$other_kid" --force
+  assert_success
 }
 
 @test "kas-keys: list keys (pagination with limit and offset)" {

--- a/otdfctl/e2e/kas-registry.bats
+++ b/otdfctl/e2e/kas-registry.bats
@@ -227,5 +227,7 @@ teardown() {
     assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.key_access_servers[] | select(.id == $id)] | length')" "0"
 
     run_otdfctl_kasr delete --id "$match_id" --force
+    assert_success
     run_otdfctl_kasr delete --id "$other_id" --force
+    assert_success
 }

--- a/otdfctl/e2e/kas-registry.bats
+++ b/otdfctl/e2e/kas-registry.bats
@@ -212,3 +212,20 @@ teardown() {
     run_otdfctl_kasr delete --id "$kas_b_id" --force
     run_otdfctl_kasr delete --id "$kas_c_id" --force
 }
+
+@test "list registered KASes supports search flag" {
+    export CREATED=""
+    search_prefix="search-kas-$BATS_TEST_NUMBER-$RANDOM"
+    match=$(./otdfctl $HOST $WITH_CREDS policy kas-registry create --name "$search_prefix-match" --uri "https://$search_prefix-match.example.com" --json)
+    other=$(./otdfctl $HOST $WITH_CREDS policy kas-registry create --name "$search_prefix-other" --uri "https://$search_prefix-other.example.com" --json)
+    match_id=$(echo "$match" | jq -r '.id')
+    other_id=$(echo "$other" | jq -r '.id')
+
+    run_otdfctl_kasr list --search "$search_prefix-match" --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg id "$match_id" '[.key_access_servers[] | select(.id == $id)] | length')" "1"
+    assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.key_access_servers[] | select(.id == $id)] | length')" "0"
+
+    run_otdfctl_kasr delete --id "$match_id" --force
+    run_otdfctl_kasr delete --id "$other_id" --force
+}

--- a/otdfctl/e2e/kas-registry.bats
+++ b/otdfctl/e2e/kas-registry.bats
@@ -214,7 +214,6 @@ teardown() {
 }
 
 @test "list registered KASes supports search flag" {
-    export CREATED=""
     search_prefix="search-kas-$BATS_TEST_NUMBER-$RANDOM"
     match=$(./otdfctl $HOST $WITH_CREDS policy kas-registry create --name "$search_prefix-match" --uri "https://$search_prefix-match.example.com" --json)
     other=$(./otdfctl $HOST $WITH_CREDS policy kas-registry create --name "$search_prefix-other" --uri "https://$search_prefix-other.example.com" --json)

--- a/otdfctl/e2e/namespaces.bats
+++ b/otdfctl/e2e/namespaces.bats
@@ -184,7 +184,9 @@ teardown_file() {
   assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.namespaces[] | select(.id == $id)] | length')" "0"
 
   run_otdfctl_nsd unsafe delete --id "$match_id" --force
+  assert_success
   run_otdfctl_nsd unsafe delete --id "$other_id" --force
+  assert_success
 }
 
 @test "Update namespace - Safe" {

--- a/otdfctl/e2e/namespaces.bats
+++ b/otdfctl/e2e/namespaces.bats
@@ -171,6 +171,22 @@ teardown_file() {
   run_otdfctl_nsd unsafe delete --id "$ns_c_id" --force
 }
 
+@test "List namespaces supports search flag" {
+  search_prefix="search-ns-$BATS_TEST_NUMBER-$RANDOM"
+  match_name="$search_prefix-match.test"
+  other_name="$search_prefix-other.test"
+  match_id=$(./otdfctl $HOST $WITH_CREDS policy namespaces create --name "$match_name" --json | jq -r '.id')
+  other_id=$(./otdfctl $HOST $WITH_CREDS policy namespaces create --name "$other_name" --json | jq -r '.id')
+
+  run_otdfctl_nsd list --search "$match_name" --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg id "$match_id" '[.namespaces[] | select(.id == $id)] | length')" "1"
+  assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.namespaces[] | select(.id == $id)] | length')" "0"
+
+  run_otdfctl_nsd unsafe delete --id "$match_id" --force
+  run_otdfctl_nsd unsafe delete --id "$other_id" --force
+}
+
 @test "Update namespace - Safe" {
   # extend labels
   run_otdfctl_ns update "$NS_ID_FLAG" -l key=value --label test=true

--- a/otdfctl/e2e/obligations.bats
+++ b/otdfctl/e2e/obligations.bats
@@ -476,6 +476,22 @@ teardown_file() {
   run_otdfctl_obl delete --id "$obl_c_id" --force
 }
 
+@test "List obligations supports search flag" {
+  search_prefix="search_obl_${BATS_TEST_NUMBER}_$RANDOM"
+  run_otdfctl_obl create --name "${search_prefix}_match" --namespace "$NS_ID" --json
+  match_id="$(echo "$output" | jq -r '.id')"
+  run_otdfctl_obl create --name "${search_prefix}_other" --namespace "$NS_ID" --json
+  other_id="$(echo "$output" | jq -r '.id')"
+
+  run_otdfctl_obl list --namespace "$NS_ID" --search "${search_prefix}_match" --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg id "$match_id" '[.obligations[] | select(.id == $id)] | length')" "1"
+  assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.obligations[] | select(.id == $id)] | length')" "0"
+
+  run_otdfctl_obl delete --id "$match_id" --force
+  run_otdfctl_obl delete --id "$other_id" --force
+}
+
 @test "Update obligation" {
   # setup an obligation to update
   run_otdfctl_obl create --name test_update_obl --namespace "$NS_ID" --json

--- a/otdfctl/e2e/obligations.bats
+++ b/otdfctl/e2e/obligations.bats
@@ -489,7 +489,9 @@ teardown_file() {
   assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.obligations[] | select(.id == $id)] | length')" "0"
 
   run_otdfctl_obl delete --id "$match_id" --force
+  assert_success
   run_otdfctl_obl delete --id "$other_id" --force
+  assert_success
 }
 
 @test "Update obligation" {

--- a/otdfctl/e2e/registered-resources.bats
+++ b/otdfctl/e2e/registered-resources.bats
@@ -236,6 +236,20 @@ teardown_file() {
   run_otdfctl_reg_res delete --id "$rr_c_id" --force
 }
 
+@test "List registered resources supports search flag" {
+  search_prefix="search_rr_${BATS_TEST_NUMBER}_$RANDOM"
+  match_id=$(./otdfctl $HOST $WITH_CREDS policy registered-resources create --name "${search_prefix}_match" --namespace "$NS_ID" --json | jq -r '.id')
+  other_id=$(./otdfctl $HOST $WITH_CREDS policy registered-resources create --name "${search_prefix}_other" --namespace "$NS_ID" --json | jq -r '.id')
+
+  run_otdfctl_reg_res list --namespace "$NS_ID" --search "${search_prefix}_match" --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg id "$match_id" '[.resources[] | select(.id == $id)] | length')" "1"
+  assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.resources[] | select(.id == $id)] | length')" "0"
+
+  run_otdfctl_reg_res delete --id "$match_id" --force
+  run_otdfctl_reg_res delete --id "$other_id" --force
+}
+
 @test "Update registered resource" {
   # setup a resource to update
   run_otdfctl_reg_res create --name test_update_rr --namespace "$NS_ID"

--- a/otdfctl/e2e/registered-resources.bats
+++ b/otdfctl/e2e/registered-resources.bats
@@ -247,7 +247,9 @@ teardown_file() {
   assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.resources[] | select(.id == $id)] | length')" "0"
 
   run_otdfctl_reg_res delete --id "$match_id" --force
+  assert_success
   run_otdfctl_reg_res delete --id "$other_id" --force
+  assert_success
 }
 
 @test "Update registered resource" {

--- a/otdfctl/e2e/subject-condition-sets.bats
+++ b/otdfctl/e2e/subject-condition-sets.bats
@@ -186,7 +186,9 @@ teardown_file() {
   assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.subject_condition_sets[] | select(.id == $id)] | length')" "0"
 
   run_delete_scs "$match_id"
+  assert_success
   run_delete_scs "$other_id"
+  assert_success
 }
 
 @test "Create a SCS with namespace id" {

--- a/otdfctl/e2e/subject-condition-sets.bats
+++ b/otdfctl/e2e/subject-condition-sets.bats
@@ -39,7 +39,7 @@ teardown_file() {
   # clear out all test env vars
   unset HOST WITH_CREDS NS_NAME NS_FQN NS_ID SCS_1 SCS_2 SCS_3
 
-  rm scs.json
+  rm -f scs.json
 }
 
 @test "Create a Subject Condition Set (SCS) - from file" {
@@ -173,6 +173,20 @@ teardown_file() {
   run_delete_scs "$scs_a_id"
   run_delete_scs "$scs_b_id"
   run_delete_scs "$scs_c_id"
+}
+
+@test "List SCS supports search flag" {
+  search_token="search-scs-${BATS_TEST_NUMBER}-${RANDOM}"
+  match_id=$(./otdfctl $HOST $WITH_CREDS policy scs create --subject-sets "$SCS_1" --namespace "$NS_ID" --label "search=$search_token-match" --json | jq -r '.id')
+  other_id=$(./otdfctl $HOST $WITH_CREDS policy scs create --subject-sets "$SCS_2" --namespace "$NS_ID" --label "search=$search_token-other" --json | jq -r '.id')
+
+  run_otdfctl_scs list --namespace "$NS_ID" --search "$search_token-match" --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r --arg id "$match_id" '[.subject_condition_sets[] | select(.id == $id)] | length')" "1"
+  assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.subject_condition_sets[] | select(.id == $id)] | length')" "0"
+
+  run_delete_scs "$match_id"
+  run_delete_scs "$other_id"
 }
 
 @test "Create a SCS with namespace id" {

--- a/otdfctl/e2e/subject-mapping.bats
+++ b/otdfctl/e2e/subject-mapping.bats
@@ -225,7 +225,9 @@ teardown_file() {
     assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.subject_mappings[] | select(.id == $id)] | length')" "0"
 
     run_otdfctl_sm delete --id "$match_id" --force
+    assert_success
     run_otdfctl_sm delete --id "$other_id" --force
+    assert_success
 }
 
 @test "Create subject mapping with namespace ID" {

--- a/otdfctl/e2e/subject-mapping.bats
+++ b/otdfctl/e2e/subject-mapping.bats
@@ -211,6 +211,23 @@ teardown_file() {
     run_otdfctl_sm delete --id "$sm_c_id" --force
 }
 
+@test "List subject mappings supports search flag" {
+    search_token="search-sm-${BATS_TEST_NUMBER}-${RANDOM}"
+    search_attr=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "$search_token" --rule ANY_OF -v "match" -v "other" --json)
+    search_val_match_id=$(echo "$search_attr" | jq -r '.values[0].id')
+    search_val_other_id=$(echo "$search_attr" | jq -r '.values[1].id')
+    match_id=$(./otdfctl $HOST $WITH_CREDS policy sm create --namespace "$NS_ID" -a "$search_val_match_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --label "search=$search_token-match" --json | jq -r '.id')
+    other_id=$(./otdfctl $HOST $WITH_CREDS policy sm create --namespace "$NS_ID" -a "$search_val_other_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --label "search=$search_token-other" --json | jq -r '.id')
+
+    run_otdfctl_sm list --namespace "$NS_ID" --search "$search_token-match" --json
+    assert_success
+    assert_equal "$(echo "$output" | jq -r --arg id "$match_id" '[.subject_mappings[] | select(.id == $id)] | length')" "1"
+    assert_equal "$(echo "$output" | jq -r --arg id "$other_id" '[.subject_mappings[] | select(.id == $id)] | length')" "0"
+
+    run_otdfctl_sm delete --id "$match_id" --force
+    run_otdfctl_sm delete --id "$other_id" --force
+}
+
 @test "Create subject mapping with namespace ID" {
     run ./otdfctl $HOST $WITH_CREDS policy subject-mappings create -a "$SM_VAL2_ID" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_2" --namespace "$NS_ID" --json
     assert_success

--- a/otdfctl/migrations/namespacedpolicy/migration_planner.go
+++ b/otdfctl/migrations/namespacedpolicy/migration_planner.go
@@ -20,12 +20,12 @@ var ErrNilPlannerHandler = errors.New("planner handler is required")
 
 type PolicyClient interface {
 	ListActions(ctx context.Context, limit, offset int32, namespace string) (*actions.ListActionsResponse, error)
-	ListSubjectConditionSets(ctx context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error)
-	ListSubjectMappings(ctx context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectMappingsResponse, error)
-	ListRegisteredResources(ctx context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*registeredresources.ListRegisteredResourcesResponse, error)
+	ListSubjectConditionSets(ctx context.Context, limit, offset int32, namespace string, search string, sort handlers.SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error)
+	ListSubjectMappings(ctx context.Context, limit, offset int32, namespace string, search string, sort handlers.SortOption) (*subjectmapping.ListSubjectMappingsResponse, error)
+	ListRegisteredResources(ctx context.Context, limit, offset int32, namespace string, search string, sort handlers.SortOption) (*registeredresources.ListRegisteredResourcesResponse, error)
 	ListRegisteredResourceValues(ctx context.Context, resourceID string, limit, offset int32) (*registeredresources.ListRegisteredResourceValuesResponse, error)
 	ListObligationTriggers(ctx context.Context, namespace string, limit, offset int32) (*obligations.ListObligationTriggersResponse, error)
-	ListNamespaces(ctx context.Context, state common.ActiveStateEnum, limit, offset int32, sort handlers.SortOption) (*namespaces.ListNamespacesResponse, error)
+	ListNamespaces(ctx context.Context, state common.ActiveStateEnum, limit, offset int32, search string, sort handlers.SortOption) (*namespaces.ListNamespacesResponse, error)
 }
 
 type MigrationPlanner struct {

--- a/otdfctl/migrations/namespacedpolicy/migration_planner_test.go
+++ b/otdfctl/migrations/namespacedpolicy/migration_planner_test.go
@@ -976,7 +976,7 @@ func (h *plannerTestHandler) ListActions(_ context.Context, limit, offset int32,
 	return &actions.ListActionsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *plannerTestHandler) ListSubjectConditionSets(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
+func (h *plannerTestHandler) ListSubjectConditionSets(_ context.Context, limit, offset int32, namespace string, search string, sort handlers.SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
 	h.subjectConditionSetCalls = append(h.subjectConditionSetCalls, namespace)
 	if resp, ok := h.subjectConditionSetsByNamespace[namespace]; ok {
 		return resp, nil
@@ -984,7 +984,7 @@ func (h *plannerTestHandler) ListSubjectConditionSets(_ context.Context, limit, 
 	return &subjectmapping.ListSubjectConditionSetsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *plannerTestHandler) ListSubjectMappings(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectMappingsResponse, error) {
+func (h *plannerTestHandler) ListSubjectMappings(_ context.Context, limit, offset int32, namespace string, search string, sort handlers.SortOption) (*subjectmapping.ListSubjectMappingsResponse, error) {
 	h.subjectMappingCalls = append(h.subjectMappingCalls, namespace)
 	if resp, ok := h.subjectMappingsByNamespace[namespace]; ok {
 		return resp, nil
@@ -992,7 +992,7 @@ func (h *plannerTestHandler) ListSubjectMappings(_ context.Context, limit, offse
 	return &subjectmapping.ListSubjectMappingsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *plannerTestHandler) ListRegisteredResources(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*registeredresources.ListRegisteredResourcesResponse, error) {
+func (h *plannerTestHandler) ListRegisteredResources(_ context.Context, limit, offset int32, namespace string, search string, sort handlers.SortOption) (*registeredresources.ListRegisteredResourcesResponse, error) {
 	h.registeredResourceCalls = append(h.registeredResourceCalls, namespace)
 	if resp, ok := h.registeredResourcesByNamespace[namespace]; ok {
 		return resp, nil
@@ -1029,7 +1029,7 @@ func (h *plannerTestHandler) ListObligationTriggers(_ context.Context, namespace
 	return &obligations.ListObligationTriggersResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *plannerTestHandler) ListNamespaces(_ context.Context, state common.ActiveStateEnum, limit, offset int32, sort handlers.SortOption) (*namespaces.ListNamespacesResponse, error) {
+func (h *plannerTestHandler) ListNamespaces(_ context.Context, state common.ActiveStateEnum, limit, offset int32, search string, sort handlers.SortOption) (*namespaces.ListNamespacesResponse, error) {
 	if h.namespacesResponse != nil {
 		return h.namespacesResponse, nil
 	}

--- a/otdfctl/migrations/namespacedpolicy/retrieve.go
+++ b/otdfctl/migrations/namespacedpolicy/retrieve.go
@@ -95,7 +95,7 @@ func (r *Retriever) listNamespaces(ctx context.Context) ([]*policy.Namespace, er
 	)
 
 	for {
-		resp, err := r.handler.ListNamespaces(ctx, common.ActiveStateEnum_ACTIVE_STATE_ENUM_ACTIVE, r.pageSize, offset, handlers.SortOption{})
+		resp, err := r.handler.ListNamespaces(ctx, common.ActiveStateEnum_ACTIVE_STATE_ENUM_ACTIVE, r.pageSize, offset, "", handlers.SortOption{})
 		if err != nil {
 			return nil, fmt.Errorf("list namespaces: %w", err)
 		}
@@ -183,7 +183,7 @@ func (r *Retriever) retrieveSubjectMappings(ctx context.Context) ([]*policy.Subj
 	)
 
 	for {
-		resp, err := r.handler.ListSubjectMappings(ctx, r.pageSize, offset, "", handlers.SortOption{})
+		resp, err := r.handler.ListSubjectMappings(ctx, r.pageSize, offset, "", "", handlers.SortOption{})
 		if err != nil {
 			return nil, fmt.Errorf("list subject mappings: %w", err)
 		}
@@ -218,7 +218,7 @@ func (r *Retriever) retrieveSubjectConditionSets(ctx context.Context) ([]*policy
 	var offset int32
 
 	for {
-		resp, err := r.handler.ListSubjectConditionSets(ctx, r.pageSize, offset, "", handlers.SortOption{})
+		resp, err := r.handler.ListSubjectConditionSets(ctx, r.pageSize, offset, "", "", handlers.SortOption{})
 		if err != nil {
 			return nil, fmt.Errorf("list subject condition sets: %w", err)
 		}
@@ -257,7 +257,7 @@ func (r *Retriever) retrieveRegisteredResources(ctx context.Context) ([]*policy.
 	)
 
 	for {
-		resp, err := r.handler.ListRegisteredResources(ctx, r.pageSize, offset, "", handlers.SortOption{})
+		resp, err := r.handler.ListRegisteredResources(ctx, r.pageSize, offset, "", "", handlers.SortOption{})
 		if err != nil {
 			return nil, fmt.Errorf("list registered resources: %w", err)
 		}
@@ -459,7 +459,7 @@ func (r *Retriever) listSubjectConditionSetsForNamespaces(ctx context.Context, n
 	for _, namespace := range dedupeTargetNamespaces(namespaces) {
 		var offset int32
 		for {
-			resp, err := r.handler.ListSubjectConditionSets(ctx, r.pageSize, offset, namespace.GetId(), handlers.SortOption{})
+			resp, err := r.handler.ListSubjectConditionSets(ctx, r.pageSize, offset, namespace.GetId(), "", handlers.SortOption{})
 			if err != nil {
 				return nil, fmt.Errorf("list subject condition sets for namespace %s: %w", namespace.GetId(), err)
 			}
@@ -491,7 +491,7 @@ func (r *Retriever) listSubjectMappingsForNamespaces(ctx context.Context, namesp
 	for _, namespace := range dedupeTargetNamespaces(namespaces) {
 		var offset int32
 		for {
-			resp, err := r.handler.ListSubjectMappings(ctx, r.pageSize, offset, namespace.GetId(), handlers.SortOption{})
+			resp, err := r.handler.ListSubjectMappings(ctx, r.pageSize, offset, namespace.GetId(), "", handlers.SortOption{})
 			if err != nil {
 				return nil, fmt.Errorf("list subject mappings for namespace %s: %w", namespace.GetId(), err)
 			}
@@ -523,7 +523,7 @@ func (r *Retriever) listRegisteredResourcesForNamespaces(ctx context.Context, na
 	for _, namespace := range dedupeTargetNamespaces(namespaces) {
 		var offset int32
 		for {
-			resp, err := r.handler.ListRegisteredResources(ctx, r.pageSize, offset, namespace.GetId(), handlers.SortOption{})
+			resp, err := r.handler.ListRegisteredResources(ctx, r.pageSize, offset, namespace.GetId(), "", handlers.SortOption{})
 			if err != nil {
 				return nil, fmt.Errorf("list registered resources for namespace %s: %w", namespace.GetId(), err)
 			}

--- a/otdfctl/migrations/namespacedpolicy/retrieve_test.go
+++ b/otdfctl/migrations/namespacedpolicy/retrieve_test.go
@@ -416,18 +416,18 @@ func (h *pagedRetrieveTestHandler) ListActions(_ context.Context, limit, offset 
 	return &actions.ListActionsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *pagedRetrieveTestHandler) ListSubjectConditionSets(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
+func (h *pagedRetrieveTestHandler) ListSubjectConditionSets(_ context.Context, limit, offset int32, namespace string, search string, sort handlers.SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
 	return &subjectmapping.ListSubjectConditionSetsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *pagedRetrieveTestHandler) ListSubjectMappings(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*subjectmapping.ListSubjectMappingsResponse, error) {
+func (h *pagedRetrieveTestHandler) ListSubjectMappings(_ context.Context, limit, offset int32, namespace string, search string, sort handlers.SortOption) (*subjectmapping.ListSubjectMappingsResponse, error) {
 	if resp, ok := h.subjectMappingPages[offset]; ok {
 		return resp, nil
 	}
 	return &subjectmapping.ListSubjectMappingsResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *pagedRetrieveTestHandler) ListRegisteredResources(_ context.Context, limit, offset int32, namespace string, sort handlers.SortOption) (*registeredresources.ListRegisteredResourcesResponse, error) {
+func (h *pagedRetrieveTestHandler) ListRegisteredResources(_ context.Context, limit, offset int32, namespace string, search string, sort handlers.SortOption) (*registeredresources.ListRegisteredResourcesResponse, error) {
 	if resp, ok := h.registeredResourcePages[offset]; ok {
 		return resp, nil
 	}
@@ -464,7 +464,7 @@ func (h *pagedRetrieveTestHandler) ListObligationTriggers(_ context.Context, nam
 	return &obligations.ListObligationTriggersResponse{Pagination: emptyPageResponse()}, nil
 }
 
-func (h *pagedRetrieveTestHandler) ListNamespaces(_ context.Context, state common.ActiveStateEnum, limit, offset int32, sort handlers.SortOption) (*namespaces.ListNamespacesResponse, error) {
+func (h *pagedRetrieveTestHandler) ListNamespaces(_ context.Context, state common.ActiveStateEnum, limit, offset int32, search string, sort handlers.SortOption) (*namespaces.ListNamespacesResponse, error) {
 	return &namespaces.ListNamespacesResponse{Pagination: emptyPageResponse()}, nil
 }
 

--- a/otdfctl/pkg/handlers/attribute.go
+++ b/otdfctl/pkg/handlers/attribute.go
@@ -54,13 +54,16 @@ func (h Handler) GetAttribute(ctx context.Context, identifier string) (*policy.A
 	return resp.GetAttribute(), nil
 }
 
-func (h Handler) ListAttributes(ctx context.Context, state common.ActiveStateEnum, limit, offset int32, sort SortOption) (*attributes.ListAttributesResponse, error) {
+func (h Handler) ListAttributes(ctx context.Context, state common.ActiveStateEnum, limit, offset int32, search string, sort SortOption) (*attributes.ListAttributesResponse, error) {
 	req := &attributes.ListAttributesRequest{
 		State: state,
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
 			Offset: offset,
 		},
+	}
+	if search != "" {
+		req.Search = &policy.Search{Term: search}
 	}
 	if !sort.IsZero() {
 		allowedFields := map[string]attributes.SortAttributesType{

--- a/otdfctl/pkg/handlers/kas-keys.go
+++ b/otdfctl/pkg/handlers/kas-keys.go
@@ -91,6 +91,7 @@ func (h Handler) ListKasKeys(
 	algorithm policy.Algorithm,
 	identifier KasIdentifier,
 	legacy *bool,
+	search string,
 	sort SortOption,
 ) (*kasregistry.ListKeysResponse, error) {
 	req := kasregistry.ListKeysRequest{
@@ -116,6 +117,9 @@ func (h Handler) ListKasKeys(
 		}
 	}
 	req.Legacy = legacy
+	if search != "" {
+		req.Search = &policy.Search{Term: search}
+	}
 	if !sort.IsZero() {
 		allowedFields := map[string]kasregistry.SortKasKeysType{
 			"key_id":     kasregistry.SortKasKeysType_SORT_KAS_KEYS_TYPE_KEY_ID,

--- a/otdfctl/pkg/handlers/kas-registry.go
+++ b/otdfctl/pkg/handlers/kas-registry.go
@@ -42,12 +42,15 @@ func (h Handler) GetKasRegistryEntry(ctx context.Context, identifer KasIdentifie
 	return resp.GetKeyAccessServer(), nil
 }
 
-func (h Handler) ListKasRegistryEntries(ctx context.Context, limit, offset int32, sort SortOption) (*kasregistry.ListKeyAccessServersResponse, error) {
+func (h Handler) ListKasRegistryEntries(ctx context.Context, limit, offset int32, search string, sort SortOption) (*kasregistry.ListKeyAccessServersResponse, error) {
 	req := &kasregistry.ListKeyAccessServersRequest{
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
 			Offset: offset,
 		},
+	}
+	if search != "" {
+		req.Search = &policy.Search{Term: search}
 	}
 	if !sort.IsZero() {
 		allowedFields := map[string]kasregistry.SortKeyAccessServersType{

--- a/otdfctl/pkg/handlers/namespaces.go
+++ b/otdfctl/pkg/handlers/namespaces.go
@@ -38,13 +38,16 @@ func (h Handler) GetNamespace(ctx context.Context, identifier string) (*policy.N
 	return resp.GetNamespace(), nil
 }
 
-func (h Handler) ListNamespaces(ctx context.Context, state common.ActiveStateEnum, limit, offset int32, sort SortOption) (*namespaces.ListNamespacesResponse, error) {
+func (h Handler) ListNamespaces(ctx context.Context, state common.ActiveStateEnum, limit, offset int32, search string, sort SortOption) (*namespaces.ListNamespacesResponse, error) {
 	req := &namespaces.ListNamespacesRequest{
 		State: state,
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
 			Offset: offset,
 		},
+	}
+	if search != "" {
+		req.Search = &policy.Search{Term: search}
 	}
 	if !sort.IsZero() {
 		allowedFields := map[string]namespaces.SortNamespacesType{

--- a/otdfctl/pkg/handlers/obligations.go
+++ b/otdfctl/pkg/handlers/obligations.go
@@ -63,7 +63,7 @@ func (h Handler) GetObligation(ctx context.Context, id, fqn string) (*policy.Obl
 	return resp.GetObligation(), nil
 }
 
-func (h Handler) ListObligations(ctx context.Context, limit, offset int32, namespace string, sort SortOption) (*obligations.ListObligationsResponse, error) {
+func (h Handler) ListObligations(ctx context.Context, limit, offset int32, namespace string, search string, sort SortOption) (*obligations.ListObligationsResponse, error) {
 	req := &obligations.ListObligationsRequest{
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
@@ -72,6 +72,9 @@ func (h Handler) ListObligations(ctx context.Context, limit, offset int32, names
 	}
 	if namespace != "" {
 		req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
+	}
+	if search != "" {
+		req.Search = &policy.Search{Term: search}
 	}
 	if !sort.IsZero() {
 		allowedFields := map[string]obligations.SortObligationsType{

--- a/otdfctl/pkg/handlers/registeredResources.go
+++ b/otdfctl/pkg/handlers/registeredResources.go
@@ -52,7 +52,7 @@ func (h Handler) GetRegisteredResource(ctx context.Context, id, name, namespace 
 	return resp.GetResource(), nil
 }
 
-func (h Handler) ListRegisteredResources(ctx context.Context, limit, offset int32, namespace string, sort SortOption) (*registeredresources.ListRegisteredResourcesResponse, error) {
+func (h Handler) ListRegisteredResources(ctx context.Context, limit, offset int32, namespace string, search string, sort SortOption) (*registeredresources.ListRegisteredResourcesResponse, error) {
 	req := &registeredresources.ListRegisteredResourcesRequest{
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
@@ -61,6 +61,9 @@ func (h Handler) ListRegisteredResources(ctx context.Context, limit, offset int3
 	}
 	if namespace != "" {
 		req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
+	}
+	if search != "" {
+		req.Search = &policy.Search{Term: search}
 	}
 	if !sort.IsZero() {
 		allowedFields := map[string]registeredresources.SortRegisteredResourcesType{

--- a/otdfctl/pkg/handlers/subjectConditionSets.go
+++ b/otdfctl/pkg/handlers/subjectConditionSets.go
@@ -19,7 +19,7 @@ func (h Handler) GetSubjectConditionSet(ctx context.Context, id string) (*policy
 	return resp.GetSubjectConditionSet(), nil
 }
 
-func (h Handler) ListSubjectConditionSets(ctx context.Context, limit, offset int32, namespace string, sort SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
+func (h Handler) ListSubjectConditionSets(ctx context.Context, limit, offset int32, namespace string, search string, sort SortOption) (*subjectmapping.ListSubjectConditionSetsResponse, error) {
 	req := &subjectmapping.ListSubjectConditionSetsRequest{
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
@@ -27,6 +27,9 @@ func (h Handler) ListSubjectConditionSets(ctx context.Context, limit, offset int
 		},
 	}
 	req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
+	if search != "" {
+		req.Search = &policy.Search{Term: search}
+	}
 	if !sort.IsZero() {
 		allowedFields := map[string]subjectmapping.SortSubjectConditionSetsType{
 			"created_at": subjectmapping.SortSubjectConditionSetsType_SORT_SUBJECT_CONDITION_SETS_TYPE_CREATED_AT,

--- a/otdfctl/pkg/handlers/subjectmappings.go
+++ b/otdfctl/pkg/handlers/subjectmappings.go
@@ -24,7 +24,7 @@ func (h Handler) GetSubjectMapping(ctx context.Context, id string) (*policy.Subj
 	return resp.GetSubjectMapping(), err
 }
 
-func (h Handler) ListSubjectMappings(ctx context.Context, limit, offset int32, namespace string, sort SortOption) (*subjectmapping.ListSubjectMappingsResponse, error) {
+func (h Handler) ListSubjectMappings(ctx context.Context, limit, offset int32, namespace string, search string, sort SortOption) (*subjectmapping.ListSubjectMappingsResponse, error) {
 	req := &subjectmapping.ListSubjectMappingsRequest{
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
@@ -32,6 +32,9 @@ func (h Handler) ListSubjectMappings(ctx context.Context, limit, offset int32, n
 		},
 	}
 	req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
+	if search != "" {
+		req.Search = &policy.Search{Term: search}
+	}
 	if !sort.IsZero() {
 		allowedFields := map[string]subjectmapping.SortSubjectMappingsType{
 			"created_at": subjectmapping.SortSubjectMappingsType_SORT_SUBJECT_MAPPINGS_TYPE_CREATED_AT,

--- a/otdfctl/tui/attributeList.go
+++ b/otdfctl/tui/attributeList.go
@@ -40,7 +40,7 @@ func InitAttributeList(ctx context.Context, id string, h handlers.Handler) (tea.
 		limit  int32 = 100
 		offset int32 = 0
 	)
-	res, _ := h.ListAttributes(ctx, common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY, limit, offset, handlers.SortOption{})
+	res, _ := h.ListAttributes(ctx, common.ActiveStateEnum_ACTIVE_STATE_ENUM_ANY, limit, offset, "", handlers.SortOption{})
 	var attrs []list.Item
 	selectIdx := 0
 	for i, attr := range res.GetAttributes() {

--- a/protocol/go/policy/selectors.pb.go
+++ b/protocol/go/policy/selectors.pb.go
@@ -7,11 +7,12 @@
 package policy
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	_ "buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/protocol/go/policy/selectors.pb.go
+++ b/protocol/go/policy/selectors.pb.go
@@ -7,12 +7,11 @@
 package policy
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	_ "buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (


### PR DESCRIPTION
## Summary

  Adds `--search` support to `otdfctl` policy list commands whose backing RPCs already support search filtering.

  ## Changes

  - Added `--search` to supported list commands:
    - `policy namespaces list`
    - `policy attributes list`
    - `policy obligations list`
    - `policy registered-resources list`
    - `policy subject-mappings list`
    - `policy subject-condition-sets list`
    - `policy kas-registry list`
    - `policy kas-registry key list`
  - Fixed two BATS robustness issues found while verifying:
    - `subject-condition-sets.bats` cleanup now tolerates missing fixture files
    - `attributes.bats` uses POSIX-compatible whitespace regex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--search` flag to multiple `policy ... list` commands to filter results by searchable fields (attributes, namespaces, obligations, registered resources, KAS registry entries, KAS keys, subject condition sets, and subject mappings), including when using `--json`.
* **Documentation**
  * Updated related man pages with a “Search Fields” section and examples for the new flag.
* **Tests**
  * Added end-to-end coverage validating that `--search` returns only matching items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->