### PR TITLE
feat(policy): Add kas_uri dimenstion to ListKeys.

### DIFF
--- a/service/policy/kasregistry/authz_resolver.go
+++ b/service/policy/kasregistry/authz_resolver.go
@@ -18,20 +18,32 @@ const (
 )
 
 var (
-	errUnexpectedGetKeyAuthzRequestType = errors.New("unexpected GetKey authz request type")
-	errResolvedKasURIEmpty              = errors.New("resolved KAS URI is empty")
-	errKeyIdentifierRequired            = errors.New("key identifier is required")
-	errKeyIDRequired                    = errors.New("key id is required")
-	errUnsupportedGetKeyIdentifier      = errors.New("unsupported GetKey identifier")
-	errResolveKasKeyForAuthz            = errors.New("failed to resolve KAS key for authz")
-	errResolvedKasKeyNil                = errors.New("resolved KAS key is nil")
+	errUnexpectedGetKeyAuthzRequestType   = errors.New("unexpected GetKey authz request type")
+	errUnexpectedListKeysAuthzRequestType = errors.New("unexpected ListKeys authz request type")
+	errResolvedKasURIEmpty                = errors.New("resolved KAS URI is empty")
+	errKeyIdentifierRequired              = errors.New("key identifier is required")
+	errKeyIDRequired                      = errors.New("key id is required")
+	errUnsupportedGetKeyIdentifier        = errors.New("unsupported GetKey identifier")
+	errResolveKasKeyForAuthz              = errors.New("failed to resolve KAS key for authz")
+	errResolvedKasKeyNil                  = errors.New("resolved KAS key is nil")
+	errResolveListKeysForAuthz            = errors.New("failed to resolve ListKeys for authz")
+	errResolvedListKeysResponseNil        = errors.New("resolved ListKeys response is nil")
 )
 
