### PR TITLE
feat(core): Disable pq algorithms due to format change

### DIFF
--- a/otdfctl/cmd/policy/kasKeys.go
+++ b/otdfctl/cmd/policy/kasKeys.go
@@ -72,7 +72,7 @@ func generateKeys(alg policy.Algorithm) (string, string, error) {
 func generateKeyPair(alg policy.Algorithm) (ocrypto.KeyPair, error) {
 	var key ocrypto.KeyPair
 	var err error
-	switch alg {
+	switch alg { //nolint:exhaustive // HPQT hybrid algorithms are intentionally unsupported by otdfctl
 	case policy.Algorithm_ALGORITHM_RSA_2048:
 		key, err = generateRSAKey(rsa2048Len)
 	case policy.Algorithm_ALGORITHM_RSA_4096:
@@ -83,12 +83,6 @@ func generateKeyPair(alg policy.Algorithm) (ocrypto.KeyPair, error) {
 		key, err = generateECCKey(ecSecp384Len)
 	case policy.Algorithm_ALGORITHM_EC_P521:
 		key, err = generateECCKey(ecSecp521Len)
-	case policy.Algorithm_ALGORITHM_HPQT_XWING:
-		key, err = ocrypto.NewKeyPair(ocrypto.HybridXWingKey)
-	case policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768:
-		key, err = ocrypto.NewKeyPair(ocrypto.HybridSecp256r1MLKEM768Key)
-	case policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024:
-		key, err = ocrypto.NewKeyPair(ocrypto.HybridSecp384r1MLKEM1024Key)
 	case policy.Algorithm_ALGORITHM_UNSPECIFIED:
 		fallthrough
 	default:

--- a/otdfctl/cmd/policy/kasKeys_test.go
+++ b/otdfctl/cmd/policy/kasKeys_test.go
@@ -3,38 +3,9 @@ package policy
 import (
 	"testing"
 
-	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/stretchr/testify/require"
 )
-
-func TestGenerateKeyPair_Hybrid(t *testing.T) {
-	tests := []struct {
-		name    string
-		alg     policy.Algorithm
-		keyType ocrypto.KeyType
-	}{
-		{"X-Wing", policy.Algorithm_ALGORITHM_HPQT_XWING, ocrypto.HybridXWingKey},
-		{"P256-MLKEM768", policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768, ocrypto.HybridSecp256r1MLKEM768Key},
-		{"P384-MLKEM1024", policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024, ocrypto.HybridSecp384r1MLKEM1024Key},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			kp, err := generateKeyPair(tt.alg)
-			require.NoError(t, err)
-			require.Equal(t, tt.keyType, kp.GetKeyType())
-
-			pubPem, err := kp.PublicKeyInPemFormat()
-			require.NoError(t, err)
-			require.NotEmpty(t, pubPem)
-
-			privPem, err := kp.PrivateKeyInPemFormat()
-			require.NoError(t, err)
-			require.NotEmpty(t, privPem)
-		})
-	}
-}
 
 func TestGenerateKeyPair_Unsupported(t *testing.T) {
 	_, err := generateKeyPair(policy.Algorithm_ALGORITHM_UNSPECIFIED)

--- a/otdfctl/docs/man/policy/kas-registry/key/create.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/create.md
@@ -75,9 +75,6 @@ otdfctl policy kas-registry key create --key-id "aws-key" --algorithm "rsa:2048"
     | `ec:secp256r1` |
     | `ec:secp384r1` |
     | `ec:secp521r1` |
-    | `hpqt:xwing` |
-    | `hpqt:secp256r1-mlkem768` |
-    | `hpqt:secp384r1-mlkem1024` |
 
 2. The `"mode"` specifies where the key that is encrypting TDFs is stored. All keys will be encrypted when stored in Virtru's DB, for modes `"local"` and `"provider"`
 

--- a/otdfctl/docs/man/policy/kas-registry/key/import.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/import.md
@@ -79,6 +79,3 @@ otdfctl policy kas-registry key import --key-id "imported-key" --algorithm "rsa:
     | `ec:secp256r1` |
     | `ec:secp384r1` |
     | `ec:secp521r1` |
-    | `hpqt:xwing` |
-    | `hpqt:secp256r1-mlkem768` |
-    | `hpqt:secp384r1-mlkem1024` |

--- a/otdfctl/docs/man/policy/kas-registry/key/rotate.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/rotate.md
@@ -88,9 +88,6 @@ otdfctl policy kas-registry key rotate --key "public-key-old" --kas "Secondary K
     | `ec:secp256r1` |
     | `ec:secp384r1` |
     | `ec:secp521r1` |
-    | `hpqt:xwing` |
-    | `hpqt:secp256r1-mlkem768` |
-    | `hpqt:secp384r1-mlkem1024` |
 
 2. The `"mode"` specifies where the key that is encrypting TDFs is stored. All keys will be encrypted when stored in Virtru's DB, for modes `"local"` and `"provider"`
 

--- a/otdfctl/pkg/cli/sdkHelpers.go
+++ b/otdfctl/pkg/cli/sdkHelpers.go
@@ -125,12 +125,6 @@ func KeyAlgToEnum(alg string) (policy.Algorithm, error) {
 		return policy.Algorithm_ALGORITHM_EC_P384, nil
 	case "ec:secp521r1":
 		return policy.Algorithm_ALGORITHM_EC_P521, nil
-	case "hpqt:xwing":
-		return policy.Algorithm_ALGORITHM_HPQT_XWING, nil
-	case "hpqt:secp256r1-mlkem768":
-		return policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768, nil
-	case "hpqt:secp384r1-mlkem1024":
-		return policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024, nil
 	default:
 		return policy.Algorithm_ALGORITHM_UNSPECIFIED, errors.New("invalid algorithm")
 	}
@@ -148,12 +142,6 @@ func KeyEnumToAlg(enum policy.Algorithm) (string, error) {
 		return "ec:secp384r1", nil
 	case policy.Algorithm_ALGORITHM_EC_P521:
 		return "ec:secp521r1", nil
-	case policy.Algorithm_ALGORITHM_HPQT_XWING:
-		return "hpqt:xwing", nil
-	case policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768:
-		return "hpqt:secp256r1-mlkem768", nil
-	case policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024:
-		return "hpqt:secp384r1-mlkem1024", nil
 	default:
 		return "", errors.New("invalid enum algorithm")
 	}

--- a/otdfctl/pkg/cli/sdkHelpers_test.go
+++ b/otdfctl/pkg/cli/sdkHelpers_test.go
@@ -17,9 +17,6 @@ func TestKeyAlgToEnum_RoundTrip(t *testing.T) {
 		{"ec:secp256r1", policy.Algorithm_ALGORITHM_EC_P256},
 		{"ec:secp384r1", policy.Algorithm_ALGORITHM_EC_P384},
 		{"ec:secp521r1", policy.Algorithm_ALGORITHM_EC_P521},
-		{"hpqt:xwing", policy.Algorithm_ALGORITHM_HPQT_XWING},
-		{"hpqt:secp256r1-mlkem768", policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768},
-		{"hpqt:secp384r1-mlkem1024", policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024},
 	}
 
 	for _, tt := range tests {

--- a/otdfctl/pkg/utils/pemvalidate.go
+++ b/otdfctl/pkg/utils/pemvalidate.go
@@ -20,7 +20,7 @@ func ValidatePublicKeyPEM(pemBytes []byte, expected policy.Algorithm) error {
 		return fmt.Errorf("invalid public key pem: %w", err)
 	}
 
-	switch expected {
+	switch expected { //nolint:exhaustive // HPQT hybrid algorithms are intentionally unsupported by otdfctl
 	case policy.Algorithm_ALGORITHM_RSA_2048:
 		if enc.KeyType() != ocrypto.RSA2048Key {
 			return errors.New("algorithm mismatch: expected RSA 2048")
@@ -40,18 +40,6 @@ func ValidatePublicKeyPEM(pemBytes []byte, expected policy.Algorithm) error {
 	case policy.Algorithm_ALGORITHM_EC_P521:
 		if enc.KeyType() != ocrypto.EC521Key {
 			return errors.New("algorithm mismatch: expected EC P-521")
-		}
-	case policy.Algorithm_ALGORITHM_HPQT_XWING:
-		if enc.KeyType() != ocrypto.HybridXWingKey {
-			return errors.New("algorithm mismatch: expected hybrid X-Wing (X25519 + ML-KEM-768)")
-		}
-	case policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768:
-		if enc.KeyType() != ocrypto.HybridSecp256r1MLKEM768Key {
-			return errors.New("algorithm mismatch: expected hybrid NIST P-256 + ML-KEM-768")
-		}
-	case policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024:
-		if enc.KeyType() != ocrypto.HybridSecp384r1MLKEM1024Key {
-			return errors.New("algorithm mismatch: expected hybrid NIST P-384 + ML-KEM-1024")
 		}
 	case policy.Algorithm_ALGORITHM_UNSPECIFIED:
 		fallthrough

--- a/otdfctl/pkg/utils/pemvalidate_test.go
+++ b/otdfctl/pkg/utils/pemvalidate_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"testing"
 
-	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/stretchr/testify/require"
 )
@@ -118,46 +117,4 @@ func TestValidatePublicKeyPEM_UnsupportedAlgorithm(t *testing.T) {
 	err = ValidatePublicKeyPEM(pemBytes, policy.Algorithm_ALGORITHM_UNSPECIFIED)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported or unspecified algorithm")
-}
-
-func TestValidatePublicKeyPEM_HybridXWing_OK(t *testing.T) {
-	kp, err := ocrypto.NewKeyPair(ocrypto.HybridXWingKey)
-	require.NoError(t, err)
-	pubPem, err := kp.PublicKeyInPemFormat()
-	require.NoError(t, err)
-
-	err = ValidatePublicKeyPEM([]byte(pubPem), policy.Algorithm_ALGORITHM_HPQT_XWING)
-	require.NoError(t, err)
-}
-
-func TestValidatePublicKeyPEM_HybridP256MLKEM768_OK(t *testing.T) {
-	kp, err := ocrypto.NewKeyPair(ocrypto.HybridSecp256r1MLKEM768Key)
-	require.NoError(t, err)
-	pubPem, err := kp.PublicKeyInPemFormat()
-	require.NoError(t, err)
-
-	err = ValidatePublicKeyPEM([]byte(pubPem), policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768)
-	require.NoError(t, err)
-}
-
-func TestValidatePublicKeyPEM_HybridP384MLKEM1024_OK(t *testing.T) {
-	kp, err := ocrypto.NewKeyPair(ocrypto.HybridSecp384r1MLKEM1024Key)
-	require.NoError(t, err)
-	pubPem, err := kp.PublicKeyInPemFormat()
-	require.NoError(t, err)
-
-	err = ValidatePublicKeyPEM([]byte(pubPem), policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024)
-	require.NoError(t, err)
-}
-
-func TestValidatePublicKeyPEM_HybridMismatch(t *testing.T) {
-	// Generate an X-Wing key but validate against a different hybrid algorithm
-	kp, err := ocrypto.NewKeyPair(ocrypto.HybridXWingKey)
-	require.NoError(t, err)
-	pubPem, err := kp.PublicKeyInPemFormat()
-	require.NoError(t, err)
-
-	err = ValidatePublicKeyPEM([]byte(pubPem), policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "algorithm mismatch")
 }


### PR DESCRIPTION
Signed-off-by: Dave Mihalcik <dmihalcik@virtru.com>

### Proposed Changes

* Disables the hybrid algorithms via otdfctl. This will skip e2e tests in xtest, allowing us to switch to the new format in  #3563

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed support for HPQT hybrid algorithm variants (e.g., `hpqt:xwing`, `hpqt:secp256r1-mlkem768`). Attempts to use these algorithms during key generation, key conversion, or public key validation will now fail with the existing “unsupported/invalid algorithm” errors.

* **Documentation**
  * Updated key management command documentation to list only supported RSA and elliptic-curve algorithm options.

* **Tests**
  * Removed hybrid-algorithm test coverage and adjusted remaining test vectors to match current supported algorithms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->