### PR TITLE
fix(policy): include attribute value fqn in subject mapping lookup

### DIFF
--- a/service/integration/subject_mappings_test.go
+++ b/service/integration/subject_mappings_test.go
@@ -497,6 +497,7 @@ func (s *SubjectMappingsSuite) TestGetSubjectMapping() {
 	s.Require().NoError(err)
 	s.NotNil(got)
 	s.Equal(fixture.AttributeValueID, got.GetId())
+	s.Equal(got.GetFqn(), sm.GetAttributeValue().GetFqn())
 	metadata := sm.GetMetadata()
 	createdAt := metadata.GetCreatedAt()
 	updatedAt := metadata.GetUpdatedAt()

--- a/service/policy/db/queries/subject_mappings.sql
+++ b/service/policy/db/queries/subject_mappings.sql
@@ -162,7 +162,7 @@ SELECT
         'id', av.id,
         'value', av.value,
         'active', av.active,
-        'fqn', fqns.fqn
+        'fqn', av_fqns.fqn
     ) AS attribute_value,
     CASE
         WHEN sm.namespace_id IS NULL THEN NULL
@@ -175,7 +175,7 @@ CROSS JOIN counted
 CROSS JOIN params p
 LEFT JOIN subject_actions sa ON sm.id = sa.subject_mapping_id
 LEFT JOIN attribute_values av ON sm.attribute_value_id = av.id
-LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+LEFT JOIN attribute_fqns av_fqns ON av.id = av_fqns.value_id
 LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
@@ -190,7 +190,7 @@ GROUP BY
     scs_ns.id, scs_ns.name, scs_ns_fqns.fqn,
     sm_ns.id, sm_ns.name, sm_ns_fqns.fqn,
     av.id, av.value, av.active,
-    fqns.fqn,
+    av_fqns.fqn,
     counted.total,
     p.resolved_field, p.resolved_direction
 ORDER BY
@@ -243,7 +243,7 @@ SELECT
         'id', av.id,
         'value', av.value,
         'active', av.active,
-        'fqn', fqns.fqn
+        'fqn', av_fqns.fqn
     ) AS attribute_value,
     CASE
         WHEN sm.namespace_id IS NULL THEN NULL
@@ -251,14 +251,14 @@ SELECT
     END AS namespace
 FROM subject_mappings sm
 LEFT JOIN attribute_values av ON sm.attribute_value_id = av.id
-LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+LEFT JOIN attribute_fqns av_fqns ON av.id = av_fqns.value_id
 LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
 LEFT JOIN attribute_namespaces sm_ns ON sm_ns.id = sm.namespace_id
 LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
 WHERE sm.id = $1
-GROUP BY av.id, fqns.fqn, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn;
+GROUP BY av.id, av_fqns.fqn, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn;
 
 -- name: matchSubjectMappings :many
 WITH subject_actions AS (

--- a/service/policy/db/queries/subject_mappings.sql
+++ b/service/policy/db/queries/subject_mappings.sql
@@ -239,20 +239,26 @@ SELECT
             ELSE JSON_BUILD_OBJECT('id', scs_ns.id, 'name', scs_ns.name, 'fqn', scs_ns_fqns.fqn)
         END
     ) AS subject_condition_set,
-    JSON_BUILD_OBJECT('id', av.id,'value', av.value,'active', av.active) AS attribute_value,
+    JSON_BUILD_OBJECT(
+        'id', av.id,
+        'value', av.value,
+        'active', av.active,
+        'fqn', fqns.fqn
+    ) AS attribute_value,
     CASE
         WHEN sm.namespace_id IS NULL THEN NULL
         ELSE JSON_BUILD_OBJECT('id', sm_ns.id, 'name', sm_ns.name, 'fqn', sm_ns_fqns.fqn)
     END AS namespace
 FROM subject_mappings sm
 LEFT JOIN attribute_values av ON sm.attribute_value_id = av.id
+LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
 LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
 LEFT JOIN attribute_namespaces sm_ns ON sm_ns.id = sm.namespace_id
 LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
 WHERE sm.id = $1