-type getKeyAuthzDBClient interface {
+type keyAuthzDBClient interface {
 	GetKey(context.Context, any) (*policy.KasKey, error)
+	ListKeys(context.Context, *kasr.ListKeysRequest) (*kasr.ListKeysResponse, error)
 }
 
 func (s *KeyAccessServerRegistry) getKeyAuthzResolver(ctx context.Context, req connect.AnyRequest) (authz.ResolverContext, error) {
+	return s.resolveGetKeyAuthzContext(ctx, req)
+}
+
+func (s *KeyAccessServerRegistry) listKeysAuthzResolver(ctx context.Context, req connect.AnyRequest) (authz.ResolverContext, error) {
+	return s.resolveListKeysAuthzContext(ctx, req, s.dbClient)
+}
+
+func (s *KeyAccessServerRegistry) resolveGetKeyAuthzContext(ctx context.Context, req connect.AnyRequest) (authz.ResolverContext, error) {
 	resolverCtx := authz.NewResolverContext()
 
 	msg, ok := req.Any().(*kasr.GetKeyRequest)
@@ -50,7 +62,22 @@ func (s *KeyAccessServerRegistry) getKeyAuthzResolver(ctx context.Context, req c
 	return resolverCtx, nil
 }
 
-func resolveGetKeyKasURI(ctx context.Context, msg *kasr.GetKeyRequest, resolverCtx *authz.ResolverContext, dbClient getKeyAuthzDBClient) (string, error) {
+func (s *KeyAccessServerRegistry) resolveListKeysAuthzContext(ctx context.Context, req connect.AnyRequest, dbClient keyAuthzDBClient) (authz.ResolverContext, error) {
+	resolverCtx := authz.NewResolverContext()
+
+	msg, ok := req.Any().(*kasr.ListKeysRequest)
+	if !ok {
+		return resolverCtx, fmt.Errorf("%w: %T", errUnexpectedListKeysAuthzRequestType, req.Any())
+	}
+
+	if err := resolveListKeysAuthzResources(ctx, msg, &resolverCtx, dbClient); err != nil {
+		return resolverCtx, err
+	}
+
+	return resolverCtx, nil
+}
+
+func resolveGetKeyKasURI(ctx context.Context, msg *kasr.GetKeyRequest, resolverCtx *authz.ResolverContext, dbClient keyAuthzDBClient) (string, error) {
 	switch identifier := msg.GetIdentifier().(type) {
 	case *kasr.GetKeyRequest_Key:
 		keyIdentifier := identifier.Key
@@ -81,4 +108,42 @@ func resolveGetKeyKasURI(ctx context.Context, msg *kasr.GetKeyRequest, resolverC
 
 	resolverCtx.SetResolvedData(resolverCacheKeyKasKey, key)
 	return key.GetKasUri(), nil
+}
+
+func resolveListKeysAuthzResources(ctx context.Context, msg *kasr.ListKeysRequest, resolverCtx *authz.ResolverContext, dbClient keyAuthzDBClient) error {
+	// TODO: Replace this ListKeys call with a smaller query that returns only the distinct KAS URIs present for the request filters.
+	resp, err := dbClient.ListKeys(ctx, msg)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errResolveListKeysForAuthz, err)
+	}
+	if resp == nil {
+		return fmt.Errorf("%w: %w", errResolveListKeysForAuthz, errResolvedListKeysResponseNil)
+	}
+
+	// List RPC resolvers only identify the resources to authorize. Do not cache
+	// the response as resolved data; handlers must run their own post-authz list
+	// query so response shaping stays in the RPC implementation.
+
+	return resolveListKeysReturnedKeyURIs(resolverCtx, resp.GetKasKeys())
+}
+
+func resolveListKeysReturnedKeyURIs(resolverCtx *authz.ResolverContext, keys []*policy.KasKey) error {
+	seen := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		kasURI := key.GetKasUri()
+		if kasURI == "" {
+			return errResolvedKasURIEmpty
+		}
+		if _, ok := seen[kasURI]; ok {
+			continue
+		}
+		seen[kasURI] = struct{}{}
+		addKasURIResource(resolverCtx, kasURI)
+	}
+	return nil
+}
+
+func addKasURIResource(resolverCtx *authz.ResolverContext, kasURI string) {
+	res := resolverCtx.NewResource()
+	res.AddDimension(authzDimensionKasURI, kasURI)
 }

--- a/service/policy/kasregistry/authz_resolver.go
+++ b/service/policy/kasregistry/authz_resolver.go
@@ -38,14 +38,14 @@ type keyAuthzDBClient interface {
 }
 
 func (s *KeyAccessServerRegistry) getKeyAuthzResolver(ctx context.Context, req connect.AnyRequest) (authz.ResolverContext, error) {
-	return s.resolveGetKeyAuthzContext(ctx, req)
+	return resolveGetKeyAuthzContext(ctx, req, s.dbClient)
 }
 
 func (s *KeyAccessServerRegistry) listKeysAuthzResolver(ctx context.Context, req connect.AnyRequest) (authz.ResolverContext, error) {
-	return s.resolveListKeysAuthzContext(ctx, req, s.dbClient)
+	return resolveListKeysAuthzContext(ctx, req, s.dbClient)
 }
 
-func (s *KeyAccessServerRegistry) resolveGetKeyAuthzContext(ctx context.Context, req connect.AnyRequest) (authz.ResolverContext, error) {
+func resolveGetKeyAuthzContext(ctx context.Context, req connect.AnyRequest, dbClient keyAuthzDBClient) (authz.ResolverContext, error) {
 	resolverCtx := authz.NewResolverContext()
 
 	msg, ok := req.Any().(*kasr.GetKeyRequest)
@@ -53,7 +53,7 @@ func (s *KeyAccessServerRegistry) resolveGetKeyAuthzContext(ctx context.Context,
 		return resolverCtx, fmt.Errorf("%w: %T", errUnexpectedGetKeyAuthzRequestType, req.Any())
 	}
 
-	kasURI, err := resolveGetKeyKasURI(ctx, msg, &resolverCtx, s.dbClient)
+	kasURI, err := resolveGetKeyKasURI(ctx, msg, &resolverCtx, dbClient)
 	if err != nil {
 		return resolverCtx, err
 	}
@@ -64,7 +64,7 @@ func (s *KeyAccessServerRegistry) resolveGetKeyAuthzContext(ctx context.Context,
 	return resolverCtx, nil
 }
 
-func (s *KeyAccessServerRegistry) resolveListKeysAuthzContext(ctx context.Context, req connect.AnyRequest, dbClient keyAuthzDBClient) (authz.ResolverContext, error) {
+func resolveListKeysAuthzContext(ctx context.Context, req connect.AnyRequest, dbClient keyAuthzDBClient) (authz.ResolverContext, error) {
 	resolverCtx := authz.NewResolverContext()
 
 	msg, ok := req.Any().(*kasr.ListKeysRequest)

--- a/service/policy/kasregistry/authz_resolver.go
+++ b/service/policy/kasregistry/authz_resolver.go
@@ -15,6 +15,8 @@ const (
 	authzDimensionKasURI = "kas_uri"
 	// resolverCacheKeyKasKey is the key used to cache a resolved KAS key in the authz resolver context.
 	resolverCacheKeyKasKey = "kas_key"
+	// resolverCacheKeyListKeysResponse is the key used to cache the authorized ListKeys response.
+	resolverCacheKeyListKeysResponse = "list_keys_response"
 )
 
 var (
@@ -120,10 +122,7 @@ func resolveListKeysAuthzResources(ctx context.Context, msg *kasr.ListKeysReques
 		return fmt.Errorf("%w: %w", errResolveListKeysForAuthz, errResolvedListKeysResponseNil)
 	}
 
-	// List RPC resolvers only identify the resources to authorize. Do not cache
-	// the response as resolved data; handlers must run their own post-authz list
-	// query so response shaping stays in the RPC implementation.
-
+	resolverCtx.SetResolvedData(resolverCacheKeyListKeysResponse, resp)
 	return resolveListKeysReturnedKeyURIs(resolverCtx, resp.GetKasKeys())
 }
 

--- a/service/policy/kasregistry/authz_resolver_test.go
+++ b/service/policy/kasregistry/authz_resolver_test.go
@@ -13,14 +13,21 @@ import (
 )
 
 type fakeGetKeyAuthzDBClient struct {
-	key        *policy.KasKey
-	err        error
-	identifier any
+	key          *policy.KasKey
+	listKeysResp *kasregistry.ListKeysResponse
+	err          error
+	identifier   any
+	listKeysReq  *kasregistry.ListKeysRequest
 }
 
 func (f *fakeGetKeyAuthzDBClient) GetKey(_ context.Context, identifier any) (*policy.KasKey, error) {
 	f.identifier = identifier
 	return f.key, f.err
+}
+
+func (f *fakeGetKeyAuthzDBClient) ListKeys(_ context.Context, req *kasregistry.ListKeysRequest) (*kasregistry.ListKeysResponse, error) {
+	f.listKeysReq = req
+	return f.listKeysResp, f.err
 }
 
 func TestGetKeyAuthzResolver_UsesRequestURI(t *testing.T) {
@@ -165,6 +172,145 @@ func TestGetKeyAuthzResolver_EmptyKasURI_ReturnsErrResolvedKasURIEmpty(t *testin
 	_, err := resolveGetKeyKasURI(t.Context(), &kasregistry.GetKeyRequest{
 		Identifier: &kasregistry.GetKeyRequest_Id{Id: validUUID},
 	}, &resolverCtx, &fakeGetKeyAuthzDBClient{key: key})
+
+	require.ErrorIs(t, err, errResolvedKasURIEmpty)
+}
+
+func TestListKeysAuthzResolver_KasURIFilterUsesReturnedKeyURIs(t *testing.T) {
+	const kasURI = "https://kas-a.example.com"
+	resp := &kasregistry.ListKeysResponse{
+		KasKeys: []*policy.KasKey{
+			{KasUri: kasURI, Key: &policy.AsymmetricKey{KeyId: validKeyID}},
+		},
+	}
+	dbClient := &fakeGetKeyAuthzDBClient{listKeysResp: resp}
+	req := &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasUri{KasUri: kasURI},
+	}
+	resolverCtx := authz.NewResolverContext()
+
+	err := resolveListKeysAuthzResources(t.Context(), req, &resolverCtx, dbClient)
+
+	require.NoError(t, err)
+	require.Len(t, resolverCtx.Resources, 1)
+	require.Equal(t, kasURI, (*resolverCtx.Resources[0])[authzDimensionKasURI])
+	require.Same(t, req, dbClient.listKeysReq)
+}
+
+func TestListKeysAuthzResolver_KasIDFilterUsesReturnedKeyURIs(t *testing.T) {
+	const kasURI = "https://kas-a.example.com"
+	dbClient := &fakeGetKeyAuthzDBClient{
+		listKeysResp: &kasregistry.ListKeysResponse{
+			KasKeys: []*policy.KasKey{
+				{KasUri: kasURI, Key: &policy.AsymmetricKey{KeyId: validKeyID}},
+			},
+		},
+	}
+	req := &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: validUUID},
+	}
+	resolverCtx := authz.NewResolverContext()
+
+	err := resolveListKeysAuthzResources(t.Context(), req, &resolverCtx, dbClient)
+
+	require.NoError(t, err)
+	require.Len(t, resolverCtx.Resources, 1)
+	require.Equal(t, kasURI, (*resolverCtx.Resources[0])[authzDimensionKasURI])
+	require.Same(t, req, dbClient.listKeysReq)
+}
+
+func TestListKeysAuthzResolver_KasNameFilterUsesReturnedKeyURIs(t *testing.T) {
+	const kasURI = "https://kas-a.example.com"
+	dbClient := &fakeGetKeyAuthzDBClient{
+		listKeysResp: &kasregistry.ListKeysResponse{
+			KasKeys: []*policy.KasKey{
+				{KasUri: kasURI, Key: &policy.AsymmetricKey{KeyId: validKeyID}},
+			},
+		},
+	}
+	req := &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasName{KasName: "kas-a"},
+	}
+	resolverCtx := authz.NewResolverContext()
+
+	err := resolveListKeysAuthzResources(t.Context(), req, &resolverCtx, dbClient)
+
+	require.NoError(t, err)
+	require.Len(t, resolverCtx.Resources, 1)
+	require.Equal(t, kasURI, (*resolverCtx.Resources[0])[authzDimensionKasURI])
+	require.Same(t, req, dbClient.listKeysReq)
+}
+
+func TestListKeysAuthzResolver_UnfilteredListUsesReturnedKeyURIs(t *testing.T) {
+	const (
+		kasURIA = "https://kas-a.example.com"
+		kasURIB = "https://kas-b.example.com"
+	)
+	dbClient := &fakeGetKeyAuthzDBClient{
+		listKeysResp: &kasregistry.ListKeysResponse{
+			KasKeys: []*policy.KasKey{
+				{KasUri: kasURIA, Key: &policy.AsymmetricKey{KeyId: "a-1"}},
+				{KasUri: kasURIA, Key: &policy.AsymmetricKey{KeyId: "a-2"}},
+				{KasUri: kasURIB, Key: &policy.AsymmetricKey{KeyId: "b-1"}},
+			},
+		},
+	}
+	resolverCtx := authz.NewResolverContext()
+
+	err := resolveListKeysAuthzResources(t.Context(), &kasregistry.ListKeysRequest{}, &resolverCtx, dbClient)
+
+	require.NoError(t, err)
+	require.Len(t, resolverCtx.Resources, 2)
+	require.Equal(t, kasURIA, (*resolverCtx.Resources[0])[authzDimensionKasURI])
+	require.Equal(t, kasURIB, (*resolverCtx.Resources[1])[authzDimensionKasURI])
+}
+
+func TestListKeysAuthzResolver_EmptyUnfilteredListUsesWildcard(t *testing.T) {
+	dbClient := &fakeGetKeyAuthzDBClient{listKeysResp: &kasregistry.ListKeysResponse{}}
+	resolverCtx := authz.NewResolverContext()
+
+	err := resolveListKeysAuthzResources(t.Context(), &kasregistry.ListKeysRequest{}, &resolverCtx, dbClient)
+
+	require.NoError(t, err)
+	require.Empty(t, resolverCtx.Resources)
+}
+
+func TestListKeysAuthzResolver_DBLookupErrorFailsResolution(t *testing.T) {
+	dbErr := errors.New("db unavailable")
+	resolverCtx := authz.NewResolverContext()
+
+	err := resolveListKeysAuthzResources(t.Context(), &kasregistry.ListKeysRequest{}, &resolverCtx, &fakeGetKeyAuthzDBClient{err: dbErr})
+
+	require.ErrorIs(t, err, errResolveListKeysForAuthz)
+	require.ErrorIs(t, err, dbErr)
+	require.Empty(t, resolverCtx.Resources)
+}
+
+func TestListKeysAuthzResolver_InvalidRequestType(t *testing.T) {
+	svc := KeyAccessServerRegistry{}
+
+	_, err := svc.listKeysAuthzResolver(t.Context(), connect.NewRequest(&kasregistry.GetKeyRequest{}))
+
+	require.ErrorIs(t, err, errUnexpectedListKeysAuthzRequestType)
+}
+
+func TestListKeysAuthzResolver_DBReturnsNilNil_ReturnsErrResolvedListKeysResponseNil(t *testing.T) {
+	resolverCtx := authz.NewResolverContext()
+
+	err := resolveListKeysAuthzResources(t.Context(), &kasregistry.ListKeysRequest{}, &resolverCtx, &fakeGetKeyAuthzDBClient{})
+
+	require.ErrorIs(t, err, errResolvedListKeysResponseNil)
+}
+
+func TestListKeysAuthzResolver_EmptyKasURI_ReturnsErrResolvedKasURIEmpty(t *testing.T) {
+	dbClient := &fakeGetKeyAuthzDBClient{
+		listKeysResp: &kasregistry.ListKeysResponse{
+			KasKeys: []*policy.KasKey{{Key: &policy.AsymmetricKey{KeyId: validKeyID}}},
+		},
+	}
+	resolverCtx := authz.NewResolverContext()
+
+	err := resolveListKeysAuthzResources(t.Context(), &kasregistry.ListKeysRequest{}, &resolverCtx, dbClient)
 
 	require.ErrorIs(t, err, errResolvedKasURIEmpty)
 }

--- a/service/policy/kasregistry/authz_resolver_test.go
+++ b/service/policy/kasregistry/authz_resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
 	"github.com/opentdf/platform/service/internal/auth/authz"
+	"github.com/opentdf/platform/service/logger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -195,6 +196,24 @@ func TestListKeysAuthzResolver_KasURIFilterUsesReturnedKeyURIs(t *testing.T) {
 	require.Len(t, resolverCtx.Resources, 1)
 	require.Equal(t, kasURI, (*resolverCtx.Resources[0])[authzDimensionKasURI])
 	require.Same(t, req, dbClient.listKeysReq)
+	require.Same(t, resp, resolverCtx.GetResolvedData(resolverCacheKeyListKeysResponse))
+}
+
+func Test_ListKeysUsesResolvedAuthorizedResponse(t *testing.T) {
+	resp := &kasregistry.ListKeysResponse{
+		KasKeys: []*policy.KasKey{
+			{KasUri: "https://kas-a.example.com", Key: &policy.AsymmetricKey{KeyId: validKeyID}},
+		},
+	}
+	resolverCtx := authz.NewResolverContext()
+	resolverCtx.SetResolvedData(resolverCacheKeyListKeysResponse, resp)
+	ctx := authz.ContextWithResolverContext(t.Context(), &resolverCtx)
+	svc := KeyAccessServerRegistry{logger: logger.CreateTestLogger()}
+
+	got, err := svc.ListKeys(ctx, connect.NewRequest(&kasregistry.ListKeysRequest{}))
+
+	require.NoError(t, err)
+	require.Same(t, resp, got.Msg)
 }
 
 func TestListKeysAuthzResolver_KasIDFilterUsesReturnedKeyURIs(t *testing.T) {

--- a/service/policy/kasregistry/key_access_server_registry.go
+++ b/service/policy/kasregistry/key_access_server_registry.go
@@ -367,6 +367,10 @@ func (s KeyAccessServerRegistry) GetKey(ctx context.Context, r *connect.Request[
 func (s KeyAccessServerRegistry) ListKeys(ctx context.Context, r *connect.Request[kasr.ListKeysRequest]) (*connect.Response[kasr.ListKeysResponse], error) {
 	s.logger.DebugContext(ctx, "listing KAS Keys")
 
+	if resp, ok := authz.GetResolvedDataFromContext(ctx, resolverCacheKeyListKeysResponse).(*kasr.ListKeysResponse); ok && resp != nil {
+		return connect.NewResponse(resp), nil
+	}
+
 	resp, err := s.dbClient.ListKeys(ctx, r.Msg)
 	if err != nil {
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed, slog.String("key_access_server_keys", r.Msg.String()))

--- a/service/policy/kasregistry/key_access_server_registry.go
+++ b/service/policy/kasregistry/key_access_server_registry.go
@@ -81,6 +81,7 @@ func NewRegistration(ns string, dbRegister serviceregistry.DBRegister) *servicer
 
 				if srp.AuthzResolverRegistry != nil {
 					srp.AuthzResolverRegistry.MustRegister("GetKey", kasrSvc.getKeyAuthzResolver)
+					srp.AuthzResolverRegistry.MustRegister("ListKeys", kasrSvc.listKeysAuthzResolver)
 				}
 
 				kasrSvc.config = cfg
@@ -365,6 +366,7 @@ func (s KeyAccessServerRegistry) GetKey(ctx context.Context, r *connect.Request[
 
 func (s KeyAccessServerRegistry) ListKeys(ctx context.Context, r *connect.Request[kasr.ListKeysRequest]) (*connect.Response[kasr.ListKeysResponse], error) {
 	s.logger.DebugContext(ctx, "listing KAS Keys")
+
 	resp, err := s.dbClient.ListKeys(ctx, r.Msg)
 	if err != nil {
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextListRetrievalFailed, slog.String("key_access_server_keys", r.Msg.String()))
@@ -386,7 +388,8 @@ func (s KeyAccessServerRegistry) RotateKey(ctx context.Context, r *connect.Reque
 			Id: i.Id,
 		}
 	case *kasr.RotateKeyRequest_Key:
-		s.logger.DebugContext(ctx,
+		s.logger.DebugContext(
+			ctx,
 			"rotating key by Kas Key",
 			slog.String("active_key_id", i.Key.GetKid()),
 			slog.String("new_key_id", r.Msg.GetNewKey().GetKeyId()),

--- a/tests-bdd/cukes/resources/platform.authz_v2.template
+++ b/tests-bdd/cukes/resources/platform.authz_v2.template
@@ -61,8 +61,15 @@ server:
         # KAS key read access for BDD-specific service-account roles.
         p, client:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-a.example.com, allow
         p, client:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-a-id.example.com, allow
+        p, client:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-a.example.com, allow
+        p, client:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-a-unfiltered.example.com, allow
+        p, client:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-a-list.example.com, allow
+        p, client:kas-a, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-a-list-id.example.com, allow
         p, client:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-b.example.com, allow
         p, client:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/GetKey, kas_uri=https://kas-b-id.example.com, allow
+        p, client:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-b.example.com, allow
+        p, client:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-b-list.example.com, allow
+        p, client:kas-b, /policy.kasregistry.KeyAccessServerRegistryService/ListKeys, kas_uri=https://kas-b-list-id.example.com, allow
       model:
   trace:
     enabled: false

--- a/tests-bdd/cukes/steps_kasregistry.go
+++ b/tests-bdd/cukes/steps_kasregistry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
+	policyunsafe "github.com/opentdf/platform/protocol/go/policy/unsafe"
 )
 
 const (
@@ -68,6 +69,48 @@ func (s *KasRegistryStepDefinitions) iCreateKASKeys(ctx context.Context, tbl *go
 		scenarioContext.RecordObject(keyID, keyResp.GetKasKey().GetKey().GetId())
 		scenarioContext.RecordObject(keyID+"_kas_uri", kasURI)
 		scenarioContext.RecordObject(keyID+"_kas_id", kasResp.GetKeyAccessServer().GetId())
+	}
+
+	return ctx, nil
+}
+
+func (s *KasRegistryStepDefinitions) iRemoveAllKASKeys(ctx context.Context) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	scenarioContext.ClearError()
+
+	resp, err := scenarioContext.SDK.KeyAccessServerRegistry.ListKeys(ctx, &kasregistry.ListKeysRequest{})
+	scenarioContext.SetError(err)
+	if err != nil {
+		return ctx, err
+	}
+
+	kasIDs := make(map[string]struct{})
+	for _, kasKey := range resp.GetKasKeys() {
+		kasID := kasKey.GetKasId()
+		if kasID != "" {
+			kasIDs[kasID] = struct{}{}
+		}
+
+		key := kasKey.GetKey()
+		_, err := scenarioContext.SDK.Unsafe.UnsafeDeleteKasKey(ctx, &policyunsafe.UnsafeDeleteKasKeyRequest{
+			Id:     key.GetId(),
+			Kid:    key.GetKeyId(),
+			KasUri: kasKey.GetKasUri(),
+		})
+		scenarioContext.SetError(err)
+		if err != nil {
+			return ctx, err
+		}
+	}
+
+	for kasID := range kasIDs {
+		_, err := scenarioContext.SDK.KeyAccessServerRegistry.DeleteKeyAccessServer(ctx, &kasregistry.DeleteKeyAccessServerRequest{
+			Id: kasID,
+		})
+		scenarioContext.SetError(err)
+		if err != nil {
+			return ctx, err
+		}
 	}
 
 	return ctx, nil
@@ -242,6 +285,7 @@ func splitKASKeyIDs(keyIDs string) []string {
 func RegisterKasRegistryStepDefinitions(ctx *godog.ScenarioContext) {
 	stepDefinitions := KasRegistryStepDefinitions{}
 	ctx.Step(`^I create KAS keys:$`, stepDefinitions.iCreateKASKeys)
+	ctx.Step(`^I remove all KAS keys$`, stepDefinitions.iRemoveAllKASKeys)
 	ctx.Step(`^I send a request to get KAS key "([^"]*)"$`, stepDefinitions.iGetKASKey)
 	ctx.Step(`^I send a request to get KAS key "([^"]*)" by stored ID$`, stepDefinitions.iGetKASKeyByStoredID)
 	ctx.Step(`^I send a request to list KAS keys$`, stepDefinitions.iListKASKeys)

--- a/tests-bdd/cukes/steps_kasregistry.go
+++ b/tests-bdd/cukes/steps_kasregistry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/cucumber/godog"
@@ -110,6 +111,7 @@ func (s *KasRegistryStepDefinitions) iGetKASKeyByStoredID(ctx context.Context, k
 func (s *KasRegistryStepDefinitions) iListKASKeys(ctx context.Context) (context.Context, error) {
 	scenarioContext := GetPlatformScenarioContext(ctx)
 	scenarioContext.ClearError()
+	scenarioContext.RecordObject(listKASKeysResponse, (*kasregistry.ListKeysResponse)(nil))
 
 	resp, err := scenarioContext.SDK.KeyAccessServerRegistry.ListKeys(ctx, &kasregistry.ListKeysRequest{})
 	scenarioContext.SetError(err)
@@ -123,6 +125,7 @@ func (s *KasRegistryStepDefinitions) iListKASKeys(ctx context.Context) (context.
 func (s *KasRegistryStepDefinitions) iListKASKeysForURI(ctx context.Context, kasURI string) (context.Context, error) {
 	scenarioContext := GetPlatformScenarioContext(ctx)
 	scenarioContext.ClearError()
+	scenarioContext.RecordObject(listKASKeysResponse, (*kasregistry.ListKeysResponse)(nil))
 
 	resp, err := scenarioContext.SDK.KeyAccessServerRegistry.ListKeys(ctx, &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasUri{KasUri: normalizeKASURI(kasURI)},
@@ -143,6 +146,7 @@ func (s *KasRegistryStepDefinitions) iListKASKeysByStoredKASID(ctx context.Conte
 	}
 
 	scenarioContext.ClearError()
+	scenarioContext.RecordObject(listKASKeysResponse, (*kasregistry.ListKeysResponse)(nil))
 	resp, err := scenarioContext.SDK.KeyAccessServerRegistry.ListKeys(ctx, &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
 	})
@@ -162,7 +166,7 @@ func (s *KasRegistryStepDefinitions) listedKASKeysContain(ctx context.Context, k
 
 	listed := listedKASKeyIDs(resp)
 	for _, keyID := range splitKASKeyIDs(keyIDs) {
-		if _, ok := listed[keyID]; !ok {
+		if !slices.Contains(listed, keyID) {
 			return fmt.Errorf("listed KAS keys did not contain %q", keyID)
 		}
 	}
@@ -182,8 +186,14 @@ func (s *KasRegistryStepDefinitions) listedKASKeysContainOnly(ctx context.Contex
 		return fmt.Errorf("expected %d listed KAS keys, got %d", len(expected), len(listed))
 	}
 
+	listedCounts := make(map[string]int, len(listed))
+	for _, keyID := range listed {
+		listedCounts[keyID]++
+	}
+
 	for _, keyID := range expected {
-		if _, ok := listed[keyID]; !ok {
+		listedCounts[keyID]--
+		if listedCounts[keyID] < 0 {
 			return fmt.Errorf("listed KAS keys did not contain %q", keyID)
 		}
 	}
@@ -207,12 +217,12 @@ func getListKASKeysResponse(ctx context.Context) (*kasregistry.ListKeysResponse,
 	return resp, nil
 }
 
-func listedKASKeyIDs(resp *kasregistry.ListKeysResponse) map[string]struct{} {
-	keyIDs := make(map[string]struct{}, len(resp.GetKasKeys()))
+func listedKASKeyIDs(resp *kasregistry.ListKeysResponse) []string {
+	keyIDs := make([]string, 0, len(resp.GetKasKeys()))
 	for _, kasKey := range resp.GetKasKeys() {
 		keyID := kasKey.GetKey().GetKeyId()
 		if keyID != "" {
-			keyIDs[keyID] = struct{}{}
+			keyIDs = append(keyIDs, keyID)
 		}
 	}
 	return keyIDs

--- a/tests-bdd/cukes/steps_kasregistry.go
+++ b/tests-bdd/cukes/steps_kasregistry.go
@@ -14,6 +14,7 @@ import (
 const (
 	bddKasPublicKeyCtx    = `YS1wZW0K`
 	expectedKASKeyColumns = 2
+	listKASKeysResponse   = "listKASKeysResponse"
 )
 
 type KasRegistryStepDefinitions struct{}
@@ -106,6 +107,90 @@ func (s *KasRegistryStepDefinitions) iGetKASKeyByStoredID(ctx context.Context, k
 	return ctx, nil
 }
 
+func (s *KasRegistryStepDefinitions) iListKASKeys(ctx context.Context) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	scenarioContext.ClearError()
+
+	resp, err := scenarioContext.SDK.KeyAccessServerRegistry.ListKeys(ctx, &kasregistry.ListKeysRequest{})
+	scenarioContext.SetError(err)
+	if resp != nil {
+		scenarioContext.RecordObject(listKASKeysResponse, resp)
+	}
+
+	return ctx, nil
+}
+
+func (s *KasRegistryStepDefinitions) iListKASKeysForURI(ctx context.Context, kasURI string) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	scenarioContext.ClearError()
+
+	resp, err := scenarioContext.SDK.KeyAccessServerRegistry.ListKeys(ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasUri{KasUri: normalizeKASURI(kasURI)},
+	})
+	scenarioContext.SetError(err)
+	if resp != nil {
+		scenarioContext.RecordObject(listKASKeysResponse, resp)
+	}
+
+	return ctx, nil
+}
+
+func (s *KasRegistryStepDefinitions) iListKASKeysByStoredKASID(ctx context.Context, keyID string) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	kasID, ok := scenarioContext.GetObject(keyID + "_kas_id").(string)
+	if !ok {
+		return ctx, fmt.Errorf("unable to extract stored KAS ID for %q", keyID)
+	}
+
+	scenarioContext.ClearError()
+	resp, err := scenarioContext.SDK.KeyAccessServerRegistry.ListKeys(ctx, &kasregistry.ListKeysRequest{
+		KasFilter: &kasregistry.ListKeysRequest_KasId{KasId: kasID},
+	})
+	scenarioContext.SetError(err)
+	if resp != nil {
+		scenarioContext.RecordObject(listKASKeysResponse, resp)
+	}
+
+	return ctx, nil
+}
+
+func (s *KasRegistryStepDefinitions) listedKASKeysContain(ctx context.Context, keyIDs string) error {
+	resp, err := getListKASKeysResponse(ctx)
+	if err != nil {
+		return err
+	}
+
+	listed := listedKASKeyIDs(resp)
+	for _, keyID := range splitKASKeyIDs(keyIDs) {
+		if _, ok := listed[keyID]; !ok {
+			return fmt.Errorf("listed KAS keys did not contain %q", keyID)
+		}
+	}
+
+	return nil
+}
+
+func (s *KasRegistryStepDefinitions) listedKASKeysContainOnly(ctx context.Context, keyIDs string) error {
+	resp, err := getListKASKeysResponse(ctx)
+	if err != nil {
+		return err
+	}
+
+	expected := splitKASKeyIDs(keyIDs)
+	listed := listedKASKeyIDs(resp)
+	if len(listed) != len(expected) {
+		return fmt.Errorf("expected %d listed KAS keys, got %d", len(expected), len(listed))
+	}
+
+	for _, keyID := range expected {
+		if _, ok := listed[keyID]; !ok {
+			return fmt.Errorf("listed KAS keys did not contain %q", keyID)
+		}
+	}
+
+	return nil
+}
+
 func normalizeKASURI(uri string) string {
 	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
 		return uri
@@ -113,9 +198,45 @@ func normalizeKASURI(uri string) string {
 	return "https://" + uri
 }
 
+func getListKASKeysResponse(ctx context.Context) (*kasregistry.ListKeysResponse, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	resp, ok := scenarioContext.GetObject(listKASKeysResponse).(*kasregistry.ListKeysResponse)
+	if !ok || resp == nil {
+		return nil, errors.New("list KAS keys response was not recorded")
+	}
+	return resp, nil
+}
+
+func listedKASKeyIDs(resp *kasregistry.ListKeysResponse) map[string]struct{} {
+	keyIDs := make(map[string]struct{}, len(resp.GetKasKeys()))
+	for _, kasKey := range resp.GetKasKeys() {
+		keyID := kasKey.GetKey().GetKeyId()
+		if keyID != "" {
+			keyIDs[keyID] = struct{}{}
+		}
+	}
+	return keyIDs
+}
+
+func splitKASKeyIDs(keyIDs string) []string {
+	parts := strings.Split(keyIDs, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
 func RegisterKasRegistryStepDefinitions(ctx *godog.ScenarioContext) {
 	stepDefinitions := KasRegistryStepDefinitions{}
 	ctx.Step(`^I create KAS keys:$`, stepDefinitions.iCreateKASKeys)
 	ctx.Step(`^I send a request to get KAS key "([^"]*)"$`, stepDefinitions.iGetKASKey)
 	ctx.Step(`^I send a request to get KAS key "([^"]*)" by stored ID$`, stepDefinitions.iGetKASKeyByStoredID)
+	ctx.Step(`^I send a request to list KAS keys$`, stepDefinitions.iListKASKeys)
+	ctx.Step(`^I send a request to list KAS keys for KAS URI "([^"]*)"$`, stepDefinitions.iListKASKeysForURI)
+	ctx.Step(`^I send a request to list KAS keys for KAS key "([^"]*)" by stored KAS ID$`, stepDefinitions.iListKASKeysByStoredKASID)
+	ctx.Step(`^the listed KAS keys should contain "([^"]*)"$`, stepDefinitions.listedKASKeysContain)
+	ctx.Step(`^the listed KAS keys should contain only "([^"]*)"$`, stepDefinitions.listedKASKeysContainOnly)
 }

--- a/tests-bdd/features/authz-v2.feature
+++ b/tests-bdd/features/authz-v2.feature
@@ -9,6 +9,23 @@ Feature: Authz v2 default policy authorization
 
   Rule: KAS registry key access
 
+    Scenario: URI-specific KAS role can list unfiltered only while all keys match its KAS URI
+      Given I use the platform as "opentdf-admin"
+      And I create KAS keys:
+        | kas_uri                              | key_id                 |
+        | https://kas-a-unfiltered.example.com | kas-a-unfiltered-kid   |
+      Given I use the platform as "kas-a"
+      When I send a request to list KAS keys
+      Then the response should be successful
+      And the listed KAS keys should contain only "kas-a-unfiltered-kid"
+      Given I use the platform as "opentdf-admin"
+      And I create KAS keys:
+        | kas_uri                              | key_id                 |
+        | https://kas-b-unfiltered.example.com | kas-b-unfiltered-kid   |
+      Given I use the platform as "kas-a"
+      When I send a request to list KAS keys
+      Then the response should be permission denied
+
     # KAS GetKey resolves kas_uri for v2 authz.
     Scenario: opentdf-admin can get KAS keys by default
       Given I use the platform as "opentdf-admin"
@@ -50,6 +67,43 @@ Feature: Authz v2 default policy authorization
       When I send a request to get KAS key "kas-b-id-kid" by stored ID
       Then the response should be successful
       When I send a request to get KAS key "kas-a-id-kid" by stored ID
+      Then the response should be permission denied
+
+    Scenario: opentdf-standard can list all KAS keys by default
+      Given I use the platform as "opentdf-admin"
+      And I create KAS keys:
+        | kas_uri                        | key_id          |
+        | https://kas-list-a.example.com | kas-list-a-kid  |
+        | https://kas-list-b.example.com | kas-list-b-kid  |
+      Given I use the platform as "opentdf-standard"
+      When I send a request to list KAS keys
+      Then the response should be successful
+      And the listed KAS keys should contain "kas-list-a-kid,kas-list-b-kid"
+
+    Scenario: URI-specific KAS role can list only its KAS URI
+      Given I use the platform as "opentdf-admin"
+      And I create KAS keys:
+        | kas_uri                        | key_id         |
+        | https://kas-a-list.example.com | kas-a-list-kid |
+        | https://kas-b-list.example.com | kas-b-list-kid |
+      Given I use the platform as "kas-a"
+      When I send a request to list KAS keys for KAS URI "https://kas-a-list.example.com"
+      Then the response should be successful
+      And the listed KAS keys should contain only "kas-a-list-kid"
+      When I send a request to list KAS keys for KAS URI "https://kas-b-list.example.com"
+      Then the response should be permission denied
+
+    Scenario: URI-specific KAS role authorizes ID-based ListKeys using resolved KAS URI
+      Given I use the platform as "opentdf-admin"
+      And I create KAS keys:
+        | kas_uri                           | key_id            |
+        | https://kas-a-list-id.example.com | kas-a-list-id-kid |
+        | https://kas-b-list-id.example.com | kas-b-list-id-kid |
+      Given I use the platform as "kas-a"
+      When I send a request to list KAS keys for KAS key "kas-a-list-id-kid" by stored KAS ID
+      Then the response should be successful
+      And the listed KAS keys should contain only "kas-a-list-id-kid"
+      When I send a request to list KAS keys for KAS key "kas-b-list-id-kid" by stored KAS ID
       Then the response should be permission denied
 
     # Security: URL values containing '&' and '=' must not be mis-parsed as

--- a/tests-bdd/features/authz-v2.feature
+++ b/tests-bdd/features/authz-v2.feature
@@ -11,17 +11,18 @@ Feature: Authz v2 default policy authorization
 
     Scenario: URI-specific KAS role can list unfiltered only while all keys match its KAS URI
       Given I use the platform as "opentdf-admin"
+      And I remove all KAS keys
       And I create KAS keys:
-        | kas_uri                              | key_id                 |
-        | https://kas-a-unfiltered.example.com | kas-a-unfiltered-kid   |
+        | kas_uri                              | key_id               |
+        | https://kas-a-unfiltered.example.com | kas-a-unfiltered-kid |
       Given I use the platform as "kas-a"
       When I send a request to list KAS keys
       Then the response should be successful
       And the listed KAS keys should contain only "kas-a-unfiltered-kid"
       Given I use the platform as "opentdf-admin"
       And I create KAS keys:
-        | kas_uri                              | key_id                 |
-        | https://kas-b-unfiltered.example.com | kas-b-unfiltered-kid   |
+        | kas_uri                              | key_id               |
+        | https://kas-b-unfiltered.example.com | kas-b-unfiltered-kid |
       Given I use the platform as "kas-a"
       When I send a request to list KAS keys
       Then the response should be permission denied


### PR DESCRIPTION
1.) Add `kas_uri` dimension to `ListKeys` rpc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for listing KAS keys through the registry API.
  * Expanded access control so key listings can be authorized by KAS URI, KAS ID, or KAS name, with results filtered to the allowed KAS scope.
  * Updated BDD coverage and policy examples to reflect the new listing behavior.

* **Bug Fixes**
  * Improved authorization handling for empty, missing, or invalid list responses to prevent incorrect access decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->