### PR TITLE
feat(policy): DSPX-2541 implement GetKeyMappingsByFqns

### DIFF
--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -1523,6 +1523,56 @@ func (s *AttributesSuite) Test_UnsafeUpdateAttribute_WithNewName() {
 	s.Contains(val.GetFqn(), updated.GetName())
 }
 
+func (s *AttributesSuite) Test_GetKeyMappingsByFqns() {
+	created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+		Name:        "test__get_key_mappings_by_fqns",
+		NamespaceId: fixtureNamespaceID,
+		Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+		Values:      []string{"alpha", "beta"},
+	})
+	s.Require().NoError(err)
+	s.NotNil(created)
+
+	got, err := s.db.PolicyClient.GetAttribute(s.ctx, created.GetId())
+	s.Require().NoError(err)
+	s.Require().Len(got.GetValues(), 2)
+
+	fqnAlpha := got.GetValues()[0].GetFqn()
+	fqnBeta := got.GetValues()[1].GetFqn()
+
+	// Without any assigned keys, the rule is returned and keys are empty.
+	mappings, err := s.db.PolicyClient.GetKeyMappingsByFqns(s.ctx, &attributes.GetKeyMappingsByFqnsRequest{
+		Fqns: []string{fqnAlpha, fqnBeta},
+	})
+	s.Require().NoError(err)
+	s.Len(mappings, 2)
+	for _, fqn := range []string{fqnAlpha, fqnBeta} {
+		m, ok := mappings[fqn]
+		s.Require().True(ok)
+		s.Equal(fqn, m.GetFqn())
+		s.Equal(policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, m.GetRule())
+		s.Empty(m.GetKeys())
+	}
+
+	// A definition-level key is inherited by values that have no key of their own.
+	kasKeyFixture := s.f.GetKasRegistryServerKeys("kas_key_1")
+	kasKey, err := s.db.PolicyClient.GetKey(s.ctx, &kasregistry.GetKeyRequest_Id{Id: kasKeyFixture.ID})
+	s.Require().NoError(err)
+	_, err = s.db.PolicyClient.AssignPublicKeyToAttribute(s.ctx, &attributes.AttributeKey{
+		AttributeId: created.GetId(),
+		KeyId:       kasKey.GetKey().GetId(),
+	})
+	s.Require().NoError(err)
+
+	mappings, err = s.db.PolicyClient.GetKeyMappingsByFqns(s.ctx, &attributes.GetKeyMappingsByFqnsRequest{
+		Fqns: []string{fqnAlpha},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(mappings, 1)
+	s.Require().Len(mappings[fqnAlpha].GetKeys(), 1)
+	validateSimpleKasKey(&s.Suite, kasKey, mappings[fqnAlpha].GetKeys()[0])
+}
+
 func (s *AttributesSuite) Test_UnsafeUpdateAttribute_NormalizesCasing() {
 	created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
 		Name:        "BANANA_PUDDING",

--- a/service/policy/attributes/attributes.go
+++ b/service/policy/attributes/attributes.go
@@ -172,6 +172,35 @@ func (s *AttributesService) GetAttributeValuesByFqns(ctx context.Context,
 	return connect.NewResponse(rsp), nil
 }
 
+func (s *AttributesService) GetKeyMappingsByFqns(ctx context.Context,
+	req *connect.Request[attributes.GetKeyMappingsByFqnsRequest],
+) (*connect.Response[attributes.GetKeyMappingsByFqnsResponse], error) {
+	ctx, span := s.Start(ctx, "GetKeyMappingsByFqns")
+	defer span.End()
+
+	rsp := &attributes.GetKeyMappingsByFqnsResponse{}
+
+	mappings, err := s.dbClient.GetKeyMappingsByFqns(ctx, req.Msg)
+	if err != nil {
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("fqns", fmt.Sprintf("%v", req.Msg.GetFqns())))
+	}
+	rsp.FqnKeyMappings = mappings
+
+	return connect.NewResponse(rsp), nil
+}
+
+// GetEntitleableAttributesByFqns is defined in the proto but implemented in a
+// follow-up change (the server-side decisioning migration). It returns
+// Unimplemented until then.
+func (s *AttributesService) GetEntitleableAttributesByFqns(ctx context.Context,
+	_ *connect.Request[attributes.GetEntitleableAttributesByFqnsRequest],
+) (*connect.Response[attributes.GetEntitleableAttributesByFqnsResponse], error) {
+	_, span := s.Start(ctx, "GetEntitleableAttributesByFqns")
+	defer span.End()
+
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("GetEntitleableAttributesByFqns is not yet implemented"))
+}
+
 func (s *AttributesService) UpdateAttribute(ctx context.Context,
 	req *connect.Request[attributes.UpdateAttributeRequest],
 ) (*connect.Response[attributes.UpdateAttributeResponse], error) {

--- a/service/policy/db/attribute_fqn.go
+++ b/service/policy/db/attribute_fqn.go
@@ -205,6 +205,50 @@ func (c *PolicyDBClient) GetAttributesByValueFqns(ctx context.Context, r *attrib
 	return list, nil
 }
 
+// GetKeyMappingsByFqns returns, for each requested attribute value FQN, the
+// governing attribute rule and the effective KAS keys needed to build key
+// splits. Keys are resolved with value > definition > namespace precedence using
+// the mapped key model (SimpleKasKey), mirroring the client-side granter
+// resolution. Values configured only with legacy KeyAccessServer grants (no
+// kas_keys) return an empty key set; migrate such policy to keys to use this API.
+func (c *PolicyDBClient) GetKeyMappingsByFqns(ctx context.Context, r *attributes.GetKeyMappingsByFqnsRequest) (map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping, error) {
+	ctx, span := c.Start(ctx, "DB:GetKeyMappingsByFqns")
+	defer span.End()
+
+	pairs, err := c.GetAttributesByValueFqns(ctx, &attributes.GetAttributeValuesByFqnsRequest{Fqns: r.GetFqns()})
+	if err != nil {
+		return nil, err
+	}
+
+	mappings := make(map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping, len(pairs))
+	for fqn, pair := range pairs {
+		attr := pair.GetAttribute()
+		mappings[fqn] = &attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping{
+			Fqn:  fqn,
+			Rule: attr.GetRule(),
+			Keys: resolveEffectiveKasKeys(pair.GetValue(), attr),
+		}
+	}
+
+	return mappings, nil
+}
+
+// resolveEffectiveKasKeys selects the effective mapped KAS keys for a value using
+// value > definition > namespace precedence, matching the SDK granter logic in
+// sdk/granter.go (newGranterFromService).
+func resolveEffectiveKasKeys(value *policy.Value, attr *policy.Attribute) []*policy.SimpleKasKey {
+	if keys := value.GetKasKeys(); len(keys) > 0 {
+		return keys
+	}
+	if keys := attr.GetKasKeys(); len(keys) > 0 {
+		return keys
+	}
+	if keys := attr.GetNamespace().GetKasKeys(); len(keys) > 0 {
+		return keys
+	}
+	return nil
+}
+
 func definitionFqnFromValueFqn(valueFqn string) string {
 	httpPrefix := "http://"
 	httpsPrefix := "https://"

--- a/service/policy/db/attribute_fqn_test.go
+++ b/service/policy/db/attribute_fqn_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"testing"
 
+	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,6 +44,65 @@ func TestDefinitionFqnFromValueFqn(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got := definitionFqnFromValueFqn(tc.valueFqn)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestResolveEffectiveKasKeys(t *testing.T) {
+	valueKey := &policy.SimpleKasKey{KasUri: "https://value-kas", KasId: "value"}
+	defKey := &policy.SimpleKasKey{KasUri: "https://def-kas", KasId: "def"}
+	nsKey := &policy.SimpleKasKey{KasUri: "https://ns-kas", KasId: "ns"}
+
+	def := func(defKeys, nsKeys []*policy.SimpleKasKey) *policy.Attribute {
+		return &policy.Attribute{
+			KasKeys:   defKeys,
+			Namespace: &policy.Namespace{KasKeys: nsKeys},
+		}
+	}
+
+	tests := []struct {
+		name  string
+		value *policy.Value
+		attr  *policy.Attribute
+		want  []*policy.SimpleKasKey
+	}{
+		{
+			name:  "value keys win over definition and namespace",
+			value: &policy.Value{KasKeys: []*policy.SimpleKasKey{valueKey}},
+			attr:  def([]*policy.SimpleKasKey{defKey}, []*policy.SimpleKasKey{nsKey}),
+			want:  []*policy.SimpleKasKey{valueKey},
+		},
+		{
+			name:  "definition keys used when value has none",
+			value: &policy.Value{},
+			attr:  def([]*policy.SimpleKasKey{defKey}, []*policy.SimpleKasKey{nsKey}),
+			want:  []*policy.SimpleKasKey{defKey},
+		},
+		{
+			name:  "namespace keys used when value and definition have none",
+			value: &policy.Value{},
+			attr:  def(nil, []*policy.SimpleKasKey{nsKey}),
+			want:  []*policy.SimpleKasKey{nsKey},
+		},
+		{
+			name:  "nil value falls back to definition",
+			value: nil,
+			attr:  def([]*policy.SimpleKasKey{defKey}, nil),
+			want:  []*policy.SimpleKasKey{defKey},
+		},
+		{
+			name:  "no keys at any level returns nil",
+			value: &policy.Value{},
+			attr:  def(nil, nil),
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveEffectiveKasKeys(tc.value, tc.attr)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
### Proposed Changes

* Implement `GetKeyMappingsByFqns`, the client-side key-split read API defined in #3627. Per requested attribute value FQN it returns the governing attribute `rule` and the effective KAS keys, resolved server-side with **value > definition > namespace** precedence over the `SimpleKasKey` model, mirroring the client-side resolution in `sdk/granter.go` (`newGranterFromService`).
* Add `resolveEffectiveKasKeys` and the `GetKeyMappingsByFqns` DB method (a projection over the existing `GetAttributesByValueFqns` retrieval).
* Stub `GetEntitleableAttributesByFqns` as `Unimplemented`; it lands in the decisioning-migration PR (it needs new SQL to fetch subject mappings, which the FQN attribute query does not return).

**Stacked on #3627** (base branch `DSPX-2541-policy-key-mapping-apis`). It uses the new protocol/go types via the workspace; once #3627 merges and `protocol/go` is released, this rebases onto `main` with a `protocol/go` dependency bump.

Limitation: values configured only with legacy `KeyAccessServer` grants (no `kas_keys`) return an empty key set. `kas_keys` is the forward model; legacy-grant handling is reconciled with the SDK migration.

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

* `go test ./service/policy/db/ -run TestResolveEffectiveKasKeys` — precedence unit test.
* `go test ./service/integration/ -run TestAttributesSuite/Test_GetKeyMappingsByFqns` — DB integration test (passes against Postgres).
* `golangci-lint run ./policy/db/... ./policy/attributes/... ./integration/...` — 0 issues.

### Related

* [DSPX-2541](https://virtru.atlassian.net/browse/DSPX-2541)
* Proto PR: #3627

[DSPX-2541]: https://virtru.atlassian.net/browse/DSPX-2541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