### PR TITLE
fix(authz): Handle multiple resources.

### DIFF
--- a/service/internal/auth/authz/casbin/v2/authorizer.go
+++ b/service/internal/auth/authz/casbin/v2/authorizer.go
@@ -319,6 +319,7 @@ func serializeDimensions(ctx *authz.ResolverContext) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Revisit deduplicating equivalent serialized resource dimensions when productionizing List RPCs/requests.
 		dims = append(dims, serialized)
 	}
 

--- a/service/internal/auth/authz/casbin/v2/authorizer.go
+++ b/service/internal/auth/authz/casbin/v2/authorizer.go
@@ -213,7 +213,10 @@ func (a *Authorizer) authorize(ctx context.Context, req *authz.Request) (*authz.
 		slog.Any("resource_dims", resourceDims),
 	)
 
-	var matchedSubject string
+	var (
+		matchedSubjects []string
+		seenSubjects    = make(map[string]struct{}, len(subjects))
+	)
 	// Casbin BatchEnforce/BulkEnforce could be investigated for efficiency if
 	// resource or subject counts grow.
 	for _, dims := range resourceDims {
@@ -231,10 +234,14 @@ func (a *Authorizer) authorize(ctx context.Context, req *authz.Request) (*authz.
 				},
 			}, nil
 		}
-		if matchedSubject == "" {
-			matchedSubject = allowedSubject
+		if allowedSubject != "" {
+			if _, seen := seenSubjects[allowedSubject]; !seen {
+				seenSubjects[allowedSubject] = struct{}{}
+				matchedSubjects = append(matchedSubjects, allowedSubject)
+			}
 		}
 	}
