### PR TITLE
feat(policy): DSPX-2541 implement GetEntitleableAttributesByFqns

### DIFF
--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -1573,6 +1573,44 @@ func (s *AttributesSuite) Test_GetKeyMappingsByFqns() {
 	validateSimpleKasKey(&s.Suite, kasKey, mappings[fqnAlpha].GetKeys()[0])
 }
 
+func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns() {
+	value1 := s.f.GetAttributeValueKey("example.com/attr/attr1/value/value1")
+	value2 := s.f.GetAttributeValueKey("example.com/attr/attr1/value/value2")
+	fqn1 := "https://example.com/attr/attr1/value/value1"
+	fqn2 := "https://example.com/attr/attr1/value/value2"
+
+	resp, err := s.db.PolicyClient.GetEntitleableAttributesByFqns(s.ctx, &attributes.GetEntitleableAttributesByFqnsRequest{
+		Fqns: []string{fqn1, fqn2},
+	})
+	s.Require().NoError(err)
+	s.Len(resp, 2)
+
+	e1 := resp[fqn1]
+	s.Require().NotNil(e1)
+	s.Equal(fqn1, e1.GetFqn())
+	s.Equal("https://example.com/attr/attr1", e1.GetAttributeFqn())
+	s.Equal(value1.ID, e1.GetValueId())
+	s.NotEqual(policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED, e1.GetRule())
+	s.Contains(e1.GetDefinitionValueFqns(), fqn1)
+	s.Contains(e1.GetDefinitionValueFqns(), fqn2)
+	// value1 has multiple value-level subject mappings in the fixtures; every
+	// returned mapping must belong to value1 (verifies grouping by FQN).
+	s.GreaterOrEqual(len(e1.GetSubjectMappings()), 3)
+	for _, sm := range e1.GetSubjectMappings() {
+		s.Equal(fqn1, sm.GetAttributeValue().GetFqn())
+		s.NotEmpty(sm.GetId())
+		s.NotNil(sm.GetSubjectConditionSet())
+	}
+
+	e2 := resp[fqn2]
+	s.Require().NotNil(e2)
+	s.Equal(value2.ID, e2.GetValueId())
+	s.GreaterOrEqual(len(e2.GetSubjectMappings()), 1)
+	for _, sm := range e2.GetSubjectMappings() {
+		s.Equal(fqn2, sm.GetAttributeValue().GetFqn())
+	}
+}
+
 func (s *AttributesSuite) Test_UnsafeUpdateAttribute_NormalizesCasing() {
 	created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
 		Name:        "BANANA_PUDDING",

--- a/service/policy/attributes/attributes.go
+++ b/service/policy/attributes/attributes.go
@@ -189,16 +189,21 @@ func (s *AttributesService) GetKeyMappingsByFqns(ctx context.Context,
 	return connect.NewResponse(rsp), nil
 }
 
-// GetEntitleableAttributesByFqns is defined in the proto but implemented in a
-// follow-up change (the server-side decisioning migration). It returns
-// Unimplemented until then.
 func (s *AttributesService) GetEntitleableAttributesByFqns(ctx context.Context,
-	_ *connect.Request[attributes.GetEntitleableAttributesByFqnsRequest],
+	req *connect.Request[attributes.GetEntitleableAttributesByFqnsRequest],
 ) (*connect.Response[attributes.GetEntitleableAttributesByFqnsResponse], error) {
-	_, span := s.Start(ctx, "GetEntitleableAttributesByFqns")
+	ctx, span := s.Start(ctx, "GetEntitleableAttributesByFqns")
 	defer span.End()
 
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("GetEntitleableAttributesByFqns is not yet implemented"))
+	rsp := &attributes.GetEntitleableAttributesByFqnsResponse{}
+
+	entitleable, err := s.dbClient.GetEntitleableAttributesByFqns(ctx, req.Msg)
+	if err != nil {
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("fqns", fmt.Sprintf("%v", req.Msg.GetFqns())))
+	}
+	rsp.FqnEntitleableAttributes = entitleable
+
+	return connect.NewResponse(rsp), nil
 }
 
 func (s *AttributesService) UpdateAttribute(ctx context.Context,

--- a/service/policy/db/attribute_fqn.go
+++ b/service/policy/db/attribute_fqn.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -231,6 +232,104 @@ func (c *PolicyDBClient) GetKeyMappingsByFqns(ctx context.Context, r *attributes
 	}
 
 	return mappings, nil
+}
+
+// GetEntitleableAttributesByFqns returns, for each requested attribute value FQN,
+// the information needed to resolve entitlements: the attribute rule, the value
+// identity, the definition's ordered value FQNs (for hierarchy rule logic), and
+// the value-level subject mappings. It runs two selective queries: the attribute
+// FQN lookup for rule/value/sibling data, and a single subject-mapping-by-FQN
+// query, avoiding the full-policy load used by the entitlement path today.
+func (c *PolicyDBClient) GetEntitleableAttributesByFqns(ctx context.Context, r *attributes.GetEntitleableAttributesByFqnsRequest) (map[string]*attributes.GetEntitleableAttributesByFqnsResponse_EntitleableAttribute, error) {
+	ctx, span := c.Start(ctx, "DB:GetEntitleableAttributesByFqns")
+	defer span.End()
+
+	fqns := r.GetFqns()
+	normalized := make([]string, len(fqns))
+	for i, fqn := range fqns {
+		normalized[i] = strings.ToLower(fqn)
+	}
+
+	pairs, err := c.GetAttributesByValueFqns(ctx, &attributes.GetAttributeValuesByFqnsRequest{Fqns: normalized})
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch value-level subject mappings for the requested FQNs in one query and
+	// group them by the value FQN they map to.
+	smRows, err := c.queries.getSubjectMappingsByValueFqns(ctx, normalized)
+	if err != nil {
+		return nil, db.WrapIfKnownInvalidQueryErr(err)
+	}
+	subjectMappingsByFqn := make(map[string][]*policy.SubjectMapping, len(smRows))
+	for _, row := range smRows {
+		sm, err := hydrateSubjectMappingForEntitlement(row)
+		if err != nil {
+			return nil, err
+		}
+		subjectMappingsByFqn[row.ValueFqn] = append(subjectMappingsByFqn[row.ValueFqn], sm)
+	}
+
+	entitleable := make(map[string]*attributes.GetEntitleableAttributesByFqnsResponse_EntitleableAttribute, len(pairs))
+	for fqn, pair := range pairs {
+		attr := pair.GetAttribute()
+
+		definitionValueFqns := make([]string, 0, len(attr.GetValues()))
+		for _, v := range attr.GetValues() {
+			definitionValueFqns = append(definitionValueFqns, v.GetFqn())
+		}
+
+		entitleable[fqn] = &attributes.GetEntitleableAttributesByFqnsResponse_EntitleableAttribute{
+			Fqn:                 fqn,
+			AttributeFqn:        attr.GetFqn(),
+			Rule:                attr.GetRule(),
+			ValueId:             pair.GetValue().GetId(),
+			DefinitionValueFqns: definitionValueFqns,
+			SubjectMappings:     subjectMappingsByFqn[fqn],
+		}
+	}
+
+	return entitleable, nil
+}
+
+// hydrateSubjectMappingForEntitlement converts a getSubjectMappingsByValueFqns
+// row into a policy.SubjectMapping, mirroring the hydration in ListSubjectMappings.
+func hydrateSubjectMappingForEntitlement(row getSubjectMappingsByValueFqnsRow) (*policy.SubjectMapping, error) {
+	metadata := &common.Metadata{}
+	if err := unmarshalMetadata(row.Metadata, metadata); err != nil {
+		return nil, err
+	}
+
+	av := &policy.Value{}
+	if err := unmarshalAttributeValue(row.AttributeValue, av); err != nil {
+		return nil, err
+	}
+
+	stdActionsBytes, err := json.Marshal(row.StandardActions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal standard actions: %w", err)
+	}
+	customActionsBytes, err := json.Marshal(row.CustomActions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal custom actions: %w", err)
+	}
+	actions := []*policy.Action{}
+	if err := unmarshalAllActionsProto(stdActionsBytes, customActionsBytes, &actions); err != nil {
+		return nil, err
+	}
+
+	scs := policy.SubjectConditionSet{}
+	if err := unmarshalSubjectConditionSet(row.SubjectConditionSet, &scs); err != nil {
+		return nil, err
+	}
+
+	return &policy.SubjectMapping{
+		Id:                  row.ID,
+		Metadata:            metadata,
+		AttributeValue:      av,
+		SubjectConditionSet: &scs,
+		Actions:             actions,
+	}, nil
 }
 
 // resolveEffectiveKasKeys selects the effective mapped KAS keys for a value using

