### PR TITLE
feat(policy): implement narrow attribute read APIs

### DIFF
--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -1653,9 +1653,10 @@ func (s *AttributesSuite) Test_GetKeyMappingsByFqns() {
 		s.Equal("r1", m.GetKeys()[0].GetPublicKey().GetKid())
 	})
 
-	s.Run("errors when a value is missing even with allow_traversal", func() {
-		// allow_traversal lets GetAttributesByValueFqns fall back to the definition
-		// for a missing value; this value-FQN API must still reject it.
+	s.Run("missing value resolves at definition level with allow_traversal", func() {
+		// allow_traversal lets a not-yet-created value fall back to its definition, so
+		// GetKeyMappingsByFqns resolves the definition's key for that value and
+		// front-loaded TDF creation still gets a key set.
 		ns, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{Name: "keymap-traversal.example"})
 		s.Require().NoError(err)
 		created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
@@ -1667,11 +1668,17 @@ func (s *AttributesSuite) Test_GetKeyMappingsByFqns() {
 		})
 		s.Require().NoError(err)
 
-		_, err = s.db.PolicyClient.GetKeyMappingsByFqns(s.ctx, &attributes.GetKeyMappingsByFqnsRequest{
-			Fqns: []string{fqnBuilder(ns.GetName(), created.GetName(), "missing_value")},
+		key1 := keyByFixture("kas_key_1")
+		_, err = s.db.PolicyClient.AssignPublicKeyToAttribute(s.ctx, &attributes.AttributeKey{
+			AttributeId: created.GetId(),
+			KeyId:       key1.GetKey().GetId(),
 		})
-		s.Require().Error(err)
-		s.Require().ErrorIs(err, db.ErrNotFound)
+		s.Require().NoError(err)
+
+		missingFqn := fqnBuilder(ns.GetName(), created.GetName(), "missing_value")
+		mappings := keysByFqn(missingFqn)
+		s.Require().Len(mappings, 1)
+		assertSingleKey(mappings[missingFqn], policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, key1)
 	})
 
 	s.Run("errors when a requested fqn does not exist", func() {
@@ -1736,10 +1743,10 @@ func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_NonExistentFqn_Fai
 	s.Require().ErrorIs(err, db.ErrNotFound)
 }
 
-func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_MissingValueAllowTraversal_Fails() {
-	// allow_traversal lets GetAttributesByValueFqns fall back to the definition for
-	// a missing value; this value-FQN API must reject it rather than return an
-	// entry with an empty value_id.
+func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_MissingValueAllowTraversal_Succeeds() {
+	// allow_traversal lets a not-yet-created value fall back to its definition, so
+	// this API returns the definition context plus an entry with an empty value
+	// identity (no value_id, no subject mappings) rather than erroring.
 	ns, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{Name: "entitleable-traversal.example"})
 	s.Require().NoError(err)
 	created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
@@ -1751,11 +1758,25 @@ func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_MissingValueAllowT
 	})
 	s.Require().NoError(err)
 
-	_, err = s.db.PolicyClient.GetEntitleableAttributesByFqns(s.ctx, &attributes.GetEntitleableAttributesByFqnsRequest{
-		Fqns: []string{fqnBuilder(ns.GetName(), created.GetName(), "missing_value")},
+	missingFqn := fqnBuilder(ns.GetName(), created.GetName(), "missing_value")
+	resp, err := s.db.PolicyClient.GetEntitleableAttributesByFqns(s.ctx, &attributes.GetEntitleableAttributesByFqnsRequest{
+		Fqns: []string{missingFqn},
 	})
-	s.Require().Error(err)
-	s.Require().ErrorIs(err, db.ErrNotFound)
+	s.Require().NoError(err)
+
+	got, err := s.db.PolicyClient.GetAttribute(s.ctx, created.GetId())
+	s.Require().NoError(err)
+	defFqn := got.GetFqn()
+	def := resp.GetDefinitions()[defFqn]
+	s.Require().NotNil(def)
+	s.Equal(policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, def.GetRule())
+
+	e := resp.GetFqnEntitleableAttributes()[missingFqn]
+	s.Require().NotNil(e)
+	s.Equal(defFqn, e.GetDefinitionFqn())
+	s.Equal(missingFqn, e.GetValue().GetFqn())
+	s.Empty(e.GetValue().GetValueId())
+	s.Empty(e.GetValue().GetSubjectMappings())
 }
 
 func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_Hierarchy() {

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -1675,6 +1675,7 @@ func (s *AttributesSuite) Test_GetKeyMappingsByFqns() {
 			Fqns: []string{"https://keymap-dne.example/attr/nope/value/nope"},
 		})
 		s.Require().Error(err)
+		s.Require().ErrorIs(err, db.ErrNotFound)
 	})
 }
 
@@ -1728,6 +1729,7 @@ func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_NonExistentFqn_Fai
 		Fqns: []string{"https://entitleable-dne.example/attr/nope/value/nope"},
 	})
 	s.Require().Error(err)
+	s.Require().ErrorIs(err, db.ErrNotFound)
 }
 
 func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_MissingValueAllowTraversal_Fails() {

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -1636,17 +1636,21 @@ func (s *AttributesSuite) Test_GetKeyMappingsByFqns() {
 		assertSingleKey(mappings[fqnGamma], policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, key1)
 	})
 
