### PR TITLE
feat(core): Re-enable pq algorithms after format change

### DIFF
--- a/otdfctl/cmd/policy/kasKeys.go
+++ b/otdfctl/cmd/policy/kasKeys.go
@@ -72,7 +72,7 @@ func generateKeys(alg policy.Algorithm) (string, string, error) {
 func generateKeyPair(alg policy.Algorithm) (ocrypto.KeyPair, error) {
 	var key ocrypto.KeyPair
 	var err error
-	switch alg { //nolint:exhaustive // HPQT hybrid algorithms are intentionally unsupported by otdfctl
+	switch alg {
 	case policy.Algorithm_ALGORITHM_RSA_2048:
 		key, err = generateRSAKey(rsa2048Len)
 	case policy.Algorithm_ALGORITHM_RSA_4096:
@@ -83,6 +83,12 @@ func generateKeyPair(alg policy.Algorithm) (ocrypto.KeyPair, error) {
 		key, err = generateECCKey(ecSecp384Len)
 	case policy.Algorithm_ALGORITHM_EC_P521:
 		key, err = generateECCKey(ecSecp521Len)
+	case policy.Algorithm_ALGORITHM_HPQT_XWING:
+		key, err = ocrypto.NewKeyPair(ocrypto.HybridXWingKey)
+	case policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768:
+		key, err = ocrypto.NewKeyPair(ocrypto.HybridSecp256r1MLKEM768Key)
+	case policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024:
+		key, err = ocrypto.NewKeyPair(ocrypto.HybridSecp384r1MLKEM1024Key)
 	case policy.Algorithm_ALGORITHM_UNSPECIFIED:
 		fallthrough
 	default:

--- a/otdfctl/cmd/policy/kasKeys_test.go
+++ b/otdfctl/cmd/policy/kasKeys_test.go
@@ -3,9 +3,38 @@ package policy
 import (
 	"testing"
 
+	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGenerateKeyPair_Hybrid(t *testing.T) {
+	tests := []struct {
+		name    string
+		alg     policy.Algorithm
+		keyType ocrypto.KeyType
+	}{
+		{"X-Wing", policy.Algorithm_ALGORITHM_HPQT_XWING, ocrypto.HybridXWingKey},
+		{"P256-MLKEM768", policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768, ocrypto.HybridSecp256r1MLKEM768Key},
+		{"P384-MLKEM1024", policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024, ocrypto.HybridSecp384r1MLKEM1024Key},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kp, err := generateKeyPair(tt.alg)
+			require.NoError(t, err)
+			require.Equal(t, tt.keyType, kp.GetKeyType())
+
+			pubPem, err := kp.PublicKeyInPemFormat()
+			require.NoError(t, err)
+			require.NotEmpty(t, pubPem)
+
+			privPem, err := kp.PrivateKeyInPemFormat()
+			require.NoError(t, err)
+			require.NotEmpty(t, privPem)
+		})
+	}
+}
 
 func TestGenerateKeyPair_Unsupported(t *testing.T) {
 	_, err := generateKeyPair(policy.Algorithm_ALGORITHM_UNSPECIFIED)

--- a/otdfctl/docs/man/policy/kas-registry/key/create.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/create.md
@@ -75,6 +75,9 @@ otdfctl policy kas-registry key create --key-id "aws-key" --algorithm "rsa:2048"
     | `ec:secp256r1` |
     | `ec:secp384r1` |
     | `ec:secp521r1` |
+    | `hpqt:xwing` |
+    | `hpqt:secp256r1-mlkem768` |
+    | `hpqt:secp384r1-mlkem1024` |
 
 2. The `"mode"` specifies where the key that is encrypting TDFs is stored. All keys will be encrypted when stored in Virtru's DB, for modes `"local"` and `"provider"`
 

--- a/otdfctl/docs/man/policy/kas-registry/key/import.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/import.md
@@ -79,3 +79,6 @@ otdfctl policy kas-registry key import --key-id "imported-key" --algorithm "rsa:
     | `ec:secp256r1` |
     | `ec:secp384r1` |
     | `ec:secp521r1` |
+    | `hpqt:xwing` |
+    | `hpqt:secp256r1-mlkem768` |
+    | `hpqt:secp384r1-mlkem1024` |

--- a/otdfctl/docs/man/policy/kas-registry/key/rotate.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/rotate.md
@@ -88,6 +88,9 @@ otdfctl policy kas-registry key rotate --key "public-key-old" --kas "Secondary K
     | `ec:secp256r1` |
     | `ec:secp384r1` |
     | `ec:secp521r1` |
+    | `hpqt:xwing` |
+    | `hpqt:secp256r1-mlkem768` |
+    | `hpqt:secp384r1-mlkem1024` |
 
 2. The `"mode"` specifies where the key that is encrypting TDFs is stored. All keys will be encrypted when stored in Virtru's DB, for modes `"local"` and `"provider"`
 

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -128,6 +128,69 @@ format_kas_name_as_uri() {
   assert_not_equal "$(echo "$output" | jq -r .key.metadata.updated_at)" "null"
 }
 
+@test "kas-keys: create key (local mode, hpqt:xwing)" {
+  KEY_ID=$(generate_key_id)
+  # Local mode: otdfctl generates the hybrid keypair internally, so we assert
+  # the public key is present/non-empty rather than matching a known value.
+  run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${KEY_ID}" --algorithm "hpqt:xwing" --mode "local" --wrapping-key-id "wrapping-key-1" --wrapping-key "${WRAPPING_KEY}" --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r .kas_id)" "${KAS_REGISTRY_ID}"
+  assert_equal "$(echo "$output" | jq -r .key.key_id)" "${KEY_ID}"
+  assert_equal "$(echo "$output" | jq -r .key.key_algorithm)" "6" # hpqt:xwing
+  assert_equal "$(echo "$output" | jq -r .key.key_mode)" "1"      # local
+  assert_equal "$(echo "$output" | jq -r .key.key_status)" "1"    # active
+  assert_equal "$(echo "$output" | jq -r .key.legacy)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.public_key_ctx.pem)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.public_key_ctx.pem)" ""
+  assert_equal "$(echo "$output" | jq -r .key.private_key_ctx.key_id)" "wrapping-key-1"
+  assert_not_equal "$(echo "$output" | jq -r .key.private_key_ctx.wrapped_key)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.private_key_ctx.wrapped_key)" ""
+  assert_not_equal "$(echo "$output" | jq -r .key.metadata.created_at)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.metadata.updated_at)" "null"
+}
+
+@test "kas-keys: create key (local mode, hpqt:secp256r1-mlkem768)" {
+  KEY_ID=$(generate_key_id)
+  # Local mode: otdfctl generates the hybrid keypair internally, so we assert
+  # the public key is present/non-empty rather than matching a known value.
+  run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${KEY_ID}" --algorithm "hpqt:secp256r1-mlkem768" --mode "local" --wrapping-key-id "wrapping-key-1" --wrapping-key "${WRAPPING_KEY}" --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r .kas_id)" "${KAS_REGISTRY_ID}"
+  assert_equal "$(echo "$output" | jq -r .key.key_id)" "${KEY_ID}"
+  assert_equal "$(echo "$output" | jq -r .key.key_algorithm)" "7" # hpqt:secp256r1-mlkem768
+  assert_equal "$(echo "$output" | jq -r .key.key_mode)" "1"      # local
+  assert_equal "$(echo "$output" | jq -r .key.key_status)" "1"    # active
+  assert_equal "$(echo "$output" | jq -r .key.legacy)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.public_key_ctx.pem)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.public_key_ctx.pem)" ""
+  assert_equal "$(echo "$output" | jq -r .key.private_key_ctx.key_id)" "wrapping-key-1"
+  assert_not_equal "$(echo "$output" | jq -r .key.private_key_ctx.wrapped_key)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.private_key_ctx.wrapped_key)" ""
+  assert_not_equal "$(echo "$output" | jq -r .key.metadata.created_at)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.metadata.updated_at)" "null"
+}
+
+@test "kas-keys: create key (local mode, hpqt:secp384r1-mlkem1024)" {
+  KEY_ID=$(generate_key_id)
+  # Local mode: otdfctl generates the hybrid keypair internally, so we assert
+  # the public key is present/non-empty rather than matching a known value.
+  run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${KEY_ID}" --algorithm "hpqt:secp384r1-mlkem1024" --mode "local" --wrapping-key-id "wrapping-key-1" --wrapping-key "${WRAPPING_KEY}" --json
+  assert_success
+  assert_equal "$(echo "$output" | jq -r .kas_id)" "${KAS_REGISTRY_ID}"
+  assert_equal "$(echo "$output" | jq -r .key.key_id)" "${KEY_ID}"
+  assert_equal "$(echo "$output" | jq -r .key.key_algorithm)" "8" # hpqt:secp384r1-mlkem1024
+  assert_equal "$(echo "$output" | jq -r .key.key_mode)" "1"      # local
+  assert_equal "$(echo "$output" | jq -r .key.key_status)" "1"    # active
+  assert_equal "$(echo "$output" | jq -r .key.legacy)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.public_key_ctx.pem)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.public_key_ctx.pem)" ""
+  assert_equal "$(echo "$output" | jq -r .key.private_key_ctx.key_id)" "wrapping-key-1"
+  assert_not_equal "$(echo "$output" | jq -r .key.private_key_ctx.wrapped_key)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.private_key_ctx.wrapped_key)" ""
+  assert_not_equal "$(echo "$output" | jq -r .key.metadata.created_at)" "null"
+  assert_not_equal "$(echo "$output" | jq -r .key.metadata.updated_at)" "null"
+}
+
 @test "kas-keys: create key (public_key mode)" {
   KEY_ID=$(generate_key_id)
   run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${KEY_ID}" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64}"  --json

--- a/otdfctl/pkg/cli/sdkHelpers.go
+++ b/otdfctl/pkg/cli/sdkHelpers.go
@@ -125,6 +125,12 @@ func KeyAlgToEnum(alg string) (policy.Algorithm, error) {
 		return policy.Algorithm_ALGORITHM_EC_P384, nil
 	case "ec:secp521r1":
 		return policy.Algorithm_ALGORITHM_EC_P521, nil
+	case "hpqt:xwing":
+		return policy.Algorithm_ALGORITHM_HPQT_XWING, nil
+	case "hpqt:secp256r1-mlkem768":
+		return policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768, nil
+	case "hpqt:secp384r1-mlkem1024":
+		return policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024, nil
 	default:
 		return policy.Algorithm_ALGORITHM_UNSPECIFIED, errors.New("invalid algorithm")
 	}
@@ -142,6 +148,12 @@ func KeyEnumToAlg(enum policy.Algorithm) (string, error) {
 		return "ec:secp384r1", nil
 	case policy.Algorithm_ALGORITHM_EC_P521:
 		return "ec:secp521r1", nil
+	case policy.Algorithm_ALGORITHM_HPQT_XWING:
+		return "hpqt:xwing", nil
+	case policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768:
+		return "hpqt:secp256r1-mlkem768", nil
+	case policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024:
+		return "hpqt:secp384r1-mlkem1024", nil
 	default:
 		return "", errors.New("invalid enum algorithm")
 	}

--- a/otdfctl/pkg/cli/sdkHelpers_test.go
+++ b/otdfctl/pkg/cli/sdkHelpers_test.go
@@ -17,6 +17,9 @@ func TestKeyAlgToEnum_RoundTrip(t *testing.T) {
 		{"ec:secp256r1", policy.Algorithm_ALGORITHM_EC_P256},
 		{"ec:secp384r1", policy.Algorithm_ALGORITHM_EC_P384},
 		{"ec:secp521r1", policy.Algorithm_ALGORITHM_EC_P521},
+		{"hpqt:xwing", policy.Algorithm_ALGORITHM_HPQT_XWING},
+		{"hpqt:secp256r1-mlkem768", policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768},
+		{"hpqt:secp384r1-mlkem1024", policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024},
 	}
 
 	for _, tt := range tests {

--- a/otdfctl/pkg/utils/pemvalidate.go
+++ b/otdfctl/pkg/utils/pemvalidate.go
@@ -20,7 +20,7 @@ func ValidatePublicKeyPEM(pemBytes []byte, expected policy.Algorithm) error {
 		return fmt.Errorf("invalid public key pem: %w", err)
 	}
 
-	switch expected { //nolint:exhaustive // HPQT hybrid algorithms are intentionally unsupported by otdfctl
+	switch expected {
 	case policy.Algorithm_ALGORITHM_RSA_2048:
 		if enc.KeyType() != ocrypto.RSA2048Key {
 			return errors.New("algorithm mismatch: expected RSA 2048")
@@ -40,6 +40,18 @@ func ValidatePublicKeyPEM(pemBytes []byte, expected policy.Algorithm) error {
 	case policy.Algorithm_ALGORITHM_EC_P521:
 		if enc.KeyType() != ocrypto.EC521Key {
 			return errors.New("algorithm mismatch: expected EC P-521")
+		}
+	case policy.Algorithm_ALGORITHM_HPQT_XWING:
+		if enc.KeyType() != ocrypto.HybridXWingKey {
+			return errors.New("algorithm mismatch: expected hybrid X-Wing (X25519 + ML-KEM-768)")
+		}
+	case policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768:
+		if enc.KeyType() != ocrypto.HybridSecp256r1MLKEM768Key {
+			return errors.New("algorithm mismatch: expected hybrid NIST P-256 + ML-KEM-768")
+		}
+	case policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024:
+		if enc.KeyType() != ocrypto.HybridSecp384r1MLKEM1024Key {
+			return errors.New("algorithm mismatch: expected hybrid NIST P-384 + ML-KEM-1024")
 		}
 	case policy.Algorithm_ALGORITHM_UNSPECIFIED:
 		fallthrough

--- a/otdfctl/pkg/utils/pemvalidate_test.go
+++ b/otdfctl/pkg/utils/pemvalidate_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"testing"
 
+	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/stretchr/testify/require"
 )
@@ -117,4 +118,46 @@ func TestValidatePublicKeyPEM_UnsupportedAlgorithm(t *testing.T) {
 	err = ValidatePublicKeyPEM(pemBytes, policy.Algorithm_ALGORITHM_UNSPECIFIED)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported or unspecified algorithm")
+}
+
+func TestValidatePublicKeyPEM_HybridXWing_OK(t *testing.T) {
+	kp, err := ocrypto.NewKeyPair(ocrypto.HybridXWingKey)
+	require.NoError(t, err)
+	pubPem, err := kp.PublicKeyInPemFormat()
+	require.NoError(t, err)
+
+	err = ValidatePublicKeyPEM([]byte(pubPem), policy.Algorithm_ALGORITHM_HPQT_XWING)
+	require.NoError(t, err)
+}
+
+func TestValidatePublicKeyPEM_HybridP256MLKEM768_OK(t *testing.T) {
+	kp, err := ocrypto.NewKeyPair(ocrypto.HybridSecp256r1MLKEM768Key)
+	require.NoError(t, err)
+	pubPem, err := kp.PublicKeyInPemFormat()
+	require.NoError(t, err)
+
+	err = ValidatePublicKeyPEM([]byte(pubPem), policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768)
+	require.NoError(t, err)
+}
+
+func TestValidatePublicKeyPEM_HybridP384MLKEM1024_OK(t *testing.T) {
+	kp, err := ocrypto.NewKeyPair(ocrypto.HybridSecp384r1MLKEM1024Key)
+	require.NoError(t, err)
+	pubPem, err := kp.PublicKeyInPemFormat()
+	require.NoError(t, err)
+
+	err = ValidatePublicKeyPEM([]byte(pubPem), policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024)
+	require.NoError(t, err)
+}
+
+func TestValidatePublicKeyPEM_HybridMismatch(t *testing.T) {
+	// Generate an X-Wing key but validate against a different hybrid algorithm
+	kp, err := ocrypto.NewKeyPair(ocrypto.HybridXWingKey)
+	require.NoError(t, err)
+	pubPem, err := kp.PublicKeyInPemFormat()
+	require.NoError(t, err)
+
+	err = ValidatePublicKeyPEM([]byte(pubPem), policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "algorithm mismatch")
 }


### PR DESCRIPTION
Reverts opentdf/platform#3625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three hybrid post-quantum key algorithms: X-Wing, Secp256r1/MLKEM768, and Secp384r1/MLKEM1024.

* **Documentation**
  * Updated key creation, import, and rotation documentation to reflect new algorithm options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->