### PR TITLE
fix(ci): always generate opentdf.yaml even when PQC keys are absent

### DIFF
--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -224,11 +224,6 @@ runs:
           # For versions 0.7.1 and later, we allow rsa:4096 ec:secp384r1 ec:secp521r1
           allowed_algorithms+=(rsa:4096 ec:secp384r1 ec:secp521r1)
         fi
-        # Only allow PQC algorithms if the platform generated PQC key files
-        if [[ ! -f kas-xwing-private.pem ]]; then
-          printf "PQC key files not found; skipping PQC configuration (platform may not support PQC key types)\n" 1>&2
-          exit 0
-        fi
         keyring='[{"kid":"ec1","alg":"ec:secp256r1"},{"kid":"r1","alg":"rsa:2048"}]'
         keys='[{"kid":"e1","alg":"ec:secp256r1","private":"kas-ec-private.pem","cert":"kas-ec-cert.pem"},{"kid":"ec1","alg":"ec:secp256r1","private":"kas-ec-private.pem","cert":"kas-ec-cert.pem"},{"kid":"r1","alg":"rsa:2048","private":"kas-private.pem","cert":"kas-cert.pem"}]'
         while IFS= read -r key_json; do


### PR DESCRIPTION
## Problem

The reusable `platform-xtest` job (e.g. [run 29361028930](https://github.com/opentdf/platform/actions/runs/29361028930/job/87180916345?pr=3581), job `xct (v0.9.0, go@main)`) fails in **Check out and start up platform** with:

```
Error: stat opentdf.yaml: no such file or directory
```

thrown by the `Enable ECC wrapping for TDFs` step (`yq ... -i opentdf.yaml`).

## Root cause

`opentdf.yaml` is never *created*. In `test/start-up-with-containers/action.yaml`, the only command that generates it — `<opentdf-dev.yaml >opentdf.yaml yq e "${yq_command}"` — is the **last line** of the `Map the config to the keys` step.

#3594 inserted an early `exit 0` near the **top** of that same step:

```bash
# Only allow PQC algorithms if the platform generated PQC key files
if [[ ! -f kas-xwing-private.pem ]]; then
  printf "PQC key files not found; skipping PQC configuration ...\n" 1>&2
  exit 0
fi
```

When the platform under test lacks PQC key generation (e.g. released tags like **v0.9.0**, which predate `service/cmd/keygen`), `kas-xwing-private.pem` is never produced, the step bails **before** writing `opentdf.yaml`, and every later step that edits it fails.

## Fix

Remove the misplaced guard from the base-config step. This is safe:

- PQC extra keys are already filtered by the `allowed_algorithms` allowlist, which no longer lists `hpqt:*` (also from #3594) — so a PQC extra key is skipped by the loop's `continue`, not fatal.
- The dedicated `Enable PQ (mlkem, xwing, and hybrid) wrapping` step keeps its **own** `if [ ! -f kas-xwing-private.pem ]` guard, so PQC config is still correctly skipped when unsupported.

Net effect: `opentdf.yaml` is always generated with the base + allowed keys; PQC is still skipped when the platform can't produce PQC keys.

## Verification

Simulated the patched step in a scratch dir with **no** `kas-xwing-private.pem` and `PLATFORM_VERSION=0.9.0`: `opentdf.yaml` is now produced and `yq e '.services.kas.preview.ec_tdf_enabled = true' -i opentdf.yaml` succeeds.

A follow-up will replace the version/file heuristics with a more principled capability probe.

Regression from #3594.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup configuration handling across supported platform versions.
  * Ensured compatible RSA and elliptic-curve algorithms are recognized consistently, even when optional post-quantum key files are unavailable.
  * Updated validation coverage for containerized startup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->