### PR TITLE
fix(deps): bump protocol/go to 0.37.0 and sdk to 0.26.0 in /service

### DIFF
--- a/service/go.mod
+++ b/service/go.mod
@@ -32,8 +32,8 @@ require (
 	github.com/opentdf/platform/lib/flattening v0.1.3
 	github.com/opentdf/platform/lib/identifier v0.4.0
 	github.com/opentdf/platform/lib/ocrypto v0.14.0
-	github.com/opentdf/platform/protocol/go v0.36.0
-	github.com/opentdf/platform/sdk v0.25.0
+	github.com/opentdf/platform/protocol/go v0.37.0
+	github.com/opentdf/platform/sdk v0.26.0
 	github.com/pressly/goose/v3 v3.24.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1

--- a/service/go.sum
+++ b/service/go.sum
@@ -273,10 +273,10 @@ github.com/opentdf/platform/lib/identifier v0.4.0 h1:gJf4FqHxqpMdMdMwhI9QmvfHEfM
 github.com/opentdf/platform/lib/identifier v0.4.0/go.mod h1:+gONr5mVf1YlLorZUeRefxiudYfC6JeQN7EwrKMk4g8=
 github.com/opentdf/platform/lib/ocrypto v0.14.0 h1:qAIOFpz72/QDhYC0oLRXgA5uEnyv1xqkc7kvWQSRFcY=
 github.com/opentdf/platform/lib/ocrypto v0.14.0/go.mod h1:TLaMvVE1aTqrgW8AZz0ZuxX/ZpI7l5IQOHyX99fdKl0=
-github.com/opentdf/platform/protocol/go v0.36.0 h1:R/Zfb3+AQPA0Ybv25rz8WpWy7SongPP2LdGHCwErZWE=
-github.com/opentdf/platform/protocol/go v0.36.0/go.mod h1:6A0vQJ5D4ZTLReWAp8Y/7jTFzlYCmL/IfMJWDHZS6M0=
-github.com/opentdf/platform/sdk v0.25.0 h1:SuHHgdFzaklDCx8zP3p9d06tDgeCbCuNhU/cUKjFd6w=
-github.com/opentdf/platform/sdk v0.25.0/go.mod h1:kl4a4PoV3YoumaL5LTJzdB+SZINyCo4A9IdnLZN9aM4=
+github.com/opentdf/platform/protocol/go v0.37.0 h1:gA4zlfxbswhEadlK/0L/UYpRjiT166EClbcJQEdYcZ0=
+github.com/opentdf/platform/protocol/go v0.37.0/go.mod h1:6A0vQJ5D4ZTLReWAp8Y/7jTFzlYCmL/IfMJWDHZS6M0=
+github.com/opentdf/platform/sdk v0.26.0 h1:WYGnB9v63Stc1xXIWmIOHRTQ+OVEJ7tYtXHPDxTrZB0=
+github.com/opentdf/platform/sdk v0.26.0/go.mod h1:CuBlWNiJyK4z97KiMGZqx1Q7x9Rl1oDassQ9v7EFa14=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=


### PR DESCRIPTION
## Summary

Bumps the two OpenTDF module pins in `service/go.mod` to their latest releases:

- `github.com/opentdf/platform/protocol/go` v0.36.0 → v0.37.0
- `github.com/opentdf/platform/sdk` v0.25.0 → v0.26.0

`main`'s service code already references `protocol/go` v0.37.0 `sdkconnect` types, so the module builds in the workspace but cannot be released at the old pins: the release-branch guard (`.github/scripts/work-init.sh`) builds each module against its pinned deps and fails. This bump makes the service module releasable and gives the in-flight service feature PRs a releasable base.

Only `service/go.mod` and `service/go.sum` change (via `go get` + `go mod tidy`).

## Notes

- Supersedes dependabot #3718, which bumps only `protocol/go` for `/service`.
- Unblocks the staged service v0.20.0 release (#3702).

## Testing

- `GOWORK=off go build ./...` in `service/` passes (mirrors the pinned-deps release guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying platform dependencies to newer versions, which may include stability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->