### PR TITLE
adr(policy): evaluate CEL for condition operators

### DIFF
--- a/docs/performance/DSPX-3673-cel-condition-evaluation/README.md
+++ b/docs/performance/DSPX-3673-cel-condition-evaluation/README.md
@@ -1,0 +1,101 @@
+# CEL vs Native Condition Evaluation Benchmarks (DSPX-3673)
+
+Reproducible benchmarks for [DSPX-3673](https://virtru.atlassian.net/browse/DSPX-3673), the spike
+asking whether [CEL](https://cel.dev) should replace the bespoke Subject Mapping condition operators
+(see `service/policy/adr/0005-dspx-3673-cel-condition-evaluation-spike.md`). Two layers, both
+in-memory below the RPC server (matching the `dspx-2754-perf-test` and `DSPX-2541-entitleable-perf-test`
+approach, no wired client / server / ERS / Keycloak):
+
+1. **Operator Engine** (no Docker): per-evaluation cost of the native operator switch vs a precompiled
+   CEL program, plus the one-time CEL compile cost, swept over condition complexity.
+2. **Full Entitlements Path** (no Docker): the cost of computing entitlements three ways, swept over
+   subject-mapping count, to separate the OPA wrapper overhead from the operator engine.
+
+A key structural finding sets up Layer 2: `entitlements.rego` only calls the `subjectmapping.resolve`
+Go builtin (`service/internal/subjectmappingbuiltin`), so Rego does not evaluate operators. The choice
+is CEL vs the Go switch; Rego is an orchestration wrapper measured separately.
+
+## Layer 1: Operator Engine
+
+`TestCELOperatorBenchmark` (`service/internal/subjectmappingbuiltin/cel_operator_bench_test.go`, build
+tag `celbench`) builds a `SubjectSet` of `groups × conds` conditions (mixed IN / NOT_IN / IN_CONTAINS,
+crafted so every condition is true and the whole set is traversed) and times three arms:
+
+- **native** — `EvaluateSubjectSet` (the hand-written switch).
+- **cel** — a `cel.Program` compiled once from the SubjectSet (`celeval`), evaluated per call by
+  binding the entity's selector values.
+- **cel_compile** — the one-time cost of compiling that program (amortized under compile-once / cache).
+
+Run (no Docker):
+```bash
+bash docs/performance/DSPX-3673-cel-condition-evaluation/run.sh   # runs both layers
+```
+Outputs `results.csv` and `charts/operator_latency.svg`.
+
+### Results
+
+| arm | 1×1 | 3×3 (9 conds) | 10×5 (50 conds) |
+|-----|-----|---------------|-----------------|
+| native | 22 ns | 490 ns | 8.6 µs |
+| cel (per-eval) | 532 ns | 4.8 µs | 32.1 µs |
+| cel_compile (one-time) | 84 µs | 355 µs | 2.3 ms |
+| cel / native | 24× | 9.8× | 3.7× |
+
+The native switch is faster per evaluation at every size (24× at one condition, narrowing to ~4× at
+50). CEL's per-eval cost stays in the sub-microsecond to tens-of-microseconds range. Compile is three
+to four orders of magnitude more expensive than a single eval, so CEL is only viable with
+compile-once / cache, never compile-per-request.
+
+## Layer 2: Full Entitlements Path
+
+`TestCELFullPathBenchmark` (`service/authorization/cel_fullpath_bench_test.go`, build tag `celbench`)
+builds N attribute mappings (each one subject mapping matching a single entity) and times three ways
+to produce entitlements over the same policy + entity:
+
+- **rego** — the status quo: `entitlements.OpaInput` (protojson marshal) plus the prepared OPA query,
+  which calls the builtin into `EvaluateSubjectMappingMultipleEntities`.
+- **go_switch** — `EvaluateSubjectMappingMultipleEntities` directly, no OPA.
+- **go_cel** — the same orchestration with condition evaluation via precompiled CEL (`celeval`).
+
+Run (no Docker):
+```bash
+bash docs/performance/DSPX-3673-cel-condition-evaluation/run.sh
+CEL_BENCH_MAX_N=1000 bash docs/performance/DSPX-3673-cel-condition-evaluation/run.sh   # cap N for speed
+```
+Outputs `fullpath_results.csv` and `charts/fullpath_{latency,allocs}.svg`.
+
+### Results
+
+| arm | N=100 | N=1,000 | N=5,000 |
+|-----|-------|---------|---------|
+| rego | 1.43 ms | 13.2 ms | 69.2 ms |
+| go_switch | 9.1 µs | 128 µs | 657 µs |
+| go_cel | 68 µs | 725 µs | 4.5 ms |
+| rego / go_switch | 158× | 103× | 105× |
+| go_cel / go_switch | 7.5× | 5.7× | 6.9× |
+
+The OPA wrapper dominates: Rego is ~100× slower than a direct Go call and allocates ~130× more
+(665,686 vs 5,077 allocs/op at N=5,000). Against that, the operator engine difference is small: `go_cel`
+is ~6–7× `go_switch`, but both are an order of magnitude under `rego`. The operator engine is not the
+bottleneck in the entitlements path; the OPA layer is.
+
+## Takeaway
+
+CEL is slower than the native switch (Layer 1), but in the path where it would actually run (Layer 2)
+that difference is dwarfed by the OPA wrapper. The case for CEL is maintainability (one engine, new
+operators become expression changes), not speed, and its cost is acceptable relative to the path it
+sits in. The larger performance lever surfaced here is the OPA wrapper itself, independent of the
+operator engine.
+
+## Environment
+
+Measured on Apple M4 Max, `go version go1.26.1 darwin/arm64`. Numbers are machine-dependent; the ratios
+are the portable result. `results.csv` and `fullpath_results.csv` are committed from a full run; the
+race detector is off (it skews timing). Regenerate with `run.sh`.
+
+## Scope
+
+Both layers run in-memory below the RPC server, matching the `DSPX-2541-entitleable-perf-test` approach
+(no wired client / server / ERS / Keycloak / DB). `celeval` is an experimental, unwired reference
+evaluator for the spike; it is not on any request path. The benchmark quantifies the OPA overhead but
+does not remove it. Hierarchy and multi-entity fan-out are out of scope.

--- a/docs/performance/DSPX-3673-cel-condition-evaluation/charts/fullpath_allocs.svg
+++ b/docs/performance/DSPX-3673-cel-condition-evaluation/charts/fullpath_allocs.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="460" font-family="sans-serif">
+<rect width="760" height="460" fill="white"/>
+<text x="380.0" y="28" text-anchor="middle" font-size="16" fill="#222222">Entitlements path allocations vs subject mappings (DSPX-3673)</text>
+<line x1="78.0" y1="56" x2="78.0" y2="396" stroke="#d9d9d9"/>
+<text x="78.0" y="414" text-anchor="middle" font-size="11" fill="#222222">1e2</text>
+<line x1="319.0" y1="56" x2="319.0" y2="396" stroke="#d9d9d9"/>
+<text x="319.0" y="414" text-anchor="middle" font-size="11" fill="#222222">1e3</text>
+<line x1="560.0" y1="56" x2="560.0" y2="396" stroke="#d9d9d9"/>
+<text x="560.0" y="414" text-anchor="middle" font-size="11" fill="#222222">1e4</text>
+<line x1="78" y1="396.0" x2="560" y2="396.0" stroke="#d9d9d9"/>
+<text x="70" y="400.0" text-anchor="end" font-size="11" fill="#222222">1e2</text>
+<line x1="78" y1="311.0" x2="560" y2="311.0" stroke="#d9d9d9"/>
+<text x="70" y="315.0" text-anchor="end" font-size="11" fill="#222222">1e3</text>
+<line x1="78" y1="226.0" x2="560" y2="226.0" stroke="#d9d9d9"/>
+<text x="70" y="230.0" text-anchor="end" font-size="11" fill="#222222">1e4</text>
+<line x1="78" y1="141.0" x2="560" y2="141.0" stroke="#d9d9d9"/>
+<text x="70" y="145.0" text-anchor="end" font-size="11" fill="#222222">1e5</text>
+<line x1="78" y1="56.0" x2="560" y2="56.0" stroke="#d9d9d9"/>
+<text x="70" y="60.0" text-anchor="end" font-size="11" fill="#222222">1e6</text>
+<rect x="78" y="56" width="482" height="340" fill="none" stroke="#333333"/>
+<text x="319.0" y="442" text-anchor="middle" font-size="13" fill="#222222">Total subject mappings (log scale)</text>
+<text x="18" y="226.0" text-anchor="middle" font-size="13" fill="#222222" transform="rotate(-90 18 226.0)">allocs/op (log scale)</text>
+<path d="M78.0,214.3 L319.0,130.3 L487.5,71.0" fill="none" stroke="#c1121f" stroke-width="2.5"/>
+<circle cx="78.0" cy="214.3" r="3" fill="#c1121f"/>
+<circle cx="319.0" cy="130.3" r="3" fill="#c1121f"/>
+<circle cx="487.5" cy="71.0" r="3" fill="#c1121f"/>
+<line x1="574" y1="64" x2="596" y2="64" stroke="#c1121f" stroke-width="2.5"/>
+<text x="602" y="68" font-size="11" fill="#222222">rego (OPA + protojson, today)</text>
+<path d="M78.0,385.5 L319.0,309.3 L487.5,251.0" fill="none" stroke="#0353a4" stroke-width="2.5"/>
+<circle cx="78.0" cy="385.5" r="3" fill="#0353a4"/>
+<circle cx="319.0" cy="309.3" r="3" fill="#0353a4"/>
+<circle cx="487.5" cy="251.0" r="3" fill="#0353a4"/>
+<line x1="574" y1="86" x2="596" y2="86" stroke="#0353a4" stroke-width="2.5"/>
+<text x="602" y="90" font-size="11" fill="#222222">go_switch (direct Go)</text>
+<path d="M78.0,288.7 L319.0,204.2 L487.5,144.9" fill="none" stroke="#2a9d3f" stroke-width="2.5"/>
+<circle cx="78.0" cy="288.7" r="3" fill="#2a9d3f"/>
+<circle cx="319.0" cy="204.2" r="3" fill="#2a9d3f"/>
+<circle cx="487.5" cy="144.9" r="3" fill="#2a9d3f"/>
+<line x1="574" y1="108" x2="596" y2="108" stroke="#2a9d3f" stroke-width="2.5"/>
+<text x="602" y="112" font-size="11" fill="#222222">go_cel (direct Go + CEL)</text>
+</svg>

--- a/docs/performance/DSPX-3673-cel-condition-evaluation/charts/fullpath_latency.svg
+++ b/docs/performance/DSPX-3673-cel-condition-evaluation/charts/fullpath_latency.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="460" font-family="sans-serif">
+<rect width="760" height="460" fill="white"/>
+<text x="380.0" y="28" text-anchor="middle" font-size="16" fill="#222222">Entitlements path latency vs subject mappings (DSPX-3673)</text>
+<line x1="78.0" y1="56" x2="78.0" y2="396" stroke="#d9d9d9"/>
+<text x="78.0" y="414" text-anchor="middle" font-size="11" fill="#222222">1e2</text>
+<line x1="319.0" y1="56" x2="319.0" y2="396" stroke="#d9d9d9"/>
+<text x="319.0" y="414" text-anchor="middle" font-size="11" fill="#222222">1e3</text>
+<line x1="560.0" y1="56" x2="560.0" y2="396" stroke="#d9d9d9"/>
+<text x="560.0" y="414" text-anchor="middle" font-size="11" fill="#222222">1e4</text>
+<line x1="78" y1="396.0" x2="560" y2="396.0" stroke="#d9d9d9"/>
+<text x="70" y="400.0" text-anchor="end" font-size="11" fill="#222222">1e3</text>
+<line x1="78" y1="328.0" x2="560" y2="328.0" stroke="#d9d9d9"/>
+<text x="70" y="332.0" text-anchor="end" font-size="11" fill="#222222">1e4</text>
+<line x1="78" y1="260.0" x2="560" y2="260.0" stroke="#d9d9d9"/>
+<text x="70" y="264.0" text-anchor="end" font-size="11" fill="#222222">1e5</text>
+<line x1="78" y1="192.0" x2="560" y2="192.0" stroke="#d9d9d9"/>
+<text x="70" y="196.0" text-anchor="end" font-size="11" fill="#222222">1e6</text>
+<line x1="78" y1="124.0" x2="560" y2="124.0" stroke="#d9d9d9"/>
+<text x="70" y="128.0" text-anchor="end" font-size="11" fill="#222222">1e7</text>
+<line x1="78" y1="56.0" x2="560" y2="56.0" stroke="#d9d9d9"/>
+<text x="70" y="60.0" text-anchor="end" font-size="11" fill="#222222">1e8</text>
+<rect x="78" y="56" width="482" height="340" fill="none" stroke="#333333"/>
+<text x="319.0" y="442" text-anchor="middle" font-size="13" fill="#222222">Total subject mappings (log scale)</text>
+<text x="18" y="226.0" text-anchor="middle" font-size="13" fill="#222222" transform="rotate(-90 18 226.0)">ns/op (log scale)</text>
+<path d="M78.0,181.5 L319.0,115.7 L487.5,66.9" fill="none" stroke="#c1121f" stroke-width="2.5"/>
+<circle cx="78.0" cy="181.5" r="3" fill="#c1121f"/>
+<circle cx="319.0" cy="115.7" r="3" fill="#c1121f"/>
+<circle cx="487.5" cy="66.9" r="3" fill="#c1121f"/>
+<line x1="574" y1="64" x2="596" y2="64" stroke="#c1121f" stroke-width="2.5"/>
+<text x="602" y="68" font-size="11" fill="#222222">rego (OPA + protojson, today)</text>
+<path d="M78.0,330.9 L319.0,252.6 L487.5,204.4" fill="none" stroke="#0353a4" stroke-width="2.5"/>
+<circle cx="78.0" cy="330.9" r="3" fill="#0353a4"/>
+<circle cx="319.0" cy="252.6" r="3" fill="#0353a4"/>
+<circle cx="487.5" cy="204.4" r="3" fill="#0353a4"/>
+<line x1="574" y1="86" x2="596" y2="86" stroke="#0353a4" stroke-width="2.5"/>
+<text x="602" y="90" font-size="11" fill="#222222">go_switch (direct Go)</text>
+<path d="M78.0,271.2 L319.0,201.5 L487.5,147.4" fill="none" stroke="#2a9d3f" stroke-width="2.5"/>
+<circle cx="78.0" cy="271.2" r="3" fill="#2a9d3f"/>
+<circle cx="319.0" cy="201.5" r="3" fill="#2a9d3f"/>
+<circle cx="487.5" cy="147.4" r="3" fill="#2a9d3f"/>
+<line x1="574" y1="108" x2="596" y2="108" stroke="#2a9d3f" stroke-width="2.5"/>
+<text x="602" y="112" font-size="11" fill="#222222">go_cel (direct Go + CEL)</text>
+</svg>

--- a/docs/performance/DSPX-3673-cel-condition-evaluation/charts/operator_latency.svg
+++ b/docs/performance/DSPX-3673-cel-condition-evaluation/charts/operator_latency.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="460" font-family="sans-serif">
+<rect width="760" height="460" fill="white"/>
+<text x="380.0" y="28" text-anchor="middle" font-size="16" fill="#222222">CEL vs native operator evaluation (DSPX-3673)</text>
+<line x1="78.0" y1="56" x2="78.0" y2="396" stroke="#d9d9d9"/>
+<text x="78.0" y="414" text-anchor="middle" font-size="11" fill="#222222">1e0</text>
+<line x1="319.0" y1="56" x2="319.0" y2="396" stroke="#d9d9d9"/>
+<text x="319.0" y="414" text-anchor="middle" font-size="11" fill="#222222">1e1</text>
+<line x1="560.0" y1="56" x2="560.0" y2="396" stroke="#d9d9d9"/>
+<text x="560.0" y="414" text-anchor="middle" font-size="11" fill="#222222">1e2</text>
+<line x1="78" y1="396.0" x2="560" y2="396.0" stroke="#d9d9d9"/>
+<text x="70" y="400.0" text-anchor="end" font-size="11" fill="#222222">1e1</text>
+<line x1="78" y1="339.3" x2="560" y2="339.3" stroke="#d9d9d9"/>
+<text x="70" y="343.3" text-anchor="end" font-size="11" fill="#222222">1e2</text>
+<line x1="78" y1="282.7" x2="560" y2="282.7" stroke="#d9d9d9"/>
+<text x="70" y="286.7" text-anchor="end" font-size="11" fill="#222222">1e3</text>
+<line x1="78" y1="226.0" x2="560" y2="226.0" stroke="#d9d9d9"/>
+<text x="70" y="230.0" text-anchor="end" font-size="11" fill="#222222">1e4</text>
+<line x1="78" y1="169.3" x2="560" y2="169.3" stroke="#d9d9d9"/>
+<text x="70" y="173.3" text-anchor="end" font-size="11" fill="#222222">1e5</text>
+<line x1="78" y1="112.7" x2="560" y2="112.7" stroke="#d9d9d9"/>
+<text x="70" y="116.7" text-anchor="end" font-size="11" fill="#222222">1e6</text>
+<line x1="78" y1="56.0" x2="560" y2="56.0" stroke="#d9d9d9"/>
+<text x="70" y="60.0" text-anchor="end" font-size="11" fill="#222222">1e7</text>
+<rect x="78" y="56" width="482" height="340" fill="none" stroke="#333333"/>
+<text x="319.0" y="442" text-anchor="middle" font-size="13" fill="#222222">Conditions per subject set (log scale)</text>
+<text x="18" y="226.0" text-anchor="middle" font-size="13" fill="#222222" transform="rotate(-90 18 226.0)">ns/op (log scale)</text>
+<path d="M78.0,376.6 L308.0,300.2 L487.5,229.6" fill="none" stroke="#0353a4" stroke-width="2.5"/>
+<circle cx="78.0" cy="376.6" r="3" fill="#0353a4"/>
+<circle cx="308.0" cy="300.2" r="3" fill="#0353a4"/>
+<circle cx="487.5" cy="229.6" r="3" fill="#0353a4"/>
+<line x1="574" y1="64" x2="596" y2="64" stroke="#0353a4" stroke-width="2.5"/>
+<text x="602" y="68" font-size="11" fill="#222222">native (Go operator switch)</text>
+<path d="M78.0,298.2 L308.0,244.1 L487.5,197.3" fill="none" stroke="#c1121f" stroke-width="2.5"/>
+<circle cx="78.0" cy="298.2" r="3" fill="#c1121f"/>
+<circle cx="308.0" cy="244.1" r="3" fill="#c1121f"/>
+<circle cx="487.5" cy="197.3" r="3" fill="#c1121f"/>
+<line x1="574" y1="86" x2="596" y2="86" stroke="#c1121f" stroke-width="2.5"/>
+<text x="602" y="90" font-size="11" fill="#222222">cel (precompiled, per-eval)</text>
+<path d="M78.0,173.5 L308.0,138.2 L487.5,92.0" fill="none" stroke="#8a8a8a" stroke-width="2.5"/>
+<circle cx="78.0" cy="173.5" r="3" fill="#8a8a8a"/>
+<circle cx="308.0" cy="138.2" r="3" fill="#8a8a8a"/>
+<circle cx="487.5" cy="92.0" r="3" fill="#8a8a8a"/>
+<line x1="574" y1="108" x2="596" y2="108" stroke="#8a8a8a" stroke-width="2.5"/>
+<text x="602" y="112" font-size="11" fill="#222222">cel_compile (one-time)</text>
+</svg>

--- a/docs/performance/DSPX-3673-cel-condition-evaluation/fullpath_results.csv
+++ b/docs/performance/DSPX-3673-cel-condition-evaluation/fullpath_results.csv
@@ -1,0 +1,10 @@
+layer,arm,mappings,ns_op,allocs_op,bytes_op
+fullpath,rego,100,1428989,13721,1849507
+fullpath,go_switch,100,9055,133,14141
+fullpath,go_cel,100,68378,1828,87616
+fullpath,rego,1000,13243956,133512,18323047
+fullpath,go_switch,1000,128323,1047,161329
+fullpath,go_cel,1000,725379,18039,902740
+fullpath,rego,5000,69193710,665686,103178438
+fullpath,go_switch,5000,657434,5077,757778
+fullpath,go_cel,5000,4532429,90065,4399943

--- a/docs/performance/DSPX-3673-cel-condition-evaluation/plot.py
+++ b/docs/performance/DSPX-3673-cel-condition-evaluation/plot.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Generate SVG charts for the DSPX-3673 CEL benchmark CSVs.
+
+Pure Python standard library only (no matplotlib, no network), so it runs on a
+fresh clone with just `python3`. Adapted from the DSPX-2541 perf script. It
+auto-detects the CSV schema by header:
+
+  operator CSV (header has `groups`):  charts/operator_latency.svg
+                                        (native vs cel vs cel_compile, x = total conditions)
+  fullpath CSV (header has `mappings`): charts/fullpath_latency.svg, charts/fullpath_allocs.svg
+                                        (rego vs go_switch vs go_cel, x = subject mappings)
+
+Usage:
+    python3 plot.py <results.csv> [charts_dir]
+"""
+
+import csv
+import math
+import os
+import sys
+
+W, H = 760, 460
+ML, MR, MT, MB = 78, 200, 56, 64  # margins (right margin holds the legend)
+PLOT_W = W - ML - MR
+PLOT_H = H - MT - MB
+GRID, AXIS, TEXT = "#d9d9d9", "#333333", "#222222"
+RED, BLUE, GREEN, GRAY = "#c1121f", "#0353a4", "#2a9d3f", "#8a8a8a"
+LOG_FLOOR = 1e-3
+
+
+def lg(v):
+    return math.log10(max(v, LOG_FLOOR))
+
+
+def bounds(vals):
+    lo, hi = math.floor(min(lg(v) for v in vals)), math.ceil(max(lg(v) for v in vals))
+    return (lo, hi) if hi > lo else (lo, lo + 1)
+
+
+def render_chart(title, x_label, y_label, series, colors, labels, order, dest):
+    """series: {name: [(x, y), ...]}; draws a log-log line chart to dest (SVG)."""
+    xs = [x for pts in series.values() for x, _ in pts]
+    ys = [y for pts in series.values() for _, y in pts]
+    if not xs:
+        return
+    xlo, xhi = bounds(xs)
+    ylo, yhi = bounds(ys)
+
+    def px(n):
+        return ML + (lg(n) - xlo) / (xhi - xlo) * PLOT_W
+
+    def py(v):
+        return MT + PLOT_H - (lg(v) - ylo) / (yhi - ylo) * PLOT_H
+
+    out = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" font-family="sans-serif">',
+           f'<rect width="{W}" height="{H}" fill="white"/>',
+           f'<text x="{W/2}" y="28" text-anchor="middle" font-size="16" fill="{TEXT}">{title}</text>']
+
+    for e in range(xlo, xhi + 1):
+        x = px(10 ** e)
+        out.append(f'<line x1="{x:.1f}" y1="{MT}" x2="{x:.1f}" y2="{MT+PLOT_H}" stroke="{GRID}"/>')
+        out.append(f'<text x="{x:.1f}" y="{MT+PLOT_H+18}" text-anchor="middle" font-size="11" fill="{TEXT}">1e{e}</text>')
+    for e in range(ylo, yhi + 1):
+        y = py(10 ** e)
+        out.append(f'<line x1="{ML}" y1="{y:.1f}" x2="{ML+PLOT_W}" y2="{y:.1f}" stroke="{GRID}"/>')
+        out.append(f'<text x="{ML-8}" y="{y+4:.1f}" text-anchor="end" font-size="11" fill="{TEXT}">1e{e}</text>')
+
+    out.append(f'<rect x="{ML}" y="{MT}" width="{PLOT_W}" height="{PLOT_H}" fill="none" stroke="{AXIS}"/>')
+    out.append(f'<text x="{ML+PLOT_W/2}" y="{H-18}" text-anchor="middle" font-size="13" fill="{TEXT}">{x_label}</text>')
+    out.append(f'<text x="18" y="{MT+PLOT_H/2}" text-anchor="middle" font-size="13" fill="{TEXT}" '
+               f'transform="rotate(-90 18 {MT+PLOT_H/2})">{y_label}</text>')
+
+    ly = MT + 8
+    for name in order:
+        pts = series.get(name)
+        if not pts:
+            continue
+        pts = sorted(pts, key=lambda p: p[0])
+        color = colors.get(name, "#666")
+        path = " ".join(f"{'M' if i == 0 else 'L'}{px(x):.1f},{py(y):.1f}" for i, (x, y) in enumerate(pts))
+        out.append(f'<path d="{path}" fill="none" stroke="{color}" stroke-width="2.5"/>')
+        for x, y in pts:
+            out.append(f'<circle cx="{px(x):.1f}" cy="{py(y):.1f}" r="3" fill="{color}"/>')
+        lx = ML + PLOT_W + 14
+        out.append(f'<line x1="{lx}" y1="{ly}" x2="{lx+22}" y2="{ly}" stroke="{color}" stroke-width="2.5"/>')
+        out.append(f'<text x="{lx+28}" y="{ly+4}" font-size="11" fill="{TEXT}">{labels.get(name, name)}</text>')
+        ly += 22
+
+    out.append("</svg>")
+    os.makedirs(os.path.dirname(dest) or ".", exist_ok=True)
+    with open(dest, "w") as fh:
+        fh.write("\n".join(out))
+    print(f"wrote {dest}")
+
+
+def plot_operator(rows, charts_dir):
+    colors = {"native": BLUE, "cel": RED, "cel_compile": GRAY}
+    labels = {
+        "native": "native (Go operator switch)",
+        "cel": "cel (precompiled, per-eval)",
+        "cel_compile": "cel_compile (one-time)",
+    }
+    series = {}
+    for r in rows:
+        x = int(r["groups"]) * int(r["conds"])  # total conditions
+        series.setdefault(r["arm"], []).append((x, float(r["ns_op"])))
+    render_chart("CEL vs native operator evaluation (DSPX-3673)",
+                 "Conditions per subject set (log scale)", "ns/op (log scale)",
+                 series, colors, labels, ("native", "cel", "cel_compile"),
+                 os.path.join(charts_dir, "operator_latency.svg"))
+
+
+def plot_fullpath(rows, charts_dir):
+    colors = {"rego": RED, "go_switch": BLUE, "go_cel": GREEN}
+    labels = {
+        "rego": "rego (OPA + protojson, today)",
+        "go_switch": "go_switch (direct Go)",
+        "go_cel": "go_cel (direct Go + CEL)",
+    }
+    lat, alloc = {}, {}
+    for r in rows:
+        n = int(r["mappings"])
+        lat.setdefault(r["arm"], []).append((n, float(r["ns_op"])))
+        alloc.setdefault(r["arm"], []).append((n, float(r["allocs_op"])))
+    order = ("rego", "go_switch", "go_cel")
+    render_chart("Entitlements path latency vs subject mappings (DSPX-3673)",
+                 "Total subject mappings (log scale)", "ns/op (log scale)",
+                 lat, colors, labels, order, os.path.join(charts_dir, "fullpath_latency.svg"))
+    render_chart("Entitlements path allocations vs subject mappings (DSPX-3673)",
+                 "Total subject mappings (log scale)", "allocs/op (log scale)",
+                 alloc, colors, labels, order, os.path.join(charts_dir, "fullpath_allocs.svg"))
+
+
+def main():
+    csv_path = sys.argv[1] if len(sys.argv) > 1 else "results.csv"
+    charts_dir = sys.argv[2] if len(sys.argv) > 2 else "charts"
+    with open(csv_path, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    if not rows:
+        print(f"no rows in {csv_path}", file=sys.stderr)
+        return 1
+    header = rows[0].keys()
+    if "groups" in header:
+        plot_operator(rows, charts_dir)
+    elif "mappings" in header:
+        plot_fullpath(rows, charts_dir)
+    else:
+        print(f"unrecognized CSV schema in {csv_path}: {list(header)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/performance/DSPX-3673-cel-condition-evaluation/results.csv
+++ b/docs/performance/DSPX-3673-cel-condition-evaluation/results.csv
@@ -1,0 +1,10 @@
+layer,arm,groups,conds,ns_op,allocs_op,bytes_op
+operator,native,1,1,22,1,16
+operator,cel,1,1,532,18,775
+operator,cel_compile,1,1,84335,1470,104992
+operator,native,3,3,490,12,168
+operator,cel,3,3,4784,148,4635
+operator,cel_compile,3,3,354877,6873,454025
+operator,native,10,5,8634,60,880
+operator,cel,10,5,32056,804,24448
+operator,cel_compile,10,5,2318284,37318,3332031

--- a/docs/performance/DSPX-3673-cel-condition-evaluation/run.sh
+++ b/docs/performance/DSPX-3673-cel-condition-evaluation/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Reproduce the DSPX-3673 CEL-vs-native benchmarks (no Docker). Both layers run
+# in-memory below the RPC server, matching the dspx-2754-perf-test / DSPX-2541
+# approach (no wired client / server / ERS / Keycloak).
+#
+#   Layer 1 (operator engine): native operator switch vs precompiled CEL, plus
+#            one-time CEL compile cost, swept over condition complexity.
+#   Layer 2 (full entitlements path): OPA rego vs direct Go switch vs direct Go
+#            + CEL, swept over subject-mapping count.
+#
+# From a fresh clone:
+#
+#   bash docs/performance/DSPX-3673-cel-condition-evaluation/run.sh
+#
+# Optional: cap the largest Layer 2 scale point to bound runtime:
+#   CEL_BENCH_MAX_N=1000 bash docs/performance/DSPX-3673-cel-condition-evaluation/run.sh
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../../.." && pwd)"
+
+OP_RESULTS="${HERE}/results.csv"
+FP_RESULTS="${HERE}/fullpath_results.csv"
+CHARTS_DIR="${HERE}/charts"
+
+cd "${REPO_ROOT}/service"
+
+echo "==> Layer 1: operator engine (native vs CEL)"
+CEL_BENCH_OP_OUT="${OP_RESULTS}" \
+  go test -tags celbench -run TestCELOperatorBenchmark -timeout 30m -v \
+  ./internal/subjectmappingbuiltin/
+
+echo "==> Layer 2: full entitlements path (rego vs go_switch vs go_cel)"
+CEL_BENCH_FP_OUT="${FP_RESULTS}" CEL_BENCH_MAX_N="${CEL_BENCH_MAX_N:-5000}" \
+  go test -tags celbench -run TestCELFullPathBenchmark -timeout 30m -v \
+  ./authorization/
+
+echo "==> Generating SVG charts"
+python3 "${HERE}/plot.py" "${OP_RESULTS}" "${CHARTS_DIR}"
+python3 "${HERE}/plot.py" "${FP_RESULTS}" "${CHARTS_DIR}"
+
+echo "==> Done."
+echo "    Data:   ${OP_RESULTS}, ${FP_RESULTS}"
+echo "    Charts: ${CHARTS_DIR}/operator_latency.svg, ${CHARTS_DIR}/fullpath_{latency,allocs}.svg"

--- a/service/authorization/cel_fullpath_bench_test.go
+++ b/service/authorization/cel_fullpath_bench_test.go
@@ -1,0 +1,253 @@
+//go:build celbench
+
+// Layer 2 of the DSPX-3673 performance deliverable: full entitlements-path benchmark. Measures the
+// per-request cost of three ways to compute entitlements over the same policy + entity:
+//
+//   - rego:      the status quo. OpaInput (protojson marshal) + the prepared OPA query, which calls
+//     the subjectmapping.resolve builtin -> EvaluateSubjectMappingMultipleEntities.
+//   - go_switch: EvaluateSubjectMappingMultipleEntities directly, no OPA.
+//   - go_cel:    the same orchestration with condition evaluation via precompiled CEL (celeval).
+//
+// rego vs go_switch isolates the OPA + serialization overhead; go_switch vs go_cel isolates the
+// operator-engine difference at full granularity. Build-tagged (celbench) and driven by
+// docs/performance/DSPX-3673-cel-condition-evaluation/run.sh (sets CEL_BENCH_FP_OUT, CEL_BENCH_MAX_N).
+//
+//	go test -tags celbench -run TestCELFullPathBenchmark ./authorization/
+package authorization_test
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/opentdf/platform/lib/flattening"
+	"github.com/opentdf/platform/protocol/go/entityresolution"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/attributes"
+	"github.com/opentdf/platform/service/authorization/policies"
+	"github.com/opentdf/platform/service/internal/entitlements"
+	"github.com/opentdf/platform/service/internal/subjectmappingbuiltin"
+	"github.com/opentdf/platform/service/internal/subjectmappingbuiltin/celeval"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const fpSelector = ".attributes.role[]"
+
+// buildFullPathFixture builds n attribute mappings, each with one subject mapping whose condition
+// set matches an entity carrying role "analyst", plus the single matching entity.
+func buildFullPathFixture(t *testing.T, n int) (map[string]*attributes.GetAttributeValuesByFqnsResponse_AttributeAndValue, *entityresolution.ResolveEntitiesResponse) {
+	t.Helper()
+	sms := make(map[string]*attributes.GetAttributeValuesByFqnsResponse_AttributeAndValue, n)
+	for i := 0; i < n; i++ {
+		fqn := fmt.Sprintf("https://example.com/attr/role/value/v%d", i)
+		sms[fqn] = &attributes.GetAttributeValuesByFqnsResponse_AttributeAndValue{
+			Value: &policy.Value{
+				Fqn: fqn,
+				SubjectMappings: []*policy.SubjectMapping{{
+					SubjectConditionSet: &policy.SubjectConditionSet{
+						SubjectSets: []*policy.SubjectSet{{
+							ConditionGroups: []*policy.ConditionGroup{{
+								BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+								Conditions: []*policy.Condition{{
+									SubjectExternalSelectorValue: fpSelector,
+									Operator:                     policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+									SubjectExternalValues:        []string{"analyst"},
+								}},
+							}},
+						}},
+					},
+				}},
+			},
+		}
+	}
+
+	props, err := structpb.NewStruct(map[string]interface{}{
+		"attributes": map[string]interface{}{"role": []interface{}{"analyst"}},
+	})
+	require.NoError(t, err)
+	ers := &entityresolution.ResolveEntitiesResponse{
+		EntityRepresentations: []*entityresolution.EntityRepresentation{{
+			OriginalId:      "entity-1",
+			AdditionalProps: []*structpb.Struct{props},
+		}},
+	}
+	return sms, ers
+}
+
+// compiledMapping holds the precompiled CEL programs for one attribute mapping's subject mappings
+// (outer slice: subject mappings; inner slice: that mapping's subject sets).
+type compiledMapping struct {
+	attr            string
+	subjectMappings [][]*celeval.Program
+}
+
+func compileMappings(t *testing.T, sms map[string]*attributes.GetAttributeValuesByFqnsResponse_AttributeAndValue) []compiledMapping {
+	t.Helper()
+	out := make([]compiledMapping, 0, len(sms))
+	for attr, av := range sms {
+		cm := compiledMapping{attr: attr}
+		for _, sm := range av.GetValue().GetSubjectMappings() {
+			programs := make([]*celeval.Program, 0)
+			for _, ss := range sm.GetSubjectConditionSet().GetSubjectSets() {
+				prog, err := celeval.CompileSubjectSet(ss)
+				require.NoError(t, err)
+				programs = append(programs, prog)
+			}
+			cm.subjectMappings = append(cm.subjectMappings, programs)
+		}
+		out = append(out, cm)
+	}
+	return out
+}
+
+// evalCELMultipleEntities mirrors EvaluateSubjectMappingMultipleEntities (subject mappings OR-ed,
+// subject sets AND-ed) but evaluates conditions with precompiled CEL programs.
+func evalCELMultipleEntities(compiled []compiledMapping, ers *entityresolution.ResolveEntitiesResponse) (map[string][]string, error) {
+	results := make(map[string][]string)
+	for _, er := range ers.GetEntityRepresentations() {
+		set := make(map[string]bool)
+		for _, entity := range er.GetAdditionalProps() {
+			flat, err := flattening.Flatten(entity.AsMap())
+			if err != nil {
+				return nil, err
+			}
+			for _, cm := range compiled {
+				matched := false
+				for _, programs := range cm.subjectMappings {
+					smResult := true
+					for _, prog := range programs {
+						r, err := prog.Eval(flat)
+						if err != nil {
+							return nil, err
+						}
+						smResult = smResult && r
+						if !smResult {
+							break
+						}
+					}
+					matched = matched || smResult
+					if matched {
+						break
+					}
+				}
+				if matched {
+					set[cm.attr] = true
+				}
+			}
+		}
+		entitlements := make([]string, 0, len(set))
+		for k := range set {
+			entitlements = append(entitlements, k)
+		}
+		results[er.GetOriginalId()] = entitlements
+	}
+	return results, nil
+}
+
+func TestCELFullPathBenchmark(t *testing.T) {
+	out := os.Getenv("CEL_BENCH_FP_OUT")
+	if out == "" {
+		out = "fullpath_results.csv"
+	}
+	maxN := 5000
+	if v := os.Getenv("CEL_BENCH_MAX_N"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		require.NoError(t, err)
+		maxN = parsed
+	}
+
+	allSizes := []int{100, 1000, 5000}
+	sizes := make([]int, 0, len(allSizes))
+	for _, n := range allSizes {
+		if n <= maxN {
+			sizes = append(sizes, n)
+		}
+	}
+
+	// Prepare the OPA query once (mirrors authorization.go loadRegoAndBuiltins).
+	subjectmappingbuiltin.SubjectMappingBuiltin()
+	regoModule, err := policies.EntitlementsRego.ReadFile("entitlements/entitlements.rego")
+	require.NoError(t, err)
+	prepared, err := rego.New(
+		rego.Query("data.opentdf.entitlements.attributes"),
+		rego.Module("entitlements.rego", string(regoModule)),
+		rego.SetRegoVersion(ast.RegoV0),
+		rego.StrictBuiltinErrors(true),
+	).PrepareForEval(context.Background())
+	require.NoError(t, err)
+
+	f, err := os.Create(out)
+	require.NoError(t, err)
+	defer f.Close()
+	w := csv.NewWriter(f)
+	defer w.Flush()
+	require.NoError(t, w.Write([]string{"layer", "arm", "mappings", "ns_op", "allocs_op", "bytes_op"}))
+
+	ctx := context.Background()
+	for _, n := range sizes {
+		sms, ers := buildFullPathFixture(t, n)
+		compiled := compileMappings(t, sms)
+
+		// Sanity: all three arms agree on the entitlement set before timing.
+		goRes, err := subjectmappingbuiltin.EvaluateSubjectMappingMultipleEntities(sms, ers.GetEntityRepresentations())
+		require.NoError(t, err)
+		celRes, err := evalCELMultipleEntities(compiled, ers)
+		require.NoError(t, err)
+		requireSameEntitlements(t, goRes, celRes)
+
+		regoB := testing.Benchmark(func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				in, _ := entitlements.OpaInput(sms, ers)
+				_, _ = prepared.Eval(ctx, rego.EvalInput(in))
+			}
+		})
+		goB := testing.Benchmark(func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = subjectmappingbuiltin.EvaluateSubjectMappingMultipleEntities(sms, ers.GetEntityRepresentations())
+			}
+		})
+		celB := testing.Benchmark(func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = evalCELMultipleEntities(compiled, ers)
+			}
+		})
+
+		writeFPRow(t, w, "rego", n, regoB)
+		writeFPRow(t, w, "go_switch", n, goB)
+		writeFPRow(t, w, "go_cel", n, celB)
+
+		t.Logf("mappings=%5d  rego=%10.1f µs  go_switch=%8.1f µs  go_cel=%8.1f µs  (rego/go_switch=%.1fx)",
+			n,
+			float64(regoB.NsPerOp())/1000, float64(goB.NsPerOp())/1000, float64(celB.NsPerOp())/1000,
+			float64(regoB.NsPerOp())/float64(goB.NsPerOp()))
+	}
+}
+
+func writeFPRow(t *testing.T, w *csv.Writer, arm string, n int, r testing.BenchmarkResult) {
+	t.Helper()
+	require.NoError(t, w.Write([]string{
+		"fullpath", arm, strconv.Itoa(n),
+		strconv.FormatInt(r.NsPerOp(), 10),
+		strconv.FormatInt(r.AllocsPerOp(), 10),
+		strconv.FormatInt(r.AllocedBytesPerOp(), 10),
+	}))
+}
+
+func requireSameEntitlements(t *testing.T, a, b map[string][]string) {
+	t.Helper()
+	require.Len(t, b, len(a))
+	for k, av := range a {
+		bv, ok := b[k]
+		require.True(t, ok)
+		sort.Strings(av)
+		sort.Strings(bv)
+		require.Equal(t, av, bv)
+	}
+}

--- a/service/go.mod
+++ b/service/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang/mock v1.6.0 // indirect
-	github.com/google/cel-go v0.26.1 // indirect
+	github.com/google/cel-go v0.26.1
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gowebpki/jcs v1.0.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect

--- a/service/internal/subjectmappingbuiltin/cel_operator_bench_test.go
+++ b/service/internal/subjectmappingbuiltin/cel_operator_bench_test.go
@@ -1,0 +1,152 @@
+//go:build celbench
+
+// Layer 1 of the DSPX-3673 performance deliverable: operator-engine micro-benchmark. Compares the
+// per-evaluation cost of the native operator switch (EvaluateSubjectSet) against a precompiled CEL
+// program (celeval), and reports the one-time CEL compile cost separately.
+//
+// Build-tagged (celbench) so it never runs in the default suite, mirroring the entpdpbench /
+// entbench gating in the existing perf deliverables. Driven by
+// docs/performance/DSPX-3673-cel-condition-evaluation/run.sh, which sets CEL_BENCH_OP_OUT.
+//
+//	go test -tags celbench -run TestCELOperatorBenchmark ./internal/subjectmappingbuiltin/
+package subjectmappingbuiltin_test
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/opentdf/platform/lib/flattening"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/service/internal/subjectmappingbuiltin"
+	"github.com/opentdf/platform/service/internal/subjectmappingbuiltin/celeval"
+	"github.com/stretchr/testify/require"
+)
+
+type opSize struct {
+	name   string
+	groups int
+	conds  int
+}
+
+// buildOperatorFixture builds a SubjectSet of groups x conds conditions (mixed legacy operators,
+// AND within each group, groups AND-ed) and an entity crafted so every condition evaluates true,
+// forcing full traversal rather than short-circuit.
+func buildOperatorFixture(groups, conds int) (*policy.SubjectSet, flattening.Flattened) {
+	attrs := map[string]interface{}{}
+	cgs := make([]*policy.ConditionGroup, 0, groups)
+
+	for g := 0; g < groups; g++ {
+		conditions := make([]*policy.Condition, 0, conds)
+		for j := 0; j < conds; j++ {
+			key := fmt.Sprintf("a%d_%d", g, j)
+			selector := "." + key + "[]"
+			var op policy.SubjectMappingOperatorEnum
+			var targets []string
+			var entityVal string
+			switch j % 3 {
+			case 0:
+				op = policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN
+				targets = []string{"match"}
+				entityVal = "match" // present -> IN true
+			case 1:
+				op = policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
+				targets = []string{"absent"}
+				entityVal = "present" // target absent -> NOT_IN true
+			default:
+				op = policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
+				targets = []string{"sub"}
+				entityVal = "xxsubxx" // contains -> IN_CONTAINS true
+			}
+			attrs[key] = []any{entityVal}
+			conditions = append(conditions, &policy.Condition{
+				SubjectExternalSelectorValue: selector,
+				Operator:                     op,
+				SubjectExternalValues:        targets,
+			})
+		}
+		cgs = append(cgs, &policy.ConditionGroup{
+			BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+			Conditions:      conditions,
+		})
+	}
+
+	flat, err := flattening.Flatten(attrs)
+	if err != nil {
+		panic(err)
+	}
+	return &policy.SubjectSet{ConditionGroups: cgs}, flat
+}
+
+func TestCELOperatorBenchmark(t *testing.T) {
+	out := os.Getenv("CEL_BENCH_OP_OUT")
+	if out == "" {
+		out = "operator_results.csv"
+	}
+
+	sizes := []opSize{
+		{"small", 1, 1},
+		{"medium", 3, 3},
+		{"large", 10, 5},
+	}
+
+	f, err := os.Create(out)
+	require.NoError(t, err)
+	defer f.Close()
+	w := csv.NewWriter(f)
+	defer w.Flush()
+	require.NoError(t, w.Write([]string{"layer", "arm", "groups", "conds", "ns_op", "allocs_op", "bytes_op"}))
+
+	for _, s := range sizes {
+		ss, flat := buildOperatorFixture(s.groups, s.conds)
+
+		// Sanity: native and CEL agree before timing.
+		prog, err := celeval.CompileSubjectSet(ss)
+		require.NoError(t, err)
+		nativeRes, err := subjectmappingbuiltin.EvaluateSubjectSet(ss, flat)
+		require.NoError(t, err)
+		celRes, err := prog.Eval(flat)
+		require.NoError(t, err)
+		require.Equal(t, nativeRes, celRes, "size=%s native and cel disagree", s.name)
+
+		native := testing.Benchmark(func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = subjectmappingbuiltin.EvaluateSubjectSet(ss, flat)
+			}
+		})
+		cel := testing.Benchmark(func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = prog.Eval(flat)
+			}
+		})
+		compile := testing.Benchmark(func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = celeval.CompileSubjectSet(ss)
+			}
+		})
+
+		writeOpRow(t, w, "native", s, native)
+		writeOpRow(t, w, "cel", s, cel)
+		writeOpRow(t, w, "cel_compile", s, compile)
+
+		t.Logf("%-7s groups=%2d conds=%2d  native=%8.1f ns/op  cel=%8.1f ns/op  compile=%10.1f ns/op  (cel/native=%.2fx)",
+			s.name, s.groups, s.conds,
+			fns(native.NsPerOp()), fns(cel.NsPerOp()), fns(compile.NsPerOp()),
+			float64(cel.NsPerOp())/float64(native.NsPerOp()))
+	}
+}
+
+func writeOpRow(t *testing.T, w *csv.Writer, arm string, s opSize, r testing.BenchmarkResult) {
+	t.Helper()
+	require.NoError(t, w.Write([]string{
+		"operator", arm,
+		strconv.Itoa(s.groups), strconv.Itoa(s.conds),
+		strconv.FormatInt(r.NsPerOp(), 10),
+		strconv.FormatInt(r.AllocsPerOp(), 10),
+		strconv.FormatInt(r.AllocedBytesPerOp(), 10),
+	}))
+}
+
+func fns(v int64) float64 { return float64(v) }

--- a/service/internal/subjectmappingbuiltin/cel_poc_test.go
+++ b/service/internal/subjectmappingbuiltin/cel_poc_test.go
@@ -1,0 +1,183 @@
+package subjectmappingbuiltin_test
+
+// Spike POC for DSPX-3673: evaluate whether CEL (https://cel.dev, cel-go) can express the
+// Subject Mapping / Subject Condition Set operators currently implemented as a hand-written
+// switch in subject_mapping_builtin.go (EvaluateCondition), plus the decomposed operators
+// proposed in https://github.com/opentdf/platform/issues/3335.
+//
+// The tests below build a CEL environment, extract entity values with the existing
+// flattening helper, and assert that a CEL expression produces the SAME result as the native
+// EvaluateCondition for the legacy operators (IN, NOT_IN, IN_CONTAINS), and the expected
+// result for the decomposed cases (ALL quantifier, case-insensitive match).
+//
+// Findings and the recommendation are written up in
+// service/policy/adr/0005-dspx-3673-cel-condition-evaluation-spike.md. This file is a spike
+// artifact: it is test-only and touches no production evaluation path.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
+	"github.com/opentdf/platform/lib/flattening"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/service/internal/subjectmappingbuiltin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const celPOCSelector = ".attributes.testing[]"
+
+// celPOCEntities are the entity representations the conditions are evaluated against. Names are
+// prefixed celPOC to avoid colliding with the shared vars in subject_mapping_builtin_test.go.
+var celPOCEntities = map[string]flattening.Flattened{
+	"has_option1_option3": celPOCFlatten(map[string]interface{}{
+		"attributes": map[string]interface{}{"testing": []any{"option1", "option3"}},
+	}),
+	"has_option4_option3": celPOCFlatten(map[string]interface{}{
+		"attributes": map[string]interface{}{"testing": []any{"option4", "option3"}},
+	}),
+	"has_option1_option2": celPOCFlatten(map[string]interface{}{
+		"attributes": map[string]interface{}{"testing": []any{"option1", "option2"}},
+	}),
+	"has_email_domain": celPOCFlatten(map[string]interface{}{
+		"attributes": map[string]interface{}{"testing": []any{"user@acme.com"}},
+	}),
+}
+
+func celPOCFlatten(m map[string]interface{}) flattening.Flattened {
+	f, err := flattening.Flatten(m)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+// celPOCSelectStrings mirrors how EvaluateCondition reads entity values: it pulls everything at
+// the selector and stringifies it (the native IN_CONTAINS path does the same with fmt.Sprintf).
+func celPOCSelectStrings(flat flattening.Flattened) []string {
+	raw := flattening.GetFromFlattened(flat, celPOCSelector)
+	out := make([]string, len(raw))
+	for i, v := range raw {
+		out[i] = fmt.Sprintf("%v", v)
+	}
+	return out
+}
+
+// celPOCEnv builds the CEL environment used for every expression in this spike. The two inputs
+// model exactly what EvaluateCondition works with: `values` are the entity values resolved by
+// the selector, `targets` are condition.SubjectExternalValues. ext.Strings provides
+// lowerAscii() for the case-insensitive case.
+func celPOCEnv(t *testing.T) *cel.Env {
+	t.Helper()
+	env, err := cel.NewEnv(
+		cel.Variable("values", cel.ListType(cel.StringType)),
+		cel.Variable("targets", cel.ListType(cel.StringType)),
+		ext.Strings(),
+	)
+	require.NoError(t, err)
+	return env
+}
+
+func celPOCEval(t *testing.T, env *cel.Env, expr string, values, targets []string) bool {
+	t.Helper()
+	astChecked, iss := env.Compile(expr)
+	require.NoError(t, iss.Err(), "compile %q", expr)
+	prg, err := env.Program(astChecked)
+	require.NoError(t, err)
+	out, _, err := prg.Eval(map[string]any{"values": values, "targets": targets})
+	require.NoError(t, err)
+	result, ok := out.Value().(bool)
+	require.True(t, ok, "expression %q did not return a bool", expr)
+	return result
+}
+
+// celExprForLegacyOperator maps each legacy SubjectMappingOperatorEnum to a CEL expression over
+// (values, targets). This is the core of the spike: it shows the bespoke operators are
+// expressible in CEL without custom built-ins.
+//
+//nolint:exhaustive // UNSPECIFIED has no operator semantics to express in CEL
+var celExprForLegacyOperator = map[policy.SubjectMappingOperatorEnum]string{
+	policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN:          `targets.exists(t, t in values)`,
+	policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN:      `!targets.exists(t, t in values)`,
+	policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS: `targets.exists(t, values.exists(v, v.contains(t)))`,
+}
+
+// TestCEL_LegacyOperatorEquivalence asserts that, for every legacy operator across a matrix of
+// target sets and entities, the CEL expression result equals the native EvaluateCondition
+// result. This is acceptance criterion #1.
+func TestCEL_LegacyOperatorEquivalence(t *testing.T) {
+	env := celPOCEnv(t)
+
+	targetSets := [][]string{
+		{"option1", "option2"},
+		{"option3"},
+		{"option9"},
+		{"acme.com"},
+	}
+
+	for op, expr := range celExprForLegacyOperator {
+		for _, targets := range targetSets {
+			for entityName, flat := range celPOCEntities {
+				condition := &policy.Condition{
+					SubjectExternalSelectorValue: celPOCSelector,
+					Operator:                     op,
+					SubjectExternalValues:        targets,
+				}
+
+				native, err := subjectmappingbuiltin.EvaluateCondition(condition, flat)
+				require.NoError(t, err)
+
+				values := celPOCSelectStrings(flat)
+				celResult := celPOCEval(t, env, expr, values, targets)
+
+				assert.Equalf(t, native, celResult,
+					"operator=%s expr=%q entity=%s targets=%v", op, expr, entityName, targets)
+			}
+		}
+	}
+}
+
+// TestCEL_DecomposedOperators covers operators from issue #3335 that the legacy enum cannot
+// express: the ALL quantifier and a case-insensitive comparison. EvaluateCondition has no
+// native equivalent, so results are checked against expected values.
+func TestCEL_DecomposedOperators(t *testing.T) {
+	env := celPOCEnv(t)
+
+	t.Run("ALL quantifier with EQUALS", func(t *testing.T) {
+		// "every target value is present in the entity values"
+		const expr = `targets.all(t, t in values)`
+		values := celPOCSelectStrings(celPOCEntities["has_option1_option2"])
+
+		assert.True(t, celPOCEval(t, env, expr, values, []string{"option1", "option2"}))
+		assert.False(t, celPOCEval(t, env, expr, values, []string{"option1", "option9"}))
+	})
+
+	t.Run("case-insensitive EQUALS via ANY", func(t *testing.T) {
+		const expr = `targets.exists(t, values.exists(v, v.lowerAscii() == t.lowerAscii()))`
+		values := celPOCSelectStrings(celPOCEntities["has_option1_option3"])
+
+		assert.True(t, celPOCEval(t, env, expr, values, []string{"OPTION1"}))
+		assert.False(t, celPOCEval(t, env, expr, values, []string{"OPTION9"}))
+	})
+
+	t.Run("ENDS_WITH for safe domain matching", func(t *testing.T) {
+		// #3335 motivation: IN_CONTAINS unsafely matches user@acme.com.attacker.ru;
+		// ENDS_WITH is the correct operator. CEL expresses it directly.
+		const expr = `targets.exists(t, values.exists(v, v.endsWith(t)))`
+		values := celPOCSelectStrings(celPOCEntities["has_email_domain"])
+
+		assert.True(t, celPOCEval(t, env, expr, values, []string{"@acme.com"}))
+		assert.False(t, celPOCEval(t, env, expr, values, []string{"@evil.com"}))
+	})
+}
+
+// TestCEL_CompileErrorsAreCaught documents a key safety property for the ADR: invalid
+// expressions fail at compile time, before any evaluation, so a malformed policy cannot reach
+// the hot path.
+func TestCEL_CompileErrorsAreCaught(t *testing.T) {
+	env := celPOCEnv(t)
+	_, iss := env.Compile(`targets.exists(t, t in nonexistent)`)
+	require.Error(t, iss.Err())
+}

--- a/service/internal/subjectmappingbuiltin/cel_poc_test.go
+++ b/service/internal/subjectmappingbuiltin/cel_poc_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/opentdf/platform/lib/flattening"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/service/internal/subjectmappingbuiltin"
+	"github.com/opentdf/platform/service/internal/subjectmappingbuiltin/celeval"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -93,23 +94,16 @@ func celPOCEval(t *testing.T, env *cel.Env, expr string, values, targets []strin
 	return result
 }
 
-// celExprForLegacyOperator maps each legacy SubjectMappingOperatorEnum to a CEL expression over
-// (values, targets). This is the core of the spike: it shows the bespoke operators are
-// expressible in CEL without custom built-ins.
-//
-//nolint:exhaustive // UNSPECIFIED has no operator semantics to express in CEL
-var celExprForLegacyOperator = map[policy.SubjectMappingOperatorEnum]string{
-	policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN:          `targets.exists(t, t in values)`,
-	policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN:      `!targets.exists(t, t in values)`,
-	policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS: `targets.exists(t, values.exists(v, v.contains(t)))`,
-}
-
 // TestCEL_LegacyOperatorEquivalence asserts that, for every legacy operator across a matrix of
-// target sets and entities, the CEL expression result equals the native EvaluateCondition
-// result. This is acceptance criterion #1.
+// target sets and entities, a condition lowered to CEL by celeval evaluates to the same result as
+// the native EvaluateCondition. This is acceptance criterion #1; celeval is the real lowering used
+// by the benchmarks, so this exercises production-shaped code rather than hand-written expressions.
 func TestCEL_LegacyOperatorEquivalence(t *testing.T) {
-	env := celPOCEnv(t)
-
+	operators := []policy.SubjectMappingOperatorEnum{
+		policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+		policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN,
+		policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS,
+	}
 	targetSets := [][]string{
 		{"option1", "option2"},
 		{"option3"},
@@ -117,23 +111,30 @@ func TestCEL_LegacyOperatorEquivalence(t *testing.T) {
 		{"acme.com"},
 	}
 
-	for op, expr := range celExprForLegacyOperator {
+	for _, op := range operators {
 		for _, targets := range targetSets {
-			for entityName, flat := range celPOCEntities {
-				condition := &policy.Condition{
-					SubjectExternalSelectorValue: celPOCSelector,
-					Operator:                     op,
-					SubjectExternalValues:        targets,
-				}
+			condition := &policy.Condition{
+				SubjectExternalSelectorValue: celPOCSelector,
+				Operator:                     op,
+				SubjectExternalValues:        targets,
+			}
+			// Wrap in a single-condition AND group so EvaluateSubjectSet(ss) == EvaluateCondition(c).
+			ss := &policy.SubjectSet{ConditionGroups: []*policy.ConditionGroup{{
+				BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+				Conditions:      []*policy.Condition{condition},
+			}}}
+			prog, err := celeval.CompileSubjectSet(ss)
+			require.NoError(t, err)
 
+			for entityName, flat := range celPOCEntities {
 				native, err := subjectmappingbuiltin.EvaluateCondition(condition, flat)
 				require.NoError(t, err)
 
-				values := celPOCSelectStrings(flat)
-				celResult := celPOCEval(t, env, expr, values, targets)
+				celResult, err := prog.Eval(flat)
+				require.NoError(t, err)
 
 				assert.Equalf(t, native, celResult,
-					"operator=%s expr=%q entity=%s targets=%v", op, expr, entityName, targets)
+					"operator=%s entity=%s targets=%v src=%q", op, entityName, targets, prog.Source())
 			}
 		}
 	}

--- a/service/internal/subjectmappingbuiltin/celeval/celeval.go
+++ b/service/internal/subjectmappingbuiltin/celeval/celeval.go
@@ -1,0 +1,263 @@
+// Package celeval is an EXPERIMENTAL, spike-only reference implementation for DSPX-3673. It lowers
+// the policy Subject Condition Set model (SubjectSet -> ConditionGroup -> Condition) to a single
+// CEL (https://cel.dev) expression and evaluates it against a flattened entity.
+//
+// It exists to benchmark CEL against the hand-written operator switch in
+// subject_mapping_builtin.go (EvaluateCondition / EvaluateConditionGroup / EvaluateSubjectSet) and
+// is the reference for the migration sketch in
+// service/policy/adr/0005-dspx-3673-cel-condition-evaluation-spike.md.
+//
+// It is NOT wired into any request path. Do not use in production without the review the ADR calls
+// for.
+//
+// Lowering matches the native semantics exactly:
+//   - SubjectSet: condition groups AND-ed (empty -> true).
+//   - ConditionGroup AND: conditions AND-ed (empty -> true). OR: conditions OR-ed (empty -> false).
+//   - Condition: the legacy SubjectMappingOperatorEnum (IN / NOT_IN / IN_CONTAINS), or, when that is
+//     unspecified, the decomposed comparison + quantifier + case_insensitive axes from issue #3335.
+//
+// Selector values are bound per request as one list(string) variable per distinct selector;
+// condition target values are baked into the compiled program as CEL list literals, so a stored
+// condition compiles once and only the entity varies per evaluation.
+package celeval
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
+	"github.com/opentdf/platform/lib/flattening"
+	"github.com/opentdf/platform/protocol/go/policy"
+)
+
+// Program is a compiled SubjectSet ready to evaluate against flattened entities.
+type Program struct {
+	prog cel.Program
+	src  string
+	vars []varBinding
+}
+
+type varBinding struct {
+	name     string
+	selector string
+}
+
+// selectorAlloc assigns a stable CEL variable name to each distinct selector in first-appearance
+// order (v0, v1, ...). CEL identifiers cannot contain the dots/brackets selectors use.
+type selectorAlloc struct {
+	byName []varBinding
+	bySel  map[string]string
+}
+
+func newSelectorAlloc() *selectorAlloc {
+	return &selectorAlloc{bySel: map[string]string{}}
+}
+
+func (s *selectorAlloc) varFor(selector string) string {
+	if name, ok := s.bySel[selector]; ok {
+		return name
+	}
+	name := fmt.Sprintf("v%d", len(s.byName))
+	s.bySel[selector] = name
+	s.byName = append(s.byName, varBinding{name: name, selector: selector})
+	return name
+}
+
+// Source returns the lowered CEL expression (useful for debugging and the ADR).
+func (p *Program) Source() string { return p.src }
+
+// CompileSubjectSet lowers ss to CEL and compiles it.
+func CompileSubjectSet(ss *policy.SubjectSet) (*Program, error) {
+	alloc := newSelectorAlloc()
+	src, err := subjectSetToCEL(ss, alloc)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := make([]cel.EnvOption, 0, len(alloc.byName)+1)
+	opts = append(opts, ext.Strings())
+	for _, vb := range alloc.byName {
+		opts = append(opts, cel.Variable(vb.name, cel.ListType(cel.StringType)))
+	}
+	env, err := cel.NewEnv(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("cel env: %w", err)
+	}
+	ast, iss := env.Compile(src)
+	if iss != nil && iss.Err() != nil {
+		return nil, fmt.Errorf("cel compile %q: %w", src, iss.Err())
+	}
+	prog, err := env.Program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("cel program: %w", err)
+	}
+	return &Program{prog: prog, src: src, vars: alloc.byName}, nil
+}
+
+// Eval binds the entity's selector values and evaluates the compiled program. The activation build
+// mirrors what the native EvaluateCondition does per condition: pull values at the selector and
+// stringify them.
+func (p *Program) Eval(flat flattening.Flattened) (bool, error) {
+	act := make(map[string]any, len(p.vars))
+	for _, vb := range p.vars {
+		raw := flattening.GetFromFlattened(flat, vb.selector)
+		vals := make([]string, len(raw))
+		for i, v := range raw {
+			vals[i] = fmt.Sprintf("%v", v)
+		}
+		act[vb.name] = vals
+	}
+	out, _, err := p.prog.Eval(act)
+	if err != nil {
+		return false, fmt.Errorf("cel eval: %w", err)
+	}
+	result, ok := out.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("cel expression did not return bool: %T", out.Value())
+	}
+	return result, nil
+}
+
+func subjectSetToCEL(ss *policy.SubjectSet, alloc *selectorAlloc) (string, error) {
+	groups := ss.GetConditionGroups()
+	if len(groups) == 0 {
+		return "true", nil
+	}
+	parts := make([]string, 0, len(groups))
+	for _, g := range groups {
+		part, err := conditionGroupToCEL(g, alloc)
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, part)
+	}
+	return joinBool(parts, "&&", "true"), nil
+}
+
+func conditionGroupToCEL(cg *policy.ConditionGroup, alloc *selectorAlloc) (string, error) {
+	var op, empty string
+	switch cg.GetBooleanOperator() {
+	case policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND:
+		op, empty = "&&", "true"
+	case policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_OR:
+		op, empty = "||", "false"
+	case policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_UNSPECIFIED:
+		return "", errors.New("unspecified condition group boolean operator")
+	default:
+		return "", errors.New("unsupported condition group boolean operator: " + cg.GetBooleanOperator().String())
+	}
+
+	conditions := cg.GetConditions()
+	parts := make([]string, 0, len(conditions))
+	for _, c := range conditions {
+		part, err := conditionToCEL(c, alloc)
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, part)
+	}
+	return joinBool(parts, op, empty), nil
+}
+
+func conditionToCEL(c *policy.Condition, alloc *selectorAlloc) (string, error) {
+	valuesVar := alloc.varFor(c.GetSubjectExternalSelectorValue())
+	targets := celListLiteral(c.GetSubjectExternalValues())
+
+	// Legacy operator takes precedence when set; otherwise use the decomposed axes (#3335).
+	//nolint:staticcheck // intentionally reads the deprecated legacy operator to match the native evaluator
+	if op := c.GetOperator(); op != policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_UNSPECIFIED {
+		//nolint:exhaustive // UNSPECIFIED is excluded by the guard above
+		switch op {
+		case policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN:
+			return existsAny(targets, valuesVar, eqPred(false)), nil
+		case policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN:
+			return "!" + existsAny(targets, valuesVar, eqPred(false)), nil
+		case policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS:
+			return existsAny(targets, valuesVar, containsPred(false)), nil
+		default:
+			return "", errors.New("unsupported subject mapping operator: " + op.String())
+		}
+	}
+
+	return decomposedToCEL(c, targets, valuesVar)
+}
+
+func decomposedToCEL(c *policy.Condition, targets, valuesVar string) (string, error) {
+	ci := c.GetCaseInsensitive().GetValue()
+
+	var pred string
+	switch c.GetComparison() {
+	case policy.ConditionComparisonOperatorEnum_CONDITION_COMPARISON_OPERATOR_ENUM_EQUALS:
+		pred = eqPred(ci)
+	case policy.ConditionComparisonOperatorEnum_CONDITION_COMPARISON_OPERATOR_ENUM_CONTAINS:
+		pred = containsPred(ci)
+	case policy.ConditionComparisonOperatorEnum_CONDITION_COMPARISON_OPERATOR_ENUM_STARTS_WITH:
+		pred = strFnPred("startsWith", ci)
+	case policy.ConditionComparisonOperatorEnum_CONDITION_COMPARISON_OPERATOR_ENUM_ENDS_WITH:
+		pred = strFnPred("endsWith", ci)
+	case policy.ConditionComparisonOperatorEnum_CONDITION_COMPARISON_OPERATOR_ENUM_UNSPECIFIED:
+		return "", errors.New("unspecified condition comparison operator")
+	default:
+		return "", errors.New("unsupported condition comparison operator: " + c.GetComparison().String())
+	}
+
+	switch c.GetQuantifier() {
+	case policy.ConditionQuantifierEnum_CONDITION_QUANTIFIER_ENUM_ANY:
+		return existsAny(targets, valuesVar, pred), nil
+	case policy.ConditionQuantifierEnum_CONDITION_QUANTIFIER_ENUM_ALL:
+		return fmt.Sprintf("%s.all(t, %s.exists(v, %s))", targets, valuesVar, pred), nil
+	case policy.ConditionQuantifierEnum_CONDITION_QUANTIFIER_ENUM_NONE:
+		return "!" + existsAny(targets, valuesVar, pred), nil
+	case policy.ConditionQuantifierEnum_CONDITION_QUANTIFIER_ENUM_UNSPECIFIED:
+		return "", errors.New("unspecified condition quantifier")
+	default:
+		return "", errors.New("unsupported condition quantifier: " + c.GetQuantifier().String())
+	}
+}
+
+// existsAny renders ANY-quantified matching: some target matches some entity value under pred.
+func existsAny(targets, valuesVar, pred string) string {
+	return fmt.Sprintf("%s.exists(t, %s.exists(v, %s))", targets, valuesVar, pred)
+}
+
+// eqPred compares entity value v to target t for equality, optionally case-insensitively.
+func eqPred(caseInsensitive bool) string {
+	if caseInsensitive {
+		return "v.lowerAscii() == t.lowerAscii()"
+	}
+	return "v == t"
+}
+
+func containsPred(caseInsensitive bool) string {
+	return strFnPred("contains", caseInsensitive)
+}
+
+// strFnPred renders a CEL string-method predicate, e.g. v.contains(t), optionally lowercasing both
+// sides for case-insensitive matching.
+func strFnPred(fn string, caseInsensitive bool) string {
+	if caseInsensitive {
+		return fmt.Sprintf("v.lowerAscii().%s(t.lowerAscii())", fn)
+	}
+	return fmt.Sprintf("v.%s(t)", fn)
+}
+
+func joinBool(parts []string, op, empty string) string {
+	if len(parts) == 0 {
+		return empty
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return "(" + strings.Join(parts, " "+op+" ") + ")"
+}
+
+func celListLiteral(values []string) string {
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = strconv.Quote(v)
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}

--- a/service/internal/subjectmappingbuiltin/celeval/celeval_test.go
+++ b/service/internal/subjectmappingbuiltin/celeval/celeval_test.go
@@ -1,0 +1,146 @@
+package celeval_test
+
+import (
+	"testing"
+
+	"github.com/opentdf/platform/lib/flattening"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/service/internal/subjectmappingbuiltin"
+	"github.com/opentdf/platform/service/internal/subjectmappingbuiltin/celeval"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+const selector = ".attributes.testing[]"
+
+func flatten(t *testing.T, values ...string) flattening.Flattened {
+	t.Helper()
+	vals := make([]any, len(values))
+	for i, v := range values {
+		vals[i] = v
+	}
+	flat, err := flattening.Flatten(map[string]interface{}{
+		"attributes": map[string]interface{}{"testing": vals},
+	})
+	require.NoError(t, err)
+	return flat
+}
+
+func legacyCondition(op policy.SubjectMappingOperatorEnum, targets ...string) *policy.Condition {
+	return &policy.Condition{
+		SubjectExternalSelectorValue: selector,
+		Operator:                     op,
+		SubjectExternalValues:        targets,
+	}
+}
+
+func group(boolOp policy.ConditionBooleanTypeEnum, conditions ...*policy.Condition) *policy.ConditionGroup {
+	return &policy.ConditionGroup{BooleanOperator: boolOp, Conditions: conditions}
+}
+
+func subjectSet(groups ...*policy.ConditionGroup) *policy.SubjectSet {
+	return &policy.SubjectSet{ConditionGroups: groups}
+}
+
+// TestEquivalenceWithNative proves the CEL lowering produces the same result as the native
+// EvaluateSubjectSet across legacy operators, both boolean group operators, and multiple groups.
+// This is the correctness backbone for the go_cel benchmark arm.
+func TestEquivalenceWithNative(t *testing.T) {
+	const (
+		in       = policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN
+		notIn    = policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN
+		contains = policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS
+		andOp    = policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND
+		orOp     = policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_OR
+	)
+
+	entities := map[string]flattening.Flattened{
+		"opt1_opt3": flatten(t, "option1", "option3"),
+		"opt4_opt3": flatten(t, "option4", "option3"),
+		"email":     flatten(t, "user@acme.com"),
+		"empty":     flatten(t),
+	}
+
+	subjectSets := map[string]*policy.SubjectSet{
+		"single IN":          subjectSet(group(andOp, legacyCondition(in, "option1", "option2"))),
+		"single NOT_IN":      subjectSet(group(andOp, legacyCondition(notIn, "option1"))),
+		"single IN_CONTAINS": subjectSet(group(andOp, legacyCondition(contains, "acme.com"))),
+		"AND group": subjectSet(group(andOp,
+			legacyCondition(in, "option1"),
+			legacyCondition(notIn, "option9"),
+		)),
+		"OR group": subjectSet(group(orOp,
+			legacyCondition(in, "option9"),
+			legacyCondition(in, "option3"),
+		)),
+		"multi group AND": subjectSet(
+			group(andOp, legacyCondition(in, "option1")),
+			group(orOp, legacyCondition(in, "option9"), legacyCondition(contains, "option")),
+		),
+	}
+
+	for ssName, ss := range subjectSets {
+		prog, err := celeval.CompileSubjectSet(ss)
+		require.NoError(t, err, "compile %s", ssName)
+
+		for entityName, flat := range entities {
+			native, err := subjectmappingbuiltin.EvaluateSubjectSet(ss, flat)
+			require.NoError(t, err)
+
+			celResult, err := prog.Eval(flat)
+			require.NoError(t, err)
+
+			assert.Equalf(t, native, celResult,
+				"subjectSet=%q entity=%q src=%q", ssName, entityName, prog.Source())
+		}
+	}
+}
+
+// TestDecomposedOperators covers the #3335 axes the legacy enum cannot express. The native
+// evaluator does not support them, so results are checked against expected values.
+func TestDecomposedOperators(t *testing.T) {
+	decomposed := func(cmp policy.ConditionComparisonOperatorEnum, q policy.ConditionQuantifierEnum, caseInsensitive bool, targets ...string) *policy.SubjectSet {
+		return subjectSet(group(policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+			&policy.Condition{
+				SubjectExternalSelectorValue: selector,
+				Comparison:                   cmp,
+				Quantifier:                   q,
+				CaseInsensitive:              wrapperspb.Bool(caseInsensitive),
+				SubjectExternalValues:        targets,
+			},
+		))
+	}
+
+	const (
+		equals   = policy.ConditionComparisonOperatorEnum_CONDITION_COMPARISON_OPERATOR_ENUM_EQUALS
+		endsWith = policy.ConditionComparisonOperatorEnum_CONDITION_COMPARISON_OPERATOR_ENUM_ENDS_WITH
+		anyQ     = policy.ConditionQuantifierEnum_CONDITION_QUANTIFIER_ENUM_ANY
+		allQ     = policy.ConditionQuantifierEnum_CONDITION_QUANTIFIER_ENUM_ALL
+		noneQ    = policy.ConditionQuantifierEnum_CONDITION_QUANTIFIER_ENUM_NONE
+	)
+
+	cases := []struct {
+		name   string
+		ss     *policy.SubjectSet
+		entity flattening.Flattened
+		want   bool
+	}{
+		{"ALL present", decomposed(equals, allQ, false, "option1", "option2"), flatten(t, "option1", "option2"), true},
+		{"ALL missing one", decomposed(equals, allQ, false, "option1", "option9"), flatten(t, "option1", "option2"), false},
+		{"NONE match", decomposed(equals, noneQ, false, "option9"), flatten(t, "option1"), true},
+		{"case-insensitive ANY", decomposed(equals, anyQ, true, "OPTION1"), flatten(t, "option1"), true},
+		{"ENDS_WITH safe domain", decomposed(endsWith, anyQ, false, "@acme.com"), flatten(t, "user@acme.com"), true},
+		{"ENDS_WITH rejects spoofed", decomposed(endsWith, anyQ, false, "@acme.com"), flatten(t, "user@acme.com.evil.ru"), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := celeval.CompileSubjectSet(tc.ss)
+			require.NoError(t, err)
+			got, err := prog.Eval(tc.entity)
+			require.NoError(t, err)
+			assert.Equalf(t, tc.want, got, "src=%q", prog.Source())
+		})
+	}
+}

--- a/service/policy/adr/0005-dspx-3673-cel-condition-evaluation-spike.md
+++ b/service/policy/adr/0005-dspx-3673-cel-condition-evaluation-spike.md
@@ -1,0 +1,133 @@
+# SPIKE: CEL as an alternative to bespoke condition operators
+
+Status: Spike findings, DSPX-3673. Recommendation below is for discussion, not yet adopted.
+
+Subject Mapping and Subject Condition Set evaluation matches entity values against policy using a
+hand-written operator set. Issue [#3335](https://github.com/opentdf/platform/issues/3335) proposes
+decomposing the operator enum into comparison + quantifier + case-insensitivity axes to add
+`STARTS_WITH` / `ENDS_WITH` and `ALL` / `NONE` without enum sprawl. The DynamicValueMapping
+subsystem (commit `090c0f6`) reuses `ConditionComparisonOperatorEnum` for the same matching
+problem. This spike asks whether [CEL](https://cel.dev) (Common Expression Language) is a better
+long-term fit than continuing to grow bespoke operators and their parallel evaluation code.
+
+## Chosen Option: Hybrid
+
+Keep the proto condition model as the stored, authored form. Add CEL as an internal evaluation
+strategy: compile each stored condition to a CEL program once, cache it, and evaluate that program
+on the hot path. Do not expose raw CEL to policy authors initially.
+
+This captures CEL's benefits (one evaluation engine, new operators become expression changes
+rather than enum + switch changes) without a proto break, without retraining authors on CEL
+syntax, and without committing other-language SDKs to a CEL runtime before that cost is measured.
+
+## What the Spike Built
+
+`service/internal/subjectmappingbuiltin/cel_poc_test.go` builds a cel-go environment and, for a
+matrix of operators, target sets, and entities, asserts the CEL result equals the native
+`EvaluateCondition` result (`service/internal/subjectmappingbuiltin/subject_mapping_builtin.go`).
+`cel-go v0.26.1` is already in `service/go.mod` (it backs proto/buf validation); the spike promotes
+it from indirect to direct.
+
+Verified results:
+
+- Every legacy operator (`IN`, `NOT_IN`, `IN_CONTAINS`) matches the native switch across all tested
+  entities and target sets.
+- The decomposed cases from #3335 that the legacy enum cannot express are evaluable in CEL: the
+  `ALL` quantifier, case-insensitive comparison (`lowerAscii()` from the cel-go strings
+  extension), and `ENDS_WITH` for safe email-domain matching.
+- Invalid expressions fail at `env.Compile`, before evaluation.
+
+Entity value extraction still uses the existing `flattening` helpers
+(`lib/flattening/flatten.go`); CEL replaces only the operator switch, not selector resolution.
+
+## Operator Mapping
+
+`values` are the entity values resolved by the selector; `targets` are
+`condition.subject_external_values`.
+
+| Current / proposed operator | CEL expression |
+| --- | --- |
+| `IN` (ANY + EQUALS) | `targets.exists(t, t in values)` |
+| `NOT_IN` (NONE) | `!targets.exists(t, t in values)` |
+| `IN_CONTAINS` (ANY + CONTAINS) | `targets.exists(t, values.exists(v, v.contains(t)))` |
+| `ALL` + EQUALS (#3335) | `targets.all(t, t in values)` |
+| `STARTS_WITH` (#3335) | `targets.exists(t, values.exists(v, v.startsWith(t)))` |
+| `ENDS_WITH` (#3335) | `targets.exists(t, values.exists(v, v.endsWith(t)))` |
+| case-insensitive EQUALS | `targets.exists(t, values.exists(v, v.lowerAscii() == t.lowerAscii()))` |
+
+The comparison axis maps to CEL string functions, the quantifier axis maps to `exists` / `all` /
+negation, and case-insensitivity maps to `lowerAscii()`. The 24 combinations #3335 lists as
+enum + flag combinations are compositions of these primitives.
+
+## Tradeoffs
+
+**Safety.** CEL is non-Turing-complete, has no unbounded loops, and reads only host-provided data.
+Expressions are type-checked at compile time, so a malformed condition is rejected before the hot
+path (verified in the POC). This matches the safety posture of the current closed operator set.
+
+**Performance.** Not benchmarked in this spike. cel-go separates compile from evaluation, so the
+intended pattern is compile-once / cache / evaluate-many. Per-evaluation cost is documented by the
+project as nanoseconds to microseconds, but a comparison against the native switch on representative
+condition sets is required before adopting CEL on the decision path. This is the main open item.
+
+**Auditability.** A CEL string is human-readable and reviewable. The decomposed proto model
+(comparison + quantifier + flag) is also auditable and is what authors would continue to edit under
+the hybrid option. Storing proto and deriving CEL keeps the audited artifact stable.
+
+**Portability.** CEL has Go, C++, and Java runtimes sharing one spec, which helps if evaluation
+moves across services. SDK clients in other languages would each need a CEL runtime only if raw
+CEL is exposed to them. The hybrid option avoids that by keeping CEL internal to the service.
+
+**Policy-Author UX.** Raw CEL is more expressive but is a new language for authors and for any
+admin UI. Keeping the structured proto model as the authoring surface avoids that cost; CEL stays
+an implementation detail.
+
+**Existing Rego Path.** `subject_mapping_builtin.go` already embeds OPA Rego
+(`open-policy-agent/opa/v1/rego`) as a registered builtin. Adopting CEL should be weighed against
+consolidating on Rego instead. CEL is lighter and already vendored for validation; Rego is heavier
+but already wired as a builtin. The spike did not benchmark the two; choosing between them is a
+prerequisite to any adoption and should be its own decision.
+
+## Migration and Backward Compatibility
+
+The condition stays in proto. Migration is internal:
+
+1. Add a function that lowers a stored `Condition` to a CEL source string: the deprecated
+   `operator` field and the decomposed `comparison` / `quantifier` / `case_insensitive` fields map
+   to the expressions in the table above. Existing stored conditions need no rewrite.
+2. Compile and cache the CEL program per condition (cache key on the lowered source). Evaluate the
+   cached program in place of the operator switch.
+3. Run CEL and the native switch side by side in tests (the POC is the seed) until parity is
+   established, then make CEL the evaluation path.
+
+No proto change, no stored-data migration, and the deprecated `operator` field keeps working
+because it is one input to the lowering step.
+
+## Options Considered
+
+### Keep Adding Bespoke Operators
+Continue the #3335 direction: decomposed enums plus a hand-written switch per axis. Lowest
+immediate change. Each new matching need still means proto plus Go plus a parallel implementation
+in DynamicValueMapping. Rejected as the long-term path because it does not stop the sprawl this
+spike was asked to address.
+
+### Expose Raw CEL to Authors
+Store CEL strings directly as the condition. Most expressive and fewest moving parts internally.
+Rejected for now: it is a proto and authoring-surface change, pushes a CEL runtime onto every SDK
+client that reads conditions, and removes the structured model admin tooling relies on. Worth
+revisiting if internal CEL adoption succeeds.
+
+### Hybrid (Chosen)
+Proto stays the authored and stored form; CEL is the internal evaluation strategy. Stops operator
+sprawl in the evaluator, no proto break, no author retraining, defers the multi-language runtime
+question. Open item: benchmark CEL against the native switch and against the existing Rego builtin
+before wiring it into the decision path.
+
+## References
+
+- Decompose operators: https://github.com/opentdf/platform/issues/3335
+- DynamicValueMapping protos: commit `090c0f65508058502d17a850691957b7beaee785`
+- CEL: https://cel.dev and https://github.com/google/cel-go
+- POC: `service/internal/subjectmappingbuiltin/cel_poc_test.go`
+- Native evaluation: `service/internal/subjectmappingbuiltin/subject_mapping_builtin.go`
+- Prior spike (format reference): DSPX-2754

--- a/service/policy/adr/0005-dspx-3673-cel-condition-evaluation-spike.md
+++ b/service/policy/adr/0005-dspx-3673-cel-condition-evaluation-spike.md
@@ -65,10 +65,14 @@ enum + flag combinations are compositions of these primitives.
 Expressions are type-checked at compile time, so a malformed condition is rejected before the hot
 path (verified in the POC). This matches the safety posture of the current closed operator set.
 
-**Performance.** Not benchmarked in this spike. cel-go separates compile from evaluation, so the
-intended pattern is compile-once / cache / evaluate-many. Per-evaluation cost is documented by the
-project as nanoseconds to microseconds, but a comparison against the native switch on representative
-condition sets is required before adopting CEL on the decision path. This is the main open item.
+**Performance.** Benchmarked; see `docs/performance/DSPX-3673-cel-condition-evaluation/`. CEL is
+slower than the native switch per evaluation (24× at one condition, narrowing to ~4× at 50), staying
+in the sub-microsecond to tens-of-microseconds range, and compile is three to four orders of
+magnitude more than a single eval (84 µs to 2.3 ms), so CEL is only viable compile-once / cache. In
+the full entitlements path, though, that gap is immaterial: the OPA wrapper costs ~100× a direct Go
+call (69 ms vs 0.66 ms at 5,000 mappings), and the CEL-based path (4.5 ms) is an order of magnitude
+under it. The operator engine is not the bottleneck in this path; the OPA layer is. CEL's per-eval
+cost is acceptable relative to the path it would sit in, so performance is not the deciding factor.
 
 **Auditability.** A CEL string is human-readable and reviewable. The decomposed proto model
 (comparison + quantifier + flag) is also auditable and is what authors would continue to edit under
@@ -82,23 +86,24 @@ CEL is exposed to them. The hybrid option avoids that by keeping CEL internal to
 admin UI. Keeping the structured proto model as the authoring surface avoids that cost; CEL stays
 an implementation detail.
 
-**Existing Rego Path.** `subject_mapping_builtin.go` already embeds OPA Rego
-(`open-policy-agent/opa/v1/rego`) as a registered builtin. Adopting CEL should be weighed against
-consolidating on Rego instead. CEL is lighter and already vendored for validation; Rego is heavier
-but already wired as a builtin. The spike did not benchmark the two; choosing between them is a
-prerequisite to any adoption and should be its own decision.
+**Existing Rego Path.** `subject_mapping_builtin.go` registers a `subjectmapping.resolve` builtin,
+and `entitlements.rego` only calls that builtin. Rego does not evaluate operators; it wraps the Go
+switch and pays protojson marshalling at the boundary (`entitlements.OpaInput`). So Rego is not a
+third operator engine, and the benchmark measures it as wrapper overhead: ~100× a direct Go call and
+~130× the allocations (665,686 vs 5,077 allocs/op at 5,000 mappings). Removing or replacing the OPA
+layer is a larger performance lever than the operator engine, and is independent of the CEL decision.
 
 ## Migration and Backward Compatibility
 
 The condition stays in proto. Migration is internal:
 
-1. Add a function that lowers a stored `Condition` to a CEL source string: the deprecated
-   `operator` field and the decomposed `comparison` / `quantifier` / `case_insensitive` fields map
-   to the expressions in the table above. Existing stored conditions need no rewrite.
+1. Lower a stored `Condition` to a CEL source string: the deprecated `operator` field and the
+   decomposed `comparison` / `quantifier` / `case_insensitive` fields map to the expressions in the
+   table above. `celeval` already implements this. Existing stored conditions need no rewrite.
 2. Compile and cache the CEL program per condition (cache key on the lowered source). Evaluate the
    cached program in place of the operator switch.
-3. Run CEL and the native switch side by side in tests (the POC is the seed) until parity is
-   established, then make CEL the evaluation path.
+3. Run CEL and the native switch side by side in tests until parity is established, then make CEL the
+   evaluation path. `celeval`'s equivalence test against `EvaluateSubjectSet` is the seed.
 
 No proto change, no stored-data migration, and the deprecated `operator` field keeps working
 because it is one input to the lowering step.
@@ -120,8 +125,9 @@ revisiting if internal CEL adoption succeeds.
 ### Hybrid (Chosen)
 Proto stays the authored and stored form; CEL is the internal evaluation strategy. Stops operator
 sprawl in the evaluator, no proto break, no author retraining, defers the multi-language runtime
-question. Open item: benchmark CEL against the native switch and against the existing Rego builtin
-before wiring it into the decision path.
+question. The benchmark closes the original open item: CEL is slower than the switch but its cost is
+small next to the OPA wrapper that surrounds it, so performance does not block adoption. The
+remaining open item is the OPA layer itself, which dominates the path and is worth its own decision.
 
 ## References
 
@@ -129,5 +135,7 @@ before wiring it into the decision path.
 - DynamicValueMapping protos: commit `090c0f65508058502d17a850691957b7beaee785`
 - CEL: https://cel.dev and https://github.com/google/cel-go
 - POC: `service/internal/subjectmappingbuiltin/cel_poc_test.go`
+- Experimental evaluator: `service/internal/subjectmappingbuiltin/celeval/` (lowering + tests; unwired)
+- Benchmarks and results: `docs/performance/DSPX-3673-cel-condition-evaluation/`
 - Native evaluation: `service/internal/subjectmappingbuiltin/subject_mapping_builtin.go`
 - Prior spike (format reference): DSPX-2754


### PR DESCRIPTION
### Proposed Changes

Spike evaluating whether CEL (https://cel.dev) is a better fit than adding more bespoke Subject Mapping condition operators (cf. #3335 and the `DynamicValueOperatorEnum` work). Research output: an ADR, a proof-of-concept, and a performance deliverable. Nothing is wired into the request path.

- **ADR** — `service/policy/adr/0005-cel-condition-evaluation-spike.md`: three options with pro/con bullets, an expressiveness analysis (CEL cases the decomposed axes cannot express), benchmark-backed tradeoffs, a migration sketch, and a recommendation to store conditions as CEL.
- **POC** — `service/internal/subjectmappingbuiltin/cel_poc_test.go`: CEL matches the native `EvaluateCondition` for the legacy operators and the decomposed cases.
- **Experimental evaluator** — `service/internal/subjectmappingbuiltin/celeval/`: lowers `SubjectSet → ConditionGroup → Condition` to a CEL program, with an equivalence test against `EvaluateSubjectSet`. Unwired; spike-only.
- **Benchmarks + perf deliverable** — `docs/performance/cel-condition-evaluation/`, driven by build-tagged (`celbench`) tests. Both layers target the v2 evaluation path (pure Go, no OPA).

### Findings

- The native switch is fastest per evaluation (3.7–23× ahead of CEL) for both legacy and decomposed operators; at the entitlements level (N subject mappings) native stays ~6–7× ahead. Both are µs-to-low-ms and scale linearly with N.
- The v2 PDP evaluates in pure Go (no OPA); per the v2 PDP perf work a decision is dominated by policy fetch/load and PDP construction, so the operator engine is a small slice. Performance does not decide the engine choice.
- The durable differentiator is expressiveness: CEL covers regex, numeric/ordinal, cross-field, dynamic set-vs-set, and cardinality logic the decomposed axes cannot express. The recommendation is to store conditions as CEL.

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation

### Testing Instructions

- `cd service && go test ./internal/subjectmappingbuiltin/...` (POC + celeval equivalence tests)
- `bash docs/performance/cel-condition-evaluation/run.sh` (regenerate benchmarks + charts; no Docker)
