### PR TITLE
fix(core): Pass the platform logger to the authz role provider factory

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -339,7 +339,7 @@ func resolveRoleProvider(ctx context.Context, cfg Config, logger *logger.Logger)
 			GroupsClaim:   cfg.Policy.GroupsClaim,
 			ClientIDClaim: cfg.Policy.ClientIDClaim,
 		}
-		provider, err := factory(ctx, providerCfg)
+		provider, err := factory(ctx, providerCfg, logger)
 		if err != nil {
 			return nil, fmt.Errorf("role provider factory failed: %w", err)
 		}

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -334,7 +334,7 @@ func TestResolveRoleProviderDefault(t *testing.T) {
 }
 
 func TestResolveRoleProviderNamed(t *testing.T) {
-	logger := logger.CreateTestLogger()
+	log := logger.CreateTestLogger()
 	cfg := Config{
 		AuthNConfig: AuthNConfig{
 			Policy: internalauthz.PolicyConfig{
@@ -344,12 +344,12 @@ func TestResolveRoleProviderNamed(t *testing.T) {
 			},
 		},
 		RoleProviderFactories: map[string]authz.RoleProviderFactory{
-			"mock": func(_ context.Context, _ authz.ProviderConfig) (authz.RoleProvider, error) {
+			"mock": func(_ context.Context, _ authz.ProviderConfig, _ *logger.Logger) (authz.RoleProvider, error) {
 				return staticProvider{roles: []string{"role:admin"}}, nil
 			},
 		},
 	}
-	provider, err := resolveRoleProvider(t.Context(), cfg, logger)
+	provider, err := resolveRoleProvider(t.Context(), cfg, log)
 	require.NoError(t, err)
 	require.NotNil(t, provider)
 }

--- a/service/pkg/authz/role_provider.go
+++ b/service/pkg/authz/role_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/opentdf/platform/service/logger"
 )
 
 // RoleProvider returns role/group identifiers used as Casbin subjects.
@@ -12,7 +13,7 @@ type RoleProvider interface {
 }
 
 // RoleProviderFactory constructs a RoleProvider at startup.
-type RoleProviderFactory func(ctx context.Context, cfg ProviderConfig) (RoleProvider, error)
+type RoleProviderFactory func(ctx context.Context, cfg ProviderConfig, log *logger.Logger) (RoleProvider, error)
 
 // ProviderConfig carries provider-specific configuration and claim selectors.
 type ProviderConfig struct {

--- a/service/pkg/server/options_test.go
+++ b/service/pkg/server/options_test.go
@@ -7,6 +7,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/opentdf/platform/service/logger"
 	"github.com/opentdf/platform/service/pkg/authz"
 	"github.com/opentdf/platform/service/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -276,7 +277,7 @@ func TestWithAuthZRoleProvider(t *testing.T) {
 
 func TestWithAuthZRoleProviderFactory(t *testing.T) {
 	var cfg StartConfig
-	cfg = WithAuthZRoleProviderFactory("mock", func(_ context.Context, _ authz.ProviderConfig) (authz.RoleProvider, error) {
+	cfg = WithAuthZRoleProviderFactory("mock", func(_ context.Context, _ authz.ProviderConfig, _ *logger.Logger) (authz.RoleProvider, error) {
 		return noopRoleProvider{}, nil
 	})(cfg)
 


### PR DESCRIPTION
### Proposed Changes

* make the platform service logger available to the casbin authz custom role provider factories

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role-provider setup so logging is available during initialization, helping with troubleshooting and reliability.
  * Updated related auth and server tests to match the new initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->