### PR TITLE
chore: fix typos in code comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM cgr.dev/chainguard/go:latest AS builder
 ARG TARGETOS TARGETARCH
 
 WORKDIR /app
-# dependencies, add local,dependant package here
+# dependencies, add local, dependent package here
 COPY protocol/ protocol/
 COPY sdk/ sdk/
 COPY lib/ lib/

--- a/docs/grpc/index.html
+++ b/docs/grpc/index.html
@@ -2968,7 +2968,7 @@ is existential over the resolved entity values. </p></td>
         
       
         <h3 id="policy.KasPublicKey">KasPublicKey</h3>
-        <p>Deprecated</p><p>A KAS public key and some associated metadata for further identifcation</p>
+        <p>Deprecated</p><p>A KAS public key and some associated metadata for further identification</p>
 
         
           <table class="field-table">

--- a/docs/openapi/authorization/authorization.openapi.yaml
+++ b/docs/openapi/authorization/authorization.openapi.yaml
@@ -814,7 +814,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/authorization/v2/authorization.openapi.yaml
+++ b/docs/openapi/authorization/v2/authorization.openapi.yaml
@@ -851,7 +851,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/policy/actions/actions.openapi.yaml
+++ b/docs/openapi/policy/actions/actions.openapi.yaml
@@ -591,7 +591,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/policy/attributes/attributes.openapi.yaml
+++ b/docs/openapi/policy/attributes/attributes.openapi.yaml
@@ -1241,7 +1241,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/policy/dynamicvaluemapping/dynamic_value_mapping.openapi.yaml
+++ b/docs/openapi/policy/dynamicvaluemapping/dynamic_value_mapping.openapi.yaml
@@ -681,7 +681,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/policy/kasregistry/key_access_server_registry.openapi.yaml
+++ b/docs/openapi/policy/kasregistry/key_access_server_registry.openapi.yaml
@@ -850,7 +850,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/policy/namespaces/namespaces.openapi.yaml
+++ b/docs/openapi/policy/namespaces/namespaces.openapi.yaml
@@ -595,7 +595,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/policy/objects.openapi.yaml
+++ b/docs/openapi/policy/objects.openapi.yaml
@@ -534,7 +534,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/policy/obligations/obligations.openapi.yaml
+++ b/docs/openapi/policy/obligations/obligations.openapi.yaml
@@ -996,7 +996,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/policy/registeredresources/registered_resources.openapi.yaml
+++ b/docs/openapi/policy/registeredresources/registered_resources.openapi.yaml
@@ -821,7 +821,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/policy/resourcemapping/resource_mapping.openapi.yaml
+++ b/docs/openapi/policy/resourcemapping/resource_mapping.openapi.yaml
@@ -801,7 +801,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/policy/subjectmapping/subject_mapping.openapi.yaml
+++ b/docs/openapi/policy/subjectmapping/subject_mapping.openapi.yaml
@@ -863,7 +863,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/docs/openapi/policy/unsafe/unsafe.openapi.yaml
+++ b/docs/openapi/policy/unsafe/unsafe.openapi.yaml
@@ -829,7 +829,7 @@ components:
       additionalProperties: false
       description: |-
         Deprecated
-         A KAS public key and some associated metadata for further identifcation
+         A KAS public key and some associated metadata for further identification
     policy.KasPublicKeySet:
       type: object
       properties:

