### PR TITLE
fix(authz): Add default role for every req.

### DIFF
--- a/service/internal/auth/authz/casbin/v2/authorizer.go
+++ b/service/internal/auth/authz/casbin/v2/authorizer.go
@@ -200,10 +200,7 @@ func (a *Authorizer) authorize(ctx context.Context, req *authz.Request) (*authz.
 		return nil, fmt.Errorf("v2 authorization subject extraction error: %w", err)
 	}
 
-	// If no subjects found, use default role
-	if len(subjects) == 0 {
-		subjects = append(subjects, rolePrefix+defaultRole)
-	}
+	subjects = append(subjects, rolePrefix+defaultRole)
 
 	resourceDims, err := serializeDimensions(req.ResourceContext)
 	if err != nil {

--- a/service/internal/auth/authz/casbin/v2/authorizer_test.go
+++ b/service/internal/auth/authz/casbin/v2/authorizer_test.go
@@ -794,6 +794,37 @@ p, role:unknown, /kas.AccessService/Rewrap, *, allow`,
 	}
 }
 
+func (s *CasbinAuthorizerSuite) TestAuthorizeV2_AllRequestsIncludeUnknownRole() {
+	cfg := authz.Config{
+		PolicyConfig: authz.PolicyConfig{
+			Version:     "v2",
+			GroupsClaim: "realm_access.roles",
+			Csv:         "p, role:unknown, /kas.AccessService/Rewrap, *, allow",
+		},
+		Logger: s.logger,
+	}
+
+	authorizer, err := s.newAuthorizer(cfg)
+	s.Require().NoError(err)
+
+	token := createTestToken(s.T(), map[string]interface{}{
+		"realm_access": map[string]interface{}{
+			"roles": []interface{}{"standard"},
+		},
+	})
+
+	decision, err := authorizer.Authorize(context.Background(), &authz.Request{
+		Token:  token,
+		RPC:    "/kas.AccessService/Rewrap",
+		Action: "read",
+	})
+
+	s.Require().NoError(err)
+	s.Require().NotNil(decision)
+	s.True(decision.Allowed)
+	s.Equal("role:unknown", decision.MatchedPolicy)
+}
+
 // Test dimension matching logic
 func TestDimensionMatch(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
1.) Follow v1 flow and add `role:unknown` for every request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization now consistently evaluates requests with the default role included, improving policy matching for all requests.
  * Requests can now match policies tied to the fallback role even when other roles are present.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->