### PR TITLE
fix(deps): bump github.com/opentdf/platform/protocol/go from 0.36.0 to 0.37.0 in /sdk

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/opentdf/platform/lib/ocrypto v0.14.0
-	github.com/opentdf/platform/protocol/go v0.36.0
+	github.com/opentdf/platform/protocol/go v0.37.0
 	github.com/stretchr/testify v1.11.1
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/oauth2 v0.36.0

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -50,8 +50,8 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/opentdf/platform/lib/ocrypto v0.14.0 h1:qAIOFpz72/QDhYC0oLRXgA5uEnyv1xqkc7kvWQSRFcY=
 github.com/opentdf/platform/lib/ocrypto v0.14.0/go.mod h1:TLaMvVE1aTqrgW8AZz0ZuxX/ZpI7l5IQOHyX99fdKl0=
-github.com/opentdf/platform/protocol/go v0.36.0 h1:R/Zfb3+AQPA0Ybv25rz8WpWy7SongPP2LdGHCwErZWE=
-github.com/opentdf/platform/protocol/go v0.36.0/go.mod h1:6A0vQJ5D4ZTLReWAp8Y/7jTFzlYCmL/IfMJWDHZS6M0=
+github.com/opentdf/platform/protocol/go v0.37.0 h1:gA4zlfxbswhEadlK/0L/UYpRjiT166EClbcJQEdYcZ0=
+github.com/opentdf/platform/protocol/go v0.37.0/go.mod h1:6A0vQJ5D4ZTLReWAp8Y/7jTFzlYCmL/IfMJWDHZS6M0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
Bumps `github.com/opentdf/platform/protocol/go` from 0.36.0 to 0.37.0 in `/sdk`.

protocol/go v0.37.0 (released from main) contains the narrow attribute-read RPC types (`GetKeyMappingsByFqns`, `GetEntitleableAttributesByFqns`). The sdk already consumes them via the generated `sdk/sdkconnect/attributes.go` wrapper merged in #3634, but `sdk/go.mod` still pinned 0.36.0, so the sdk module could not build against its pinned dependency (only via the workspace).

Manual dependency bump modeled on #3681. No code changes — `sdk/go.mod` + `sdk/go.sum` only.

Unblocks the next sdk release, which the service release (#3697) depends on.

Verified: `cd sdk && GOWORK=off go build ./... && GOWORK=off go test ./... -short` pass against the pinned v0.37.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal Go dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->