--- a/examples/cmd/attributes.go
+++ b/examples/cmd/attributes.go
@@ -111,7 +111,8 @@ func listAttributes(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		slog.Info("found attributes in namespace",
+		slog.Info(
+			"found attributes in namespace",
 			slog.Int("count", len(lsr.GetAttributes())),
 			slog.String("ns", n),
 		)
@@ -136,7 +137,8 @@ func listAttributes(cmd *cobra.Command) error {
 func nsuuid(ctx context.Context, s *sdk.SDK, u string) (string, error) {
 	url, err := url.Parse(u)
 	if err != nil {
-		slog.Error("namespace url.Parse",
+		slog.Error(
+			"namespace url.Parse",
 			slog.String("url", u),
 			slog.Any("error", err),
 		)
@@ -169,7 +171,7 @@ func attruuid(ctx context.Context, s *sdk.SDK, nsu, fqn string) (string, error) 
 			return a.GetId(), nil
 		}
 	}
-	return "", fmt.Errorf("%w: unable to find attibute [%s]", ErrNotFound, fqn)
+	return "", fmt.Errorf("%w: unable to find attribute [%s]", ErrNotFound, fqn)
 }
 
 func avuuid(ctx context.Context, s *sdk.SDK, auuid, vs string) (string, error) {
@@ -183,7 +185,7 @@ func avuuid(ctx context.Context, s *sdk.SDK, auuid, vs string) (string, error) {
 			return v.GetId(), nil
 		}
 	}
-	return "", fmt.Errorf("%w: unable to find attibute value [%s]", ErrNotFound, vs)
+	return "", fmt.Errorf("%w: unable to find attribute value [%s]", ErrNotFound, vs)
 }
 
 func addNamespace(ctx context.Context, s *sdk.SDK, u string) (string, error) {
@@ -224,7 +226,8 @@ func addAttribute(cmd *cobra.Command) error {
 	}
 	attrEl, err := url.PathUnescape(m[2])
 	if err != nil {
-		slog.Error("url.PathUnescape(attr)",
+		slog.Error(
+			"url.PathUnescape(attr)",
 			slog.String("attr", m[2]),
 			slog.Any("error", err),
 		)
@@ -234,7 +237,8 @@ func addAttribute(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	slog.Info("created attribute",
+	slog.Info(
+		"created attribute",
 		slog.String("passedin", attrEl),
 		slog.String("id", aid),
 	)
@@ -270,13 +274,15 @@ func removeAttribute(cmd *cobra.Command) error {
 				Fqn: strings.ToLower(attr),
 			})
 			if err != nil {
-				slog.Error("failed to UnsafeDeleteAttribute",
+				slog.Error(
+					"failed to UnsafeDeleteAttribute",
 					slog.String("id", auuid),
 					slog.Any("error", err),
 				)
 				return err
 			}
-			slog.Info("deleted attribute",
+			slog.Info(
+				"deleted attribute",
 				slog.String("attr", attr),
 				slog.Any("resp", resp),
 			)
@@ -286,13 +292,15 @@ func removeAttribute(cmd *cobra.Command) error {
 			Id: auuid,
 		})
 		if err != nil {
-			slog.Error("failed to DeactivateAttribute",
+			slog.Error(
+				"failed to DeactivateAttribute",
 				slog.String("id", auuid),
 				slog.Any("error", err),
 			)
 			return err
 		}
-		slog.Info("deactivated attribute",
+		slog.Info(
+			"deactivated attribute",
 			slog.String("attr", attr),
 			slog.Any("resp", resp),
 		)
@@ -310,13 +318,15 @@ func removeAttribute(cmd *cobra.Command) error {
 				Fqn: strings.ToLower(attr + "/value/" + url.PathEscape(v)),
 			})
 			if err != nil {
-				slog.Error("failed to UnsafeDeleteAttributeValue",
+				slog.Error(
+					"failed to UnsafeDeleteAttributeValue",
 					slog.Any("error", err),
 					slog.String("id", avu),
 				)
 				return err
 			}
-			slog.Info("deactivated attribute value",
+			slog.Info(
+				"deactivated attribute value",
 				slog.String("attr", attr),
 				slog.String("value", v),
 				slog.Any("resp", r),
@@ -326,13 +336,15 @@ func removeAttribute(cmd *cobra.Command) error {
 				Id: avu,
 			})
 			if err != nil {
-				slog.Error("failed to DeactivateAttributeValue",
+				slog.Error(
+					"failed to DeactivateAttributeValue",
 					slog.String("id", avu),
 					slog.Any("error", err),
 				)
 				return err
 			}
-			slog.Info("deactivated attribute value",
+			slog.Info(
+				"deactivated attribute value",
 				slog.String("attr", attr),
 				slog.String("value", v),
 				slog.Any("resp", r),
@@ -364,7 +376,8 @@ func upsertAttr(ctx context.Context, s *sdk.SDK, auth, name string, values []str
 	})
 	if err != nil {
 		//nolint:sloglint // safe to log auth in examples
-		slog.Error("failed to CreateAttribute",
+		slog.Error(
+			"failed to CreateAttribute",
 			slog.String("auth", auth),
 			slog.String("name", name),
 			slog.Any("values", values),

--- a/lib/fixtures/keycloak.go
+++ b/lib/fixtures/keycloak.go
@@ -996,7 +996,8 @@ func getRealmRolesByList(ctx context.Context, realmName string, tm *TokenManager
 			ctx,
 			token.AccessToken,
 			realmName,
-			roleName)
+			roleName,
+		)
 		if err != nil {
 			slog.Error("error getting realm role for realm",
 				slog.String("role", roleName),
@@ -1217,7 +1218,7 @@ func createCertExchange(ctx context.Context, connectParams *KeycloakConnectParam
 
 	authExecutions, err := client.GetAuthenticationExecutions(ctx, token.AccessToken, connectParams.Realm, topLevelFlowName)
 	if err != nil {
-		slog.Error("error gettings executions", slog.Any("error", err))
+		slog.Error("error getting executions", slog.Any("error", err))
 		return err
 	}
 	if len(authExecutions) != 1 {
@@ -1251,7 +1252,8 @@ func createCertExchange(ctx context.Context, connectParams *KeycloakConnectParam
 	config["x509-cert-auth.certificate-policy-mode"] = "All"
 	executionConfig["config"] = config
 	if err := updateExecutionConfig(ctx, client, execution, connectParams, token.AccessToken, executionConfig); err != nil {
-		slog.Error("error updating x509 auth flow configs",
+		slog.Error(
+			"error updating x509 auth flow configs",
 			slog.String("client_id", clientID),
 			slog.Any("error", err),
 		)
@@ -1260,7 +1262,8 @@ func createCertExchange(ctx context.Context, connectParams *KeycloakConnectParam
 
 	execution.Requirement = &requiredRequirement
 	if err := client.UpdateAuthenticationExecution(ctx, token.AccessToken, connectParams.Realm, topLevelFlowName, *execution); err != nil {
-		slog.Error("error updating x509 auth flow requjirement",
+		slog.Error(
+			"error updating x509 auth flow requjirement",
 			slog.String("client_id", clientID),
 			slog.Any("error", err),
 		)
@@ -1295,7 +1298,8 @@ func createCertExchange(ctx context.Context, connectParams *KeycloakConnectParam
 	flowBindings["direct_grant"] = *flowID
 	updatedClient.AuthenticationFlowBindingOverrides = &flowBindings
 	if err := client.UpdateClient(ctx, token.AccessToken, connectParams.Realm, *updatedClient); err != nil {
-		slog.Error("error updating client auth flow binding overrides",
+		slog.Error(
+			"error updating client auth flow binding overrides",
 			slog.String("client_id", clientID),
 			slog.Any("error", err),
 		)
@@ -1303,7 +1307,8 @@ func createCertExchange(ctx context.Context, connectParams *KeycloakConnectParam
 	}
 
 	//nolint:sloglint // allow existing emojis
-	slog.Info("✅ created Cert Exchange Authentication",
+	slog.Info(
+		"✅ created Cert Exchange Authentication",
 		slog.String("flow_id", *flowID),
 	)
 

--- a/otdfctl/e2e/registered-resources.bats
+++ b/otdfctl/e2e/registered-resources.bats
@@ -431,7 +431,7 @@ teardown_file() {
     assert_failure
     assert_output --partial "Either 'id' or 'fqn' must be provided"
 
-  # invalud id
+  # invalid id
   run_otdfctl_reg_res_values get --id 'not_a_uuid'
     assert_failure
     assert_output --partial "must be a valid UUID"

--- a/otdfctl/pkg/handlers/kas-registry.go
+++ b/otdfctl/pkg/handlers/kas-registry.go
@@ -15,20 +15,20 @@ type KasIdentifier struct {
 	URI  string
 }
 
-func (h Handler) GetKasRegistryEntry(ctx context.Context, identifer KasIdentifier) (*policy.KeyAccessServer, error) {
+func (h Handler) GetKasRegistryEntry(ctx context.Context, identifier KasIdentifier) (*policy.KeyAccessServer, error) {
 	req := &kasregistry.GetKeyAccessServerRequest{}
 	switch {
-	case identifer.ID != "":
+	case identifier.ID != "":
 		req.Identifier = &kasregistry.GetKeyAccessServerRequest_KasId{
-			KasId: identifer.ID,
+			KasId: identifier.ID,
 		}
-	case identifer.Name != "":
+	case identifier.Name != "":
 		req.Identifier = &kasregistry.GetKeyAccessServerRequest_Name{
-			Name: identifer.Name,
+			Name: identifier.Name,
 		}
-	case identifer.URI != "":
+	case identifier.URI != "":
 		req.Identifier = &kasregistry.GetKeyAccessServerRequest_Uri{
-			Uri: identifer.URI,
+			Uri: identifier.URI,
 		}
 	default:
 		return nil, errors.New("id, name or uri must be provided")

--- a/protocol/go/policy/objects.pb.go
+++ b/protocol/go/policy/objects.pb.go
@@ -2207,7 +2207,7 @@ func (x *Key) GetMetadata() *common.Metadata {
 }
 
 // Deprecated
-// A KAS public key and some associated metadata for further identifcation
+// A KAS public key and some associated metadata for further identification
 type KasPublicKey struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/sdk/granter.go
+++ b/sdk/granter.go
@@ -237,7 +237,8 @@ func (r *granter) addGrant(fqn AttributeValueFQN, kas string, attr *policy.Attri
 func (r *granter) addMappedKey(fqn AttributeValueFQN, sk *policy.SimpleKasKey) error {
 	key := sk.GetPublicKey()
 	if key == nil || key.GetKid() == "" || key.GetPem() == "" {
-		r.logger.Debug("invalid cached key in policy service",
+		r.logger.Debug(
+			"invalid cached key in policy service",
 			slog.String("kas", sk.GetKasUri()),
 			slog.Any("value", fqn),
 		)
@@ -254,7 +255,8 @@ func (r *granter) addMappedKey(fqn AttributeValueFQN, sk *policy.SimpleKasKey) e
 
 	rl, err := NewResourceLocator(sk.GetKasUri())
 	if err != nil {
-		r.logger.Debug("invalid KAS URL in policy service",
+		r.logger.Debug(
+			"invalid KAS URL in policy service",
 			slog.String("kas", sk.GetKasUri()),
 			slog.Any("value", fqn),
 			slog.Any("error", err),
@@ -262,7 +264,8 @@ func (r *granter) addMappedKey(fqn AttributeValueFQN, sk *policy.SimpleKasKey) e
 		return fmt.Errorf("invalid KAS URL in policy service associated with [%s]: %w", fqn, err)
 	}
 	rl.identifier = key.GetKid()
-	r.logger.Debug("added mapped key",
+	r.logger.Debug(
+		"added mapped key",
 		slog.Any("fqn", fqn),
 		slog.String("kas", sk.GetKasUri()),
 		slog.String("kid", key.GetKid()),
@@ -324,7 +327,8 @@ func (r *granter) addAllGrants(fqn AttributeValueFQN, ag grantableObject, attr *
 	// Check for mapped keys
 	for _, k := range ag.GetKasKeys() {
 		if k == nil || k.GetKasUri() == "" {
-			r.logger.Debug("invalid KAS key in policy service",
+			r.logger.Debug(
+				"invalid KAS key in policy service",
 				slog.Any("simple_kas_key", k),
 				slog.Any("value", fqn),
 			)
@@ -335,7 +339,8 @@ func (r *granter) addAllGrants(fqn AttributeValueFQN, ag grantableObject, attr *
 		result = r.typ
 		err := r.addMappedKey(fqn, k)
 		if err != nil {
-			r.logger.Debug("failed to add mapped key",
+			r.logger.Debug(
+				"failed to add mapped key",
 				slog.Any("fqn", fqn),
 				slog.String("kas", kasURI),
 				slog.Any("error", err),
@@ -361,7 +366,8 @@ func (r *granter) addAllGrants(fqn AttributeValueFQN, ag grantableObject, attr *
 				for _, k := range g.GetKasKeys() {
 					err := r.addMappedKey(fqn, k)
 					if err != nil {
-						r.logger.Warn("failed to add mapped key",
+						r.logger.Warn(
+							"failed to add mapped key",
 							slog.Any("fqn", fqn),
 							slog.String("kas", kasURI),
 							slog.Any("error", err),
@@ -372,7 +378,8 @@ func (r *granter) addAllGrants(fqn AttributeValueFQN, ag grantableObject, attr *
 			}
 			ks := g.GetPublicKey().GetCached().GetKeys()
 			if len(ks) == 0 {
-				r.logger.Debug("no cached key in policy service",
+				r.logger.Debug(
+					"no cached key in policy service",
 					slog.String("kas", kasURI),
 					slog.Any("value", fqn),
 				)
@@ -380,7 +387,8 @@ func (r *granter) addAllGrants(fqn AttributeValueFQN, ag grantableObject, attr *
 			}
 			for _, k := range ks {
 				if k.GetKid() == "" || k.GetPem() == "" {
-					r.logger.Debug("invalid cached key in policy service",
+					r.logger.Debug(
+						"invalid cached key in policy service",
 						slog.String("kas", kasURI),
 						slog.Any("value", fqn),
 						slog.Any("key", k),
@@ -398,7 +406,8 @@ func (r *granter) addAllGrants(fqn AttributeValueFQN, ag grantableObject, attr *
 				}
 				err := r.addMappedKey(fqn, sk)
 				if err != nil {
-					r.logger.Warn("failed to add mapped key",
+					r.logger.Warn(
+						"failed to add mapped key",
 						slog.Any("fqn", fqn),
 						slog.String("kas", kasURI),
 						slog.Any("error", err),
@@ -518,7 +527,8 @@ func storeKeysToCache(logger *slog.Logger, kases []*policy.KeyAccessServer, keys
 			if kc != nil && ki.GetKid() != "" && ki.GetPem() != "" {
 				rl, err := NewResourceLocator(kas.GetUri())
 				if err != nil {
-					logger.Debug("failed to create ResourceLocator",
+					logger.Debug(
+						"failed to create ResourceLocator",
 						slog.String("kas", kas.GetUri()),
 						slog.Any("error", err),
 					)
@@ -553,7 +563,8 @@ func storeKeysToCache(logger *slog.Logger, kases []*policy.KeyAccessServer, keys
 		if kc != nil && key.GetPublicKey().GetKid() != "" && key.GetPublicKey().GetPem() != "" {
 			rl, err := NewResourceLocator(key.GetKasUri())
 			if err != nil {
-				logger.Debug("failed to create ResourceLocator",
+				logger.Debug(
+					"failed to create ResourceLocator",
 					slog.String("kas", key.GetKasUri()),
 					slog.Any("error", err),
 				)
@@ -821,7 +832,7 @@ func (r *granter) insertKeysForAttribute(e attributeBooleanExpression) (booleanK
 		for _, term := range clause.values {
 			grant := r.byAttribute(term)
 			if grant == nil {
-				return booleanKeyExpression{}, fmt.Errorf("no defintion or grant found for [%s]", term)
+				return booleanKeyExpression{}, fmt.Errorf("no definition or grant found for [%s]", term)
 			}
 			kases := grant.kases
 			if len(kases) == 0 {
@@ -836,7 +847,8 @@ func (r *granter) insertKeysForAttribute(e attributeBooleanExpression) (booleanK
 					var err error
 					rl, err = NewResourceLocator(kas)
 					if err != nil {
-						r.logger.Warn("invalid KAS URL in policy service",
+						r.logger.Warn(
+							"invalid KAS URL in policy service",
 							slog.String("kas", kas),
 							slog.Any("value", term),
 							slog.Any("error", err),

--- a/sdk/granter_test.go
+++ b/sdk/granter_test.go
@@ -776,7 +776,8 @@ func TestReasonerConstructAttributeBoolean(t *testing.T) {
 				func() string {
 					j++
 					return strconv.Itoa(j)
-				})
+				},
+			)
 			require.NoError(t, err)
 			assert.Equal(t, tc.tpl, tpl)
 		})
@@ -923,14 +924,14 @@ func TestReasonerSpecificityWithNamespaces(t *testing.T) {
 		plan     []keySplitStep
 	}{
 		{
-			"no grants on value, attr, namesapce should result in provided kas",
+			"no grants on value, attr, namespace should result in provided kas",
 			"nogrant.nogrant.nogrant => default",
 			[]AttributeValueFQN{uns2uns},
 			[]string{kasUs},
 			[]keySplitStep{{kasUs, ""}},
 		},
 		{
-			"grant on namesapce with no grant on attr or value should result in only namesapce specfific kas split step",
+			"grant on namespace with no grant on attr or value should result in only namespace-specific kas split step",
 			"grant.nogrant.nogrant => nsSpecificKas",
 			[]AttributeValueFQN{spk2uns2uns},
 			[]string{kasUs},

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -208,7 +208,7 @@ func WithCustomCoreConnection(conn *ConnectRPCConnection) Option {
 	}
 }
 
-// WithExtraClientOptions returns an Option that adds extra connect rpc client options to the conect rpc clients
+// WithExtraClientOptions returns an Option that adds extra connect rpc client options to the connect rpc clients
 func WithExtraClientOptions(opts ...connect.ClientOption) Option {
 	return func(c *config) {
 		c.extraClientOptions = opts

--- a/sdk/resource_locator.go
+++ b/sdk/resource_locator.go
@@ -92,16 +92,16 @@ func (rl ResourceLocator) GetIdentifier() (string, error) {
 	// read the identifier if it exists
 	switch rl.protocol & 0xf0 {
 	case identifierNone, urlProtocolHTTPS:
-		return "", fmt.Errorf("legacy resource locator identifer: %x", rl.protocol)
+		return "", fmt.Errorf("legacy resource locator identifier: %x", rl.protocol)
 	case identifier2Byte, identifier8Byte, identifier32Byte:
 		if rl.identifier == "" {
-			return "", fmt.Errorf("no resource locator identifer: %d", rl.protocol)
+			return "", fmt.Errorf("no resource locator identifier: %d", rl.protocol)
 		}
 		// remove padding
 		cleanedIdentifier := strings.TrimRight(rl.identifier, "\x00")
 		return cleanedIdentifier, nil
 	}
-	return "", fmt.Errorf("unsupported identifer protocol: %x", rl.protocol)
+	return "", fmt.Errorf("unsupported identifier protocol: %x", rl.protocol)
 }
 
 // GetURL - Retrieve a fully qualified protocol+body URL string from a ResourceLocator struct

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -1452,7 +1452,7 @@ func (r *Reader) buildKey(_ context.Context, results []kaoResult) error {
 		base64Hash := ocrypto.Base64Encode(completeHashBuilder.Bytes())
 
 		if string(hashOfAssertionAsHex) != assertionHash {
-			return fmt.Errorf("%w: assertion hash missmatch", ErrAssertionFailure{ID: assertion.ID})
+			return fmt.Errorf("%w: assertion hash mismatch", ErrAssertionFailure{ID: assertion.ID})
 		}
 
 		if assertionSig != string(base64Hash) {
@@ -1491,7 +1491,7 @@ func (r *Reader) doPayloadKeyUnwrap(ctx context.Context) error { //nolint:gocogn
 		return err
 	}
 	for kasurl, req := range reqs {
-		// if ignoreing allowlist then warn
+		// if ignoring allowlist then warn
 		// if kas url is not allowed then return error
 		if r.config.ignoreAllowList {
 			getLogger().WarnContext(ctx, "kasAllowlist is ignored, kas url is allowed", slog.String("kas_url", kasurl))

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -251,7 +251,7 @@ func WithTargetMode(mode string) TDFOption {
 	}
 }
 
-// Schema Validation where 0 = none (skip), 1 = lax (allowing novel entries, 'falsy' values for unkowns), 2 = strict (rejecting novel entries, strict match to manifest schema)
+// Schema Validation where 0 = none (skip), 1 = lax (allowing novel entries, 'falsy' values for unknowns), 2 = strict (rejecting novel entries, strict match to manifest schema)
 type SchemaValidationIntensity int
 
 const (

--- a/service/authorization/authorization.go
+++ b/service/authorization/authorization.go
@@ -372,7 +372,8 @@ func (as *AuthorizationService) GetEntitlements(ctx context.Context, req *connec
 		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to build rego input"))
 	}
 
-	results, err := as.eval.Eval(ctx,
+	results, err := as.eval.Eval(
+		ctx,
 		rego.EvalInput(in),
 	)
 	if err != nil {
@@ -428,7 +429,8 @@ func (as *AuthorizationService) GetEntitlements(ctx context.Context, req *connec
 			entitlement, valueOK := value.(string)
 			// If value is not okay skip adding to entitlements
 			if !valueOK {
-				as.logger.WarnContext(ctx, "issue with adding entitlement",
+				as.logger.WarnContext(
+					ctx, "issue with adding entitlement",
 					slog.String("entity_id", entity.GetId()),
 					slog.String("entitlement", entitlement),
 				)
@@ -518,7 +520,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 	}
 	if err != nil {
 		// if attribute an FQN does not exist
-		// return deny for all entity chains aginst this RAs
+		// return deny for all entity chains against these RAs
 		if errors.Is(err, status.Error(codes.NotFound, db.ErrTextNotFound)) || errors.Is(err, ErrEmptyStringAttribute) {
 			for raIdx, ra := range dr.GetResourceAttributes() {
 				for ecIdx, ec := range dr.GetEntityChains() {
@@ -617,9 +619,9 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 			auditECEntitlements := make([]audit.EntityChainEntitlement, 0)
 			auditEntityDecisions := make([]audit.EntityDecision, 0)
 
-			// Entitlements for environment entites in chain
+			// Entitlements for environment entities in chain
 			envEntityAttrValues := make(map[string][]string)
-			// Entitlementsfor sbuject entities in chain
+			// Entitlements for subject entities in chain
 			subjectEntityAttrValues := make(map[string][]string)
 
 			// handle empty entity / attr list

--- a/service/authorization/authorization_test.go
+++ b/service/authorization/authorization_test.go
@@ -150,10 +150,12 @@ func Test_GetDecisionsAllOf_Pass(t *testing.T) {
 	testrego := rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1":["https://www.example.org/attr/foo/value/value1"]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err := testrego.PrepareForEval(t.Context())
@@ -250,10 +252,12 @@ func Test_GetDecisionsAllOf_Pass(t *testing.T) {
 	testrego = rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1": ["https://www.example.org/attr/foo/value/value1", "https://www.example.org/attr/foo/value/value2"]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err = testrego.PrepareForEval(t.Context())
@@ -341,10 +345,12 @@ func Test_GetDecisions_AllOf_Fail(t *testing.T) {
 	testrego := rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1": ["https://www.example.org/attr/foo/value/value1"]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err := testrego.PrepareForEval(t.Context())
@@ -420,10 +426,12 @@ func Test_GetDecisionsAllOfWithEnvironmental_Pass(t *testing.T) {
 	testrego := rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e2":["https://www.example.org/attr/foo/value/value1"], "e1":[]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err := testrego.PrepareForEval(t.Context())
@@ -519,10 +527,12 @@ func Test_GetDecisionsAllOfWithEnvironmental_Fail(t *testing.T) {
 	testrego := rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e2":["https://www.example.org/attr/foo/value/value1"], "e1":[]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err := testrego.PrepareForEval(t.Context())
@@ -619,10 +629,12 @@ func Test_GetEntitlementsSimple(t *testing.T) {
 	rego := rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1":["https://www.example.org/attr/foo/value/value1"]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err := rego.PrepareForEval(t.Context())
@@ -694,10 +706,12 @@ func Test_GetEntitlementsFqnCasing(t *testing.T) {
 	rego := rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1":["https://www.example.org/attr/foo/value/value1"]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err := rego.PrepareForEval(t.Context())
@@ -774,10 +788,12 @@ func Test_GetEntitlements_HandlesPagination(t *testing.T) {
 	rego := rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1":["https://www.example.org/attr/foo/value/value1"]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err := rego.PrepareForEval(t.Context())
@@ -868,10 +884,12 @@ func Test_GetEntitlementsWithComprehensiveHierarchy(t *testing.T) {
 	rego := rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1":["https://www.example.org/attr/foo/value/value1"]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err := rego.PrepareForEval(t.Context())
@@ -1110,10 +1128,12 @@ func Test_GetDecisions_RA_FQN_Edge_Cases(t *testing.T) {
 	testrego := rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1":[]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err := testrego.PrepareForEval(t.Context())
@@ -1167,7 +1187,7 @@ func Test_GetDecisions_RA_FQN_Edge_Cases(t *testing.T) {
 	assert.Len(t, resp.Msg.GetDecisionResponses(), 1)
 	assert.Equal(t, authorization.DecisionResponse_DECISION_DENY, resp.Msg.GetDecisionResponses()[0].GetDecision())
 
-	//////////  TEST2: FQN that doesnt exist //////////
+	//////////  TEST2: FQN that does not exist //////////
 
 	// will hit getAttributesByValueFqns but will get error
 	getAttributesByValueFqnsResponse = attr.GetAttributeValuesByFqnsResponse{}
@@ -1329,10 +1349,12 @@ func Test_GetDecisionsAllOf_Pass_EC_RA_Length_Mismatch(t *testing.T) {
 	testrego := rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1":["https://www.example.org/attr/foo/value/value1"]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err := testrego.PrepareForEval(t.Context())
@@ -1452,10 +1474,12 @@ func Test_GetDecisionsAllOf_Pass_EC_RA_Length_Mismatch(t *testing.T) {
 	testrego = rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1": ["https://www.example.org/attr/foo/value/value1", "https://www.example.org/attr/foo/value/value2"]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err = testrego.PrepareForEval(t.Context())
@@ -1522,10 +1546,12 @@ func Test_GetDecisionsAllOf_Pass_EC_RA_Length_Mismatch(t *testing.T) {
 	testrego = rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1": ["https://www.example.org/attr/foo/value/value1", "https://www.example.org/attr/foo/value/value2", "https://www.example.org/attr/foo/value/value3"]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err = testrego.PrepareForEval(t.Context())
@@ -1646,10 +1672,12 @@ func Test_GetDecisions_Empty_EC_RA(t *testing.T) {
 	testrego := rego.New(
 		rego.SetRegoVersion(ast.RegoV0),
 		rego.Query("data.example.p"),
-		rego.Module("example.rego",
+		rego.Module(
+			"example.rego",
 			`package example
 			p = {"e1":[]} { true }`,
-		))
+		),
+	)
 
 	// Run evaluation.
 	prepared, err := testrego.PrepareForEval(t.Context())

--- a/service/authorization/authorization_test_structures.go
+++ b/service/authorization/authorization_test_structures.go
@@ -245,7 +245,7 @@ func (*paginatedMockSubjectMappingClient) DeleteAllUnmappedSubjectConditionSets(
 	return &sm.DeleteAllUnmappedSubjectConditionSetsResponse{}, nil
 }
 
-// // Mock paginated attributs client for testing ////
+// // Mock paginated attributes client for testing ////
 type paginatedMockAttributesClient struct{}
 
 var (

--- a/service/entityresolution/keycloak/entity_resolution.go
+++ b/service/entityresolution/keycloak/entity_resolution.go
@@ -344,7 +344,7 @@ func EntityResolution(ctx context.Context,
 }
 
 func typeToGenericJSONMap[Marshalable any](inputStruct Marshalable, logger *logger.Logger) (map[string]interface{}, error) {
-	// For now, since we dont' know the "shape" of the entity/user record or representation we will get from a specific entity store,
+	// For now, since we don't know the "shape" of the entity/user record or representation we will get from a specific entity store,
 	tmpDoc, err := json.Marshal(inputStruct)
 	if err != nil {
 		logger.Error("error marshalling input type!", slog.String("error", err.Error()))

--- a/service/entityresolution/keycloak/v2/entity_resolution.go
+++ b/service/entityresolution/keycloak/v2/entity_resolution.go
@@ -163,7 +163,8 @@ func EntityResolution(ctx context.Context,
 	var resolvedEntities []*entityresolutionV2.EntityRepresentation
 
 	for idx, ident := range payload {
-		logger.DebugContext(ctx,
+		logger.DebugContext(
+			ctx,
 			"lookup",
 			slog.Any("entity", ident.GetEntityType()),
 		)
@@ -173,7 +174,8 @@ func EntityResolution(ctx context.Context,
 		exactMatch := true
 		switch ident.GetEntityType().(type) {
 		case *entity.Entity_ClientId:
-			logger.DebugContext(ctx,
+			logger.DebugContext(
+				ctx,
 				"looking up",
 				slog.Any("type", ident.GetEntityType()),
 				slog.String("client_id", ident.GetClientId()),
@@ -239,7 +241,8 @@ func EntityResolution(ctx context.Context,
 				connect.NewError(connect.CodeInternal, ErrGetRetrievalFailed)
 		case len(users) == 1:
 			user := users[0]
-			logger.DebugContext(ctx,
+			logger.DebugContext(
+				ctx,
 				"user",
 				slog.Any("details", user),
 				slog.String("entity", ident.String()),
@@ -345,7 +348,7 @@ func EntityResolution(ctx context.Context,
 }
 
 func typeToGenericJSONMap[Marshalable any](inputStruct Marshalable, logger *logger.Logger) (map[string]interface{}, error) {
-	// For now, since we dont' know the "shape" of the entity/user record or representation we will get from a specific entity store,
+	// For now, since we don't know the "shape" of the entity/user record or representation we will get from a specific entity store,
 	tmpDoc, err := json.Marshal(inputStruct)
 	if err != nil {
 		logger.Error("error marshalling input type!", slog.String("error", err.Error()))
@@ -370,7 +373,8 @@ func expandGroup(ctx context.Context, groupID string, kcConnector *Connector, kc
 	if err == nil {
 		grpMembers, memberErr := retrieveGroupMembers(ctx, logger, *grp.ID, kcConfig.Realm, svcCache, kcConnector)
 		if memberErr == nil {
-			logger.DebugContext(ctx,
+			logger.DebugContext(
+				ctx,
 				"adding members",
 				slog.Int("amount", len(grpMembers)),
 				slog.String("from group", *grp.Name),

--- a/service/integration/attribute_values_test.go
+++ b/service/integration/attribute_values_test.go
@@ -739,7 +739,7 @@ func (s *AttributeValuesSuite) Test_UnsafeReactivateAttributeValue_DoesNotReacti
 	s.False(gotVal.GetActive().GetValue())
 }
 
-// Add tests for assinging key to value / removing key from value
+// Add tests for assigning key to value / removing key from value
 
 func (s *AttributeValuesSuite) Test_AssignPublicKeyToAttributeValue_Returns_Error_When_Attribute_Not_Found() {
 	kasKeys := s.f.GetKasRegistryServerKeys("kas_key_1")

--- a/service/integration/kas_registry_key_test.go
+++ b/service/integration/kas_registry_key_test.go
@@ -1216,7 +1216,7 @@ func (s *KasRegistryKeySuite) Test_RotateKey_NoAttributeKeyMapping_Success() {
 	s.Equal(newKey.GetPrivateKeyCtx().GetWrappedKey(), rotatedInKey.GetKasKey().GetKey().GetPrivateKeyCtx().GetWrappedKey())
 	s.Equal(policy.KeyStatus_KEY_STATUS_ACTIVE, rotatedInKey.GetKasKey().GetKey().GetKeyStatus())
 
-	// Validate the rotated resoureces in the response.
+	// Validate the rotated resources in the response.
 	s.Equal(rotatedInKey.GetRotatedResources().GetRotatedOutKey().GetKey().GetId(), keyMap[rotateKey].GetKey().GetId())
 	s.Empty(rotatedInKey.GetRotatedResources().GetAttributeDefinitionMappings())
 	s.Empty(rotatedInKey.GetRotatedResources().GetNamespaceMappings())
@@ -2684,7 +2684,7 @@ func (s *KasRegistryKeySuite) setupAttributesForRotate(numAttrsToRotate, numAttr
 			attributesToNotRotate[i-numAttrsToNotRotate] = noRotateAttr
 		}
 	}
-	// Go through and assing the values to public keys
+	// Go through and assign the values to public keys
 	for _, value := range attributesToRotate[0].GetValues() {
 		if value.GetId() == "" {
 			continue

--- a/service/internal/access/pdp.go
+++ b/service/internal/access/pdp.go
@@ -103,7 +103,7 @@ func (pdp *Pdp) groupDataAttributesByDefinition(ctx context.Context, dataAttribu
 	return groupings, nil
 }
 
-// maps defintion FQN to definition object
+// maps definition FQN to definition object
 func (pdp *Pdp) mapFqnToDefinitions(ctx context.Context, attributeDefinitions []*policy.Attribute) (map[string]*policy.Attribute, error) {
 	grouped := make(map[string]*policy.Attribute)
 

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -148,7 +148,7 @@ func CreateTestLogger() *Logger {
 	return logger
 }
 
-// TODO: We can filter by keys if we need to in the future so they don't get proccessed by the masqer
+// TODO: We can filter by keys if we need to in the future so they don't get processed by the masqer
 func (l *Logger) replaceAttrChain(groups []string, a slog.Attr) slog.Attr {
 	return audit.ReplaceAttrAuditLevel(groups, a)
 }

--- a/service/pkg/db/errors.go
+++ b/service/pkg/db/errors.go
@@ -67,7 +67,8 @@ func WrapIfKnownInvalidQueryErr(err error) error {
 		case pgerrcode.CheckViolation:
 			return errors.Join(ErrCheckViolation, e)
 		default:
-			slog.Error("unknown error code",
+			slog.Error(
+				"unknown error code",
 				slog.String("error", e.Message),
 				slog.String("code", e.Code),
 			)
@@ -124,7 +125,7 @@ const (
 	ErrTextRestrictViolation            = "intended action would violate a restriction"
 	ErrTextFqnMissingValue              = "FQN must specify a valid value and be of format 'https://<namespace>/attr/<attribute name>/value/<value>'"
 	ErrTextListLimitTooLarge            = "requested pagination limit must be less than or equal to configured limit"
-	ErrTextInvalidIdentifier            = "value sepcified as the identifier is invalid"
+	ErrTextInvalidIdentifier            = "value specified as the identifier is invalid"
 	ErrorTextUnknownIdentifier          = "could not match identifier to known type"
 	ErrorTextUpdateToUnspecified        = "cannot update to unspecified value"
 	ErrTextKeyRotationFailed            = "key rotation failed"

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -280,7 +280,7 @@ func Start(f ...StartOptions) error {
 			return fmt.Errorf("could not retrieve oidc configuration: %w", err)
 		}
 
-		// provide token endpoint -- sdk cannot discover it since well-known service isnt running yet
+		// provide token endpoint -- sdk cannot discover it since well-known service is not running yet
 		sdkOptions = append(sdkOptions, sdk.WithTokenEndpoint(oidcconfig.TokenEndpoint)) //nolint:staticcheck // Backward-compatible explicit token endpoint option.
 	}
 

--- a/service/policy/db/obligations.go
+++ b/service/policy/db/obligations.go
@@ -748,7 +748,7 @@ func (c PolicyDBClient) resolveObligationTriggerActionID(ctx context.Context, ac
 
 	actionName := strings.ToLower(action.GetName())
 	if actionName == "" {
-		// this shouldnt happen due to proto validation, but just in case
+		// this should not happen due to proto validation, but just in case
 		return "", errors.Join(
 			db.ErrMissingValue,
 			errors.New("action identifier must include either id or name"),

--- a/service/policy/namespaces/namespaces_test.go
+++ b/service/policy/namespaces/namespaces_test.go
@@ -94,7 +94,7 @@ func TestCreateNamespace_WithInvalidCharacter_Fails(t *testing.T) {
 		"name?123.net",
 		"name*123.org",
 		"name:123.uk",
-		// preceeding and trailing hyphens
+		// preceding and trailing hyphens
 		"-name.org",
 		"name.org-",
 	}

--- a/service/policy/objects.proto
+++ b/service/policy/objects.proto
@@ -457,7 +457,7 @@ enum KasPublicKeyAlgEnum {
 }
 
 // Deprecated
-// A KAS public key and some associated metadata for further identifcation
+// A KAS public key and some associated metadata for further identification
 message KasPublicKey {
   // x509 ASN.1 content in PEM envelope, usually
   string pem = 1 [(buf.validate.field).string = {

--- a/service/policy/resourcemapping/resource_mapping_test.go
+++ b/service/policy/resourcemapping/resource_mapping_test.go
@@ -468,7 +468,7 @@ func Test_UpdateResourceMappingRequest_Succeeds(t *testing.T) {
 			"",
 			[]string{"term1"},
 			"",
-			"empty valud ID",
+			"empty valid ID",
 		},
 		{
 			"",


### PR DESCRIPTION
## Summary
- Fix spelling and minor grammar issues in Go comments, test labels, and user-facing strings
- Keep code-adjacent plaintext fixes together with the Go cleanup
- Regenerate proto outputs after updating the policy proto comment

## Testing
- make proto-generate
- git diff --check origin/main...HEAD
- uvx codespell --skip='docs/openapi/**,docs/grpc/**,protocol/go/**' --ignore-words-list='doesnot,allk' <changed files>
- cd sdk && go test -run TestREADMECodeBlocks
- go test ./sdk ./examples/cmd ./otdfctl/pkg/handlers ./service/authorization ./service/entityresolution/keycloak ./service/entityresolution/keycloak/v2 ./service/internal/access ./service/logger ./service/pkg/db ./service/policy/resourcemapping ./service/policy/namespaces ./service/policy/db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple spelling and grammar issues across API docs, OpenAPI specs, comments, and examples for clearer wording.
* **Bug Fixes**
  * Improved several user-facing error and log messages for readability and consistency.
  * Fixed a handler parameter name typo to match the expected identifier naming.
* **Tests**
  * Cleaned up test comments and descriptions without changing test behavior or coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->