### PR TITLE
feat(policy): populate entitleable definition namespace

### DIFF
--- a/service/go.mod
+++ b/service/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/opentdf/platform/lib/flattening v0.1.3
 	github.com/opentdf/platform/lib/identifier v0.4.0
 	github.com/opentdf/platform/lib/ocrypto v0.14.0
-	github.com/opentdf/platform/protocol/go v0.37.0
+	github.com/opentdf/platform/protocol/go v0.38.0
 	github.com/opentdf/platform/sdk v0.26.0
 	github.com/pressly/goose/v3 v3.24.3
 	github.com/spf13/cobra v1.9.1

--- a/service/go.sum
+++ b/service/go.sum
@@ -273,8 +273,8 @@ github.com/opentdf/platform/lib/identifier v0.4.0 h1:gJf4FqHxqpMdMdMwhI9QmvfHEfM
 github.com/opentdf/platform/lib/identifier v0.4.0/go.mod h1:+gONr5mVf1YlLorZUeRefxiudYfC6JeQN7EwrKMk4g8=
 github.com/opentdf/platform/lib/ocrypto v0.14.0 h1:qAIOFpz72/QDhYC0oLRXgA5uEnyv1xqkc7kvWQSRFcY=
 github.com/opentdf/platform/lib/ocrypto v0.14.0/go.mod h1:TLaMvVE1aTqrgW8AZz0ZuxX/ZpI7l5IQOHyX99fdKl0=
-github.com/opentdf/platform/protocol/go v0.37.0 h1:gA4zlfxbswhEadlK/0L/UYpRjiT166EClbcJQEdYcZ0=
-github.com/opentdf/platform/protocol/go v0.37.0/go.mod h1:6A0vQJ5D4ZTLReWAp8Y/7jTFzlYCmL/IfMJWDHZS6M0=
+github.com/opentdf/platform/protocol/go v0.38.0 h1:RwZDf/ICdKVhCvcGMWf6QSRC7aKwH0A7QvicIdwr3Jw=
+github.com/opentdf/platform/protocol/go v0.38.0/go.mod h1:6A0vQJ5D4ZTLReWAp8Y/7jTFzlYCmL/IfMJWDHZS6M0=
 github.com/opentdf/platform/sdk v0.26.0 h1:WYGnB9v63Stc1xXIWmIOHRTQ+OVEJ7tYtXHPDxTrZB0=
 github.com/opentdf/platform/sdk v0.26.0/go.mod h1:CuBlWNiJyK4z97KiMGZqx1Q7x9Rl1oDassQ9v7EFa14=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=

--- a/service/integration/attributes_test.go
+++ b/service/integration/attributes_test.go
@@ -1708,6 +1708,14 @@ func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns() {
 	s.Equal(policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, def.GetRule())
 	s.Empty(def.GetValues())
 
+	// The definition carries its namespace identity (id, name, fqn) only; grants,
+	// keys, and metadata are not populated.
+	s.NotEmpty(def.GetNamespace().GetId())
+	s.Equal("https://example.com", def.GetNamespace().GetFqn())
+	s.Equal("example.com", def.GetNamespace().GetName())
+	s.Empty(def.GetNamespace().GetGrants())
+	s.Empty(def.GetNamespace().GetKasKeys())
+
 	// Per-requested-value entries reference the definition and carry subject
 	// mappings grouped by value FQN. Every returned mapping must belong to the
 	// requested value (verifies grouping by FQN).
@@ -1767,6 +1775,9 @@ func (s *AttributesSuite) Test_GetEntitleableAttributesByFqns_MissingValueAllowT
 	def := resp.GetDefinitions()[defFqn]
 	s.Require().NotNil(def)
 	s.Equal(policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, def.GetRule())
+	// The definition (and its namespace) still resolves under allow_traversal.
+	s.Equal(ns.GetId(), def.GetNamespace().GetId())
+	s.Equal(got.GetNamespace().GetFqn(), def.GetNamespace().GetFqn())
 
 	e := resp.GetFqnEntitleableAttributes()[missingFqn]
 	s.Require().NotNil(e)

--- a/service/policy/db/attribute_fqn.go
+++ b/service/policy/db/attribute_fqn.go
@@ -343,6 +343,12 @@ func (c *PolicyDBClient) GetEntitleableAttributesByFqns(ctx context.Context, r *
 		if _, ok := rsp.GetDefinitions()[defFqn]; !ok {
 			def := &attributes.GetEntitleableAttributesByFqnsResponse_EntitleableDefinition{
 				Rule: attr.GetRule(),
+				// Identity only; grants, keys, and metadata are intentionally omitted.
+				Namespace: &policy.Namespace{
+					Id:   attr.GetNamespace().GetId(),
+					Name: attr.GetNamespace().GetName(),
+					Fqn:  attr.GetNamespace().GetFqn(),
+				},
 			}
 			if attr.GetRule() == policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY {
 				def.Values = make([]*attributes.GetEntitleableAttributesByFqnsResponse_EntitleableValue, 0, len(attr.GetValues()))


### PR DESCRIPTION
## Summary

Populates the `namespace` field on `GetEntitleableAttributesByFqnsResponse.EntitleableDefinition`, consuming the field added to `protocol/go` in #3727 (released as v0.38.0).

- Bumps `service/go.mod` protocol/go v0.37.0 → v0.38.0.
- `GetEntitleableAttributesByFqns` now sets each definition's namespace to a trimmed identity (`{id, name, fqn}`). Grants, keys, and metadata are intentionally omitted, matching the proto contract. The identity is already loaded by the existing `GetAttributesByValueFqns` fetch (`service/policy/db/attributes.go`), so this is a zero-cost in-memory copy with no additional query.

The Access PDP needs the definition namespace `id` (not derivable from the value FQN) for strict namespaced-policy decisioning and registered-resource matching. This unblocks the future PDP migration to the entitleable API.

## Testing

- `GOWORK=off go build ./...` passes against the pinned protocol/go v0.38.0 (mirrors the release-branch guard).
- `go vet` and `golangci-lint` clean.
- Integration tests updated: `Test_GetEntitleableAttributesByFqns` asserts the namespace identity is populated and that grants/keys are empty; the allow_traversal case asserts the definition namespace still resolves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribute lookup results so returned definitions now include the correct namespace identity.
  * Fixed namespace details shown for entitleable attributes, including name and fully qualified name consistency.
* **Tests**
  * Strengthened integration coverage to verify namespace identity and expected empty grant/key fields in attribute responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->