-GROUP BY av.id, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn;
+GROUP BY av.id, fqns.fqn, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn;
 
 -- name: matchSubjectMappings :many
 WITH subject_actions AS (

--- a/service/policy/db/subject_mappings.sql.go
+++ b/service/policy/db/subject_mappings.sql.go
@@ -263,7 +263,7 @@ SELECT
         'id', av.id,
         'value', av.value,
         'active', av.active,
-        'fqn', fqns.fqn
+        'fqn', av_fqns.fqn
     ) AS attribute_value,
     CASE
         WHEN sm.namespace_id IS NULL THEN NULL
@@ -271,14 +271,14 @@ SELECT
     END AS namespace
 FROM subject_mappings sm
 LEFT JOIN attribute_values av ON sm.attribute_value_id = av.id
-LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+LEFT JOIN attribute_fqns av_fqns ON av.id = av_fqns.value_id
 LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
 LEFT JOIN attribute_namespaces sm_ns ON sm_ns.id = sm.namespace_id
 LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
 WHERE sm.id = $1
-GROUP BY av.id, fqns.fqn, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn
+GROUP BY av.id, av_fqns.fqn, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn
 `
 
 type getSubjectMappingRow struct {
@@ -333,7 +333,7 @@ type getSubjectMappingRow struct {
 //	        'id', av.id,
 //	        'value', av.value,
 //	        'active', av.active,
-//	        'fqn', fqns.fqn
+//	        'fqn', av_fqns.fqn
 //	    ) AS attribute_value,
 //	    CASE
 //	        WHEN sm.namespace_id IS NULL THEN NULL
@@ -341,14 +341,14 @@ type getSubjectMappingRow struct {
 //	    END AS namespace
 //	FROM subject_mappings sm
 //	LEFT JOIN attribute_values av ON sm.attribute_value_id = av.id
-//	LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+//	LEFT JOIN attribute_fqns av_fqns ON av.id = av_fqns.value_id
 //	LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 //	LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 //	LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
 //	LEFT JOIN attribute_namespaces sm_ns ON sm_ns.id = sm.namespace_id
 //	LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
 //	WHERE sm.id = $1
-//	GROUP BY av.id, fqns.fqn, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn
+//	GROUP BY av.id, av_fqns.fqn, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn
 func (q *Queries) getSubjectMapping(ctx context.Context, id string) (getSubjectMappingRow, error) {
 	row := q.db.QueryRow(ctx, getSubjectMapping, id)
 	var i getSubjectMappingRow
@@ -581,7 +581,7 @@ SELECT
         'id', av.id,
         'value', av.value,
         'active', av.active,
-        'fqn', fqns.fqn
+        'fqn', av_fqns.fqn
     ) AS attribute_value,
     CASE
         WHEN sm.namespace_id IS NULL THEN NULL
@@ -594,7 +594,7 @@ CROSS JOIN counted
 CROSS JOIN params p
 LEFT JOIN subject_actions sa ON sm.id = sa.subject_mapping_id
 LEFT JOIN attribute_values av ON sm.attribute_value_id = av.id
-LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+LEFT JOIN attribute_fqns av_fqns ON av.id = av_fqns.value_id
 LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
@@ -609,7 +609,7 @@ GROUP BY
     scs_ns.id, scs_ns.name, scs_ns_fqns.fqn,
     sm_ns.id, sm_ns.name, sm_ns_fqns.fqn,
     av.id, av.value, av.active,
-    fqns.fqn,
+    av_fqns.fqn,
     counted.total,
     p.resolved_field, p.resolved_direction
 ORDER BY
@@ -722,7 +722,7 @@ type listSubjectMappingsRow struct {
 //	        'id', av.id,
 //	        'value', av.value,
 //	        'active', av.active,
-//	        'fqn', fqns.fqn
+//	        'fqn', av_fqns.fqn
 //	    ) AS attribute_value,
 //	    CASE
 //	        WHEN sm.namespace_id IS NULL THEN NULL
@@ -735,7 +735,7 @@ type listSubjectMappingsRow struct {
 //	CROSS JOIN params p
 //	LEFT JOIN subject_actions sa ON sm.id = sa.subject_mapping_id
 //	LEFT JOIN attribute_values av ON sm.attribute_value_id = av.id
-//	LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+//	LEFT JOIN attribute_fqns av_fqns ON av.id = av_fqns.value_id
 //	LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 //	LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 //	LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
@@ -750,7 +750,7 @@ type listSubjectMappingsRow struct {
 //	    scs_ns.id, scs_ns.name, scs_ns_fqns.fqn,
 //	    sm_ns.id, sm_ns.name, sm_ns_fqns.fqn,
 //	    av.id, av.value, av.active,
-//	    fqns.fqn,
+//	    av_fqns.fqn,
 //	    counted.total,
 //	    p.resolved_field, p.resolved_direction
 //	ORDER BY

--- a/service/policy/db/subject_mappings.sql.go
+++ b/service/policy/db/subject_mappings.sql.go
@@ -259,20 +259,26 @@ SELECT
             ELSE JSON_BUILD_OBJECT('id', scs_ns.id, 'name', scs_ns.name, 'fqn', scs_ns_fqns.fqn)
         END
     ) AS subject_condition_set,
-    JSON_BUILD_OBJECT('id', av.id,'value', av.value,'active', av.active) AS attribute_value,
+    JSON_BUILD_OBJECT(
+        'id', av.id,
+        'value', av.value,
+        'active', av.active,
+        'fqn', fqns.fqn
+    ) AS attribute_value,
     CASE
         WHEN sm.namespace_id IS NULL THEN NULL
         ELSE JSON_BUILD_OBJECT('id', sm_ns.id, 'name', sm_ns.name, 'fqn', sm_ns_fqns.fqn)
     END AS namespace
 FROM subject_mappings sm
 LEFT JOIN attribute_values av ON sm.attribute_value_id = av.id
+LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
 LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
 LEFT JOIN attribute_namespaces sm_ns ON sm_ns.id = sm.namespace_id
 LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
 WHERE sm.id = $1
-GROUP BY av.id, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn
+GROUP BY av.id, fqns.fqn, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn
 `
 
 type getSubjectMappingRow struct {
@@ -323,20 +329,26 @@ type getSubjectMappingRow struct {
 //	            ELSE JSON_BUILD_OBJECT('id', scs_ns.id, 'name', scs_ns.name, 'fqn', scs_ns_fqns.fqn)
 //	        END
 //	    ) AS subject_condition_set,
-//	    JSON_BUILD_OBJECT('id', av.id,'value', av.value,'active', av.active) AS attribute_value,
+//	    JSON_BUILD_OBJECT(
+//	        'id', av.id,
+//	        'value', av.value,
+//	        'active', av.active,
+//	        'fqn', fqns.fqn
+//	    ) AS attribute_value,
 //	    CASE
 //	        WHEN sm.namespace_id IS NULL THEN NULL
 //	        ELSE JSON_BUILD_OBJECT('id', sm_ns.id, 'name', sm_ns.name, 'fqn', sm_ns_fqns.fqn)
 //	    END AS namespace
 //	FROM subject_mappings sm
 //	LEFT JOIN attribute_values av ON sm.attribute_value_id = av.id
+//	LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
 //	LEFT JOIN subject_condition_set scs ON scs.id = sm.subject_condition_set_id
 //	LEFT JOIN attribute_namespaces scs_ns ON scs_ns.id = scs.namespace_id
 //	LEFT JOIN attribute_fqns scs_ns_fqns ON scs_ns_fqns.namespace_id = scs_ns.id AND scs_ns_fqns.attribute_id IS NULL AND scs_ns_fqns.value_id IS NULL
 //	LEFT JOIN attribute_namespaces sm_ns ON sm_ns.id = sm.namespace_id
 //	LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
 //	WHERE sm.id = $1
-//	GROUP BY av.id, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn
+//	GROUP BY av.id, fqns.fqn, sm.id, scs.id, scs.namespace_id, scs_ns.id, scs_ns.name, scs_ns_fqns.fqn, sm_ns.id, sm_ns.name, sm_ns_fqns.fqn
 func (q *Queries) getSubjectMapping(ctx context.Context, id string) (getSubjectMappingRow, error) {
 	row := q.db.QueryRow(ctx, getSubjectMapping, id)
 	var i getSubjectMappingRow


### PR DESCRIPTION
## Changes
- Include attribute value FQN in GetSubjectMapping responses.
- Align GetSubjectMapping attribute value shape with ListSubjectMappings.
- Assert subject mapping lookups return the embedded attribute value FQN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subject mapping results now return the correct attribute value FQN consistently across single-item and list views.
  * Improved alignment between fetched mapping details and separately retrieved attribute values, reducing mismatches in displayed mapping data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->