### PR TITLE
feat(sdk): DSPX-2754 add DynamicValueMapping service client wrapper

### DIFF
--- a/sdk/codegen/main.go
+++ b/sdk/codegen/main.go
@@ -67,6 +67,10 @@ var clientsToGenerateList = []runner.ClientsToGenerate{
 		GrpcPackagePath:     "github.com/opentdf/platform/protocol/go/policy/subjectmapping",
 	},
 	{
+		GrpcClientInterface: "DynamicValueMappingServiceClient",
+		GrpcPackagePath:     "github.com/opentdf/platform/protocol/go/policy/dynamicvaluemapping",
+	},
+	{
 		GrpcClientInterface: "UnsafeServiceClient",
 		GrpcPackagePath:     "github.com/opentdf/platform/protocol/go/policy/unsafe",
 	},

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/opentdf/platform/lib/ocrypto v0.12.0
-	github.com/opentdf/platform/protocol/go v0.33.1
+	github.com/opentdf/platform/protocol/go v0.34.0
 	github.com/stretchr/testify v1.11.1
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/oauth2 v0.36.0

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -50,8 +50,8 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/opentdf/platform/lib/ocrypto v0.12.0 h1:N449KWy7VdMO0JwfsrG0kM6Uy8VrEnVvBciwzRHwnlg=
 github.com/opentdf/platform/lib/ocrypto v0.12.0/go.mod h1:51UTmAWO6C8ghuMXiktpn63N+fLUQxY6zo8D65Ly0wQ=