--- a/service/policy/db/queries/subject_mappings.sql
+++ b/service/policy/db/queries/subject_mappings.sql
@@ -202,6 +202,66 @@ ORDER BY
 LIMIT @limit_
 OFFSET @offset_;
 
+-- name: getSubjectMappingsByValueFqns :many
+-- Returns value-level subject mappings for the provided attribute value FQNs,
+-- for entitlement resolution. Each row carries the value FQN it maps to so the
+-- caller can group mappings by FQN. Namespace-level mappings (no attribute value)
+-- are excluded by the inner join on attribute_values.
+WITH subject_actions AS (
+    SELECT
+        sma.subject_mapping_id,
+        COALESCE(
+            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                END
+            )) FILTER (WHERE a.is_standard = TRUE),
+            '[]'::JSONB
+        ) AS standard_actions,
+        COALESCE(
+            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                END
+            )) FILTER (WHERE a.is_standard = FALSE),
+            '[]'::JSONB
+        ) AS custom_actions
+    FROM subject_mapping_actions sma
+    JOIN actions a ON sma.action_id = a.id
+    LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
+    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
+    GROUP BY sma.subject_mapping_id
+)
+SELECT
+    sm.id,
+    fqns.fqn AS value_fqn,
+    sa.standard_actions,
+    sa.custom_actions,
+    JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', sm.metadata -> 'labels', 'created_at', sm.created_at, 'updated_at', sm.updated_at)) AS metadata,
+    JSON_BUILD_OBJECT(
+        'id', scs.id,
+        'metadata', JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', scs.metadata->'labels', 'created_at', scs.created_at, 'updated_at', scs.updated_at)),
+        'subject_sets', scs.condition,
+        'namespace', CASE
+            WHEN scs.namespace_id IS NULL THEN NULL
+            ELSE JSON_BUILD_OBJECT('id', scs_ns.id, 'name', scs_ns.name, 'fqn', scs_ns_fqns.fqn)
+        END
+    ) AS subject_condition_set,
+    JSON_BUILD_OBJECT(
+        'id', av.id,
+        'value', av.value,
+        'active', av.active,
+        'fqn', fqns.fqn
+    ) AS attribute_value
+FROM subject_mappings sm
+JOIN attribute_values av ON sm.attribute_value_id = av.id
+JOIN attribute_fqns fqns ON av.id = fqns.value_id
+LEFT JOIN subject_actions sa ON sm.id = sa.subject_mapping_id
+LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
+LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
+LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
+WHERE fqns.fqn = ANY(@value_fqns::TEXT[]);
+
 -- name: getSubjectMapping :one
 SELECT
     sm.id,