+	matchedSubject := strings.Join(matchedSubjects, ", ")
 
 	return &authz.Decision{
 		Allowed:       true,

--- a/service/internal/auth/authz/casbin/v2/authorizer.go
+++ b/service/internal/auth/authz/casbin/v2/authorizer.go
@@ -201,8 +201,7 @@ func (a *Authorizer) authorize(ctx context.Context, req *authz.Request) (*authz.
 		subjects = append(subjects, rolePrefix+defaultRole)
 	}
 
-	// Serialize dimensions to canonical string
-	dims, err := serializeDimensions(req.ResourceContext)
+	resourceDims, err := serializeDimensions(req.ResourceContext)
 	if err != nil {
 		return nil, fmt.Errorf("v2 authorization invalid resource dimensions: %w", err)
 	}
@@ -211,24 +210,56 @@ func (a *Authorizer) authorize(ctx context.Context, req *authz.Request) (*authz.
 		"v2 authorization check",
 		slog.Any("subjects", subjects),
 		slog.String("rpc", req.RPC),
-		slog.String("dims", dims),
+		slog.Any("resource_dims", resourceDims),
 	)
 
-	// Check each subject (role or username)
-	// Track if any enforcement succeeded without error to distinguish
-	// "all denied" from "all errored" (system failure)
+	var matchedSubject string
+	// Casbin BatchEnforce/BulkEnforce could be investigated for efficiency if
+	// resource or subject counts grow.
+	for _, dims := range resourceDims {
+		allowed, allowedSubject, enforcementErr := a.authorizeResource(req.RPC, dims, subjects)
+		if enforcementErr != nil {
+			return nil, fmt.Errorf("v2 authorization system error: %w", enforcementErr)
+		}
+		if !allowed {
+			return &authz.Decision{
+				Allowed: false,
+				Reason:  fmt.Sprintf("v2: denied %s with dims=%s", req.RPC, dims),
+				Mode:    authz.ModeV2,
+				Metadata: authz.DecisionMetadata{
+					GroupsClaim: a.groupsClaim,
+				},
+			}, nil
+		}
+		if matchedSubject == "" {
+			matchedSubject = allowedSubject
+		}
+	}
+
+	return &authz.Decision{
+		Allowed:       true,
+		Reason:        fmt.Sprintf("v2: %s on %s", matchedSubject, req.RPC),
+		Mode:          authz.ModeV2,
+		MatchedPolicy: matchedSubject,
+		Metadata: authz.DecisionMetadata{
+			GroupsClaim: a.groupsClaim,
+		},
+	}, nil
+}
+
+func (a *Authorizer) authorizeResource(rpc, dims string, subjects []string) (bool, string, error) {
 	var (
 		anyCheckedSuccessfully bool
 		lastErr                error
 	)
 
 	for _, subject := range subjects {
-		allowed, err := a.enforcer.Enforce(subject, req.RPC, dims)
+		allowed, err := a.enforcer.Enforce(subject, rpc, dims)
 		if err != nil {
 			a.logger.Error(
 				"v2 enforcement error",
 				slog.String("subject", subject),
-				slog.String("rpc", req.RPC),
+				slog.String("rpc", rpc),
 				slog.String("dims", dims),
 				slog.Any("error", err),
 			)
@@ -237,81 +268,66 @@ func (a *Authorizer) authorize(ctx context.Context, req *authz.Request) (*authz.
 		}
 
 		anyCheckedSuccessfully = true
-
 		if allowed {
 			a.logger.Debug(
 				"v2 authorization allowed",
 				slog.String("subject", subject),
-				slog.String("rpc", req.RPC),
+				slog.String("rpc", rpc),
 				slog.String("dims", dims),
 			)
-			return &authz.Decision{
-				Allowed:       true,
-				Reason:        fmt.Sprintf("v2: %s on %s with dims=%s", subject, req.RPC, dims),
-				Mode:          authz.ModeV2,
-				MatchedPolicy: subject,
-				Metadata: authz.DecisionMetadata{
-					GroupsClaim: a.groupsClaim,
-				},
-			}, nil
+			return true, subject, nil
 		}
 	}
 
-	// If ALL subjects failed with errors (none checked successfully),
-	// return a system error instead of a denial
 	if !anyCheckedSuccessfully && lastErr != nil {
-		return nil, fmt.Errorf("v2 authorization system error: %w", lastErr)
+		return false, "", lastErr
 	}
 
 	a.logger.Debug(
 		"v2 authorization denied",
 		slog.Any("subjects", subjects),
-		slog.String("rpc", req.RPC),
+		slog.String("rpc", rpc),
 		slog.String("dims", dims),
 	)
-
-	return &authz.Decision{
-		Allowed: false,
-		Reason:  fmt.Sprintf("v2: denied %s with dims=%s", req.RPC, dims),
-		Mode:    authz.ModeV2,
-		Metadata: authz.DecisionMetadata{
-			GroupsClaim: a.groupsClaim,
-		},
-	}, nil
+	return false, "", nil
 }
 
-// serializeDimensions converts ResolverContext to canonical dimension string.
+// serializeDimensions converts ResolverContext resources to canonical dimension strings.
+// Each non-empty resource is serialized independently so each resource's dimensions
+// are evaluated with all-of semantics.
 // Format: key1=value1&key2=value2 (keys sorted alphabetically)
-// Returns "*" if no dimensions are present.
-func serializeDimensions(ctx *authz.ResolverContext) (string, error) {
+// Returns ["*"] if no dimensions are present.
+func serializeDimensions(ctx *authz.ResolverContext) ([]string, error) {
 	if ctx == nil || len(ctx.Resources) == 0 {
-		return "*", nil
+		return []string{"*"}, nil
 	}
 
-	// Collect all dimensions from all resources
-	allDims := make(map[string]string)
+	dims := make([]string, 0, len(ctx.Resources))
 	for _, resource := range ctx.Resources {
-		if resource == nil {
+		if resource == nil || len(*resource) == 0 {
 			continue
 		}
-		for k, v := range *resource {
-			if !isValidDimensionKey(k) {
-				return "", fmt.Errorf("invalid dimension key %q: keys must not contain any of %q", k, disallowedDimensionKeyChars)
-			}
-			if existing, exists := allDims[k]; exists && existing != v {
-				return "", fmt.Errorf("conflicting values for dimension key %q: %q != %q", k, existing, v)
-			}
-			allDims[k] = v
+
+		serialized, err := serializeResource(resource)
+		if err != nil {
+			return nil, err
 		}
+		dims = append(dims, serialized)
 	}
 
-	if len(allDims) == 0 {
-		return "*", nil
+	if len(dims) == 0 {
+		return []string{"*"}, nil
 	}
 
-	// Sort keys for canonical ordering
-	keys := make([]string, 0, len(allDims))
-	for k := range allDims {
+	return dims, nil
+}
+
+func serializeResource(resource *authz.ResolverResource) (string, error) {
+	keys := make([]string, 0, len(*resource))
+	for k := range *resource {
+		if !isValidDimensionKey(k) {
+			return "", fmt.Errorf("invalid dimension key %q: keys must not contain any of %q", k, disallowedDimensionKeyChars)
+		}
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
@@ -323,7 +339,7 @@ func serializeDimensions(ctx *authz.ResolverContext) (string, error) {
 	// readable because pair parsing splits on the first '='.
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
-		parts = append(parts, fmt.Sprintf("%s=%s", k, escapeDimensionValue(allDims[k])))
+		parts = append(parts, fmt.Sprintf("%s=%s", k, escapeDimensionValue((*resource)[k])))
 	}
 
 	return strings.Join(parts, "&"), nil

--- a/service/internal/auth/authz/casbin/v2/authorizer_test.go
+++ b/service/internal/auth/authz/casbin/v2/authorizer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -269,6 +270,136 @@ func (s *CasbinAuthorizerSuite) TestAuthorizeV2_MultipleDimensions() {
 	decision, err = authorizer.Authorize(context.Background(), wrongAttrReq)
 	s.Require().NoError(err)
 	s.False(decision.Allowed, "should NOT be allowed with wrong attribute")
+}
+
+func (s *CasbinAuthorizerSuite) TestAuthorizeV2_MultipleResourcesAllOf() {
+	cfg := authz.Config{
+		PolicyConfig: authz.PolicyConfig{
+			Version:     "v2",
+			GroupsClaim: "realm_access.roles",
+			Csv:         `p, role:hr-admin, /policy.attributes.AttributesService/Update*, namespace=hr, allow`, // ? This really should be a List req
+		},
+		Logger: s.logger,
+	}
+
+	authorizer, err := s.newAuthorizer(cfg)
+	s.Require().NoError(err)
+
+	token := createTestToken(s.T(), map[string]interface{}{
+		"realm_access": map[string]interface{}{
+			"roles": []interface{}{"hr-admin"},
+		},
+	})
+
+	allowedReq := &authz.Request{
+		Token:  token,
+		RPC:    "/policy.attributes.AttributesService/UpdateAttribute",
+		Action: "write",
+		ResourceContext: &authz.ResolverContext{
+			Resources: []*authz.ResolverResource{
+				{"namespace": "hr", "attribute": "classification"},
+				{"namespace": "hr", "attribute": "department"},
+			},
+		},
+	}
+
+	decision, err := authorizer.Authorize(s.T().Context(), allowedReq)
+	s.Require().NoError(err)
+	s.True(decision.Allowed, "all HR resources should be allowed")
+
+	deniedReq := &authz.Request{
+		Token:  token,
+		RPC:    "/policy.attributes.AttributesService/UpdateAttribute",
+		Action: "write",
+		ResourceContext: &authz.ResolverContext{
+			Resources: []*authz.ResolverResource{
+				{"namespace": "hr", "attribute": "classification"},
+				{"namespace": "finance", "attribute": "payroll"},
+			},
+		},
+	}
+
+	decision, err = authorizer.Authorize(s.T().Context(), deniedReq)
+	s.Require().NoError(err)
+	s.False(decision.Allowed, "one denied resource should deny the aggregate request")
+}
+
+func (s *CasbinAuthorizerSuite) TestAuthorizeV2_MultipleResourcesSkipsNilAndEmpty() {
+	cfg := authz.Config{
+		PolicyConfig: authz.PolicyConfig{
+			Version:     "v2",
+			GroupsClaim: "realm_access.roles",
+			Csv:         `p, role:hr-admin, /policy.attributes.AttributesService/Update*, namespace=hr, allow`,
+		},
+		Logger: s.logger,
+	}
+
+	authorizer, err := s.newAuthorizer(cfg)
+	s.Require().NoError(err)
+
+	token := createTestToken(s.T(), map[string]interface{}{
+		"realm_access": map[string]interface{}{
+			"roles": []interface{}{"hr-admin"},
+		},
+	})
+	emptyResource := authz.ResolverResource{}
+
+	decision, err := authorizer.Authorize(s.T().Context(), &authz.Request{
+		Token:  token,
+		RPC:    "/policy.attributes.AttributesService/UpdateAttribute",
+		Action: "write",
+		ResourceContext: &authz.ResolverContext{
+			Resources: []*authz.ResolverResource{
+				nil,
+				&emptyResource,
+				{"namespace": "hr", "attribute": "classification"},
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.True(decision.Allowed, "nil and empty resources should be skipped when a real resource is present")
+}
+
+func (s *CasbinAuthorizerSuite) TestAuthorizeV2_EnforcementErrorReturnsSystemError() {
+	brokenModel := strings.Replace(
+		modelV2,
+		"m = g(r.sub, p.sub) && keyMatch(r.rpc, p.rpc) && dimensionMatch(r.dims, p.dims)",
+		"m = g(r.sub, p.sub) && keyMatch(r.rpc, p.rpc) && missingDimensionMatch(r.dims, p.dims)",
+		1,
+	)
+	cfg := authz.Config{
+		PolicyConfig: authz.PolicyConfig{
+			Version:     "v2",
+			GroupsClaim: "realm_access.roles",
+			Model:       brokenModel,
+			Csv:         `p, role:hr-admin, /policy.attributes.AttributesService/Update*, namespace=hr, allow`,
+		},
+		Logger: s.logger,
+	}
+
+	authorizer, err := s.newAuthorizer(cfg)
+	s.Require().NoError(err)
+
+	token := createTestToken(s.T(), map[string]interface{}{
+		"realm_access": map[string]interface{}{
+			"roles": []interface{}{"hr-admin"},
+		},
+	})
+
+	decision, err := authorizer.Authorize(s.T().Context(), &authz.Request{
+		Token:  token,
+		RPC:    "/policy.attributes.AttributesService/UpdateAttribute",
+		Action: "write",
+		ResourceContext: &authz.ResolverContext{
+			Resources: []*authz.ResolverResource{
+				{"namespace": "hr"},
+			},
+		},
+	})
+
+	s.Require().Error(err)
+	s.Nil(decision)
+	s.Contains(err.Error(), "v2 authorization system error")
 }
 
 func (s *CasbinAuthorizerSuite) TestAuthorizeV2_WildcardDimension() {
@@ -654,7 +785,7 @@ func TestDimensionMatch(t *testing.T) {
 			expected:   true,
 		},
 		{
-			name:       "exact match multiple dimensions",
+			name:       "exact match multiple dimensions - order insensitive",
 			reqDims:    "attribute=classification&namespace=hr",
 			policyDims: "namespace=hr&attribute=classification",
 			expected:   true,
@@ -722,18 +853,18 @@ func TestSerializeDimensions(t *testing.T) {
 	tests := []struct {
 		name      string
 		ctx       *authz.ResolverContext
-		expected  string
+		expected  []string
 		expectErr bool
 	}{
 		{
 			name:     "nil context",
 			ctx:      nil,
-			expected: "*",
+			expected: []string{"*"},
 		},
 		{
 			name:     "empty context",
 			ctx:      &authz.ResolverContext{},
-			expected: "*",
+			expected: []string{"*"},
 		},
 		{
 			name: "single dimension",
@@ -742,7 +873,7 @@ func TestSerializeDimensions(t *testing.T) {
 					{"namespace": "hr"},
 				},
 			},
-			expected: "namespace=hr",
+			expected: []string{"namespace=hr"},
 		},
 		{
 			name: "multiple dimensions sorted alphabetically",
@@ -751,27 +882,51 @@ func TestSerializeDimensions(t *testing.T) {
 					{"namespace": "hr", "attribute": "classification"},
 				},
 			},
-			expected: "attribute=classification&namespace=hr",
+			expected: []string{"attribute=classification&namespace=hr"},
 		},
 		{
-			name: "multiple resources merged",
+			name: "multiple resources remain independent",
 			ctx: &authz.ResolverContext{
 				Resources: []*authz.ResolverResource{
-					{"namespace": "hr"},
-					{"attribute": "classification"},
+					{"namespace": "hr", "attribute": "classification"},
+					{"namespace": "finance", "attribute": "payroll"},
 				},
 			},
-			expected: "attribute=classification&namespace=hr",
+			expected: []string{
+				"attribute=classification&namespace=hr",
+				"attribute=payroll&namespace=finance",
+			},
 		},
 		{
-			name: "conflicting duplicate dimension key fails",
+			name: "conflicting duplicate keys across resources are allowed",
 			ctx: &authz.ResolverContext{
 				Resources: []*authz.ResolverResource{
 					{"namespace": "hr"},
 					{"namespace": "finance"},
 				},
 			},
-			expectErr: true,
+			expected: []string{"namespace=hr", "namespace=finance"},
+		},
+		{
+			name: "mixed real nil and empty resources skips nil and empty",
+			ctx: &authz.ResolverContext{
+				Resources: []*authz.ResolverResource{
+					nil,
+					{},
+					{"namespace": "hr"},
+				},
+			},
+			expected: []string{"namespace=hr"},
+		},
+		{
+			name: "only nil and empty resources returns wildcard",
+			ctx: &authz.ResolverContext{
+				Resources: []*authz.ResolverResource{
+					nil,
+					{},
+				},
+			},
+			expected: []string{"*"},
 		},
 		{
 			name: "invalid key with separator fails",
@@ -866,7 +1021,8 @@ func TestSerializeDimensions_InjectionPrevention(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := serializeDimensions(tc.ctx)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expected, result)
+			require.Len(t, result, 1)
+			assert.Equal(t, tc.expected, result[0])
 		})
 	}
 }
@@ -926,8 +1082,9 @@ func TestParseDimensions_RoundTrip(t *testing.T) {
 
 			serialized, err := serializeDimensions(ctx)
 			require.NoError(t, err)
+			require.Len(t, serialized, 1)
 
-			parsed, ok := parseDimensions(serialized)
+			parsed, ok := parseDimensions(serialized[0])
 			require.True(t, ok, "parseDimensions must succeed on serialized output")
 			assert.Equal(t, tc.input, parsed, "round-trip must preserve original values exactly")
 		})
@@ -1010,9 +1167,10 @@ func TestDimensionMatch_WithURIValues(t *testing.T) {
 			}
 			serialized, err := serializeDimensions(ctx)
 			require.NoError(t, err)
+			require.Len(t, serialized, 1)
 
-			result := dimensionMatch(serialized, tc.policyDims)
-			assert.Equal(t, tc.expected, result, "dimensionMatch(%q, %q)", serialized, tc.policyDims)
+			result := dimensionMatch(serialized[0], tc.policyDims)
+			assert.Equal(t, tc.expected, result, "dimensionMatch(%q, %q)", serialized[0], tc.policyDims)
 		})
 	}
 }

--- a/service/internal/auth/authz/casbin/v2/authorizer_test.go
+++ b/service/internal/auth/authz/casbin/v2/authorizer_test.go
@@ -324,6 +324,46 @@ func (s *CasbinAuthorizerSuite) TestAuthorizeV2_MultipleResourcesAllOf() {
 	s.False(decision.Allowed, "one denied resource should deny the aggregate request")
 }
 
+func (s *CasbinAuthorizerSuite) TestAuthorizeV2_MultipleResourcesCollectsUniqueMatchedSubjects() {
+	cfg := authz.Config{
+		PolicyConfig: authz.PolicyConfig{
+			Version:     "v2",
+			GroupsClaim: "realm_access.roles",
+			Csv: `p, role:hr-admin, /policy.attributes.AttributesService/Update*, namespace=hr, allow
+p, role:finance-admin, /policy.attributes.AttributesService/Update*, namespace=finance, allow`,
+		},
+		Logger: s.logger,
+	}
+
+	authorizer, err := s.newAuthorizer(cfg)
+	s.Require().NoError(err)
+
+	token := createTestToken(s.T(), map[string]interface{}{
+		"realm_access": map[string]interface{}{
+			"roles": []interface{}{"hr-admin", "finance-admin"},
+		},
+	})
+
+	decision, err := authorizer.Authorize(s.T().Context(), &authz.Request{
+		Token:  token,
+		RPC:    "/policy.attributes.AttributesService/UpdateAttribute",
+		Action: "write",
+		ResourceContext: &authz.ResolverContext{
+			Resources: []*authz.ResolverResource{
+				{"namespace": "hr", "attribute": "classification"},
+				{"namespace": "finance", "attribute": "payroll"},
+				{"namespace": "hr", "attribute": "department"},
+			},
+		},
+	})
+
+	s.Require().NoError(err)
+	s.Require().NotNil(decision)
+	s.True(decision.Allowed)
+	s.Equal("role:hr-admin, role:finance-admin", decision.MatchedPolicy)
+	s.Equal("v2: role:hr-admin, role:finance-admin on /policy.attributes.AttributesService/UpdateAttribute", decision.Reason)
+}
+
 func (s *CasbinAuthorizerSuite) TestAuthorizeV2_MultipleResourcesSkipsNilAndEmpty() {
 	cfg := authz.Config{
 		PolicyConfig: authz.PolicyConfig{

--- a/service/internal/auth/interceptor_authz_test.go
+++ b/service/internal/auth/interceptor_authz_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -498,6 +499,39 @@ func (s *InterceptorAuthzSuite) TestAuthorizeV2_InvokesRegisteredResolver() {
 	s.True(resolverCalled, "registered resolver should be invoked")
 	s.Require().NotNil(result.resourceContext)
 	s.Equal("resolved", result.resourceContext.GetResolvedData("attribute"))
+}
+
+func (s *InterceptorAuthzSuite) TestAuthorizeV2_ResolverErrorFailsClosed() {
+	csvPolicy := "p, role:hr-admin, /policy.attributes.AttributesService/*, namespace=hr, allow"
+	registry := internalauthz.NewResolverRegistry()
+	scopedRegistry := registry.ScopedForService(&grpc.ServiceDesc{
+		ServiceName: "policy.attributes.AttributesService",
+		Methods: []grpc.MethodDesc{
+			{MethodName: "UpdateAttribute"},
+		},
+	})
+
+	scopedRegistry.MustRegister("UpdateAttribute", func(_ context.Context, _ connect.AnyRequest) (internalauthz.ResolverContext, error) {
+		return internalauthz.NewResolverContext(), errors.New("resolver db unavailable")
+	})
+
+	authn := &Authentication{
+		logger:                s.logger,
+		authorizer:            s.createV2Authorizer(csvPolicy),
+		authzResolverRegistry: registry,
+	}
+
+	req := &authzTestRequest{
+		Request:   connect.NewRequest(&attributes.GetAttributeRequest{}),
+		procedure: "/policy.attributes.AttributesService/UpdateAttribute",
+	}
+
+	result := authn.authorize(s.T().Context(), s.logger, s.newTokenWithRoles("hr-admin"), req, ActionWrite)
+
+	s.Require().Error(result.err)
+	s.Equal(connect.CodePermissionDenied, result.errCode)
+	s.Equal("authorization context resolution failed", result.err.Error())
+	s.Nil(result.decision)
 }
 
 func (s *InterceptorAuthzSuite) TestV2_EmptyToken() {

--- a/service/policy/kasregistry/authz_resolver_test.go
+++ b/service/policy/kasregistry/authz_resolver_test.go
@@ -2,6 +2,7 @@ package kasregistry
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -61,6 +62,67 @@ func TestGetKeyAuthzResolver_UsesPolicyDBClientAndCachesResolvedKey(t *testing.T
 	require.Equal(t, kasURI, resolvedURI)
 	require.Same(t, identifier, dbClient.identifier)
 	require.Same(t, key, resolverCtx.GetResolvedData(resolverCacheKeyKasKey))
+}
+
+func TestGetKeyAuthzResolver_UsesPolicyDBClientForIDRequest(t *testing.T) {
+	kasURI := "https://kas-a.example.com"
+	key := &policy.KasKey{
+		KasUri: kasURI,
+		Key: &policy.AsymmetricKey{
+			KeyId: validKeyID,
+		},
+	}
+	dbClient := &fakeGetKeyAuthzDBClient{key: key}
+	identifier := &kasregistry.GetKeyRequest_Id{Id: validUUID}
+	resolverCtx := authz.NewResolverContext()
+
+	resolvedURI, err := resolveGetKeyKasURI(t.Context(), &kasregistry.GetKeyRequest{
+		Identifier: identifier,
+	}, &resolverCtx, dbClient)
+
+	require.NoError(t, err)
+	require.Equal(t, kasURI, resolvedURI)
+	require.Same(t, identifier, dbClient.identifier)
+	require.Same(t, key, resolverCtx.GetResolvedData(resolverCacheKeyKasKey))
+}
+
+func TestGetKeyAuthzResolver_UsesPolicyDBClientForKeyIdentifierWithoutURI(t *testing.T) {
+	kasURI := "https://kas-a.example.com"
+	key := &policy.KasKey{
+		KasUri: kasURI,
+		Key: &policy.AsymmetricKey{
+			KeyId: validKeyID,
+		},
+	}
+	dbClient := &fakeGetKeyAuthzDBClient{key: key}
+	identifier := &kasregistry.GetKeyRequest_Key{
+		Key: &kasregistry.KasKeyIdentifier{
+			Identifier: &kasregistry.KasKeyIdentifier_KasId{KasId: validUUID},
+			Kid:        validKeyID,
+		},
+	}
+	resolverCtx := authz.NewResolverContext()
+
+	resolvedURI, err := resolveGetKeyKasURI(t.Context(), &kasregistry.GetKeyRequest{
+		Identifier: identifier,
+	}, &resolverCtx, dbClient)
+
+	require.NoError(t, err)
+	require.Equal(t, kasURI, resolvedURI)
+	require.Same(t, identifier, dbClient.identifier)
+	require.Same(t, key, resolverCtx.GetResolvedData(resolverCacheKeyKasKey))
+}
+
+func TestGetKeyAuthzResolver_DBLookupErrorFailsResolution(t *testing.T) {
+	dbErr := errors.New("db unavailable")
+	resolverCtx := authz.NewResolverContext()
+
+	_, err := resolveGetKeyKasURI(t.Context(), &kasregistry.GetKeyRequest{
+		Identifier: &kasregistry.GetKeyRequest_Id{Id: validUUID},
+	}, &resolverCtx, &fakeGetKeyAuthzDBClient{err: dbErr})
+
+	require.ErrorIs(t, err, errResolveKasKeyForAuthz)
+	require.ErrorIs(t, err, dbErr)
 }
 
 func TestGetKeyAuthzResolver_InvalidRequestType(t *testing.T) {

--- a/tests-bdd/cukes/resources/platform.authz_v2.template
+++ b/tests-bdd/cukes/resources/platform.authz_v2.template
@@ -60,7 +60,9 @@ server:
       extension: |
         # KAS key read access for BDD-specific service-account roles.
         p, client:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-a.example.com, allow
+        p, client:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-a-id.example.com, allow
         p, client:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-b.example.com, allow
+        p, client:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-b-id.example.com, allow
       model:
   trace:
     enabled: false

--- a/tests-bdd/cukes/steps_kasregistry.go
+++ b/tests-bdd/cukes/steps_kasregistry.go
@@ -91,6 +91,21 @@ func (s *KasRegistryStepDefinitions) iGetKASKey(ctx context.Context, keyID strin
 	return ctx, nil
 }
 
+func (s *KasRegistryStepDefinitions) iGetKASKeyByStoredID(ctx context.Context, keyID string) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	storedID, ok := scenarioContext.GetObject(keyID).(string)
+	if !ok {
+		return ctx, fmt.Errorf("unable to extract stored KAS key ID for %q", keyID)
+	}
+
+	scenarioContext.ClearError()
+	_, err := scenarioContext.SDK.KeyAccessServerRegistry.GetKey(ctx, &kasregistry.GetKeyRequest{
+		Identifier: &kasregistry.GetKeyRequest_Id{Id: storedID},
+	})
+	scenarioContext.SetError(err)
+	return ctx, nil
+}
+
 func (s *KasRegistryStepDefinitions) iListKASKeysForURI(ctx context.Context, kasURI string) (context.Context, error) {
 	scenarioContext := GetPlatformScenarioContext(ctx)
 	scenarioContext.ClearError()
@@ -112,5 +127,6 @@ func RegisterKasRegistryStepDefinitions(ctx *godog.ScenarioContext) {
 	stepDefinitions := KasRegistryStepDefinitions{}
 	ctx.Step(`^I create KAS keys:$`, stepDefinitions.iCreateKASKeys)
 	ctx.Step(`^I send a request to get KAS key "([^"]*)"$`, stepDefinitions.iGetKASKey)
+	ctx.Step(`^I send a request to get KAS key "([^"]*)" by stored ID$`, stepDefinitions.iGetKASKeyByStoredID)
 	ctx.Step(`^I send a request to list KAS keys for URI "([^"]*)"$`, stepDefinitions.iListKASKeysForURI)
 }

--- a/tests-bdd/features/authz-v2.feature
+++ b/tests-bdd/features/authz-v2.feature
@@ -57,6 +57,23 @@ Feature: Authz v2 default policy authorization
       When I send a request to list KAS keys for URI "https://kas-a.example.com"
       Then the response should be permission denied
 
+    Scenario: URI-specific KAS roles authorize ID-based GetKey using resolved KAS URI
+      Given I use the platform as "opentdf-admin"
+      And I create KAS keys:
+        | kas_uri                      | key_id       |
+        | https://kas-a-id.example.com | kas-a-id-kid |
+        | https://kas-b-id.example.com | kas-b-id-kid |
+      Given I use the platform as "kas-a"
+      When I send a request to get KAS key "kas-a-id-kid" by stored ID
+      Then the response should be successful
+      When I send a request to get KAS key "kas-b-id-kid" by stored ID
+      Then the response should be permission denied
+      Given I use the platform as "kas-b"
+      When I send a request to get KAS key "kas-b-id-kid" by stored ID
+      Then the response should be successful
+      When I send a request to get KAS key "kas-a-id-kid" by stored ID
+      Then the response should be permission denied
+
     # Security: URL values containing '&' and '=' must not be mis-parsed as
     # extra dimensions. A kas-a scoped role must not gain access to a different
     # KAS key whose URI injects a trailing "kas_uri=https://kas-a.example.com".


### PR DESCRIPTION
Summary

  - Updates the Casbin v2 authorizer to serialize each resolved resource independently instead of merging all resource dimensions into one map.
  - Enforces all-of semantics for multi-resource requests: every non-empty resolved resource must be authorized, or the aggregate request is denied.
  - Allows duplicate dimension keys across separate resources while preserving validation within each resource.
  - Preserves existing escaping behavior for special dimension values.
  - Skips nil and empty resolver resources, falling back to wildcard dimensions only when no real resource dimensions are present.
  - Adds coverage for multi-resource allow/deny behavior, resolver failures, enforcement errors, and KAS GetKey authorization by stored ID.
  - Extends Authz v2 BDD fixtures and feature coverage for URI-scoped KAS roles resolving ID-based GetKey requests through the stored KAS URI.