-github.com/opentdf/platform/protocol/go v0.33.1 h1:nLg5D++Oo1hlgPD6nR+AchnfpkZeOQFGzJMz2MmJM4U=
-github.com/opentdf/platform/protocol/go v0.33.1/go.mod h1:6A0vQJ5D4ZTLReWAp8Y/7jTFzlYCmL/IfMJWDHZS6M0=
+github.com/opentdf/platform/protocol/go v0.34.0 h1:HJstzUyOnbE8c39UIAf3ASkjkkqLEMxy/D0oiUWuzSA=
+github.com/opentdf/platform/protocol/go v0.34.0/go.mod h1:6A0vQJ5D4ZTLReWAp8Y/7jTFzlYCmL/IfMJWDHZS6M0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -96,6 +96,7 @@ type SDK struct {
 	RegisteredResources     sdkconnect.RegisteredResourcesServiceClient
 	ResourceMapping         sdkconnect.ResourceMappingServiceClient
 	SubjectMapping          sdkconnect.SubjectMappingServiceClient
+	DynamicValueMapping     sdkconnect.DynamicValueMappingServiceClient
 	Unsafe                  sdkconnect.UnsafeServiceClient
 	KeyManagement           sdkconnect.KeyManagementServiceClient
 	wellknownConfiguration  sdkconnect.WellKnownServiceClient
@@ -229,6 +230,7 @@ func New(platformEndpoint string, opts ...Option) (*SDK, error) {
 		RegisteredResources:     sdkconnect.NewRegisteredResourcesServiceClientConnectWrapper(platformConn.Client, platformConn.Endpoint, platformConn.Options...),
 		ResourceMapping:         sdkconnect.NewResourceMappingServiceClientConnectWrapper(platformConn.Client, platformConn.Endpoint, platformConn.Options...),
 		SubjectMapping:          sdkconnect.NewSubjectMappingServiceClientConnectWrapper(platformConn.Client, platformConn.Endpoint, platformConn.Options...),
+		DynamicValueMapping:     sdkconnect.NewDynamicValueMappingServiceClientConnectWrapper(platformConn.Client, platformConn.Endpoint, platformConn.Options...),
 		Unsafe:                  sdkconnect.NewUnsafeServiceClientConnectWrapper(platformConn.Client, platformConn.Endpoint, platformConn.Options...),
 		KeyAccessServerRegistry: sdkconnect.NewKeyAccessServerRegistryServiceClientConnectWrapper(platformConn.Client, platformConn.Endpoint, platformConn.Options...),
 		Authorization:           sdkconnect.NewAuthorizationServiceClientConnectWrapper(platformConn.Client, platformConn.Endpoint, platformConn.Options...),

--- a/sdk/sdkconnect/dynamicvaluemapping.go
+++ b/sdk/sdkconnect/dynamicvaluemapping.go
@@ -1,0 +1,70 @@
+// Wrapper for DynamicValueMappingServiceClient (generated code) DO NOT EDIT
+package sdkconnect
+
+import (
+	"connectrpc.com/connect"
+	"context"
+	"github.com/opentdf/platform/protocol/go/policy/dynamicvaluemapping"
+	"github.com/opentdf/platform/protocol/go/policy/dynamicvaluemapping/dynamicvaluemappingconnect"
+)
+
+type DynamicValueMappingServiceClientConnectWrapper struct {
+	dynamicvaluemappingconnect.DynamicValueMappingServiceClient
+}
+
+func NewDynamicValueMappingServiceClientConnectWrapper(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) *DynamicValueMappingServiceClientConnectWrapper {
+	return &DynamicValueMappingServiceClientConnectWrapper{DynamicValueMappingServiceClient: dynamicvaluemappingconnect.NewDynamicValueMappingServiceClient(httpClient, baseURL, opts...)}
+}
+
+type DynamicValueMappingServiceClient interface {
+	ListDynamicValueMappings(ctx context.Context, req *dynamicvaluemapping.ListDynamicValueMappingsRequest) (*dynamicvaluemapping.ListDynamicValueMappingsResponse, error)
+	GetDynamicValueMapping(ctx context.Context, req *dynamicvaluemapping.GetDynamicValueMappingRequest) (*dynamicvaluemapping.GetDynamicValueMappingResponse, error)
+	CreateDynamicValueMapping(ctx context.Context, req *dynamicvaluemapping.CreateDynamicValueMappingRequest) (*dynamicvaluemapping.CreateDynamicValueMappingResponse, error)
+	UpdateDynamicValueMapping(ctx context.Context, req *dynamicvaluemapping.UpdateDynamicValueMappingRequest) (*dynamicvaluemapping.UpdateDynamicValueMappingResponse, error)
+	DeleteDynamicValueMapping(ctx context.Context, req *dynamicvaluemapping.DeleteDynamicValueMappingRequest) (*dynamicvaluemapping.DeleteDynamicValueMappingResponse, error)
+}
+
+func (w *DynamicValueMappingServiceClientConnectWrapper) ListDynamicValueMappings(ctx context.Context, req *dynamicvaluemapping.ListDynamicValueMappingsRequest) (*dynamicvaluemapping.ListDynamicValueMappingsResponse, error) {
+	// Wrap Connect RPC client request
+	res, err := w.DynamicValueMappingServiceClient.ListDynamicValueMappings(ctx, connect.NewRequest(req))
+	if res == nil {
+		return nil, err
+	}
+	return res.Msg, err
+}
+
+func (w *DynamicValueMappingServiceClientConnectWrapper) GetDynamicValueMapping(ctx context.Context, req *dynamicvaluemapping.GetDynamicValueMappingRequest) (*dynamicvaluemapping.GetDynamicValueMappingResponse, error) {
+	// Wrap Connect RPC client request
+	res, err := w.DynamicValueMappingServiceClient.GetDynamicValueMapping(ctx, connect.NewRequest(req))
+	if res == nil {
+		return nil, err
+	}
+	return res.Msg, err
+}
+
+func (w *DynamicValueMappingServiceClientConnectWrapper) CreateDynamicValueMapping(ctx context.Context, req *dynamicvaluemapping.CreateDynamicValueMappingRequest) (*dynamicvaluemapping.CreateDynamicValueMappingResponse, error) {
+	// Wrap Connect RPC client request
+	res, err := w.DynamicValueMappingServiceClient.CreateDynamicValueMapping(ctx, connect.NewRequest(req))
+	if res == nil {
+		return nil, err
+	}
+	return res.Msg, err
+}
+
+func (w *DynamicValueMappingServiceClientConnectWrapper) UpdateDynamicValueMapping(ctx context.Context, req *dynamicvaluemapping.UpdateDynamicValueMappingRequest) (*dynamicvaluemapping.UpdateDynamicValueMappingResponse, error) {
+	// Wrap Connect RPC client request
+	res, err := w.DynamicValueMappingServiceClient.UpdateDynamicValueMapping(ctx, connect.NewRequest(req))
+	if res == nil {
+		return nil, err
+	}
+	return res.Msg, err
+}
+
+func (w *DynamicValueMappingServiceClientConnectWrapper) DeleteDynamicValueMapping(ctx context.Context, req *dynamicvaluemapping.DeleteDynamicValueMappingRequest) (*dynamicvaluemapping.DeleteDynamicValueMappingResponse, error) {
+	// Wrap Connect RPC client request
+	res, err := w.DynamicValueMappingServiceClient.DeleteDynamicValueMapping(ctx, connect.NewRequest(req))
+	if res == nil {
+		return nil, err
+	}
+	return res.Msg, err
+}


### PR DESCRIPTION
### Proposed Changes

* Add the `sdkconnect` client wrapper for the new `DynamicValueMappingService` and register it on the SDK.
* Bump `protocol/go` to **v0.34.0** (released from #3580), which carries the `policy/dynamicvaluemapping` package.

This is the **sdk** step of the DSPX-2754 consumer split. Sequencing:
1. `protocol/go` protos + generated code (#3580) — merged, released as v0.34.0.
2. **sdk** wrapper (this PR) — depends on protocol/go v0.34.0.
3. service consumer (#3568) — depends on this sdk release; will bump `sdk` once it is released.

### Checklist

- [ ] I have added or updated unit tests
- [x] I have added or updated documentation (generated wrapper)

### Testing Instructions

- `cd sdk && GOWORK=off go build ./... && GOWORK=off GOFLAGS=-mod=mod go mod tidy` (clean)
- `make connect-wrapper-generate` produces no diff

### Related

- Jira: https://virtru.atlassian.net/browse/DSPX-2754
- protocol PR: #3580 (merged) · consumer PR: #3568 (depends on this)