-	s.Run("legacy grants only: keys empty (grants are ignored)", func() {
-		// value1 (and its definition attr1) are configured only with legacy
-		// KeyAccessServer grants and no key mappings. This API resolves kas_keys
-		// and ignores grants, so the key set must be empty.
+	s.Run("legacy grants resolve to keys (grants with cached keys only)", func() {
+		// value1 is configured only with legacy KeyAccessServer grants (no key
+		// mappings): one to a cached-key KAS (local.kas.com:3000, kid r1) and one
+		// to a remote-only KAS (kas.example.com). Grants are resolved into the key
+		// set, but only grants that carry a cached public key can be returned; the
+		// remote-only grant is skipped (no kid/pem to hand the client).
 		fqn := "https://example.com/attr/attr1/value/value1"
 		mappings := keysByFqn(fqn)
 		s.Require().Len(mappings, 1)
 		m := mappings[fqn]
 		s.Require().NotNil(m)
 		s.Equal(policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, m.GetRule())
-		s.Empty(m.GetKeys())
+		s.Require().Len(m.GetKeys(), 1)
+		s.Equal("https://local.kas.com:3000", m.GetKeys()[0].GetKasUri())
+		s.Equal("r1", m.GetKeys()[0].GetPublicKey().GetKid())
 	})
 
 	s.Run("errors when a value is missing even with allow_traversal", func() {
@@ -1827,6 +1831,53 @@ func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_Hierarchy() {
 	// The requested low value carries no subject mappings (the only mapping is on
 	// the mid value); confirms the per-value entry does not inherit sibling mappings.
 	s.Empty(e.GetValue().GetSubjectMappings())
+}
+
+func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_SubjectMappingNamespace() {
+	// The entitleable subject mappings must carry the subject mapping's own
+	// namespace, which the PDP's strict namespaced-entitlements filter relies on.
+	created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+		Name:        "test__entitleable_sm_namespace",
+		NamespaceId: fixtureNamespaceID,
+		Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+		Values:      []string{"v1"},
+	})
+	s.Require().NoError(err)
+	got, err := s.db.PolicyClient.GetAttribute(s.ctx, created.GetId())
+	s.Require().NoError(err)
+	val := got.GetValues()[0]
+
+	_, err = s.db.PolicyClient.CreateSubjectMapping(s.ctx, &subjectmapping.CreateSubjectMappingRequest{
+		AttributeValueId: val.GetId(),
+		NamespaceId:      fixtureNamespaceID,
+		// A namespaced subject mapping requires an action in the same namespace; use
+		// a custom action (the standard actions are unnamespaced).
+		Actions: []*policy.Action{{Name: "entitleable_ns_read"}},
+		NewSubjectConditionSet: &subjectmapping.SubjectConditionSetCreate{
+			SubjectSets: []*policy.SubjectSet{{
+				ConditionGroups: []*policy.ConditionGroup{{
+					BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+					Conditions: []*policy.Condition{{
+						SubjectExternalSelectorValue: ".clearance",
+						Operator:                     policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+						SubjectExternalValues:        []string{"secret"},
+					}},
+				}},
+			}},
+		},
+	})
+	s.Require().NoError(err)
+
+	resp, err := s.db.PolicyClient.GetEntitleableAttributesByFqns(s.ctx, &attributes.GetEntitleableAttributesByFqnsRequest{
+		Fqns: []string{val.GetFqn()},
+	})
+	s.Require().NoError(err)
+	e := resp.GetFqnEntitleableAttributes()[val.GetFqn()]
+	s.Require().NotNil(e)
+	sms := e.GetValue().GetSubjectMappings()
+	s.Require().Len(sms, 1)
+	s.Require().NotNil(sms[0].GetNamespace())
+	s.Equal(fixtureNamespaceID, sms[0].GetNamespace().GetId())
 }
 
 func (s *AttributesSuite) Test_UnsafeUpdateAttribute_NormalizesCasing() {

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -1636,21 +1636,18 @@ func (s *AttributesSuite) Test_GetKeyMappingsByFqns() {
 		assertSingleKey(mappings[fqnGamma], policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, key1)
 	})
 
-	s.Run("legacy grants resolve to keys (grants with cached keys only)", func() {
+	s.Run("legacy grants are not resolved to keys (client resolves grants)", func() {
 		// value1 is configured only with legacy KeyAccessServer grants (no key
-		// mappings): one to a cached-key KAS (local.kas.com:3000, kid r1) and one
-		// to a remote-only KAS (kas.example.com). Grants are resolved into the key
-		// set, but only grants that carry a cached public key can be returned; the
-		// remote-only grant is skipped (no kid/pem to hand the client).
+		// mappings). This API returns mapped keys only, so the key set is empty and
+		// the client granter resolves the grants via GetAttributeValuesByFqns. The
+		// rule is still populated.
 		fqn := "https://example.com/attr/attr1/value/value1"
 		mappings := keysByFqn(fqn)
 		s.Require().Len(mappings, 1)
 		m := mappings[fqn]
 		s.Require().NotNil(m)
 		s.Equal(policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, m.GetRule())
-		s.Require().Len(m.GetKeys(), 1)
-		s.Equal("https://local.kas.com:3000", m.GetKeys()[0].GetKasUri())
-		s.Equal("r1", m.GetKeys()[0].GetPublicKey().GetKid())
+		s.Empty(m.GetKeys())
 	})
 
 	s.Run("missing value resolves at definition level with allow_traversal", func() {

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy/attributes"
 	"github.com/opentdf/platform/protocol/go/policy/kasregistry"
 	"github.com/opentdf/platform/protocol/go/policy/namespaces"
+	"github.com/opentdf/platform/protocol/go/policy/subjectmapping"
 	"github.com/opentdf/platform/protocol/go/policy/unsafe"
 	"github.com/opentdf/platform/service/internal/fixtures"
 	"github.com/opentdf/platform/service/pkg/db"
@@ -1521,6 +1522,309 @@ func (s *AttributesSuite) Test_UnsafeUpdateAttribute_WithNewName() {
 	s.NotNil(val)
 	s.Equal(fqns[1], val.GetFqn())
 	s.Contains(val.GetFqn(), updated.GetName())
+}
+
+func (s *AttributesSuite) Test_GetKeyMappingsByFqns() {
+	keyByFixture := func(name string) *policy.KasKey {
+		f := s.f.GetKasRegistryServerKeys(name)
+		k, err := s.db.PolicyClient.GetKey(s.ctx, &kasregistry.GetKeyRequest_Id{Id: f.ID})
+		s.Require().NoError(err)
+		return k
+	}
+	keysByFqn := func(fqns ...string) map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping {
+		m, err := s.db.PolicyClient.GetKeyMappingsByFqns(s.ctx, &attributes.GetKeyMappingsByFqnsRequest{Fqns: fqns})
+		s.Require().NoError(err)
+		return m
+	}
+	assertSingleKey := func(m *attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping, expectedRule policy.AttributeRuleTypeEnum, expected *policy.KasKey) {
+		s.Require().NotNil(m)
+		s.Equal(expectedRule, m.GetRule())
+		s.Require().Len(m.GetKeys(), 1)
+		validateSimpleKasKey(&s.Suite, expected, m.GetKeys()[0])
+	}
+
+	s.Run("rule returned and keys empty when none assigned", func() {
+		created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+			Name:        "test__keymap_none",
+			NamespaceId: fixtureNamespaceID,
+			Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+			Values:      []string{"alpha", "beta"},
+		})
+		s.Require().NoError(err)
+		got, err := s.db.PolicyClient.GetAttribute(s.ctx, created.GetId())
+		s.Require().NoError(err)
+		fqnAlpha, fqnBeta := got.GetValues()[0].GetFqn(), got.GetValues()[1].GetFqn()
+
+		mappings := keysByFqn(fqnAlpha, fqnBeta)
+		s.Len(mappings, 2)
+		for _, fqn := range []string{fqnAlpha, fqnBeta} {
+			m, ok := mappings[fqn]
+			s.Require().True(ok)
+			s.Equal(policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, m.GetRule())
+			s.Empty(m.GetKeys())
+		}
+	})
+
+	s.Run("definition-level key inherited by value with no key", func() {
+		created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+			Name:        "test__keymap_def",
+			NamespaceId: fixtureNamespaceID,
+			Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+			Values:      []string{"alpha"},
+		})
+		s.Require().NoError(err)
+		got, err := s.db.PolicyClient.GetAttribute(s.ctx, created.GetId())
+		s.Require().NoError(err)
+		fqnAlpha := got.GetValues()[0].GetFqn()
+
+		key1 := keyByFixture("kas_key_1")
+		_, err = s.db.PolicyClient.AssignPublicKeyToAttribute(s.ctx, &attributes.AttributeKey{
+			AttributeId: created.GetId(),
+			KeyId:       key1.GetKey().GetId(),
+		})
+		s.Require().NoError(err)
+
+		mappings := keysByFqn(fqnAlpha)
+		s.Require().Len(mappings, 1)
+		assertSingleKey(mappings[fqnAlpha], policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, key1)
+	})
+
+	s.Run("value-level keys: multiple values resolve to their own keys", func() {
+		created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+			Name:        "test__keymap_values",
+			NamespaceId: fixtureNamespaceID,
+			Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+			Values:      []string{"alpha", "beta"},
+		})
+		s.Require().NoError(err)
+		got, err := s.db.PolicyClient.GetAttribute(s.ctx, created.GetId())
+		s.Require().NoError(err)
+		v1, v2 := got.GetValues()[0], got.GetValues()[1]
+
+		key1, key2 := keyByFixture("kas_key_1"), keyByFixture("kas_key_2")
+		_, err = s.db.PolicyClient.AssignPublicKeyToValue(s.ctx, &attributes.ValueKey{ValueId: v1.GetId(), KeyId: key1.GetKey().GetId()})
+		s.Require().NoError(err)
+		_, err = s.db.PolicyClient.AssignPublicKeyToValue(s.ctx, &attributes.ValueKey{ValueId: v2.GetId(), KeyId: key2.GetKey().GetId()})
+		s.Require().NoError(err)
+
+		mappings := keysByFqn(v1.GetFqn(), v2.GetFqn())
+		s.Require().Len(mappings, 2)
+		assertSingleKey(mappings[v1.GetFqn()], policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, key1)
+		assertSingleKey(mappings[v2.GetFqn()], policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, key2)
+	})
+
+	s.Run("namespace-level key inherited when no value or definition key", func() {
+		ns, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{Name: "keymap-ns.example"})
+		s.Require().NoError(err)
+		created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+			Name:        "test__keymap_ns",
+			NamespaceId: ns.GetId(),
+			Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+			Values:      []string{"gamma"},
+		})
+		s.Require().NoError(err)
+		got, err := s.db.PolicyClient.GetAttribute(s.ctx, created.GetId())
+		s.Require().NoError(err)
+		fqnGamma := got.GetValues()[0].GetFqn()
+
+		key1 := keyByFixture("kas_key_1")
+		_, err = s.db.PolicyClient.AssignPublicKeyToNamespace(s.ctx, &namespaces.NamespaceKey{NamespaceId: ns.GetId(), KeyId: key1.GetKey().GetId()})
+		s.Require().NoError(err)
+
+		mappings := keysByFqn(fqnGamma)
+		s.Require().Len(mappings, 1)
+		assertSingleKey(mappings[fqnGamma], policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, key1)
+	})
+
+	s.Run("legacy grants only: keys empty (grants are ignored)", func() {
+		// value1 (and its definition attr1) are configured only with legacy
+		// KeyAccessServer grants and no key mappings. This API resolves kas_keys
+		// and ignores grants, so the key set must be empty.
+		fqn := "https://example.com/attr/attr1/value/value1"
+		mappings := keysByFqn(fqn)
+		s.Require().Len(mappings, 1)
+		m := mappings[fqn]
+		s.Require().NotNil(m)
+		s.Equal(policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, m.GetRule())
+		s.Empty(m.GetKeys())
+	})
+
+	s.Run("errors when a value is missing even with allow_traversal", func() {
+		// allow_traversal lets GetAttributesByValueFqns fall back to the definition
+		// for a missing value; this value-FQN API must still reject it.
+		ns, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{Name: "keymap-traversal.example"})
+		s.Require().NoError(err)
+		created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+			Name:           "test__keymap_traversal",
+			NamespaceId:    ns.GetId(),
+			Rule:           policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+			Values:         []string{"alpha"},
+			AllowTraversal: &wrapperspb.BoolValue{Value: true},
+		})
+		s.Require().NoError(err)
+
+		_, err = s.db.PolicyClient.GetKeyMappingsByFqns(s.ctx, &attributes.GetKeyMappingsByFqnsRequest{
+			Fqns: []string{fqnBuilder(ns.GetName(), created.GetName(), "missing_value")},
+		})
+		s.Require().Error(err)
+		s.Require().ErrorIs(err, db.ErrNotFound)
+	})
+
+	s.Run("errors when a requested fqn does not exist", func() {
+		_, err := s.db.PolicyClient.GetKeyMappingsByFqns(s.ctx, &attributes.GetKeyMappingsByFqnsRequest{
+			Fqns: []string{"https://keymap-dne.example/attr/nope/value/nope"},
+		})
+		s.Require().Error(err)
+	})
+}
+
+func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns() {
+	value1 := s.f.GetAttributeValueKey("example.com/attr/attr1/value/value1")
+	value2 := s.f.GetAttributeValueKey("example.com/attr/attr1/value/value2")
+	defFqn := "https://example.com/attr/attr1"
+	fqn1 := "https://example.com/attr/attr1/value/value1"
+	fqn2 := "https://example.com/attr/attr1/value/value2"
+
+	resp, err := s.db.PolicyClient.GetEntitleableAttributesByFqns(s.ctx, &attributes.GetEntitleableAttributesByFqnsRequest{
+		Fqns: []string{fqn1, fqn2},
+	})
+	s.Require().NoError(err)
+
+	// The definition is returned once (deduped) even though two of its values were
+	// requested. attr1 is ANY_OF, so its values list is empty (only hierarchy
+	// definitions carry their values).
+	s.Len(resp.GetDefinitions(), 1)
+	def := resp.GetDefinitions()[defFqn]
+	s.Require().NotNil(def)
+	s.Equal(policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, def.GetRule())
+	s.Empty(def.GetValues())
+
+	// Per-requested-value entries reference the definition and carry subject
+	// mappings grouped by value FQN. Every returned mapping must belong to the
+	// requested value (verifies grouping by FQN).
+	s.Len(resp.GetFqnEntitleableAttributes(), 2)
+	assertValueEntry := func(fqn, valueID string, minSMs int) {
+		e := resp.GetFqnEntitleableAttributes()[fqn]
+		s.Require().NotNil(e)
+		s.Equal(defFqn, e.GetDefinitionFqn())
+		s.Equal(fqn, e.GetValue().GetFqn())
+		s.Equal(valueID, e.GetValue().GetValueId())
+		s.GreaterOrEqual(len(e.GetValue().GetSubjectMappings()), minSMs)
+		for _, sm := range e.GetValue().GetSubjectMappings() {
+			s.Equal(fqn, sm.GetAttributeValue().GetFqn())
+			s.NotEmpty(sm.GetId())
+			s.NotNil(sm.GetSubjectConditionSet())
+		}
+	}
+	// value1 has multiple value-level subject mappings in the fixtures; value2 has one.
+	assertValueEntry(fqn1, value1.ID, 3)
+	assertValueEntry(fqn2, value2.ID, 1)
+}
+
+func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_NonExistentFqn_Fails() {
+	// Matches GetAttributeValuesByFqns: a requested FQN that does not exist errors
+	// rather than being silently absent.
+	_, err := s.db.PolicyClient.GetEntitleableAttributesByFqns(s.ctx, &attributes.GetEntitleableAttributesByFqnsRequest{
+		Fqns: []string{"https://entitleable-dne.example/attr/nope/value/nope"},
+	})
+	s.Require().Error(err)
+}
+
+func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_MissingValueAllowTraversal_Fails() {
+	// allow_traversal lets GetAttributesByValueFqns fall back to the definition for
+	// a missing value; this value-FQN API must reject it rather than return an
+	// entry with an empty value_id.
+	ns, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{Name: "entitleable-traversal.example"})
+	s.Require().NoError(err)
+	created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+		Name:           "test__entitleable_traversal",
+		NamespaceId:    ns.GetId(),
+		Rule:           policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+		Values:         []string{"alpha"},
+		AllowTraversal: &wrapperspb.BoolValue{Value: true},
+	})
+	s.Require().NoError(err)
+
+	_, err = s.db.PolicyClient.GetEntitleableAttributesByFqns(s.ctx, &attributes.GetEntitleableAttributesByFqnsRequest{
+		Fqns: []string{fqnBuilder(ns.GetName(), created.GetName(), "missing_value")},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, db.ErrNotFound)
+}
+
+func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_Hierarchy() {
+	// A hierarchy definition's full ordered values (with subject mappings) are
+	// returned once, even when only one value is requested.
+	created, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+		Name:        "test__entitleable_hierarchy",
+		NamespaceId: fixtureNamespaceID,
+		Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY,
+		Values:      []string{"high", "mid", "low"},
+	})
+	s.Require().NoError(err)
+
+	got, err := s.db.PolicyClient.GetAttribute(s.ctx, created.GetId())
+	s.Require().NoError(err)
+	s.Require().Len(got.GetValues(), 3)
+	defFqn := got.GetFqn()
+	highFqn := got.GetValues()[0].GetFqn()
+	midFqn := got.GetValues()[1].GetFqn()
+	lowFqn := got.GetValues()[2].GetFqn()
+
+	// A subject mapping on the middle value, to confirm hierarchy values carry SMs.
+	_, err = s.db.PolicyClient.CreateSubjectMapping(s.ctx, &subjectmapping.CreateSubjectMappingRequest{
+		AttributeValueId: got.GetValues()[1].GetId(),
+		Actions:          []*policy.Action{s.f.GetStandardAction(policydb.ActionRead.String())},
+		NewSubjectConditionSet: &subjectmapping.SubjectConditionSetCreate{
+			SubjectSets: []*policy.SubjectSet{{
+				ConditionGroups: []*policy.ConditionGroup{{
+					BooleanOperator: policy.ConditionBooleanTypeEnum_CONDITION_BOOLEAN_TYPE_ENUM_AND,
+					Conditions: []*policy.Condition{{
+						SubjectExternalSelectorValue: ".clearance",
+						Operator:                     policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+						SubjectExternalValues:        []string{"mid"},
+					}},
+				}},
+			}},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Request only the lowest value; the response must still carry the whole
+	// definition's ordered values plus the mid value's subject mapping.
+	resp, err := s.db.PolicyClient.GetEntitleableAttributesByFqns(s.ctx, &attributes.GetEntitleableAttributesByFqnsRequest{
+		Fqns: []string{lowFqn},
+	})
+	s.Require().NoError(err)
+
+	// Only the requested value is in the per-FQN map; the hierarchy siblings come
+	// back via the definition's values, not as extra entitleable attributes.
+	s.Len(resp.GetFqnEntitleableAttributes(), 1)
+	_, hasHigh := resp.GetFqnEntitleableAttributes()[highFqn]
+	_, hasMid := resp.GetFqnEntitleableAttributes()[midFqn]
+	s.False(hasHigh)
+	s.False(hasMid)
+
+	def := resp.GetDefinitions()[defFqn]
+	s.Require().NotNil(def)
+	s.Equal(policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY, def.GetRule())
+	s.Require().Len(def.GetValues(), 3)
+	// Ordered high -> mid -> low (definition values_order).
+	s.Equal(highFqn, def.GetValues()[0].GetFqn())
+	s.Equal(midFqn, def.GetValues()[1].GetFqn())
+	s.Equal(lowFqn, def.GetValues()[2].GetFqn())
+	// The mid value carries the subject mapping; siblings have none.
+	s.Len(def.GetValues()[1].GetSubjectMappings(), 1)
+	s.Empty(def.GetValues()[0].GetSubjectMappings())
+	s.Empty(def.GetValues()[2].GetSubjectMappings())
+
+	e := resp.GetFqnEntitleableAttributes()[lowFqn]
+	s.Require().NotNil(e)
+	s.Equal(defFqn, e.GetDefinitionFqn())
+	s.Equal(lowFqn, e.GetValue().GetFqn())
+	// The requested low value carries no subject mappings (the only mapping is on
+	// the mid value); confirms the per-value entry does not inherit sibling mappings.
+	s.Empty(e.GetValue().GetSubjectMappings())
 }
 
 func (s *AttributesSuite) Test_UnsafeUpdateAttribute_NormalizesCasing() {

--- a/service/policy/attributes/attributes.go
+++ b/service/policy/attributes/attributes.go
@@ -172,16 +172,35 @@ func (s *AttributesService) GetAttributeValuesByFqns(ctx context.Context,
 	return connect.NewResponse(rsp), nil
 }
 
-func (s *AttributesService) GetKeyMappingsByFqns(_ context.Context, _ *connect.Request[attributes.GetKeyMappingsByFqnsRequest]) (*connect.Response[attributes.GetKeyMappingsByFqnsResponse], error) {
-	// Server implementation lands in the follow-up service PR; the proto and
-	// generated code are released first.
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("GetKeyMappingsByFqns is not yet implemented"))
+func (s *AttributesService) GetKeyMappingsByFqns(ctx context.Context,
+	req *connect.Request[attributes.GetKeyMappingsByFqnsRequest],
+) (*connect.Response[attributes.GetKeyMappingsByFqnsResponse], error) {
+	ctx, span := s.Start(ctx, "GetKeyMappingsByFqns")
+	defer span.End()
+
+	rsp := &attributes.GetKeyMappingsByFqnsResponse{}
+
+	mappings, err := s.dbClient.GetKeyMappingsByFqns(ctx, req.Msg)
+	if err != nil {
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("fqns", fmt.Sprintf("%v", req.Msg.GetFqns())))
+	}
+	rsp.FqnKeyMappings = mappings
+
+	return connect.NewResponse(rsp), nil
 }
 
-func (s *AttributesService) GetEntitleableAttributesByFqns(_ context.Context, _ *connect.Request[attributes.GetEntitleableAttributesByFqnsRequest]) (*connect.Response[attributes.GetEntitleableAttributesByFqnsResponse], error) {
-	// Server implementation lands in the follow-up service PR; the proto and
-	// generated code are released first.
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("GetEntitleableAttributesByFqns is not yet implemented"))
+func (s *AttributesService) GetEntitleableAttributesByFqns(ctx context.Context,
+	req *connect.Request[attributes.GetEntitleableAttributesByFqnsRequest],
+) (*connect.Response[attributes.GetEntitleableAttributesByFqnsResponse], error) {
+	ctx, span := s.Start(ctx, "GetEntitleableAttributesByFqns")
+	defer span.End()
+
+	rsp, err := s.dbClient.GetEntitleableAttributesByFqns(ctx, req.Msg)
+	if err != nil {
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.String("fqns", fmt.Sprintf("%v", req.Msg.GetFqns())))
+	}
+
+	return connect.NewResponse(rsp), nil
 }
 
 func (s *AttributesService) UpdateAttribute(ctx context.Context,

--- a/service/policy/db/attribute_fqn.go
+++ b/service/policy/db/attribute_fqn.go
@@ -385,26 +385,48 @@ func hydrateSubjectMappingForEntitlement(row getSubjectMappingsByValueFqnsRow) (
 		return nil, err
 	}
 
+	// The subject mapping's own namespace is needed for strict namespaced-mode
+	// entitlement filtering in the PDP (NewPolicyDecisionPoint reads sm.Namespace).
+	namespace, err := hydrateNamespaceFromInterface(row.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
 	return &policy.SubjectMapping{
 		Id:                  row.ID,
 		Metadata:            metadata,
 		AttributeValue:      av,
 		SubjectConditionSet: &scs,
 		Actions:             actions,
+		Namespace:           namespace,
 	}, nil
 }
 
 // resolveEffectiveKasKeys selects the effective mapped KAS keys for a value using
 // value > definition > namespace precedence, matching the SDK granter logic in
 // sdk/granter.go (newGranterFromService).
+// resolveEffectiveKasKeys returns the most-specific effective keys for a value
+// with value > definition > namespace precedence. Within a level, mapped keys
+// (kas_keys) are preferred; if a level has none, its legacy KAS grants are
+// converted to keys. Resolution stops at the first level that yields any key, so
+// grant-configured policy resolves the same way the client granter did before.
 func resolveEffectiveKasKeys(value *policy.Value, attr *policy.Attribute) []*policy.SimpleKasKey {
 	if keys := value.GetKasKeys(); len(keys) > 0 {
+		return keys
+	}
+	if keys := grantsToSimpleKasKeys(value.GetGrants()); len(keys) > 0 {
 		return keys
 	}
 	if keys := attr.GetKasKeys(); len(keys) > 0 {
 		return keys
 	}
+	if keys := grantsToSimpleKasKeys(attr.GetGrants()); len(keys) > 0 {
+		return keys
+	}
 	if keys := attr.GetNamespace().GetKasKeys(); len(keys) > 0 {
+		return keys
+	}
+	if keys := grantsToSimpleKasKeys(attr.GetNamespace().GetGrants()); len(keys) > 0 {
 		return keys
 	}
 	return nil

--- a/service/policy/db/attribute_fqn.go
+++ b/service/policy/db/attribute_fqn.go
@@ -216,6 +216,9 @@ func (c *PolicyDBClient) GetKeyMappingsByFqns(ctx context.Context, r *attributes
 	defer span.End()
 
 	fqns := r.GetFqns()
+	if len(fqns) == 0 {
+		return map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping{}, nil
+	}
 	normalized := make([]string, len(fqns))
 	for i, fqn := range fqns {
 		normalized[i] = strings.ToLower(fqn)
@@ -257,6 +260,12 @@ func (c *PolicyDBClient) GetEntitleableAttributesByFqns(ctx context.Context, r *
 	defer span.End()
 
 	fqns := r.GetFqns()
+	if len(fqns) == 0 {
+		return &attributes.GetEntitleableAttributesByFqnsResponse{
+			Definitions:              map[string]*attributes.GetEntitleableAttributesByFqnsResponse_EntitleableDefinition{},
+			FqnEntitleableAttributes: map[string]*attributes.GetEntitleableAttributesByFqnsResponse_EntitleableAttribute{},
+		}, nil
+	}
 	normalized := make([]string, len(fqns))
 	for i, fqn := range fqns {
 		normalized[i] = strings.ToLower(fqn)

--- a/service/policy/db/attribute_fqn.go
+++ b/service/policy/db/attribute_fqn.go
@@ -205,12 +205,37 @@ func (c *PolicyDBClient) GetAttributesByValueFqns(ctx context.Context, r *attrib
 	return list, nil
 }
 
+// resolveValueFqns normalizes the requested FQNs, resolves them via
+// GetAttributesByValueFqns, and rejects any FQN that resolved only to a
+// definition (nil value, which GetAttributesByValueFqns returns when a value is
+// missing and allow_traversal is enabled). These value-FQN APIs require a
+// concrete value per requested FQN. Returns the normalized FQNs and the resolved
+// pairs.
+func (c *PolicyDBClient) resolveValueFqns(ctx context.Context, fqns []string) ([]string, map[string]*attributes.GetAttributeValuesByFqnsResponse_AttributeAndValue, error) {
+	normalized := make([]string, len(fqns))
+	for i, fqn := range fqns {
+		normalized[i] = strings.ToLower(fqn)
+	}
+
+	pairs, err := c.GetAttributesByValueFqns(ctx, &attributes.GetAttributeValuesByFqnsRequest{Fqns: normalized})
+	if err != nil {
+		return nil, nil, err
+	}
+	for fqn, pair := range pairs {
+		if pair.GetValue() == nil {
+			return nil, nil, fmt.Errorf("could not find value for FQN [%s]: %w", fqn, db.ErrNotFound)
+		}
+	}
+	return normalized, pairs, nil
+}
+
 // GetKeyMappingsByFqns returns, for each requested attribute value FQN, the
 // governing attribute rule and the effective KAS keys needed to build key
-// splits. Keys are resolved with value > definition > namespace precedence using
-// the mapped key model (SimpleKasKey), mirroring the client-side granter
-// resolution. Values configured only with legacy KeyAccessServer grants (no
-// kas_keys) return an empty key set; migrate such policy to keys to use this API.
+// splits. Keys are resolved with value > definition > namespace precedence,
+// preferring the mapped key model (SimpleKasKey) but falling back to legacy
+// KeyAccessServer grants at each level, mirroring the client-side granter
+// resolution. Grants without a usable cached public key (missing kid/pem) yield
+// no key for that level.
 func (c *PolicyDBClient) GetKeyMappingsByFqns(ctx context.Context, r *attributes.GetKeyMappingsByFqnsRequest) (map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping, error) {
 	ctx, span := c.Start(ctx, "DB:GetKeyMappingsByFqns")
 	defer span.End()
@@ -219,22 +244,10 @@ func (c *PolicyDBClient) GetKeyMappingsByFqns(ctx context.Context, r *attributes
 	if len(fqns) == 0 {
 		return map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping{}, nil
 	}
-	normalized := make([]string, len(fqns))
-	for i, fqn := range fqns {
-		normalized[i] = strings.ToLower(fqn)
-	}
 
-	pairs, err := c.GetAttributesByValueFqns(ctx, &attributes.GetAttributeValuesByFqnsRequest{Fqns: normalized})
+	_, pairs, err := c.resolveValueFqns(ctx, fqns)
 	if err != nil {
 		return nil, err
-	}
-	// GetAttributesByValueFqns resolves to the definition (with a nil value) when a
-	// value FQN is missing and the attribute has allow_traversal enabled. This API
-	// is value-FQN specific, so reject any FQN that did not resolve to a value.
-	for fqn, pair := range pairs {
-		if pair.GetValue() == nil {
-			return nil, fmt.Errorf("could not find value for FQN [%s]: %w", fqn, db.ErrNotFound)
-		}
 	}
 
 	mappings := make(map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping, len(pairs))
@@ -266,22 +279,9 @@ func (c *PolicyDBClient) GetEntitleableAttributesByFqns(ctx context.Context, r *
 			FqnEntitleableAttributes: map[string]*attributes.GetEntitleableAttributesByFqnsResponse_EntitleableAttribute{},
 		}, nil
 	}
-	normalized := make([]string, len(fqns))
-	for i, fqn := range fqns {
-		normalized[i] = strings.ToLower(fqn)
-	}
-
-	pairs, err := c.GetAttributesByValueFqns(ctx, &attributes.GetAttributeValuesByFqnsRequest{Fqns: normalized})
+	normalized, pairs, err := c.resolveValueFqns(ctx, fqns)
 	if err != nil {
 		return nil, err
-	}
-	// GetAttributesByValueFqns resolves to the definition (with a nil value) when a
-	// value FQN is missing and the attribute has allow_traversal enabled. This API
-	// is value-FQN specific, so reject any FQN that did not resolve to a value.
-	for fqn, pair := range pairs {
-		if pair.GetValue() == nil {
-			return nil, fmt.Errorf("could not find value for FQN [%s]: %w", fqn, db.ErrNotFound)
-		}
 	}
 
 	// Build the subject-mapping fetch set: the requested value FQNs plus, for every

--- a/service/policy/db/attribute_fqn.go
+++ b/service/policy/db/attribute_fqn.go
@@ -402,9 +402,6 @@ func hydrateSubjectMappingForEntitlement(row getSubjectMappingsByValueFqnsRow) (
 	}, nil
 }
 
-// resolveEffectiveKasKeys selects the effective mapped KAS keys for a value using
-// value > definition > namespace precedence, matching the SDK granter logic in
-// sdk/granter.go (newGranterFromService).
 // resolveEffectiveKasKeys returns the most-specific effective keys for a value
 // with value > definition > namespace precedence. Within a level, mapped keys
 // (kas_keys) are preferred; if a level has none, its legacy KAS grants are

--- a/service/policy/db/attribute_fqn.go
+++ b/service/policy/db/attribute_fqn.go
@@ -205,6 +205,202 @@ func (c *PolicyDBClient) GetAttributesByValueFqns(ctx context.Context, r *attrib
 	return list, nil
 }
 
+// GetKeyMappingsByFqns returns, for each requested attribute value FQN, the
+// governing attribute rule and the effective KAS keys needed to build key
+// splits. Keys are resolved with value > definition > namespace precedence using
+// the mapped key model (SimpleKasKey), mirroring the client-side granter
+// resolution. Values configured only with legacy KeyAccessServer grants (no
+// kas_keys) return an empty key set; migrate such policy to keys to use this API.
+func (c *PolicyDBClient) GetKeyMappingsByFqns(ctx context.Context, r *attributes.GetKeyMappingsByFqnsRequest) (map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping, error) {
+	ctx, span := c.Start(ctx, "DB:GetKeyMappingsByFqns")
+	defer span.End()
+
+	fqns := r.GetFqns()
+	normalized := make([]string, len(fqns))
+	for i, fqn := range fqns {
+		normalized[i] = strings.ToLower(fqn)
+	}
+
+	pairs, err := c.GetAttributesByValueFqns(ctx, &attributes.GetAttributeValuesByFqnsRequest{Fqns: normalized})
+	if err != nil {
+		return nil, err
+	}
+	// GetAttributesByValueFqns resolves to the definition (with a nil value) when a
+	// value FQN is missing and the attribute has allow_traversal enabled. This API
+	// is value-FQN specific, so reject any FQN that did not resolve to a value.
+	for fqn, pair := range pairs {
+		if pair.GetValue() == nil {
+			return nil, fmt.Errorf("could not find value for FQN [%s]: %w", fqn, db.ErrNotFound)
+		}
+	}
+
+	mappings := make(map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping, len(pairs))
+	for fqn, pair := range pairs {
+		attr := pair.GetAttribute()
+		mappings[fqn] = &attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping{
+			Rule: attr.GetRule(),
+			Keys: resolveEffectiveKasKeys(pair.GetValue(), attr),
+		}
+	}
+
+	return mappings, nil
+}
+
+// GetEntitleableAttributesByFqns returns, for each requested attribute value FQN,
+// the information needed to resolve entitlements: the attribute rule, the value
+// identity, the definition's ordered value FQNs (for hierarchy rule logic), and
+// the value-level subject mappings. It runs two selective queries: the attribute
+// FQN lookup for rule/value/sibling data, and a single subject-mapping-by-FQN
+// query, avoiding the full-policy load used by the entitlement path today.
+func (c *PolicyDBClient) GetEntitleableAttributesByFqns(ctx context.Context, r *attributes.GetEntitleableAttributesByFqnsRequest) (*attributes.GetEntitleableAttributesByFqnsResponse, error) {
+	ctx, span := c.Start(ctx, "DB:GetEntitleableAttributesByFqns")
+	defer span.End()
+
+	fqns := r.GetFqns()
+	normalized := make([]string, len(fqns))
+	for i, fqn := range fqns {
+		normalized[i] = strings.ToLower(fqn)
+	}
+
+	pairs, err := c.GetAttributesByValueFqns(ctx, &attributes.GetAttributeValuesByFqnsRequest{Fqns: normalized})
+	if err != nil {
+		return nil, err
+	}
+	// GetAttributesByValueFqns resolves to the definition (with a nil value) when a
+	// value FQN is missing and the attribute has allow_traversal enabled. This API
+	// is value-FQN specific, so reject any FQN that did not resolve to a value.
+	for fqn, pair := range pairs {
+		if pair.GetValue() == nil {
+			return nil, fmt.Errorf("could not find value for FQN [%s]: %w", fqn, db.ErrNotFound)
+		}
+	}
+
+	// Build the subject-mapping fetch set: the requested value FQNs plus, for every
+	// hierarchy definition referenced, all of its value FQNs (so the hierarchy
+	// siblings' subject mappings are available for entitlement propagation).
+	smFetchSet := make(map[string]struct{}, len(normalized))
+	for _, fqn := range normalized {
+		smFetchSet[fqn] = struct{}{}
+	}
+	for _, pair := range pairs {
+		attr := pair.GetAttribute()
+		if attr.GetRule() != policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY {
+			continue
+		}
+		for _, v := range attr.GetValues() {
+			smFetchSet[v.GetFqn()] = struct{}{}
+		}
+	}
+	smFetchFqns := make([]string, 0, len(smFetchSet))
+	for fqn := range smFetchSet {
+		smFetchFqns = append(smFetchFqns, fqn)
+	}
+
+	// Fetch the value-level subject mappings in one query, grouped by value FQN.
+	smRows, err := c.queries.getSubjectMappingsByValueFqns(ctx, smFetchFqns)
+	if err != nil {
+		return nil, db.WrapIfKnownInvalidQueryErr(err)
+	}
+	subjectMappingsByFqn := make(map[string][]*policy.SubjectMapping, len(smRows))
+	for _, row := range smRows {
+		sm, err := hydrateSubjectMappingForEntitlement(row)
+		if err != nil {
+			return nil, err
+		}
+		subjectMappingsByFqn[row.ValueFqn] = append(subjectMappingsByFqn[row.ValueFqn], sm)
+	}
+
+	entitleableValue := func(fqn, valueID string) *attributes.GetEntitleableAttributesByFqnsResponse_EntitleableValue {
+		return &attributes.GetEntitleableAttributesByFqnsResponse_EntitleableValue{
+			Fqn:             fqn,
+			ValueId:         valueID,
+			SubjectMappings: subjectMappingsByFqn[fqn],
+		}
+	}
+
+	rsp := &attributes.GetEntitleableAttributesByFqnsResponse{
+		Definitions:              make(map[string]*attributes.GetEntitleableAttributesByFqnsResponse_EntitleableDefinition, len(pairs)),
+		FqnEntitleableAttributes: make(map[string]*attributes.GetEntitleableAttributesByFqnsResponse_EntitleableAttribute, len(pairs)),
+	}
+
+	for fqn, pair := range pairs {
+		attr := pair.GetAttribute()
+		defFqn := attr.GetFqn()
+
+		// One definition entry per referenced definition. For hierarchy, carry the
+		// ordered values with their subject mappings; for any_of/all_of, leave empty.
+		if _, ok := rsp.GetDefinitions()[defFqn]; !ok {
+			def := &attributes.GetEntitleableAttributesByFqnsResponse_EntitleableDefinition{
+				Rule: attr.GetRule(),
+			}
+			if attr.GetRule() == policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY {
+				def.Values = make([]*attributes.GetEntitleableAttributesByFqnsResponse_EntitleableValue, 0, len(attr.GetValues()))
+				for _, v := range attr.GetValues() {
+					def.Values = append(def.Values, entitleableValue(v.GetFqn(), v.GetId()))
+				}
+			}
+			rsp.Definitions[defFqn] = def
+		}
+
+		rsp.FqnEntitleableAttributes[fqn] = &attributes.GetEntitleableAttributesByFqnsResponse_EntitleableAttribute{
+			DefinitionFqn: defFqn,
+			Value:         entitleableValue(fqn, pair.GetValue().GetId()),
+		}
+	}
+
+	return rsp, nil
+}
+
+// hydrateSubjectMappingForEntitlement converts a getSubjectMappingsByValueFqns
+// row into a policy.SubjectMapping, mirroring the hydration in ListSubjectMappings.
+func hydrateSubjectMappingForEntitlement(row getSubjectMappingsByValueFqnsRow) (*policy.SubjectMapping, error) {
+	metadata := &common.Metadata{}
+	if err := unmarshalMetadata(row.Metadata, metadata); err != nil {
+		return nil, err
+	}
+
+	av := &policy.Value{}
+	if err := unmarshalAttributeValue(row.AttributeValue, av); err != nil {
+		return nil, err
+	}
+
+	// standard_actions / custom_actions are selected as ::jsonb, so sqlc yields raw
+	// []byte that unmarshalAllActionsProto consumes directly (no json.Marshal round-trip).
+	actions := []*policy.Action{}
+	if err := unmarshalAllActionsProto(row.StandardActions, row.CustomActions, &actions); err != nil {
+		return nil, err
+	}
+
+	scs := policy.SubjectConditionSet{}
+	if err := unmarshalSubjectConditionSet(row.SubjectConditionSet, &scs); err != nil {
+		return nil, err
+	}
+
+	return &policy.SubjectMapping{
+		Id:                  row.ID,
+		Metadata:            metadata,
+		AttributeValue:      av,
+		SubjectConditionSet: &scs,
+		Actions:             actions,
+	}, nil
+}
+
+// resolveEffectiveKasKeys selects the effective mapped KAS keys for a value using
+// value > definition > namespace precedence, matching the SDK granter logic in
+// sdk/granter.go (newGranterFromService).
+func resolveEffectiveKasKeys(value *policy.Value, attr *policy.Attribute) []*policy.SimpleKasKey {
+	if keys := value.GetKasKeys(); len(keys) > 0 {
+		return keys
+	}
+	if keys := attr.GetKasKeys(); len(keys) > 0 {
+		return keys
+	}
+	if keys := attr.GetNamespace().GetKasKeys(); len(keys) > 0 {
+		return keys
+	}
+	return nil
+}
+
 func definitionFqnFromValueFqn(valueFqn string) string {
 	httpPrefix := "http://"
 	httpsPrefix := "https://"

--- a/service/policy/db/attribute_fqn.go
+++ b/service/policy/db/attribute_fqn.go
@@ -226,14 +226,13 @@ func (c *PolicyDBClient) resolveValueFqns(ctx context.Context, fqns []string) ([
 }
 
 // GetKeyMappingsByFqns returns, for each requested attribute value FQN, the
-// governing attribute rule and the effective KAS keys needed to build key
-// splits. Keys are resolved with value > definition > namespace precedence,
-// preferring the mapped key model (SimpleKasKey) but falling back to legacy
-// KeyAccessServer grants at each level, mirroring the client-side granter
-// resolution. Grants without a usable cached public key (missing kid/pem) yield
-// no key for that level. A value that does not exist under a definition with
+// governing attribute rule and the effective mapped KAS keys needed to build key
+// splits, resolved with value > definition > namespace precedence. Only mapped
+// keys (kas_keys) are returned; a value configured only with legacy KAS grants
+// yields an empty key set, and the client granter resolves those grants via
+// GetAttributeValuesByFqns. A value that does not exist under a definition with
 // allow_traversal resolves at the definition (then namespace) level, so
-// front-loaded TDF creation still gets a key set.
+// front-loaded TDF creation still gets a mapped key set.
 func (c *PolicyDBClient) GetKeyMappingsByFqns(ctx context.Context, r *attributes.GetKeyMappingsByFqnsRequest) (map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping, error) {
 	ctx, span := c.Start(ctx, "DB:GetKeyMappingsByFqns")
 	defer span.End()
@@ -252,7 +251,7 @@ func (c *PolicyDBClient) GetKeyMappingsByFqns(ctx context.Context, r *attributes
 	for fqn, pair := range pairs {
 		attr := pair.GetAttribute()
 		// A nil value is an allow_traversal miss; resolveEffectiveKasKeys skips the
-		// (absent) value level and resolves from the definition/namespace.
+		// (absent) value level and resolves mapped keys from the definition/namespace.
 		mappings[fqn] = &attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping{
 			Rule: attr.GetRule(),
 			Keys: resolveEffectiveKasKeys(pair.GetValue(), attr),
@@ -408,28 +407,20 @@ func hydrateSubjectMappingForEntitlement(row getSubjectMappingsByValueFqnsRow) (
 	}, nil
 }
 
-// resolveEffectiveKasKeys returns the most-specific effective keys for a value
-// with value > definition > namespace precedence. Within a level, mapped keys
-// (kas_keys) are preferred; if a level has none, its legacy KAS grants are
-// converted to keys. Resolution stops at the first level that yields any key, so
-// grant-configured policy resolves the same way the client granter did before.
+// resolveEffectiveKasKeys returns the most-specific mapped KAS keys for a value
+// with value > definition > namespace precedence, stopping at the first level
+// that has mapped keys (kas_keys). Legacy KAS grants are intentionally not
+// resolved here: a value configured only with grants yields no key, and the
+// client granter falls back to GetAttributeValuesByFqns to resolve grants
+// (including remote grants that cannot be represented as a SimpleKasKey).
 func resolveEffectiveKasKeys(value *policy.Value, attr *policy.Attribute) []*policy.SimpleKasKey {
 	if keys := value.GetKasKeys(); len(keys) > 0 {
-		return keys
-	}
-	if keys := grantsToSimpleKasKeys(value.GetGrants()); len(keys) > 0 {
 		return keys
 	}
 	if keys := attr.GetKasKeys(); len(keys) > 0 {
 		return keys
 	}
-	if keys := grantsToSimpleKasKeys(attr.GetGrants()); len(keys) > 0 {
-		return keys
-	}
 	if keys := attr.GetNamespace().GetKasKeys(); len(keys) > 0 {
-		return keys
-	}
-	if keys := grantsToSimpleKasKeys(attr.GetNamespace().GetGrants()); len(keys) > 0 {
 		return keys
 	}
 	return nil

--- a/service/policy/db/attribute_fqn.go
+++ b/service/policy/db/attribute_fqn.go
@@ -205,12 +205,13 @@ func (c *PolicyDBClient) GetAttributesByValueFqns(ctx context.Context, r *attrib
 	return list, nil
 }
 
-// resolveValueFqns normalizes the requested FQNs, resolves them via
-// GetAttributesByValueFqns, and rejects any FQN that resolved only to a
-// definition (nil value, which GetAttributesByValueFqns returns when a value is
-// missing and allow_traversal is enabled). These value-FQN APIs require a
-// concrete value per requested FQN. Returns the normalized FQNs and the resolved
-// pairs.
+// resolveValueFqns normalizes the requested FQNs and resolves them via
+// GetAttributesByValueFqns, returning the normalized FQNs and the resolved pairs.
+// Definition-only pairs (nil value) are retained: GetAttributesByValueFqns
+// returns them when a value is missing but its definition sets allow_traversal,
+// so callers can resolve at the definition level for front-loaded TDF creation.
+// Missing values without allow_traversal already error inside
+// GetAttributesByValueFqns, so a surviving nil value always means traversal.
 func (c *PolicyDBClient) resolveValueFqns(ctx context.Context, fqns []string) ([]string, map[string]*attributes.GetAttributeValuesByFqnsResponse_AttributeAndValue, error) {
 	normalized := make([]string, len(fqns))
 	for i, fqn := range fqns {
@@ -221,11 +222,6 @@ func (c *PolicyDBClient) resolveValueFqns(ctx context.Context, fqns []string) ([
 	if err != nil {
 		return nil, nil, err
 	}
-	for fqn, pair := range pairs {
-		if pair.GetValue() == nil {
-			return nil, nil, fmt.Errorf("could not find value for FQN [%s]: %w", fqn, db.ErrNotFound)
-		}
-	}
 	return normalized, pairs, nil
 }
 
@@ -235,7 +231,9 @@ func (c *PolicyDBClient) resolveValueFqns(ctx context.Context, fqns []string) ([
 // preferring the mapped key model (SimpleKasKey) but falling back to legacy
 // KeyAccessServer grants at each level, mirroring the client-side granter
 // resolution. Grants without a usable cached public key (missing kid/pem) yield
-// no key for that level.
+// no key for that level. A value that does not exist under a definition with
+// allow_traversal resolves at the definition (then namespace) level, so
+// front-loaded TDF creation still gets a key set.
 func (c *PolicyDBClient) GetKeyMappingsByFqns(ctx context.Context, r *attributes.GetKeyMappingsByFqnsRequest) (map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping, error) {
 	ctx, span := c.Start(ctx, "DB:GetKeyMappingsByFqns")
 	defer span.End()
@@ -253,6 +251,8 @@ func (c *PolicyDBClient) GetKeyMappingsByFqns(ctx context.Context, r *attributes
 	mappings := make(map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping, len(pairs))
 	for fqn, pair := range pairs {
 		attr := pair.GetAttribute()
+		// A nil value is an allow_traversal miss; resolveEffectiveKasKeys skips the
+		// (absent) value level and resolves from the definition/namespace.
 		mappings[fqn] = &attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping{
 			Rule: attr.GetRule(),
 			Keys: resolveEffectiveKasKeys(pair.GetValue(), attr),
@@ -268,6 +268,9 @@ func (c *PolicyDBClient) GetKeyMappingsByFqns(ctx context.Context, r *attributes
 // the value-level subject mappings. It runs two selective queries: the attribute
 // FQN lookup for rule/value/sibling data, and a single subject-mapping-by-FQN
 // query, avoiding the full-policy load used by the entitlement path today.
+// A value that does not exist under a definition with allow_traversal is returned
+// with its definition and an empty value identity (no value_id, no subject
+// mappings), so front-loaded values still carry their definition context.
 func (c *PolicyDBClient) GetEntitleableAttributesByFqns(ctx context.Context, r *attributes.GetEntitleableAttributesByFqnsRequest) (*attributes.GetEntitleableAttributesByFqnsResponse, error) {
 	ctx, span := c.Start(ctx, "DB:GetEntitleableAttributesByFqns")
 	defer span.End()
@@ -351,6 +354,9 @@ func (c *PolicyDBClient) GetEntitleableAttributesByFqns(ctx context.Context, r *
 			rsp.Definitions[defFqn] = def
 		}
 
+		// For an allow_traversal miss, pair.GetValue() is nil: GetId() yields "" and
+		// there are no value-level subject mappings, so the entry carries only the
+		// definition context and an empty value identity.
 		rsp.FqnEntitleableAttributes[fqn] = &attributes.GetEntitleableAttributesByFqnsResponse_EntitleableAttribute{
 			DefinitionFqn: defFqn,
 			Value:         entitleableValue(fqn, pair.GetValue().GetId()),

--- a/service/policy/db/attribute_fqn_test.go
+++ b/service/policy/db/attribute_fqn_test.go
@@ -61,7 +61,8 @@ func TestResolveEffectiveKasKeys(t *testing.T) {
 		}
 	}
 
-	// Legacy grants with a cached public key resolve to SimpleKasKeys.
+	// Legacy grants are never resolved to keys here: grant-configured values yield
+	// no mapped key, and the client granter resolves grants via its fallback.
 	grantKAS := func(uri, id, kid string) *policy.KeyAccessServer {
 		return &policy.KeyAccessServer{
 			Uri: uri,
@@ -73,13 +74,6 @@ func TestResolveEffectiveKasKeys(t *testing.T) {
 					}},
 				},
 			},
-		}
-	}
-	grantKey := func(uri, id, kid string) *policy.SimpleKasKey {
-		return &policy.SimpleKasKey{
-			KasUri:    uri,
-			KasId:     id,
-			PublicKey: &policy.SimpleKasPublicKey{Algorithm: policy.Algorithm_ALGORITHM_RSA_2048, Kid: kid, Pem: "pem"},
 		}
 	}
 	valueGrant := grantKAS("https://vg-kas", "vg", "vgk")
@@ -123,39 +117,33 @@ func TestResolveEffectiveKasKeys(t *testing.T) {
 			want:  nil,
 		},
 		{
-			name:  "value grant resolves when no mapped keys",
+			name:  "value grant only yields no key (resolved by client fallback)",
 			value: &policy.Value{Grants: []*policy.KeyAccessServer{valueGrant}},
 			attr:  def(nil, nil),
-			want:  []*policy.SimpleKasKey{grantKey("https://vg-kas", "vg", "vgk")},
+			want:  nil,
 		},
 		{
-			name:  "value mapped key preferred over value grant",
+			name:  "value mapped key returned, value grant ignored",
 			value: &policy.Value{KasKeys: []*policy.SimpleKasKey{valueKey}, Grants: []*policy.KeyAccessServer{valueGrant}},
 			attr:  def(nil, nil),
 			want:  []*policy.SimpleKasKey{valueKey},
 		},
 		{
-			name:  "value grant preferred over definition mapped key",
+			name:  "definition mapped key preferred over value grant",
 			value: &policy.Value{Grants: []*policy.KeyAccessServer{valueGrant}},
 			attr:  def([]*policy.SimpleKasKey{defKey}, nil),
-			want:  []*policy.SimpleKasKey{grantKey("https://vg-kas", "vg", "vgk")},
+			want:  []*policy.SimpleKasKey{defKey},
 		},
 		{
-			name:  "definition grant used when value has none",
+			name:  "definition grant only yields no key",
 			value: &policy.Value{},
 			attr:  &policy.Attribute{Grants: []*policy.KeyAccessServer{defGrant}, Namespace: &policy.Namespace{}},
-			want:  []*policy.SimpleKasKey{grantKey("https://dg-kas", "dg", "dgk")},
+			want:  nil,
 		},
 		{
-			name:  "namespace grant used when value and definition have none",
+			name:  "namespace grant only yields no key",
 			value: &policy.Value{},
 			attr:  &policy.Attribute{Namespace: &policy.Namespace{Grants: []*policy.KeyAccessServer{nsGrant}}},
-			want:  []*policy.SimpleKasKey{grantKey("https://ng-kas", "ng", "ngk")},
-		},
-		{
-			name:  "grant without a cached key is skipped",
-			value: &policy.Value{Grants: []*policy.KeyAccessServer{{Uri: "https://remote-only", Id: "ro"}}},
-			attr:  def(nil, nil),
 			want:  nil,
 		},
 	}

--- a/service/policy/db/attribute_fqn_test.go
+++ b/service/policy/db/attribute_fqn_test.go
@@ -61,6 +61,31 @@ func TestResolveEffectiveKasKeys(t *testing.T) {
 		}
 	}
 
+	// Legacy grants with a cached public key resolve to SimpleKasKeys.
+	grantKAS := func(uri, id, kid string) *policy.KeyAccessServer {
+		return &policy.KeyAccessServer{
+			Uri: uri,
+			Id:  id,
+			PublicKey: &policy.PublicKey{
+				PublicKey: &policy.PublicKey_Cached{
+					Cached: &policy.KasPublicKeySet{Keys: []*policy.KasPublicKey{
+						{Kid: kid, Pem: "pem", Alg: policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048},
+					}},
+				},
+			},
+		}
+	}
+	grantKey := func(uri, id, kid string) *policy.SimpleKasKey {
+		return &policy.SimpleKasKey{
+			KasUri:    uri,
+			KasId:     id,
+			PublicKey: &policy.SimpleKasPublicKey{Algorithm: policy.Algorithm_ALGORITHM_RSA_2048, Kid: kid, Pem: "pem"},
+		}
+	}
+	valueGrant := grantKAS("https://vg-kas", "vg", "vgk")
+	defGrant := grantKAS("https://dg-kas", "dg", "dgk")
+	nsGrant := grantKAS("https://ng-kas", "ng", "ngk")
+
 	tests := []struct {
 		name  string
 		value *policy.Value
@@ -94,6 +119,42 @@ func TestResolveEffectiveKasKeys(t *testing.T) {
 		{
 			name:  "no keys at any level returns nil",
 			value: &policy.Value{},
+			attr:  def(nil, nil),
+			want:  nil,
+		},
+		{
+			name:  "value grant resolves when no mapped keys",
+			value: &policy.Value{Grants: []*policy.KeyAccessServer{valueGrant}},
+			attr:  def(nil, nil),
+			want:  []*policy.SimpleKasKey{grantKey("https://vg-kas", "vg", "vgk")},
+		},
+		{
+			name:  "value mapped key preferred over value grant",
+			value: &policy.Value{KasKeys: []*policy.SimpleKasKey{valueKey}, Grants: []*policy.KeyAccessServer{valueGrant}},
+			attr:  def(nil, nil),
+			want:  []*policy.SimpleKasKey{valueKey},
+		},
+		{
+			name:  "value grant preferred over definition mapped key",
+			value: &policy.Value{Grants: []*policy.KeyAccessServer{valueGrant}},
+			attr:  def([]*policy.SimpleKasKey{defKey}, nil),
+			want:  []*policy.SimpleKasKey{grantKey("https://vg-kas", "vg", "vgk")},
+		},
+		{
+			name:  "definition grant used when value has none",
+			value: &policy.Value{},
+			attr:  &policy.Attribute{Grants: []*policy.KeyAccessServer{defGrant}, Namespace: &policy.Namespace{}},
+			want:  []*policy.SimpleKasKey{grantKey("https://dg-kas", "dg", "dgk")},
+		},
+		{
+			name:  "namespace grant used when value and definition have none",
+			value: &policy.Value{},
+			attr:  &policy.Attribute{Namespace: &policy.Namespace{Grants: []*policy.KeyAccessServer{nsGrant}}},
+			want:  []*policy.SimpleKasKey{grantKey("https://ng-kas", "ng", "ngk")},
+		},
+		{
+			name:  "grant without a cached key is skipped",
+			value: &policy.Value{Grants: []*policy.KeyAccessServer{{Uri: "https://remote-only", Id: "ro"}}},
 			attr:  def(nil, nil),
 			want:  nil,
 		},

--- a/service/policy/db/attribute_fqn_test.go
+++ b/service/policy/db/attribute_fqn_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"testing"
 
+	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,6 +44,64 @@ func TestDefinitionFqnFromValueFqn(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got := definitionFqnFromValueFqn(tc.valueFqn)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestResolveEffectiveKasKeys(t *testing.T) {
+	valueKey := &policy.SimpleKasKey{KasUri: "https://value-kas", KasId: "value"}
+	defKey := &policy.SimpleKasKey{KasUri: "https://def-kas", KasId: "def"}
+	nsKey := &policy.SimpleKasKey{KasUri: "https://ns-kas", KasId: "ns"}
+
+	def := func(defKeys, nsKeys []*policy.SimpleKasKey) *policy.Attribute {
+		return &policy.Attribute{
+			KasKeys:   defKeys,
+			Namespace: &policy.Namespace{KasKeys: nsKeys},
+		}
+	}
+
+	tests := []struct {
+		name  string
+		value *policy.Value
+		attr  *policy.Attribute
+		want  []*policy.SimpleKasKey
+	}{
+		{
+			name:  "value keys win over definition and namespace",
+			value: &policy.Value{KasKeys: []*policy.SimpleKasKey{valueKey}},
+			attr:  def([]*policy.SimpleKasKey{defKey}, []*policy.SimpleKasKey{nsKey}),
+			want:  []*policy.SimpleKasKey{valueKey},
+		},
+		{
+			name:  "definition keys used when value has none",
+			value: &policy.Value{},
+			attr:  def([]*policy.SimpleKasKey{defKey}, []*policy.SimpleKasKey{nsKey}),
+			want:  []*policy.SimpleKasKey{defKey},
+		},
+		{
+			name:  "namespace keys used when value and definition have none",
+			value: &policy.Value{},
+			attr:  def(nil, []*policy.SimpleKasKey{nsKey}),
+			want:  []*policy.SimpleKasKey{nsKey},
+		},
+		{
+			name:  "nil value falls back to definition",
+			value: nil,
+			attr:  def([]*policy.SimpleKasKey{defKey}, nil),
+			want:  []*policy.SimpleKasKey{defKey},
+		},
+		{
+			name:  "no keys at any level returns nil",
+			value: &policy.Value{},
+			attr:  def(nil, nil),
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveEffectiveKasKeys(tc.value, tc.attr)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/service/policy/db/grant_mappings.go
+++ b/service/policy/db/grant_mappings.go
@@ -39,64 +39,6 @@ func mapAlgorithmToKasPublicKeyAlg(alg policy.Algorithm) policy.KasPublicKeyAlgE
 	}
 }
 
-func mapKasPublicKeyAlgToAlgorithm(alg policy.KasPublicKeyAlgEnum) policy.Algorithm {
-	switch alg {
-	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048:
-		return policy.Algorithm_ALGORITHM_RSA_2048
-	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096:
-		return policy.Algorithm_ALGORITHM_RSA_4096
-	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1:
-		return policy.Algorithm_ALGORITHM_EC_P256
-	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1:
-		return policy.Algorithm_ALGORITHM_EC_P384
-	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1:
-		return policy.Algorithm_ALGORITHM_EC_P521
-	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING:
-		return policy.Algorithm_ALGORITHM_HPQT_XWING
-	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768:
-		return policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768
-	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024:
-		return policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024
-	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_MLKEM_768:
-		return policy.Algorithm_ALGORITHM_MLKEM_768
-	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_MLKEM_1024:
-		return policy.Algorithm_ALGORITHM_MLKEM_1024
-	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED:
-		return policy.Algorithm_ALGORITHM_UNSPECIFIED
-	default:
-		return policy.Algorithm_ALGORITHM_UNSPECIFIED
-	}
-}
-
-// grantsToSimpleKasKeys converts legacy KAS grants into SimpleKasKeys using each
-// grant's cached public keys, so grant-configured policy resolves to the same
-// key set that the mapped-key model produces. Grants without a usable cached
-// public key (missing kid or pem) are skipped: a SimpleKasKey without both cannot
-// be consumed by the client key-split builder.
-func grantsToSimpleKasKeys(grants []*policy.KeyAccessServer) []*policy.SimpleKasKey {
-	keys := make([]*policy.SimpleKasKey, 0)
-	for _, grant := range grants {
-		if grant.GetUri() == "" {
-			continue
-		}
-		for _, pk := range grant.GetPublicKey().GetCached().GetKeys() {
-			if pk.GetKid() == "" || pk.GetPem() == "" {
-				continue
-			}
-			keys = append(keys, &policy.SimpleKasKey{
-				KasUri: grant.GetUri(),
-				KasId:  grant.GetId(),
-				PublicKey: &policy.SimpleKasPublicKey{
-					Algorithm: mapKasPublicKeyAlgToAlgorithm(pk.GetAlg()),
-					Kid:       pk.GetKid(),
-					Pem:       pk.GetPem(),
-				},
-			})
-		}
-	}
-	return keys
-}
-
 func mapKasKeysToGrants(keys []*policy.SimpleKasKey, existingGrants []*policy.KeyAccessServer, l *logger.Logger) ([]*policy.KeyAccessServer, error) {
 	kasMap := make(map[string]*policy.KeyAccessServer)
 

--- a/service/policy/db/grant_mappings.go
+++ b/service/policy/db/grant_mappings.go
@@ -39,6 +39,64 @@ func mapAlgorithmToKasPublicKeyAlg(alg policy.Algorithm) policy.KasPublicKeyAlgE
 	}
 }
 
+func mapKasPublicKeyAlgToAlgorithm(alg policy.KasPublicKeyAlgEnum) policy.Algorithm {
+	switch alg {
+	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048:
+		return policy.Algorithm_ALGORITHM_RSA_2048
+	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_RSA_4096:
+		return policy.Algorithm_ALGORITHM_RSA_4096
+	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1:
+		return policy.Algorithm_ALGORITHM_EC_P256
+	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP384R1:
+		return policy.Algorithm_ALGORITHM_EC_P384
+	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP521R1:
+		return policy.Algorithm_ALGORITHM_EC_P521
+	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_HPQT_XWING:
+		return policy.Algorithm_ALGORITHM_HPQT_XWING
+	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP256R1_MLKEM768:
+		return policy.Algorithm_ALGORITHM_HPQT_SECP256R1_MLKEM768
+	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024:
+		return policy.Algorithm_ALGORITHM_HPQT_SECP384R1_MLKEM1024
+	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_MLKEM_768:
+		return policy.Algorithm_ALGORITHM_MLKEM_768
+	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_MLKEM_1024:
+		return policy.Algorithm_ALGORITHM_MLKEM_1024
+	case policy.KasPublicKeyAlgEnum_KAS_PUBLIC_KEY_ALG_ENUM_UNSPECIFIED:
+		return policy.Algorithm_ALGORITHM_UNSPECIFIED
+	default:
+		return policy.Algorithm_ALGORITHM_UNSPECIFIED
+	}
+}
+
+// grantsToSimpleKasKeys converts legacy KAS grants into SimpleKasKeys using each
+// grant's cached public keys, so grant-configured policy resolves to the same
+// key set that the mapped-key model produces. Grants without a usable cached
+// public key (missing kid or pem) are skipped: a SimpleKasKey without both cannot
+// be consumed by the client key-split builder.
+func grantsToSimpleKasKeys(grants []*policy.KeyAccessServer) []*policy.SimpleKasKey {
+	keys := make([]*policy.SimpleKasKey, 0)
+	for _, grant := range grants {
+		if grant == nil || grant.GetUri() == "" {
+			continue
+		}
+		for _, pk := range grant.GetPublicKey().GetCached().GetKeys() {
+			if pk.GetKid() == "" || pk.GetPem() == "" {
+				continue
+			}
+			keys = append(keys, &policy.SimpleKasKey{
+				KasUri: grant.GetUri(),
+				KasId:  grant.GetId(),
+				PublicKey: &policy.SimpleKasPublicKey{
+					Algorithm: mapKasPublicKeyAlgToAlgorithm(pk.GetAlg()),
+					Kid:       pk.GetKid(),
+					Pem:       pk.GetPem(),
+				},
+			})
+		}
+	}
+	return keys
+}
+
 func mapKasKeysToGrants(keys []*policy.SimpleKasKey, existingGrants []*policy.KeyAccessServer, l *logger.Logger) ([]*policy.KeyAccessServer, error) {
 	kasMap := make(map[string]*policy.KeyAccessServer)
 

--- a/service/policy/db/grant_mappings.go
+++ b/service/policy/db/grant_mappings.go
@@ -76,7 +76,7 @@ func mapKasPublicKeyAlgToAlgorithm(alg policy.KasPublicKeyAlgEnum) policy.Algori
 func grantsToSimpleKasKeys(grants []*policy.KeyAccessServer) []*policy.SimpleKasKey {
 	keys := make([]*policy.SimpleKasKey, 0)
 	for _, grant := range grants {
-		if grant == nil || grant.GetUri() == "" {
+		if grant.GetUri() == "" {
 			continue
 		}
 		for _, pk := range grant.GetPublicKey().GetCached().GetKeys() {

--- a/service/policy/db/queries/subject_mappings.sql
+++ b/service/policy/db/queries/subject_mappings.sql
@@ -202,6 +202,76 @@ ORDER BY
 LIMIT @limit_
 OFFSET @offset_;
 
+-- name: getSubjectMappingsByValueFqns :many
+-- Returns value-level subject mappings for the provided attribute value FQNs,
+-- for entitlement resolution. Each row carries the value FQN it maps to so the
+-- caller can group mappings by FQN. Namespace-level mappings (no attribute value)
+-- are excluded by the inner join on attribute_values. The requested FQNs are
+-- resolved to their subject mappings first (filtered_subject_mappings) so action
+-- aggregation only scans the matching mappings rather than the whole table.
+WITH filtered_subject_mappings AS (
+    SELECT sm.id
+    FROM subject_mappings sm
+    JOIN attribute_values av ON sm.attribute_value_id = av.id
+    JOIN attribute_fqns fqns ON av.id = fqns.value_id
+    WHERE fqns.fqn = ANY(@value_fqns::TEXT[])
+), subject_actions AS (
+    SELECT
+        sma.subject_mapping_id,
+        COALESCE(
+            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                END
+            )) FILTER (WHERE a.is_standard = TRUE),
+            '[]'::JSONB
+        ) AS standard_actions,
+        COALESCE(
+            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                END
+            )) FILTER (WHERE a.is_standard = FALSE),
+            '[]'::JSONB
+        ) AS custom_actions
+    FROM filtered_subject_mappings fsm
+    JOIN subject_mapping_actions sma ON sma.subject_mapping_id = fsm.id
+    JOIN actions a ON sma.action_id = a.id
+    LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
+    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
+    GROUP BY sma.subject_mapping_id
+)
+SELECT
+    sm.id,
+    fqns.fqn AS value_fqn,
+    sa.standard_actions::jsonb AS standard_actions,
+    sa.custom_actions::jsonb AS custom_actions,
+    JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', sm.metadata -> 'labels', 'created_at', sm.created_at, 'updated_at', sm.updated_at)) AS metadata,
+    JSON_BUILD_OBJECT(
+        'id', scs.id,
+        'metadata', JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', scs.metadata->'labels', 'created_at', scs.created_at, 'updated_at', scs.updated_at)),
+        'subject_sets', scs.condition,
+        'namespace', CASE
+            WHEN scs.namespace_id IS NULL THEN NULL
+            ELSE JSON_BUILD_OBJECT('id', scs_ns.id, 'name', scs_ns.name, 'fqn', scs_ns_fqns.fqn)
+        END
+    ) AS subject_condition_set,
+    JSON_BUILD_OBJECT(
+        'id', av.id,
+        'value', av.value,
+        'active', av.active,
+        'fqn', fqns.fqn
+    ) AS attribute_value
+FROM subject_mappings sm
+JOIN filtered_subject_mappings fsm ON fsm.id = sm.id
+JOIN attribute_values av ON sm.attribute_value_id = av.id
+JOIN attribute_fqns fqns ON av.id = fqns.value_id
+LEFT JOIN subject_actions sa ON sm.id = sa.subject_mapping_id
+LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
+LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
+LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
+WHERE fqns.fqn = ANY(@value_fqns::TEXT[]);
+
 -- name: getSubjectMapping :one
 SELECT
     sm.id,

--- a/service/policy/db/queries/subject_mappings.sql
+++ b/service/policy/db/queries/subject_mappings.sql
@@ -247,6 +247,10 @@ SELECT
     sa.standard_actions::jsonb AS standard_actions,
     sa.custom_actions::jsonb AS custom_actions,
     JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', sm.metadata -> 'labels', 'created_at', sm.created_at, 'updated_at', sm.updated_at)) AS metadata,
+    CASE
+        WHEN sm.namespace_id IS NULL THEN NULL
+        ELSE JSON_BUILD_OBJECT('id', sm_ns.id, 'name', sm_ns.name, 'fqn', sm_ns_fqns.fqn)
+    END AS namespace,
     JSON_BUILD_OBJECT(
         'id', scs.id,
         'metadata', JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', scs.metadata->'labels', 'created_at', scs.created_at, 'updated_at', scs.updated_at)),
@@ -270,6 +274,8 @@ LEFT JOIN subject_actions sa ON sm.id = sa.subject_mapping_id
 LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
+LEFT JOIN attribute_namespaces sm_ns ON sm_ns.id = sm.namespace_id
+LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
 WHERE fqns.fqn = ANY(@value_fqns::TEXT[]);
 
 -- name: getSubjectMapping :one

--- a/service/policy/db/subject_mappings.sql.go
+++ b/service/policy/db/subject_mappings.sql.go
@@ -391,6 +391,10 @@ SELECT
     sa.standard_actions::jsonb AS standard_actions,
     sa.custom_actions::jsonb AS custom_actions,
     JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', sm.metadata -> 'labels', 'created_at', sm.created_at, 'updated_at', sm.updated_at)) AS metadata,
+    CASE
+        WHEN sm.namespace_id IS NULL THEN NULL
+        ELSE JSON_BUILD_OBJECT('id', sm_ns.id, 'name', sm_ns.name, 'fqn', sm_ns_fqns.fqn)
+    END AS namespace,
     JSON_BUILD_OBJECT(
         'id', scs.id,
         'metadata', JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', scs.metadata->'labels', 'created_at', scs.created_at, 'updated_at', scs.updated_at)),
@@ -414,17 +418,20 @@ LEFT JOIN subject_actions sa ON sm.id = sa.subject_mapping_id
 LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
+LEFT JOIN attribute_namespaces sm_ns ON sm_ns.id = sm.namespace_id
+LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
 WHERE fqns.fqn = ANY($1::TEXT[])
 `
 
 type getSubjectMappingsByValueFqnsRow struct {
-	ID                  string `json:"id"`
-	ValueFqn            string `json:"value_fqn"`
-	StandardActions     []byte `json:"standard_actions"`
-	CustomActions       []byte `json:"custom_actions"`
-	Metadata            []byte `json:"metadata"`
-	SubjectConditionSet []byte `json:"subject_condition_set"`
-	AttributeValue      []byte `json:"attribute_value"`
+	ID                  string      `json:"id"`
+	ValueFqn            string      `json:"value_fqn"`
+	StandardActions     []byte      `json:"standard_actions"`
+	CustomActions       []byte      `json:"custom_actions"`
+	Metadata            []byte      `json:"metadata"`
+	Namespace           interface{} `json:"namespace"`
+	SubjectConditionSet []byte      `json:"subject_condition_set"`
+	AttributeValue      []byte      `json:"attribute_value"`
 }
 
 // Returns value-level subject mappings for the provided attribute value FQNs,
@@ -472,6 +479,10 @@ type getSubjectMappingsByValueFqnsRow struct {
 //	    sa.standard_actions::jsonb AS standard_actions,
 //	    sa.custom_actions::jsonb AS custom_actions,
 //	    JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', sm.metadata -> 'labels', 'created_at', sm.created_at, 'updated_at', sm.updated_at)) AS metadata,
+//	    CASE
+//	        WHEN sm.namespace_id IS NULL THEN NULL
+//	        ELSE JSON_BUILD_OBJECT('id', sm_ns.id, 'name', sm_ns.name, 'fqn', sm_ns_fqns.fqn)
+//	    END AS namespace,
 //	    JSON_BUILD_OBJECT(
 //	        'id', scs.id,
 //	        'metadata', JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', scs.metadata->'labels', 'created_at', scs.created_at, 'updated_at', scs.updated_at)),
@@ -495,6 +506,8 @@ type getSubjectMappingsByValueFqnsRow struct {
 //	LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 //	LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 //	LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
+//	LEFT JOIN attribute_namespaces sm_ns ON sm_ns.id = sm.namespace_id
+//	LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
 //	WHERE fqns.fqn = ANY($1::TEXT[])
 func (q *Queries) getSubjectMappingsByValueFqns(ctx context.Context, valueFqns []string) ([]getSubjectMappingsByValueFqnsRow, error) {
 	rows, err := q.db.Query(ctx, getSubjectMappingsByValueFqns, valueFqns)
@@ -511,6 +524,7 @@ func (q *Queries) getSubjectMappingsByValueFqns(ctx context.Context, valueFqns [
 			&i.StandardActions,
 			&i.CustomActions,
 			&i.Metadata,
+			&i.Namespace,
 			&i.SubjectConditionSet,
 			&i.AttributeValue,
 		); err != nil {

--- a/service/policy/db/subject_mappings.sql.go
+++ b/service/policy/db/subject_mappings.sql.go
@@ -352,6 +352,178 @@ func (q *Queries) getSubjectMapping(ctx context.Context, id string) (getSubjectM
 	return i, err
 }
 
+const getSubjectMappingsByValueFqns = `-- name: getSubjectMappingsByValueFqns :many
+WITH filtered_subject_mappings AS (
+    SELECT sm.id
+    FROM subject_mappings sm
+    JOIN attribute_values av ON sm.attribute_value_id = av.id
+    JOIN attribute_fqns fqns ON av.id = fqns.value_id
+    WHERE fqns.fqn = ANY($1::TEXT[])
+), subject_actions AS (
+    SELECT
+        sma.subject_mapping_id,
+        COALESCE(
+            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                END
+            )) FILTER (WHERE a.is_standard = TRUE),
+            '[]'::JSONB
+        ) AS standard_actions,
+        COALESCE(
+            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+                END
+            )) FILTER (WHERE a.is_standard = FALSE),
+            '[]'::JSONB
+        ) AS custom_actions
+    FROM filtered_subject_mappings fsm
+    JOIN subject_mapping_actions sma ON sma.subject_mapping_id = fsm.id
+    JOIN actions a ON sma.action_id = a.id
+    LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
+    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
+    GROUP BY sma.subject_mapping_id
+)
+SELECT
+    sm.id,
+    fqns.fqn AS value_fqn,
+    sa.standard_actions::jsonb AS standard_actions,
+    sa.custom_actions::jsonb AS custom_actions,
+    JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', sm.metadata -> 'labels', 'created_at', sm.created_at, 'updated_at', sm.updated_at)) AS metadata,
+    JSON_BUILD_OBJECT(
+        'id', scs.id,
+        'metadata', JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', scs.metadata->'labels', 'created_at', scs.created_at, 'updated_at', scs.updated_at)),
+        'subject_sets', scs.condition,
+        'namespace', CASE
+            WHEN scs.namespace_id IS NULL THEN NULL
+            ELSE JSON_BUILD_OBJECT('id', scs_ns.id, 'name', scs_ns.name, 'fqn', scs_ns_fqns.fqn)
+        END
+    ) AS subject_condition_set,
+    JSON_BUILD_OBJECT(
+        'id', av.id,
+        'value', av.value,
+        'active', av.active,
+        'fqn', fqns.fqn
+    ) AS attribute_value
+FROM subject_mappings sm
+JOIN filtered_subject_mappings fsm ON fsm.id = sm.id
+JOIN attribute_values av ON sm.attribute_value_id = av.id
+JOIN attribute_fqns fqns ON av.id = fqns.value_id
+LEFT JOIN subject_actions sa ON sm.id = sa.subject_mapping_id
+LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
+LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
+LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
+WHERE fqns.fqn = ANY($1::TEXT[])
+`
+
+type getSubjectMappingsByValueFqnsRow struct {
+	ID                  string `json:"id"`
+	ValueFqn            string `json:"value_fqn"`
+	StandardActions     []byte `json:"standard_actions"`
+	CustomActions       []byte `json:"custom_actions"`
+	Metadata            []byte `json:"metadata"`
+	SubjectConditionSet []byte `json:"subject_condition_set"`
+	AttributeValue      []byte `json:"attribute_value"`
+}
+
+// Returns value-level subject mappings for the provided attribute value FQNs,
+// for entitlement resolution. Each row carries the value FQN it maps to so the
+// caller can group mappings by FQN. Namespace-level mappings (no attribute value)
+// are excluded by the inner join on attribute_values. The requested FQNs are
+// resolved to their subject mappings first (filtered_subject_mappings) so action
+// aggregation only scans the matching mappings rather than the whole table.
+//
+//	WITH filtered_subject_mappings AS (
+//	    SELECT sm.id
+//	    FROM subject_mappings sm
+//	    JOIN attribute_values av ON sm.attribute_value_id = av.id
+//	    JOIN attribute_fqns fqns ON av.id = fqns.value_id
+//	    WHERE fqns.fqn = ANY($1::TEXT[])
+//	), subject_actions AS (
+//	    SELECT
+//	        sma.subject_mapping_id,
+//	        COALESCE(
+//	            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+//	                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+//	                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+//	                END
+//	            )) FILTER (WHERE a.is_standard = TRUE),
+//	            '[]'::JSONB
+//	        ) AS standard_actions,
+//	        COALESCE(
+//	            JSONB_AGG(JSONB_BUILD_OBJECT('id', a.id, 'name', a.name,
+//	                'namespace', CASE WHEN a.namespace_id IS NULL THEN NULL
+//	                    ELSE JSONB_BUILD_OBJECT('id', ans.id, 'name', ans.name, 'fqn', ans_fqns.fqn)
+//	                END
+//	            )) FILTER (WHERE a.is_standard = FALSE),
+//	            '[]'::JSONB
+//	        ) AS custom_actions
+//	    FROM filtered_subject_mappings fsm
+//	    JOIN subject_mapping_actions sma ON sma.subject_mapping_id = fsm.id
+//	    JOIN actions a ON sma.action_id = a.id
+//	    LEFT JOIN attribute_namespaces ans ON ans.id = a.namespace_id
+//	    LEFT JOIN attribute_fqns ans_fqns ON ans_fqns.namespace_id = ans.id AND ans_fqns.attribute_id IS NULL AND ans_fqns.value_id IS NULL
+//	    GROUP BY sma.subject_mapping_id
+//	)
+//	SELECT
+//	    sm.id,
+//	    fqns.fqn AS value_fqn,
+//	    sa.standard_actions::jsonb AS standard_actions,
+//	    sa.custom_actions::jsonb AS custom_actions,
+//	    JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', sm.metadata -> 'labels', 'created_at', sm.created_at, 'updated_at', sm.updated_at)) AS metadata,
+//	    JSON_BUILD_OBJECT(
+//	        'id', scs.id,
+//	        'metadata', JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', scs.metadata->'labels', 'created_at', scs.created_at, 'updated_at', scs.updated_at)),
+//	        'subject_sets', scs.condition,
+//	        'namespace', CASE
+//	            WHEN scs.namespace_id IS NULL THEN NULL
+//	            ELSE JSON_BUILD_OBJECT('id', scs_ns.id, 'name', scs_ns.name, 'fqn', scs_ns_fqns.fqn)
+//	        END
+//	    ) AS subject_condition_set,
+//	    JSON_BUILD_OBJECT(
+//	        'id', av.id,
+//	        'value', av.value,
+//	        'active', av.active,
+//	        'fqn', fqns.fqn
+//	    ) AS attribute_value
+//	FROM subject_mappings sm
+//	JOIN filtered_subject_mappings fsm ON fsm.id = sm.id
+//	JOIN attribute_values av ON sm.attribute_value_id = av.id
+//	JOIN attribute_fqns fqns ON av.id = fqns.value_id
+//	LEFT JOIN subject_actions sa ON sm.id = sa.subject_mapping_id
+//	LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
+//	LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
+//	LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
+//	WHERE fqns.fqn = ANY($1::TEXT[])
+func (q *Queries) getSubjectMappingsByValueFqns(ctx context.Context, valueFqns []string) ([]getSubjectMappingsByValueFqnsRow, error) {
+	rows, err := q.db.Query(ctx, getSubjectMappingsByValueFqns, valueFqns)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []getSubjectMappingsByValueFqnsRow
+	for rows.Next() {
+		var i getSubjectMappingsByValueFqnsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ValueFqn,
+			&i.StandardActions,
+			&i.CustomActions,
+			&i.Metadata,
+			&i.SubjectConditionSet,
+			&i.AttributeValue,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSubjectConditionSets = `-- name: listSubjectConditionSets :many
 
 WITH params AS (


### PR DESCRIPTION
## Proposed Changes

Service implementation of the narrow attribute read APIs. Stacked on #3634 (proto + generated code).

- `GetKeyMappingsByFqns` / `GetEntitleableAttributesByFqns` DB methods with value > definition > namespace key resolution (mirrors `sdk/granter.go`).
- New lean `getSubjectMappingsByValueFqns` query (single round-trip; action aggregation restricted to the requested FQNs).
- Value-FQN guards: reject `allow_traversal` definition-only fallbacks.
- Real server handlers replacing #3634's Unimplemented stubs.
- Integration + unit tests; regenerated SQL.

## Stack
1. #3634 — proto + generated + docs + sdkconnect wrapper
2. **this PR** — service implementation

Base is #3634; rebase onto `main` once it merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving key mappings and entitleable attributes by attribute FQNs.
  * Returned richer attribute results, including hierarchy-aware values and associated subject mappings.
  * Added support for value-level subject mapping lookup in entitlement responses.

* **Bug Fixes**
  * Improved fallback behavior for missing values and inherited mappings.
  * Ensured non-existent FQNs return a not-found error.
  * Fixed key resolution precedence so value-level mappings take priority over higher-level fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->