### PR TITLE
docs: fix minor spelling typos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM cgr.dev/chainguard/go:latest AS builder
 ARG TARGETOS TARGETARCH
 
 WORKDIR /app
-# dependencies, add local,dependant package here
+# dependencies, add local,dependent package here
 COPY protocol/ protocol/
 COPY sdk/ sdk/
 COPY lib/ lib/

--- a/opentdf-core-mode.yaml
+++ b/opentdf-core-mode.yaml
@@ -1,5 +1,5 @@
 # configures the platform to startup without a KAS instances, without a built-in ERS instance, and without endpoint authentication
-# build off of this config file if you are running your ERS and KAS instances seperately or if you only need the policy features
+# build off of this config file if you are running your ERS and KAS instances separately or if you only need the policy features
 mode: core
 sdk_config:
   entityresolution:

--- a/opentdf-kas-mode.yaml
+++ b/opentdf-kas-mode.yaml
@@ -1,5 +1,5 @@
 # configures the platform to run only the KAS and well known service
-# build off this config file if you intend on running a (or multiple) seperate kas instance(s)
+# build off this config file if you intend on running a (or multiple) separate kas instance(s)
 mode: kas
 sdk_config:
   core:

--- a/otdfctl/docs/man/policy/_index.md
+++ b/otdfctl/docs/man/policy/_index.md
@@ -12,7 +12,7 @@ command:
       default: 'false'
 ---
 
-Policy is a set of rules that are enforced by the platform. Specific to the the data-centric
+Policy is a set of rules that are enforced by the platform. Specific to the data-centric
 security, policy revolves around data attributes (referred to as attributes). Within the context
 of attributes are namespaces, values, subject-mappings, resource-mappings, registered-resources, key-access-server grants,
 and other key elements.

--- a/otdfctl/docs/man/policy/attributes/_index.md
+++ b/otdfctl/docs/man/policy/attributes/_index.md
@@ -9,5 +9,5 @@ command:
 
 Commands to manage attributes within the platform.
 
-Attributes are used to to define the properties of a piece of data. These attributes will then be
+Attributes are used to define the properties of a piece of data. These attributes will then be
 used to define the access controls based on subject encodings and entity entitlements.

--- a/service/authorization/authorization.go
+++ b/service/authorization/authorization.go
@@ -617,7 +617,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 			auditECEntitlements := make([]audit.EntityChainEntitlement, 0)
 			auditEntityDecisions := make([]audit.EntityDecision, 0)
 
-			// Entitlements for environment entites in chain
+			// Entitlements for environment entities in chain
 			envEntityAttrValues := make(map[string][]string)
 			// Entitlementsfor sbuject entities in chain
 			subjectEntityAttrValues := make(map[string][]string)

--- a/service/authorization/authorization_test_structures.go
+++ b/service/authorization/authorization_test_structures.go
@@ -245,7 +245,7 @@ func (*paginatedMockSubjectMappingClient) DeleteAllUnmappedSubjectConditionSets(
 	return &sm.DeleteAllUnmappedSubjectConditionSetsResponse{}, nil
 }
 
-// // Mock paginated attributs client for testing ////
+// // Mock paginated attributes client for testing ////
 type paginatedMockAttributesClient struct{}
 
 var (

--- a/service/integration/wiremock/README.md
+++ b/service/integration/wiremock/README.md
@@ -2,7 +2,7 @@
 
 A Docker container with [wiremock](https://wiremock.org/) + [wiremock grpc extension](https://wiremock.org/docs/grpc/)
 
-WireMock requires service decriptions for the proto spec.  To generate service descriptions:
+WireMock requires service descriptions for the proto spec.  To generate service descriptions:
 
 ```shell
 buf build ../../proto \


### PR DESCRIPTION
### Proposed Changes

Fixes minor spelling typos.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation

### Testing Instructions

Verified that code comments formatting and lints still pass successfully by running `make fmt` and `make lint` on the authorization service module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed several spelling and duplicate-word errors across setup, policy, and integration docs.
  * Improved clarity in configuration comments and usage notes.
  * Corrected a minor comment in authorization-related code without changing behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->