--- a/service/policy/db/subject_mappings.sql.go
+++ b/service/policy/db/subject_mappings.sql.go
@@ -352,6 +352,160 @@ func (q *Queries) getSubjectMapping(ctx context.Context, id string) (getSubjectM
 	return i, err
 }
 
+const getSubjectMappingsByValueFqns = `-- name: getSubjectMappingsByValueFqns :many
+WITH subject_actions AS (
+    SELECT
+        sma.subject_mapping_id,
+        COALESCE(
+            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                END
+            )) FILTER (WHERE a.is_standard = TRUE),
+            '[]'::JSONB
+        ) AS standard_actions,
+        COALESCE(
+            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                END
+            )) FILTER (WHERE a.is_standard = FALSE),
+            '[]'::JSONB
+        ) AS custom_actions
+    FROM subject_mapping_actions sma
+    JOIN actions a ON sma.action_id = a.id
+    LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
+    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
+    GROUP BY sma.subject_mapping_id
+)
+SELECT
+    sm.id,
+    fqns.fqn AS value_fqn,
+    sa.standard_actions,
+    sa.custom_actions,
+    JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', sm.metadata -> 'labels', 'created_at', sm.created_at, 'updated_at', sm.updated_at)) AS metadata,
+    JSON_BUILD_OBJECT(
+        'id', scs.id,
+        'metadata', JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', scs.metadata->'labels', 'created_at', scs.created_at, 'updated_at', scs.updated_at)),
+        'subject_sets', scs.condition,
+        'namespace', CASE
+            WHEN scs.namespace_id IS NULL THEN NULL
+            ELSE JSON_BUILD_OBJECT('id', scs_ns.id, 'name', scs_ns.name, 'fqn', scs_ns_fqns.fqn)
+        END
+    ) AS subject_condition_set,
+    JSON_BUILD_OBJECT(
+        'id', av.id,
+        'value', av.value,
+        'active', av.active,
+        'fqn', fqns.fqn
+    ) AS attribute_value
+FROM subject_mappings sm
+JOIN attribute_values av ON sm.attribute_value_id = av.id
+JOIN attribute_fqns fqns ON av.id = fqns.value_id
+LEFT JOIN subject_actions sa ON sm.id = sa.subject_mapping_id
+LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
+LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
+LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
+WHERE fqns.fqn = ANY($1::TEXT[])
+`
+
+type getSubjectMappingsByValueFqnsRow struct {
+	ID                  string      `json:"id"`
+	ValueFqn            string      `json:"value_fqn"`
+	StandardActions     interface{} `json:"standard_actions"`
+	CustomActions       interface{} `json:"custom_actions"`
+	Metadata            []byte      `json:"metadata"`
+	SubjectConditionSet []byte      `json:"subject_condition_set"`
+	AttributeValue      []byte      `json:"attribute_value"`
+}
+
+// Returns value-level subject mappings for the provided attribute value FQNs,
+// for entitlement resolution. Each row carries the value FQN it maps to so the
+// caller can group mappings by FQN. Namespace-level mappings (no attribute value)
+// are excluded by the inner join on attribute_values.
+//
+//	WITH subject_actions AS (
+//	    SELECT
+//	        sma.subject_mapping_id,
+//	        COALESCE(
+//	            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+//	                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+//	                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+//	                END
+//	            )) FILTER (WHERE a.is_standard = TRUE),
+//	            '[]'::JSONB
+//	        ) AS standard_actions,
+//	        COALESCE(
+//	            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+//	                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+//	                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+//	                END
+//	            )) FILTER (WHERE a.is_standard = FALSE),
+//	            '[]'::JSONB
+//	        ) AS custom_actions
+//	    FROM subject_mapping_actions sma
+//	    JOIN actions a ON sma.action_id = a.id
+//	    LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
+//	    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
+//	    GROUP BY sma.subject_mapping_id
+//	)
+//	SELECT
+//	    sm.id,
+//	    fqns.fqn AS value_fqn,
+//	    sa.standard_actions,
+//	    sa.custom_actions,
+//	    JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', sm.metadata -> 'labels', 'created_at', sm.created_at, 'updated_at', sm.updated_at)) AS metadata,
+//	    JSON_BUILD_OBJECT(
+//	        'id', scs.id,
+//	        'metadata', JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', scs.metadata->'labels', 'created_at', scs.created_at, 'updated_at', scs.updated_at)),
+//	        'subject_sets', scs.condition,
+//	        'namespace', CASE
+//	            WHEN scs.namespace_id IS NULL THEN NULL
+//	            ELSE JSON_BUILD_OBJECT('id', scs_ns.id, 'name', scs_ns.name, 'fqn', scs_ns_fqns.fqn)
+//	        END
+//	    ) AS subject_condition_set,
+//	    JSON_BUILD_OBJECT(
+//	        'id', av.id,
+//	        'value', av.value,
+//	        'active', av.active,
+//	        'fqn', fqns.fqn
+//	    ) AS attribute_value
+//	FROM subject_mappings sm
+//	JOIN attribute_values av ON sm.attribute_value_id = av.id
+//	JOIN attribute_fqns fqns ON av.id = fqns.value_id
+//	LEFT JOIN subject_actions sa ON sm.id = sa.subject_mapping_id
+//	LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
+//	LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
+//	LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
+//	WHERE fqns.fqn = ANY($1::TEXT[])
+func (q *Queries) getSubjectMappingsByValueFqns(ctx context.Context, valueFqns []string) ([]getSubjectMappingsByValueFqnsRow, error) {
+	rows, err := q.db.Query(ctx, getSubjectMappingsByValueFqns, valueFqns)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []getSubjectMappingsByValueFqnsRow
+	for rows.Next() {
+		var i getSubjectMappingsByValueFqnsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ValueFqn,
+			&i.StandardActions,
+			&i.CustomActions,
+			&i.Metadata,
+			&i.SubjectConditionSet,
+			&i.AttributeValue,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSubjectConditionSets = `-- name: listSubjectConditionSets :many
 
 WITH params AS (


### PR DESCRIPTION
### Proposed Changes

* Implement `GetEntitleableAttributesByFqns`, the server-side decisioning read API defined in #3627 (replaces the `Unimplemented` stub from #3628). Per requested attribute value FQN it returns the attribute `rule`, the value id, the definition's ordered value FQNs (for hierarchy rule logic), and the value-level subject mappings.
* Add a lean `getSubjectMappingsByValueFqns` SQL query (sqlc) so subject mappings are fetched by FQN in a single roundtrip, instead of the full `ListAllSubjectMappings` load the entitlement path uses today. The handler runs two selective queries (attribute FQN lookup + subject-mapping-by-FQN) and groups results into an FQN-keyed map.

**Stacked on #3628** (base `DSPX-2541-attribute-read-api-handlers`). This delivers the API only; migrating the v1/v2 decisioning + PDP consumers onto it and adding namespace-scoped fetch is a separate PR (it depends on the tenancy model, still under discussion).

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

* `go test ./service/integration/ -run TestAttributesSuite/Test_GetEntitleableAttributesByFqns` — passes against Postgres (verifies rule, value id, ordered definition FQNs, and subject mappings grouped by FQN).
* `golangci-lint run ./policy/db/... ./policy/attributes/... ./integration/...` — 0 issues.

### Related

* [DSPX-2541](https://virtru.atlassian.net/browse/DSPX-2541)
* Proto PR: #3627 · Key API PR: #3628

[DSPX-2541]: https://virtru.atlassian.net/browse/DSPX-2541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