### PR TITLE
chore(docs): fix typos in plaintext files

### DIFF
--- a/adr/decisions/2025-06-16-expected-use-cases-sdk-205.md
+++ b/adr/decisions/2025-06-16-expected-use-cases-sdk-205.md
@@ -16,7 +16,7 @@ informed: '@strantalis @jrschumacher @c-r33d @damorris25'
 ## Decision Outcome
 
 1. v2.0.5 of SDK should work with < v2.0.4 of platform
-2. < v2.0.5 of SDK should work with >= v2.0.5 of plaform
+2. < v2.0.5 of SDK should work with >= v2.0.5 of platform
 3. We should not have a WithBaseKeyEnabled option, instead the platform version should be derived from the well-known. For v2.0.5 of the SDK we will prefer to use the base key if present and set properly. If it is not, we will fallback to using the default kases. In v2.0.6 the plan would be to error if the platform is >= v2.0.5 and the base key is not set.
 4. When creating a split plan if the SDK notices that there are key mappings it will **only** use those key mappings instead of grants. If no key mappings are present, the sdk will fallback to grants.
 

--- a/docs/Contributing-errors.md
+++ b/docs/Contributing-errors.md
@@ -33,7 +33,7 @@ This document focuses on the first category, go `error` typed return values.
   will require us to support the variable or deprecate it
   - Wrap with an non-exported type or `fmt.Errorf` to provide additional context to ops
     without exposing more handling capabilities to the application
-- Returned errors may be explicity ignored with an `_`.
+- Returned errors may be explicitly ignored with an `_`.
 - Errors in `defer` blocks should either be returned or wrapped and returned using named return types
   OR logged in place
 
@@ -108,7 +108,7 @@ The value of Ant Design as a product excuses some of the grammar and language ba
 but anecdotally, it seems that English-as-a-second-language (ESL) speakers (who also don’t know Chinese) tend to favor English-driven tooling.
 
 Errors should use proper grammar and spelling.
-Usefulness and accuracy of errors is reenforced by the quality of the grammar and spelling of errors.
+Usefulness and accuracy of errors is reinforced by the quality of the grammar and spelling of errors.
 This is especially true when we are striving for international usage while not having the capacity for internationalization.
 
 Errors should be idiomatic with the language.

--- a/opentdf-core-mode.yaml
+++ b/opentdf-core-mode.yaml
@@ -1,5 +1,5 @@
 # configures the platform to startup without a KAS instances, without a built-in ERS instance, and without endpoint authentication
-# build off of this config file if you are running your ERS and KAS instances seperately or if you only need the policy features
+# build off of this config file if you are running your ERS and KAS instances separately or if you only need the policy features
 mode: core
 sdk_config:
   entityresolution:

--- a/opentdf-kas-mode.yaml
+++ b/opentdf-kas-mode.yaml
@@ -1,5 +1,5 @@
 # configures the platform to run only the KAS and well known service
-# build off this config file if you intend on running a (or multiple) seperate kas instance(s)
+# build off this config file if you intend on running one or multiple separate KAS instances
 mode: kas
 sdk_config:
   core:

--- a/otdfctl/docs/man/auth/login.md
+++ b/otdfctl/docs/man/auth/login.md
@@ -9,7 +9,7 @@ command:
       shorthand: i
       required: true
     - name: port
-      description: A preferred port number to faciliate the auth flow process.
+      description: A preferred port number to facilitate the auth flow process.
       shorthand: p
       required: false
 ---

--- a/otdfctl/docs/man/policy/kas-registry/key/unsafe/delete.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/unsafe/delete.md
@@ -5,7 +5,7 @@ command:
   flags:
     - name: id
       shorthand: i
-      description: Sytem given ID of the key
+      description: System-given ID of the key
       required: true
     - name: kas-uri
       description: The URI of the KAS instance

--- a/service/integration/wiremock/README.md
+++ b/service/integration/wiremock/README.md
@@ -2,7 +2,7 @@
 
 A Docker container with [wiremock](https://wiremock.org/) + [wiremock grpc extension](https://wiremock.org/docs/grpc/)
 
-WireMock requires service decriptions for the proto spec.  To generate service descriptions:
+WireMock requires service descriptions for the proto spec.  To generate service descriptions:
 
 ```shell
 buf build ../../proto \
@@ -37,6 +37,5 @@ Get Decision:
 ```shell
 grpcurl -plaintext -d '{}' -protoset grpc/service.dsc localhost:8080 authorization.AuthorizationService/GetDecisions
 ```
-
 
 

--- a/service/policy/adr/0002-pagination-list-rpcs.md
+++ b/service/policy/adr/0002-pagination-list-rpcs.md
@@ -119,7 +119,7 @@ message ListRequest {
 }
 
 message ListResponse {
-    // ...existing fields and response data ommitted
+    // ...existing fields and response data omitted
     // cursors are encoded by the server as base64'd 'created_at' timestamps
     string previous_cursor = 4;
     string next_cursor = 4;

--- a/service/policy/adr/0003-database-transactions.md
+++ b/service/policy/adr/0003-database-transactions.md
@@ -16,7 +16,7 @@ Due to the complex nature of some operations within the Policy service, we need 
 
 Primary drivers for implementing database transactions:
 - Unsafe operations that update namespace/attribute definition names or attribute values and require FQNs to be updated for consistency
-- Attribute defintion creation with multiple attribute values that must be created atomically
+- Attribute definition creation with multiple attribute values that must be created atomically
 
 > [!NOTE]
 > There are likely to be more as the service matures and more complex operations are required.


### PR DESCRIPTION
## Summary
- Fix spelling and minor grammar issues in Markdown documentation and YAML config comments
- Keep generated docs, code, proto, scripts, and build files out of this PR

## Testing
- git diff --check origin/main...HEAD
- uvx codespell <changed Markdown/YAML files>