### PR TITLE
chore(ci): Lets xtest run against main platform and PR go-sdk

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -496,8 +496,8 @@ jobs:
     uses: opentdf/tests/.github/workflows/xtest.yml@main
     with:
       focus-sdk: go
-      # use commit instead of ref so we can "go get" specific sdk version
-      platform-ref: ${{ github.event.pull_request.head.sha || github.sha }} lts
+      platform-ref: ${{ github.event.pull_request.head.sha || github.sha }} lts main
+      otdfctl-ref: ${{ github.event.pull_request.head.sha || github.sha }} main
 
   tests-bdd:
     name: Cucumber BDD Tests


### PR DESCRIPTION
### Proposed Changes

- The previous configuration for the xtest job would run two versions of platform and one version of go-sdk:
   - at the pull version and LTS versions of platform
- This fixes it so there will be a third block of runs against the main version of platform, and a fourth SDK type, go@pr


### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration testing by aligning platform and CLI E2E tests to specific commit references, improving test reliability and consistency across pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->