### PR TITLE
fix(authz): Address pr comments.

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -345,6 +345,11 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
+		if decision == nil {
+			log.ErrorContext(ctx, "authorization error", slog.String("error", "authorizer returned nil decision")) //nolint:contextcheck // checkToken derives ctx from r.Context.
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
 		if !decision.Allowed {
 			log.WarnContext( //nolint:contextcheck // checkToken derives ctx from r.Context.
 				ctx,
@@ -670,6 +675,17 @@ func (a *Authentication) authorize(
 		log.ErrorContext(
 			ctx, "authorization error",
 			slog.Any("error", authzErr),
+			slog.String("procedure", req.Spec().Procedure),
+		)
+		return authzResult{
+			err:     errors.New("authorization system error"),
+			errCode: connect.CodeInternal,
+		}
+	}
+	if decision == nil {
+		log.ErrorContext(
+			ctx, "authorization error",
+			slog.String("error", "authorizer returned nil decision"),
 			slog.String("procedure", req.Spec().Procedure),
 		)
 		return authzResult{

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -69,13 +69,17 @@ type FakeAccessTokenSource struct {
 }
 
 type recordingAuthorizer struct {
-	req      *internalauthz.Request
-	decision *internalauthz.Decision
-	err      error
+	req               *internalauthz.Request
+	decision          *internalauthz.Decision
+	err               error
+	returnNilDecision bool
 }
 
 func (a *recordingAuthorizer) Authorize(_ context.Context, req *internalauthz.Request) (*internalauthz.Decision, error) {
 	a.req = req
+	if a.returnNilDecision {
+		return nil, a.err
+	}
 	if a.decision != nil || a.err != nil {
 		return a.decision, a.err
 	}
@@ -571,6 +575,42 @@ func (s *AuthSuite) Test_MuxHandler_NilAuthorizerReturnsInternalServerError() {
 	}, logger.CreateTestLogger(), func(_ string, _ any) error { return nil })
 	s.Require().NoError(err)
 	auth.authorizer = nil
+
+	called := false
+	handler := auth.MuxHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/attributes/example/value", nil)
+	req.Header.Set("Authorization", "Bearer "+string(signedTok))
+
+	handler.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusInternalServerError, rec.Code)
+	s.False(called)
+}
+
+func (s *AuthSuite) Test_MuxHandler_NilAuthorizerDecisionReturnsInternalServerError() {
+	tok := jwt.New()
+	s.Require().NoError(tok.Set(jwt.ExpirationKey, time.Now().Add(time.Hour)))
+	s.Require().NoError(tok.Set("iss", s.server.URL))
+	s.Require().NoError(tok.Set("aud", "test"))
+	s.Require().NoError(tok.Set("cid", "client-123"))
+	signedTok, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, s.key))
+	s.Require().NoError(err)
+
+	policyCfg := internalauthz.PolicyConfig{ClientIDClaim: "cid"}
+	s.Require().NoError(defaults.Set(&policyCfg))
+	auth, err := NewAuthenticator(s.T().Context(), Config{
+		AuthNConfig: AuthNConfig{
+			EnforceDPoP: false,
+			Issuer:      s.server.URL,
+			Audience:    "test",
+			Policy:      policyCfg,
+		},
+	}, logger.CreateTestLogger(), func(_ string, _ any) error { return nil })
+	s.Require().NoError(err)
+	auth.authorizer = &recordingAuthorizer{returnNilDecision: true}
 
 	called := false
 	handler := auth.MuxHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {

--- a/service/internal/auth/authz/authorizer.go
+++ b/service/internal/auth/authz/authorizer.go
@@ -189,6 +189,7 @@ func New(cfg Config) (Authorizer, error) {
 	engine := cfg.Engine
 	if engine == "" {
 		engine = DefaultEngine
+		cfg.Engine = engine
 	}
 
 	factory, exists := GetFactory(engine)

--- a/service/internal/auth/authz/authorizer_test.go
+++ b/service/internal/auth/authz/authorizer_test.go
@@ -139,6 +139,33 @@ func TestNew_DefaultValues(t *testing.T) {
 	assert.Equal(t, testFactoryName, receivedCfg.Engine)
 }
 
+func TestNew_DefaultEnginePassedToFactory(t *testing.T) {
+	var receivedCfg Config
+	testFactory := func(cfg Config) (Authorizer, error) {
+		receivedCfg = cfg
+		return &mockAuthorizer{version: cfg.Version}, nil
+	}
+
+	factoriesMu.Lock()
+	previousFactory, hadPreviousFactory := factories[DefaultEngine]
+	factories[DefaultEngine] = testFactory
+	factoriesMu.Unlock()
+	t.Cleanup(func() {
+		factoriesMu.Lock()
+		defer factoriesMu.Unlock()
+		if hadPreviousFactory {
+			factories[DefaultEngine] = previousFactory
+			return
+		}
+		delete(factories, DefaultEngine)
+	})
+
+	auth, err := New(Config{})
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+	assert.Equal(t, DefaultEngine, receivedCfg.Engine)
+}
+
 func TestApplyOptions_Empty(t *testing.T) {
 	cfg := applyOptions()
 	assert.Nil(t, cfg.RoleProvider)

--- a/service/internal/auth/authz/policy.go
+++ b/service/internal/auth/authz/policy.go
@@ -46,7 +46,8 @@ type PolicyConfig struct {
 
 	Model string `mapstructure:"model" json:"model"`
 
-	// Override the default string-adapter
+	// Adapter is intentionally any to allow future adapter config shapes beyond Casbin persist.Adapter.
+	// Conversion and validation happen downstream.
 	Adapter any `mapstructure:"-" json:"-"`
 }
 

--- a/service/internal/auth/authz/resolver.go
+++ b/service/internal/auth/authz/resolver.go
@@ -2,6 +2,7 @@ package authz
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -52,6 +53,8 @@ type ResolverRegistry struct {
 	resolvers map[string]ResolverFunc // full method path -> resolver
 }
 
+var errResolverAlreadyRegistered = errors.New("resolver already registered")
+
 // NewResolverRegistry creates a new resolver registry.
 func NewResolverRegistry() *ResolverRegistry {
 	return &ResolverRegistry{
@@ -86,8 +89,11 @@ func (r *ResolverRegistry) ScopedForService(serviceDesc *grpc.ServiceDesc) *Scop
 func (r *ResolverRegistry) register(fullMethodPath string, resolver ResolverFunc) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.resolvers == nil {
+		r.resolvers = make(map[string]ResolverFunc)
+	}
 	if _, exists := r.resolvers[fullMethodPath]; exists {
-		return fmt.Errorf("resolver already registered for method %q", fullMethodPath)
+		return errors.Join(errResolverAlreadyRegistered, fmt.Errorf("method %q", fullMethodPath))
 	}
 	r.resolvers[fullMethodPath] = resolver
 	return nil

--- a/service/internal/auth/authz/resolver.go
+++ b/service/internal/auth/authz/resolver.go
@@ -83,10 +83,14 @@ func (r *ResolverRegistry) ScopedForService(serviceDesc *grpc.ServiceDesc) *Scop
 
 // register is internal - adds a resolver for a specific full method path.
 // External callers should use ScopedResolverRegistry.
-func (r *ResolverRegistry) register(fullMethodPath string, resolver ResolverFunc) {
+func (r *ResolverRegistry) register(fullMethodPath string, resolver ResolverFunc) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if _, exists := r.resolvers[fullMethodPath]; exists {
+		return fmt.Errorf("resolver already registered for method %q", fullMethodPath)
+	}
 	r.resolvers[fullMethodPath] = resolver
+	return nil
 }
 
 // ScopedResolverRegistry is a namespace-scoped view of the registry.
@@ -112,8 +116,7 @@ func (s *ScopedResolverRegistry) Register(methodName string, resolver ResolverFu
 
 	// Build full method path: /<ServiceName>/<MethodName>
 	fullPath := "/" + s.serviceDesc.ServiceName + "/" + methodName
-	s.parent.register(fullPath, resolver)
-	return nil
+	return s.parent.register(fullPath, resolver)
 }
 
 // MustRegister is like Register but panics on error.

--- a/service/internal/auth/authz/resolver_test.go
+++ b/service/internal/auth/authz/resolver_test.go
@@ -2,6 +2,7 @@ package authz
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -48,7 +49,7 @@ func (s *ResolverSuite) TestRegistry_RegisterAndGet() {
 	}
 
 	// Use internal register method (normally called via scoped registry)
-	registry.register("/test.Service/TestMethod", testResolver)
+	s.Require().NoError(registry.register("/test.Service/TestMethod", testResolver))
 
 	resolver, ok := registry.Get("/test.Service/TestMethod")
 	s.True(ok)
@@ -72,10 +73,12 @@ func (s *ResolverSuite) TestRegistry_ThreadSafety() {
 		go func(id int) {
 			defer wg.Done()
 			for j := range numOperations {
-				methodPath := "/test.Service/Method" + string(rune('A'+id%26)) + string(rune('0'+j%10))
-				registry.register(methodPath, func(_ context.Context, _ connect.AnyRequest) (ResolverContext, error) {
+				methodPath := fmt.Sprintf("/test.Service/Method%d_%d", id, j)
+				if err := registry.register(methodPath, func(_ context.Context, _ connect.AnyRequest) (ResolverContext, error) {
 					return NewResolverContext(), nil
-				})
+				}); err != nil {
+					s.T().Errorf("register resolver: %v", err)
+				}
 			}
 		}(i)
 	}
@@ -146,6 +149,38 @@ func (s *ResolverSuite) TestScoped_Register_ValidMethod() {
 	s.NotNil(resolver)
 }
 
+func (s *ResolverSuite) TestScoped_Register_DuplicateMethodReturnsErrorAndKeepsOriginal() {
+	registry := NewResolverRegistry()
+	serviceDesc := &grpc.ServiceDesc{
+		ServiceName: "policy.AttributesService",
+		Methods: []grpc.MethodDesc{
+			{MethodName: "CreateAttribute"},
+		},
+	}
+	scoped := registry.ScopedForService(serviceDesc)
+
+	firstResolverCalled := false
+	firstResolver := func(_ context.Context, _ connect.AnyRequest) (ResolverContext, error) {
+		firstResolverCalled = true
+		return NewResolverContext(), nil
+	}
+	secondResolver := func(_ context.Context, _ connect.AnyRequest) (ResolverContext, error) {
+		s.Fail("duplicate registration overwrote original resolver")
+		return NewResolverContext(), nil
+	}
+
+	s.Require().NoError(scoped.Register("CreateAttribute", firstResolver))
+	err := scoped.Register("CreateAttribute", secondResolver)
+
+	s.Require().Error(err)
+	s.Contains(err.Error(), `resolver already registered for method "/policy.AttributesService/CreateAttribute"`)
+	resolver, ok := registry.Get("/policy.AttributesService/CreateAttribute")
+	s.True(ok)
+	_, callErr := resolver(s.T().Context(), nil)
+	s.Require().NoError(callErr)
+	s.True(firstResolverCalled)
+}
+
 func (s *ResolverSuite) TestScoped_Register_InvalidMethod() {
 	registry := NewResolverRegistry()
 	serviceDesc := &grpc.ServiceDesc{
@@ -193,6 +228,27 @@ func (s *ResolverSuite) TestScoped_MustRegister_ValidMethod() {
 	resolver, ok := registry.Get("/policy.AttributesService/GetAttribute")
 	s.True(ok)
 	s.NotNil(resolver)
+}
+
+func (s *ResolverSuite) TestScoped_MustRegister_DuplicateMethodPanics() {
+	registry := NewResolverRegistry()
+	serviceDesc := &grpc.ServiceDesc{
+		ServiceName: "policy.AttributesService",
+		Methods: []grpc.MethodDesc{
+			{MethodName: "GetAttribute"},
+		},
+	}
+	scoped := registry.ScopedForService(serviceDesc)
+
+	testResolver := func(_ context.Context, _ connect.AnyRequest) (ResolverContext, error) {
+		return NewResolverContext(), nil
+	}
+
+	scoped.MustRegister("GetAttribute", testResolver)
+
+	s.Panics(func() {
+		scoped.MustRegister("GetAttribute", testResolver)
+	})
 }
 
 func (s *ResolverSuite) TestScoped_MustRegister_InvalidMethod_Panics() {

--- a/service/internal/auth/authz/resolver_test.go
+++ b/service/internal/auth/authz/resolver_test.go
@@ -60,6 +60,26 @@ func (s *ResolverSuite) TestRegistry_RegisterAndGet() {
 	s.True(called)
 }
 
+func (s *ResolverSuite) TestRegistry_ZeroValueRegisterAndGet() {
+	var registry ResolverRegistry
+	called := false
+	testResolver := func(_ context.Context, _ connect.AnyRequest) (ResolverContext, error) {
+		called = true
+		return NewResolverContext(), nil
+	}
+
+	s.Require().NoError(registry.register("/test.Service/TestMethod", testResolver))
+	s.NotNil(registry.resolvers)
+
+	resolver, ok := registry.Get("/test.Service/TestMethod")
+	s.True(ok)
+	s.NotNil(resolver)
+
+	_, err := resolver(s.T().Context(), nil)
+	s.Require().NoError(err)
+	s.True(called)
+}
+
 func (s *ResolverSuite) TestRegistry_ThreadSafety() {
 	registry := NewResolverRegistry()
 	const numGoroutines = 100
@@ -173,7 +193,8 @@ func (s *ResolverSuite) TestScoped_Register_DuplicateMethodReturnsErrorAndKeepsO
 	err := scoped.Register("CreateAttribute", secondResolver)
 
 	s.Require().Error(err)
-	s.Contains(err.Error(), `resolver already registered for method "/policy.AttributesService/CreateAttribute"`)
+	s.Require().ErrorIs(err, errResolverAlreadyRegistered)
+	s.Contains(err.Error(), `method "/policy.AttributesService/CreateAttribute"`)
 	resolver, ok := registry.Get("/policy.AttributesService/CreateAttribute")
 	s.True(ok)
 	_, callErr := resolver(s.T().Context(), nil)
@@ -246,9 +267,16 @@ func (s *ResolverSuite) TestScoped_MustRegister_DuplicateMethodPanics() {
 
 	scoped.MustRegister("GetAttribute", testResolver)
 
-	s.Panics(func() {
+	func() {
+		defer func() {
+			panicValue := recover()
+			s.Require().NotNil(panicValue)
+			err, ok := panicValue.(error)
+			s.Require().True(ok)
+			s.Require().ErrorIs(err, errResolverAlreadyRegistered)
+		}()
 		scoped.MustRegister("GetAttribute", testResolver)
-	})
+	}()
 }
 
 func (s *ResolverSuite) TestScoped_MustRegister_InvalidMethod_Panics() {

--- a/service/internal/auth/authz/role_provider.go
+++ b/service/internal/auth/authz/role_provider.go
@@ -46,7 +46,6 @@ func (p *JWTClaimsRoleProvider) Roles(_ context.Context, token jwt.Token, _ plat
 			p.logger.Warn(
 				"claim not found",
 				slog.String("claim", p.groupsClaim),
-				slog.Any("claims", claim),
 			)
 		}
 		return nil, nil
@@ -110,7 +109,6 @@ func (p *JWTClaimsRoleProvider) nestedClaim(claim any, selectors []string) any {
 		p.logger.Warn(
 			"claim not found",
 			slog.String("claim", p.groupsClaim),
-			slog.Any("claims", nested),
 		)
 	}
 	return nested

--- a/service/internal/auth/authz/subject_extractor.go
+++ b/service/internal/auth/authz/subject_extractor.go
@@ -98,6 +98,9 @@ func (e SubjectExtractor) ClientIDFromToken(ctx context.Context, token jwt.Token
 	if e.ClientIDClaim == "" {
 		return "", ErrClientIDClaimNotConfigured
 	}
+	if token == nil {
+		return "", ErrTokenRequired
+	}
 	claims, err := token.AsMap(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse token as a map and find claim at [%s]: %w", e.ClientIDClaim, err)
@@ -114,17 +117,15 @@ func (e SubjectExtractor) ClientIDFromToken(ctx context.Context, token jwt.Token
 }
 
 func normalizeRoles(roles []string, usePrefix bool) []string {
-	if !usePrefix {
-		return roles
-	}
-	prefixed := make([]string, 0, len(roles))
+	normalized := make([]string, 0, len(roles))
+
 	for _, role := range roles {
 		if role == "" {
 			continue
 		}
-		prefixed = append(prefixed, subjectWithPrefix(role, SubjectRolePrefix, usePrefix))
+		normalized = append(normalized, subjectWithPrefix(role, SubjectRolePrefix, usePrefix))
 	}
-	return prefixed
+	return normalized
 }
 
 func subjectWithPrefix(subject, prefix string, usePrefix bool) string {

--- a/service/internal/auth/authz/subject_extractor_test.go
+++ b/service/internal/auth/authz/subject_extractor_test.go
@@ -54,6 +54,21 @@ func TestSubjectExtractorCanPrefixSubjects(t *testing.T) {
 	require.Equal(t, []string{"role:admin"}, roles)
 }
 
+func TestSubjectExtractorFiltersEmptyRolesWithoutPrefix(t *testing.T) {
+	token := jwt.New()
+	require.NoError(t, token.Set("preferred_username", "alice"))
+
+	extractor := SubjectExtractor{
+		UserNameClaim: "preferred_username",
+		RoleProvider:  staticRoleProvider{roles: []string{"admin", "", "viewer"}},
+	}
+
+	subjects, roles, err := extractor.BuildSubjectFromToken(t.Context(), token, platformauthz.RoleRequest{}, false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin", "viewer", "alice"}, subjects)
+	require.Equal(t, []string{"admin", "viewer"}, roles)
+}
+
 func TestSubjectExtractorRequiresTokenWhenClaimsAreNotCached(t *testing.T) {
 	extractor := SubjectExtractor{
 		UserNameClaim: "preferred_username",
@@ -66,6 +81,15 @@ func TestSubjectExtractorRequiresTokenWhenClaimsAreNotCached(t *testing.T) {
 	require.ErrorIs(t, err, ErrTokenRequired)
 	require.Nil(t, subjects)
 	require.Nil(t, roles)
+}
+
+func TestSubjectExtractorClientIDFromNilToken(t *testing.T) {
+	extractor := SubjectExtractor{ClientIDClaim: "azp"}
+
+	got, err := extractor.ClientIDFromToken(t.Context(), nil)
+
+	require.Empty(t, got)
+	require.ErrorIs(t, err, ErrTokenRequired)
 }
 
 func TestSubjectExtractorClientIDFromToken(t *testing.T) {

--- a/service/policy/kasregistry/authz_resolver.go
+++ b/service/policy/kasregistry/authz_resolver.go
@@ -31,7 +31,7 @@ type getKeyAuthzDBClient interface {
 	GetKey(context.Context, any) (*policy.KasKey, error)
 }
 
-func (s KeyAccessServerRegistry) getKeyAuthzResolver(ctx context.Context, req connect.AnyRequest) (authz.ResolverContext, error) {
+func (s *KeyAccessServerRegistry) getKeyAuthzResolver(ctx context.Context, req connect.AnyRequest) (authz.ResolverContext, error) {
 	resolverCtx := authz.NewResolverContext()
 
 	msg, ok := req.Any().(*kasr.GetKeyRequest)

--- a/tests-bdd/cukes/steps_localplatform.go
+++ b/tests-bdd/cukes/steps_localplatform.go
@@ -37,6 +37,8 @@ const (
 	debugVersion                       = "DEBUG"
 	platformImageEnvironment           = "PLATFORM_IMAGE"
 	platformImageEnvironmentLocalImage = "platform-cukes:latest"
+	clientID                           = "opentdf"
+	platformClientSecret               = "secret"
 	userContextKey                     = "platform_users"
 )
 
@@ -123,7 +125,7 @@ func (s *LocalPlatformStepDefinitions) commonLocalPlatform(ctx context.Context, 
 			platformSDK, err := otdf.New(
 				scenarioContext.ScenarioOptions.PlatformEndpoint,
 				otdf.WithInsecureSkipVerifyConn(),
-				otdf.WithClientCredentials("opentdf", "secret", nil),
+				otdf.WithClientCredentials(clientID, platformClientSecret, nil),
 			)
 			if err != nil {
 				return ctx, err
@@ -237,13 +239,10 @@ func (s *LocalPlatformStepDefinitions) commonLocalPlatform(ctx context.Context, 
 		})
 	}
 
-	const clientID = "opentdf"
-	const clientSecret = "secret"
-
 	platformSDK, err := otdf.New(
 		scenarioContext.ScenarioOptions.PlatformEndpoint,
 		otdf.WithInsecureSkipVerifyConn(),
-		otdf.WithClientCredentials(clientID, clientSecret, nil),
+		otdf.WithClientCredentials(clientID, platformClientSecret, nil),
 	)
 	if err != nil {
 		return ctx, err
@@ -314,7 +313,7 @@ func (s *LocalPlatformStepDefinitions) iUseThePlatformAs(ctx context.Context, ro
 	platformSDK, err := otdf.New(
 		scenarioContext.ScenarioOptions.PlatformEndpoint,
 		otdf.WithInsecureSkipVerifyConn(),
-		otdf.WithClientCredentials(clientID, "secret", nil),
+		otdf.WithClientCredentials(clientID, platformClientSecret, nil),
 	)
 	if err != nil {
 		return ctx, err


### PR DESCRIPTION
## Summary

  - Hardened authz decision handling so nil authorization decisions fail closed instead of panicking.
  - Added regression coverage for nil authorizer decisions in the HTTP authz path.
  - Prevented duplicate authz resolver registration from silently overwriting existing resolvers.
  - Fixed default authz engine handling so factories receive the resolved default engine.
  - Hardened subject extraction for nil tokens and empty role values.
  - Simplified role normalization to filter/prefix roles in a single pass.
  - Kept `PolicyConfig.Adapter` intentionally typed as `any` to allow future adapter configuration shapes beyond Casbin `persist.Adapter`.
  - Updated KAS `GetKey` authz resolver to use a pointer receiver so it does not capture stale registry state.
  - Cleaned up misleading role-provider log fields.
  - Extracted the BDD platform client secret into a shared constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization system now gracefully handles edge cases with proper error responses instead of crashes
  * Fixed default authorization engine configuration to apply correctly
  * Prevented duplicate authorization resolver registrations
  * Added validation to prevent errors from null tokens

* **Tests**
  * Added comprehensive test coverage for authorization edge cases and configuration scenarios

* **Improvements**
  * Enhanced security by removing sensitive authentication data from logs
  * Clarified authorization configuration documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->