### PR TITLE
fix(authz): use standard Keycloak token exchange

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     - ${KEYS_DIR:-./keys}/localhost.crt:/etc/x509/tls/localhost.crt
     - ${KEYS_DIR:-./keys}/localhost.key:/etc/x509/tls/localhost.key
     - ${KEYS_DIR:-./keys}/ca.jks:/truststore/truststore.jks
-    image: keycloak/keycloak:25.0
+    image: keycloak/keycloak:26.2
     restart: always
     command:
     - "start-dev"
@@ -27,10 +27,9 @@ services:
       KC_HTTP_PORT: "8888"
       KC_HTTPS_PORT: "8443"
       KC_HTTP_MANAGEMENT_PORT: "9001"
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: changeme
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: changeme
       #KC_HOSTNAME_URL: http://localhost:8888/auth
-      KC_FEATURES: "preview,token-exchange"
       KC_HEALTH_ENABLED: "true"
       KC_HTTPS_KEY_STORE_PASSWORD: "password"
       KC_HTTPS_KEY_STORE_FILE: "/truststore/truststore.jks"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     - ${KEYS_DIR:-./keys}/localhost.crt:/etc/x509/tls/localhost.crt
     - ${KEYS_DIR:-./keys}/localhost.key:/etc/x509/tls/localhost.key
     - ${KEYS_DIR:-./keys}/ca.jks:/truststore/truststore.jks
-    image: us-docker.pkg.dev/prj-infra-automation-ktbz/remote-proxy-quay/keycloak/keycloak:26.4.0
+    image: quay.io/keycloak/keycloak:26.4.0
     restart: always
     command:
     - "start-dev"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     - ${KEYS_DIR:-./keys}/localhost.crt:/etc/x509/tls/localhost.crt
     - ${KEYS_DIR:-./keys}/localhost.key:/etc/x509/tls/localhost.key
     - ${KEYS_DIR:-./keys}/ca.jks:/truststore/truststore.jks
-    image: keycloak/keycloak:26.2
+    image: us-docker.pkg.dev/prj-infra-automation-ktbz/remote-proxy-quay/keycloak/keycloak:26.4.0
     restart: always
     command:
     - "start-dev"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     - ${KEYS_DIR:-./keys}/localhost.crt:/etc/x509/tls/localhost.crt
     - ${KEYS_DIR:-./keys}/localhost.key:/etc/x509/tls/localhost.key
     - ${KEYS_DIR:-./keys}/ca.jks:/truststore/truststore.jks
-    image: quay.io/keycloak/keycloak:26.4.0
+    image: ghcr.io/opentdf/keycloak-standard:26.4.0
     restart: always
     command:
     - "start-dev"

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.25.5
 
-toolchain go1.25.9
+toolchain go1.25.11
 
 use (
 	./examples

--- a/lib/fixtures/keycloak.go
+++ b/lib/fixtures/keycloak.go
@@ -21,6 +21,7 @@ const (
 	kcErrUnknown = -1
 
 	standardTokenExchangeEnabledAttribute = "standard.token.exchange.enabled"
+	dpopBoundAccessTokensAttribute        = "dpop.bound.access.tokens"
 	keycloakBoolTrue                      = "true"
 
 	// Token refresh constants
@@ -104,6 +105,29 @@ func SetupKeycloak(ctx context.Context, kcConnectParams KeycloakConnectParams) e
 }
 
 func SetupKeycloakWithConfig(ctx context.Context, kcConnectParams KeycloakConnectParams, tmConfig *TokenManagerConfig) error {
+	return setupKeycloakWithConfig(ctx, kcConnectParams, tmConfig, keycloakSetupOptions{
+		includeCustomDPoPMapper: true,
+		includeCertExchange:     true,
+	})
+}
+
+func SetupStandardKeycloak(ctx context.Context, kcConnectParams KeycloakConnectParams) error {
+	return SetupStandardKeycloakWithConfig(ctx, kcConnectParams, nil)
+}
+
+func SetupStandardKeycloakWithConfig(ctx context.Context, kcConnectParams KeycloakConnectParams, tmConfig *TokenManagerConfig) error {
+	return setupKeycloakWithConfig(ctx, kcConnectParams, tmConfig, keycloakSetupOptions{
+		includeCustomDPoPMapper: false,
+		includeCertExchange:     false,
+	})
+}
+
+type keycloakSetupOptions struct {
+	includeCustomDPoPMapper bool
+	includeCertExchange     bool
+}
+
+func setupKeycloakWithConfig(ctx context.Context, kcConnectParams KeycloakConnectParams, tmConfig *TokenManagerConfig, options keycloakSetupOptions) error {
 	// Create TokenManager
 	tm, err := NewTokenManager(ctx, &kcConnectParams, tmConfig)
 	if err != nil {
@@ -175,31 +199,7 @@ func SetupKeycloakWithConfig(ctx context.Context, kcConnectParams KeycloakConnec
 	opentdfAuthorizationClientID := "tdf-authorization-svc"
 	realmMangementClientName := "realm-management"
 
-	protocolMappers := []gocloak.ProtocolMapperRepresentation{
-		{
-			Name:           gocloak.StringP("audience-mapper"),
-			Protocol:       gocloak.StringP("openid-connect"),
-			ProtocolMapper: gocloak.StringP("oidc-audience-mapper"),
-			Config: &map[string]string{
-				"included.client.audience": kcConnectParams.Audience,
-				"included.custom.audience": "custom_audience",
-				"access.token.claim":       "true",
-				"id.token.claim":           "true",
-			},
-		},
-		{
-			Name:           gocloak.StringP("dpop-mapper"),
-			Protocol:       gocloak.StringP("openid-connect"),
-			ProtocolMapper: gocloak.StringP("virtru-oidc-protocolmapper"),
-			Config: &map[string]string{
-				"claim.name":         "tdf_claims",
-				"client.dpop":        "true",
-				"tdf_claims.enabled": "true",
-				"access.token.claim": "true",
-				"client.publickey":   "X-VirtruPubKey",
-			},
-		},
-	}
+	protocolMappers := defaultProtocolMappers(kcConnectParams.Audience, options.includeCustomDPoPMapper)
 
 	// Create Roles
 	roles := []string{opentdfAdminRoleName, opentdfStandardRoleName, testingOnlyRoleName}
@@ -246,7 +246,7 @@ func SetupKeycloakWithConfig(ctx context.Context, kcConnectParams KeycloakConnec
 	}
 
 	// Create OpenTDF Client
-	_, err = createClient(ctx, tm, &kcConnectParams, gocloak.Client{
+	opentdfClient := gocloak.Client{
 		ClientID:                gocloak.StringP(opentdfClientID),
 		Enabled:                 gocloak.BoolP(true),
 		Name:                    gocloak.StringP(opentdfClientID),
@@ -254,7 +254,11 @@ func SetupKeycloakWithConfig(ctx context.Context, kcConnectParams KeycloakConnec
 		ClientAuthenticatorType: gocloak.StringP("client-secret"),
 		Secret:                  gocloak.StringP("secret"),
 		ProtocolMappers:         &protocolMappers,
-	}, []gocloak.Role{*opentdfAdminRole}, nil)
+	}
+	if !options.includeCustomDPoPMapper {
+		opentdfClient = withDPoPBoundAccessTokens(opentdfClient)
+	}
+	_, err = createClient(ctx, tm, &kcConnectParams, opentdfClient, []gocloak.Role{*opentdfAdminRole}, nil)
 	if err != nil {
 		return err
 	}
@@ -288,7 +292,7 @@ func SetupKeycloakWithConfig(ctx context.Context, kcConnectParams KeycloakConnec
 	}
 
 	// Create TDF SDK Client
-	sdkNumericID, err := createClient(ctx, tm, &kcConnectParams, gocloak.Client{
+	opentdfSdkClient := gocloak.Client{
 		ClientID: gocloak.StringP(opentdfSdkClientID),
 		Enabled:  gocloak.BoolP(true),
 		// OptionalClientScopes:    &[]string{"testscope"},
@@ -298,7 +302,11 @@ func SetupKeycloakWithConfig(ctx context.Context, kcConnectParams KeycloakConnec
 		Secret:                    gocloak.StringP("secret"),
 		DirectAccessGrantsEnabled: gocloak.BoolP(true),
 		ProtocolMappers:           &protocolMappers,
-	}, []gocloak.Role{*opentdfStandardRole, *testingOnlyRole}, nil)
+	}
+	if !options.includeCustomDPoPMapper {
+		opentdfSdkClient = withDPoPBoundAccessTokens(opentdfSdkClient)
+	}
+	sdkNumericID, err := createClient(ctx, tm, &kcConnectParams, opentdfSdkClient, []gocloak.Role{*opentdfStandardRole, *testingOnlyRole}, nil)
 	if err != nil {
 		return err
 	}
@@ -375,11 +383,44 @@ func SetupKeycloakWithConfig(ctx context.Context, kcConnectParams KeycloakConnec
 	if err := createTokenExchange(ctx, &kcConnectParams, opentdfClientID, opentdfSdkClientID); err != nil {
 		return err
 	}
-	if err := createCertExchange(ctx, &kcConnectParams, "x509-auth-flow", opentdfSdkClientID); err != nil {
-		return err
+	if options.includeCertExchange {
+		if err := createCertExchange(ctx, &kcConnectParams, "x509-auth-flow", opentdfSdkClientID); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+func defaultProtocolMappers(audience string, includeCustomDPoPMapper bool) []gocloak.ProtocolMapperRepresentation {
+	protocolMappers := []gocloak.ProtocolMapperRepresentation{
+		{
+			Name:           gocloak.StringP("audience-mapper"),
+			Protocol:       gocloak.StringP("openid-connect"),
+			ProtocolMapper: gocloak.StringP("oidc-audience-mapper"),
+			Config: &map[string]string{
+				"included.client.audience": audience,
+				"included.custom.audience": "custom_audience",
+				"access.token.claim":       "true",
+				"id.token.claim":           "true",
+			},
+		},
+	}
+	if includeCustomDPoPMapper {
+		protocolMappers = append(protocolMappers, gocloak.ProtocolMapperRepresentation{
+			Name:           gocloak.StringP("dpop-mapper"),
+			Protocol:       gocloak.StringP("openid-connect"),
+			ProtocolMapper: gocloak.StringP("virtru-oidc-protocolmapper"),
+			Config: &map[string]string{
+				"claim.name":         "tdf_claims",
+				"client.dpop":        "true",
+				"tdf_claims.enabled": "true",
+				"access.token.claim": "true",
+				"client.publickey":   "X-VirtruPubKey",
+			},
+		})
+	}
+	return protocolMappers
 }
 
 func SetupCustomKeycloak(ctx context.Context, kcParams KeycloakConnectParams, keycloakData KeycloakData) error {
@@ -1119,13 +1160,21 @@ func exactClientByClientID(clients []*gocloak.Client, clientID string) (gocloak.
 }
 
 func withStandardTokenExchangeEnabled(client gocloak.Client) gocloak.Client {
+	return withClientAttribute(client, standardTokenExchangeEnabledAttribute, keycloakBoolTrue)
+}
+
+func withDPoPBoundAccessTokens(client gocloak.Client) gocloak.Client {
+	return withClientAttribute(client, dpopBoundAccessTokensAttribute, keycloakBoolTrue)
+}
+
+func withClientAttribute(client gocloak.Client, key, value string) gocloak.Client {
 	attributes := make(map[string]string)
 	if client.Attributes != nil {
-		for key, value := range *client.Attributes {
-			attributes[key] = value
+		for existingKey, existingValue := range *client.Attributes {
+			attributes[existingKey] = existingValue
 		}
 	}
-	attributes[standardTokenExchangeEnabledAttribute] = keycloakBoolTrue
+	attributes[key] = value
 	client.Attributes = &attributes
 	return client
 }

--- a/lib/fixtures/keycloak.go
+++ b/lib/fixtures/keycloak.go
@@ -20,6 +20,8 @@ const (
 	kcErrNone    = 0
 	kcErrUnknown = -1
 
+	standardTokenExchangeEnabledAttribute = "standard.token.exchange.enabled"
+
 	// Token refresh constants
 	defaultTokenBufferSeconds    = 120 // 2 minutes before expiration
 	defaultFallbackExpiryMinutes = 5   // Fallback when token doesn't provide ExpiresIn
@@ -1076,104 +1078,38 @@ func createTokenExchangeWithTokenManager(ctx context.Context, connectParams *Key
 	}
 	client := tm.GetClient()
 
-	// Step 1- enable permissions for target client
-	idForTargetClientID, err := getIDOfClient(ctx, tm, connectParams, &targetClientID)
+	requesterClients, err := client.GetClients(ctx, token.AccessToken, connectParams.Realm, gocloak.GetClientsParams{
+		ClientID: gocloak.StringP(startClientID),
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting token exchange requester client %q: %w", startClientID, err)
 	}
-	enabled := true
-	mgmtPermissionsRepr, err := client.UpdateClientManagementPermissions(ctx, token.AccessToken,
-		connectParams.Realm, *idForTargetClientID,
-		gocloak.ManagementPermissionRepresentation{Enabled: &enabled})
-	if err != nil {
-		slog.Error("error creating management permissions", slog.Any("error", err))
-		return err
+	if len(requesterClients) == 0 {
+		return fmt.Errorf("token exchange requester client %q not found", startClientID)
 	}
-	tokenExchangePolicyPermissionResourceID := mgmtPermissionsRepr.Resource
-	scopePermissions := *mgmtPermissionsRepr.ScopePermissions
-	tokenExchangePolicyScopePermissionID := scopePermissions["token-exchange"]
-	slog.Debug("creating management permission",
-		slog.String("resource", *tokenExchangePolicyPermissionResourceID),
-		slog.String("scope_permission_id", tokenExchangePolicyScopePermissionID))
 
-	slog.Debug("step 2 - get realm mgmt client id")
-	realmMangementClientName := "realm-management"
-	realmManagementClientID, err := getIDOfClient(ctx, tm, connectParams, &realmMangementClientName)
-	if err != nil {
-		return err
+	requesterClient := withStandardTokenExchangeEnabled(*requesterClients[0])
+	if err := client.UpdateClient(ctx, token.AccessToken, connectParams.Realm, requesterClient); err != nil {
+		return fmt.Errorf("error enabling standard token exchange for requester client %q targeting %q: %w", startClientID, targetClientID, err)
 	}
-	slog.Debug("client information",
-		slog.String("client_name", realmMangementClientName),
-		slog.String("client_id", *realmManagementClientID))
 
-	slog.Debug("step 3 - add policy for token exchange")
-	policyType := "client"
-	policyName := fmt.Sprintf("%s-%s-exchange-policy", targetClientID, startClientID)
-	realmMgmtExchangePolicyRepresentation := gocloak.PolicyRepresentation{
-		Logic: gocloak.POSITIVE,
-		Name:  &policyName,
-		Type:  &policyType,
-	}
-	policyClients := []string{startClientID}
-	realmMgmtExchangePolicyRepresentation.Clients = &policyClients
+	slog.Info("enabled standard token exchange for client",
+		slog.String("requester_client_id", startClientID),
+		slog.String("target_client_id", targetClientID))
 
-	realmMgmtPolicy, err := client.CreatePolicy(ctx, token.AccessToken, connectParams.Realm,
-		*realmManagementClientID, realmMgmtExchangePolicyRepresentation)
-	if err != nil {
-		switch kcErrCode(err) {
-		case http.StatusConflict:
-			//nolint:sloglint // allow existing emojis
-			slog.Warn("⏭️ policy already exists; skipping remainder of token exchange creation", slog.String("policy", *realmMgmtExchangePolicyRepresentation.Name))
-			return nil
-		default:
-			slog.Error("error creating realm management policy", slog.Any("error", err))
-			return err
-		}
-	}
-	tokenExchangePolicyID := realmMgmtPolicy.ID
-	//nolint:sloglint // allow existing emojis
-	slog.Info("✅ created token exchange policy", slog.String("policy_id", *tokenExchangePolicyID))
-
-	slog.Debug("step 4 - get token exchange scope identifier")
-	resourceRep, err := client.GetResource(ctx, token.AccessToken, connectParams.Realm, *realmManagementClientID, *tokenExchangePolicyPermissionResourceID)
-	if err != nil {
-		slog.Error("error getting resource", slog.Any("error", err))
-		return err
-	}
-	var tokenExchangeScopeID *string
-	tokenExchangeScopeID = nil
-	for _, scope := range *resourceRep.Scopes {
-		if *scope.Name == "token-exchange" {
-			tokenExchangeScopeID = scope.ID
-		}
-	}
-	if tokenExchangeScopeID == nil {
-		return errors.New("no token exchange scope found")
-	}
-	slog.Debug("token exchange scope information",
-		slog.String("scope_id", *tokenExchangeScopeID))
-
-	clientPermissionName := "token-exchange.permission.client." + *idForTargetClientID
-	clientType := "Scope"
-	clientPermissionResources := []string{*tokenExchangePolicyPermissionResourceID}
-	clientPermissionPolicies := []string{*tokenExchangePolicyID}
-	clientPermissionScopes := []string{*tokenExchangeScopeID}
-	permissionScopePolicyRepresentation := gocloak.PolicyRepresentation{
-		ID:               &tokenExchangePolicyScopePermissionID,
-		Name:             &clientPermissionName,
-		Type:             &clientType,
-		Logic:            gocloak.POSITIVE,
-		DecisionStrategy: gocloak.UNANIMOUS,
-		Resources:        &clientPermissionResources,
-		Policies:         &clientPermissionPolicies,
-		Scopes:           &clientPermissionScopes,
-	}
-	if err := client.UpdatePermissionScope(ctx, token.AccessToken, connectParams.Realm,
-		*realmManagementClientID, tokenExchangePolicyScopePermissionID, permissionScopePolicyRepresentation); err != nil {
-		slog.Error("error creating permission scope", slog.Any("error", err))
-		return err
-	}
 	return nil
+}
+
+func withStandardTokenExchangeEnabled(client gocloak.Client) gocloak.Client {
+	attributes := make(map[string]string)
+	if client.Attributes != nil {
+		for key, value := range *client.Attributes {
+			attributes[key] = value
+		}
+	}
+	attributes[standardTokenExchangeEnabledAttribute] = "true"
+	client.Attributes = &attributes
+	return client
 }
 
 func createCertExchange(ctx context.Context, connectParams *KeycloakConnectParams, topLevelFlowName, clientID string) error {

--- a/lib/fixtures/keycloak.go
+++ b/lib/fixtures/keycloak.go
@@ -23,6 +23,7 @@ const (
 	standardTokenExchangeEnabledAttribute = "standard.token.exchange.enabled"
 	dpopBoundAccessTokensAttribute        = "dpop.bound.access.tokens" //nolint:gosec // Keycloak client attribute name, not a credential.
 	keycloakBoolTrue                      = "true"
+	oidcAudienceMapper                    = "oidc-audience-mapper"
 
 	// Token refresh constants
 	defaultTokenBufferSeconds    = 120 // 2 minutes before expiration
@@ -397,7 +398,7 @@ func defaultProtocolMappers(audience string, includeCustomDPoPMapper bool) []goc
 		{
 			Name:           gocloak.StringP("audience-mapper"),
 			Protocol:       gocloak.StringP("openid-connect"),
-			ProtocolMapper: gocloak.StringP("oidc-audience-mapper"),
+			ProtocolMapper: gocloak.StringP(oidcAudienceMapper),
 			Config: &map[string]string{
 				"included.client.audience": audience,
 				"included.custom.audience": "custom_audience",
@@ -1179,7 +1180,7 @@ func withClientAudienceMapper(client gocloak.Client, audience string) gocloak.Cl
 	}
 
 	for _, mapper := range mappers {
-		if mapper.ProtocolMapper == nil || *mapper.ProtocolMapper != "oidc-audience-mapper" || mapper.Config == nil {
+		if mapper.ProtocolMapper == nil || *mapper.ProtocolMapper != oidcAudienceMapper || mapper.Config == nil {
 			continue
 		}
 		if (*mapper.Config)["included.client.audience"] == audience {
@@ -1191,7 +1192,7 @@ func withClientAudienceMapper(client gocloak.Client, audience string) gocloak.Cl
 	mappers = append(mappers, gocloak.ProtocolMapperRepresentation{
 		Name:           gocloak.StringP("token-exchange-audience-" + audience),
 		Protocol:       gocloak.StringP("openid-connect"),
-		ProtocolMapper: gocloak.StringP("oidc-audience-mapper"),
+		ProtocolMapper: gocloak.StringP(oidcAudienceMapper),
 		Config: &map[string]string{
 			"included.client.audience": audience,
 			"access.token.claim":       "true",

--- a/lib/fixtures/keycloak.go
+++ b/lib/fixtures/keycloak.go
@@ -21,6 +21,7 @@ const (
 	kcErrUnknown = -1
 
 	standardTokenExchangeEnabledAttribute = "standard.token.exchange.enabled"
+	keycloakBoolTrue                      = "true"
 
 	// Token refresh constants
 	defaultTokenBufferSeconds    = 120 // 2 minutes before expiration
@@ -1088,7 +1089,12 @@ func createTokenExchangeWithTokenManager(ctx context.Context, connectParams *Key
 		return fmt.Errorf("token exchange requester client %q not found", startClientID)
 	}
 
-	requesterClient := withStandardTokenExchangeEnabled(*requesterClients[0])
+	requesterClient, err := exactClientByClientID(requesterClients, startClientID)
+	if err != nil {
+		return err
+	}
+
+	requesterClient = withStandardTokenExchangeEnabled(requesterClient)
 	if err := client.UpdateClient(ctx, token.AccessToken, connectParams.Realm, requesterClient); err != nil {
 		return fmt.Errorf("error enabling standard token exchange for requester client %q targeting %q: %w", startClientID, targetClientID, err)
 	}
@@ -1100,6 +1106,18 @@ func createTokenExchangeWithTokenManager(ctx context.Context, connectParams *Key
 	return nil
 }
 
+func exactClientByClientID(clients []*gocloak.Client, clientID string) (gocloak.Client, error) {
+	for _, client := range clients {
+		if client == nil || client.ClientID == nil {
+			continue
+		}
+		if *client.ClientID == clientID {
+			return *client, nil
+		}
+	}
+	return gocloak.Client{}, fmt.Errorf("token exchange requester client %q not found by exact clientID match", clientID)
+}
+
 func withStandardTokenExchangeEnabled(client gocloak.Client) gocloak.Client {
 	attributes := make(map[string]string)
 	if client.Attributes != nil {
@@ -1107,7 +1125,7 @@ func withStandardTokenExchangeEnabled(client gocloak.Client) gocloak.Client {
 			attributes[key] = value
 		}
 	}
-	attributes[standardTokenExchangeEnabledAttribute] = "true"
+	attributes[standardTokenExchangeEnabledAttribute] = keycloakBoolTrue
 	client.Attributes = &attributes
 	return client
 }

--- a/lib/fixtures/keycloak.go
+++ b/lib/fixtures/keycloak.go
@@ -21,7 +21,7 @@ const (
 	kcErrUnknown = -1
 
 	standardTokenExchangeEnabledAttribute = "standard.token.exchange.enabled"
-	dpopBoundAccessTokensAttribute        = "dpop.bound.access.tokens"
+	dpopBoundAccessTokensAttribute        = "dpop.bound.access.tokens" //nolint:gosec // Keycloak client attribute name, not a credential.
 	keycloakBoolTrue                      = "true"
 
 	// Token refresh constants
@@ -379,8 +379,8 @@ func setupKeycloakWithConfig(ctx context.Context, kcConnectParams KeycloakConnec
 		panic("Oh no!, failed to create user :(")
 	}
 
-	// Create token exchange opentdf->opentdf sdk
-	if err := createTokenExchange(ctx, &kcConnectParams, opentdfClientID, opentdfSdkClientID); err != nil {
+	// Enable standard token exchange for the requester client.
+	if err := createTokenExchange(ctx, &kcConnectParams, opentdfClientID); err != nil {
 		return err
 	}
 	if options.includeCertExchange {
@@ -555,7 +555,7 @@ func SetupCustomKeycloakWithConfig(ctx context.Context, kcParams KeycloakConnect
 		// create token exchanges
 		if realmToCreate.TokenExchanges != nil {
 			for _, tokenExchange := range realmToCreate.TokenExchanges {
-				err := createTokenExchangeWithTokenManager(ctx, &kcConnectParams, tm, tokenExchange.StartClientID, tokenExchange.TargetClientID)
+				err := createTokenExchangeWithTokenManager(ctx, &kcConnectParams, tm, tokenExchange.StartClientID)
 				if err != nil {
 					return err
 				}
@@ -1103,16 +1103,16 @@ func getIDOfClient(ctx context.Context, tm *TokenManager, connectParams *Keycloa
 	return clientID, nil
 }
 
-func createTokenExchange(ctx context.Context, connectParams *KeycloakConnectParams, startClientID string, targetClientID string) error {
+func createTokenExchange(ctx context.Context, connectParams *KeycloakConnectParams, startClientID string) error {
 	// Create TokenManager and delegate to TokenManager version
 	tm, err := NewTokenManager(ctx, connectParams, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create token manager: %w", err)
 	}
-	return createTokenExchangeWithTokenManager(ctx, connectParams, tm, startClientID, targetClientID)
+	return createTokenExchangeWithTokenManager(ctx, connectParams, tm, startClientID)
 }
 
-func createTokenExchangeWithTokenManager(ctx context.Context, connectParams *KeycloakConnectParams, tm *TokenManager, startClientID string, targetClientID string) error {
+func createTokenExchangeWithTokenManager(ctx context.Context, connectParams *KeycloakConnectParams, tm *TokenManager, startClientID string) error {
 	// Get fresh token
 	token, err := tm.GetToken(ctx)
 	if err != nil {
@@ -1137,12 +1137,11 @@ func createTokenExchangeWithTokenManager(ctx context.Context, connectParams *Key
 
 	requesterClient = withStandardTokenExchangeEnabled(requesterClient)
 	if err := client.UpdateClient(ctx, token.AccessToken, connectParams.Realm, requesterClient); err != nil {
-		return fmt.Errorf("error enabling standard token exchange for requester client %q targeting %q: %w", startClientID, targetClientID, err)
+		return fmt.Errorf("error enabling standard token exchange for requester client %q: %w", startClientID, err)
 	}
 
 	slog.Info("enabled standard token exchange for client",
-		slog.String("requester_client_id", startClientID),
-		slog.String("target_client_id", targetClientID))
+		slog.String("requester_client_id", startClientID))
 
 	return nil
 }

--- a/lib/fixtures/keycloak.go
+++ b/lib/fixtures/keycloak.go
@@ -380,7 +380,7 @@ func setupKeycloakWithConfig(ctx context.Context, kcConnectParams KeycloakConnec
 	}
 
 	// Enable standard token exchange for the requester client.
-	if err := createTokenExchange(ctx, &kcConnectParams, opentdfClientID); err != nil {
+	if err := createTokenExchange(ctx, &kcConnectParams, opentdfClientID, opentdfSdkClientID); err != nil {
 		return err
 	}
 	if options.includeCertExchange {
@@ -555,7 +555,7 @@ func SetupCustomKeycloakWithConfig(ctx context.Context, kcParams KeycloakConnect
 		// create token exchanges
 		if realmToCreate.TokenExchanges != nil {
 			for _, tokenExchange := range realmToCreate.TokenExchanges {
-				err := createTokenExchangeWithTokenManager(ctx, &kcConnectParams, tm, tokenExchange.StartClientID)
+				err := createTokenExchangeWithTokenManager(ctx, &kcConnectParams, tm, tokenExchange.StartClientID, tokenExchange.TargetClientID)
 				if err != nil {
 					return err
 				}
@@ -1103,16 +1103,16 @@ func getIDOfClient(ctx context.Context, tm *TokenManager, connectParams *Keycloa
 	return clientID, nil
 }
 
-func createTokenExchange(ctx context.Context, connectParams *KeycloakConnectParams, startClientID string) error {
+func createTokenExchange(ctx context.Context, connectParams *KeycloakConnectParams, startClientID, targetClientID string) error {
 	// Create TokenManager and delegate to TokenManager version
 	tm, err := NewTokenManager(ctx, connectParams, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create token manager: %w", err)
 	}
-	return createTokenExchangeWithTokenManager(ctx, connectParams, tm, startClientID)
+	return createTokenExchangeWithTokenManager(ctx, connectParams, tm, startClientID, targetClientID)
 }
 
-func createTokenExchangeWithTokenManager(ctx context.Context, connectParams *KeycloakConnectParams, tm *TokenManager, startClientID string) error {
+func createTokenExchangeWithTokenManager(ctx context.Context, connectParams *KeycloakConnectParams, tm *TokenManager, startClientID, targetClientID string) error {
 	// Get fresh token
 	token, err := tm.GetToken(ctx)
 	if err != nil {
@@ -1136,12 +1136,14 @@ func createTokenExchangeWithTokenManager(ctx context.Context, connectParams *Key
 	}
 
 	requesterClient = withStandardTokenExchangeEnabled(requesterClient)
+	requesterClient = withClientAudienceMapper(requesterClient, targetClientID)
 	if err := client.UpdateClient(ctx, token.AccessToken, connectParams.Realm, requesterClient); err != nil {
 		return fmt.Errorf("error enabling standard token exchange for requester client %q: %w", startClientID, err)
 	}
 
 	slog.Info("enabled standard token exchange for client",
-		slog.String("requester_client_id", startClientID))
+		slog.String("requester_client_id", startClientID),
+		slog.String("target_client_id", targetClientID))
 
 	return nil
 }
@@ -1164,6 +1166,39 @@ func withStandardTokenExchangeEnabled(client gocloak.Client) gocloak.Client {
 
 func withDPoPBoundAccessTokens(client gocloak.Client) gocloak.Client {
 	return withClientAttribute(client, dpopBoundAccessTokensAttribute, keycloakBoolTrue)
+}
+
+func withClientAudienceMapper(client gocloak.Client, audience string) gocloak.Client {
+	if audience == "" {
+		return client
+	}
+
+	mappers := make([]gocloak.ProtocolMapperRepresentation, 0)
+	if client.ProtocolMappers != nil {
+		mappers = append(mappers, (*client.ProtocolMappers)...)
+	}
+
+	for _, mapper := range mappers {
+		if mapper.ProtocolMapper == nil || *mapper.ProtocolMapper != "oidc-audience-mapper" || mapper.Config == nil {
+			continue
+		}
+		if (*mapper.Config)["included.client.audience"] == audience {
+			client.ProtocolMappers = &mappers
+			return client
+		}
+	}
+
+	mappers = append(mappers, gocloak.ProtocolMapperRepresentation{
+		Name:           gocloak.StringP("token-exchange-audience-" + audience),
+		Protocol:       gocloak.StringP("openid-connect"),
+		ProtocolMapper: gocloak.StringP("oidc-audience-mapper"),
+		Config: &map[string]string{
+			"included.client.audience": audience,
+			"access.token.claim":       "true",
+		},
+	})
+	client.ProtocolMappers = &mappers
+	return client
 }
 
 func withClientAttribute(client gocloak.Client, key, value string) gocloak.Client {

--- a/lib/fixtures/keycloak_test.go
+++ b/lib/fixtures/keycloak_test.go
@@ -65,6 +65,36 @@ func TestWithDPoPBoundAccessTokens(t *testing.T) {
 	}
 }
 
+func TestWithClientAudienceMapper(t *testing.T) {
+	client := withClientAudienceMapper(gocloak.Client{}, "opentdf-sdk")
+
+	if client.ProtocolMappers == nil {
+		t.Fatal("expected protocol mappers to be set")
+	}
+	if got := len(*client.ProtocolMappers); got != 1 {
+		t.Fatalf("expected one protocol mapper, got %d", got)
+	}
+	mapper := (*client.ProtocolMappers)[0]
+	if got := *mapper.ProtocolMapper; got != "oidc-audience-mapper" {
+		t.Fatalf("expected audience mapper, got %q", got)
+	}
+	if got := (*mapper.Config)["included.client.audience"]; got != "opentdf-sdk" {
+		t.Fatalf("expected opentdf-sdk audience, got %q", got)
+	}
+}
+
+func TestWithClientAudienceMapperDoesNotDuplicateExistingAudience(t *testing.T) {
+	client := withClientAudienceMapper(gocloak.Client{}, "opentdf-sdk")
+	client = withClientAudienceMapper(client, "opentdf-sdk")
+
+	if client.ProtocolMappers == nil {
+		t.Fatal("expected protocol mappers to be set")
+	}
+	if got := len(*client.ProtocolMappers); got != 1 {
+		t.Fatalf("expected one protocol mapper, got %d", got)
+	}
+}
+
 func TestDefaultProtocolMappersForStandardKeycloakExcludeCustomDPoPMapper(t *testing.T) {
 	mappers := defaultProtocolMappers("https://platform.example", false)
 

--- a/lib/fixtures/keycloak_test.go
+++ b/lib/fixtures/keycloak_test.go
@@ -19,7 +19,7 @@ func TestWithStandardTokenExchangeEnabled(t *testing.T) {
 	if updatedClient.Attributes == nil {
 		t.Fatal("expected attributes to be set")
 	}
-	if got := (*updatedClient.Attributes)[standardTokenExchangeEnabledAttribute]; got != "true" {
+	if got := (*updatedClient.Attributes)[standardTokenExchangeEnabledAttribute]; got != keycloakBoolTrue {
 		t.Fatalf("expected %s to be true, got %q", standardTokenExchangeEnabledAttribute, got)
 	}
 	if got := (*updatedClient.Attributes)["client.secret.creation.time"]; got != "12345" {
@@ -36,7 +36,33 @@ func TestWithStandardTokenExchangeEnabledInitializesAttributes(t *testing.T) {
 	if updatedClient.Attributes == nil {
 		t.Fatal("expected attributes to be initialized")
 	}
-	if got := (*updatedClient.Attributes)[standardTokenExchangeEnabledAttribute]; got != "true" {
+	if got := (*updatedClient.Attributes)[standardTokenExchangeEnabledAttribute]; got != keycloakBoolTrue {
 		t.Fatalf("expected %s to be true, got %q", standardTokenExchangeEnabledAttribute, got)
+	}
+}
+
+func TestExactClientByClientID(t *testing.T) {
+	const clientID = "opentdf"
+	clients := []*gocloak.Client{
+		{ClientID: gocloak.StringP("opentdf-extra")},
+		{ClientID: gocloak.StringP(clientID), ID: gocloak.StringP("uuid-opentdf")},
+	}
+
+	client, err := exactClientByClientID(clients, clientID)
+	if err != nil {
+		t.Fatalf("expected exact client match: %v", err)
+	}
+	if got := *client.ID; got != "uuid-opentdf" {
+		t.Fatalf("expected exact client uuid, got %q", got)
+	}
+}
+
+func TestExactClientByClientIDReturnsErrorForPrefixOnlyMatch(t *testing.T) {
+	clients := []*gocloak.Client{
+		{ClientID: gocloak.StringP("opentdf-extra")},
+	}
+
+	if _, err := exactClientByClientID(clients, "opentdf"); err == nil {
+		t.Fatal("expected exact client match error")
 	}
 }

--- a/lib/fixtures/keycloak_test.go
+++ b/lib/fixtures/keycloak_test.go
@@ -75,7 +75,7 @@ func TestWithClientAudienceMapper(t *testing.T) {
 		t.Fatalf("expected one protocol mapper, got %d", got)
 	}
 	mapper := (*client.ProtocolMappers)[0]
-	if got := *mapper.ProtocolMapper; got != "oidc-audience-mapper" {
+	if got := *mapper.ProtocolMapper; got != oidcAudienceMapper {
 		t.Fatalf("expected audience mapper, got %q", got)
 	}
 	if got := (*mapper.Config)["included.client.audience"]; got != "opentdf-sdk" {
@@ -101,7 +101,7 @@ func TestDefaultProtocolMappersForStandardKeycloakExcludeCustomDPoPMapper(t *tes
 	if len(mappers) != 1 {
 		t.Fatalf("expected only the audience mapper, got %d mappers", len(mappers))
 	}
-	if got := *mappers[0].ProtocolMapper; got != "oidc-audience-mapper" {
+	if got := *mappers[0].ProtocolMapper; got != oidcAudienceMapper {
 		t.Fatalf("expected audience mapper, got %q", got)
 	}
 }

--- a/lib/fixtures/keycloak_test.go
+++ b/lib/fixtures/keycloak_test.go
@@ -41,6 +41,56 @@ func TestWithStandardTokenExchangeEnabledInitializesAttributes(t *testing.T) {
 	}
 }
 
+func TestWithDPoPBoundAccessTokens(t *testing.T) {
+	existingAttributes := map[string]string{
+		"client.secret.creation.time": "12345",
+	}
+	client := gocloak.Client{
+		Attributes: &existingAttributes,
+	}
+
+	updatedClient := withDPoPBoundAccessTokens(client)
+
+	if updatedClient.Attributes == nil {
+		t.Fatal("expected attributes to be set")
+	}
+	if got := (*updatedClient.Attributes)[dpopBoundAccessTokensAttribute]; got != keycloakBoolTrue {
+		t.Fatalf("expected %s to be true, got %q", dpopBoundAccessTokensAttribute, got)
+	}
+	if got := (*updatedClient.Attributes)["client.secret.creation.time"]; got != "12345" {
+		t.Fatalf("expected existing attribute to be preserved, got %q", got)
+	}
+	if _, ok := existingAttributes[dpopBoundAccessTokensAttribute]; ok {
+		t.Fatal("expected original attributes map to remain unchanged")
+	}
+}
+
+func TestDefaultProtocolMappersForStandardKeycloakExcludeCustomDPoPMapper(t *testing.T) {
+	mappers := defaultProtocolMappers("https://platform.example", false)
+
+	if len(mappers) != 1 {
+		t.Fatalf("expected only the audience mapper, got %d mappers", len(mappers))
+	}
+	if got := *mappers[0].ProtocolMapper; got != "oidc-audience-mapper" {
+		t.Fatalf("expected audience mapper, got %q", got)
+	}
+}
+
+func TestDefaultProtocolMappersForCustomKeycloakIncludeCustomDPoPMapper(t *testing.T) {
+	mappers := defaultProtocolMappers("https://platform.example", true)
+
+	found := false
+	for _, mapper := range mappers {
+		if mapper.ProtocolMapper != nil && *mapper.ProtocolMapper == "virtru-oidc-protocolmapper" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected custom Keycloak setup to include virtru-oidc-protocolmapper")
+	}
+}
+
 func TestExactClientByClientID(t *testing.T) {
 	const clientID = "opentdf"
 	clients := []*gocloak.Client{

--- a/lib/fixtures/keycloak_test.go
+++ b/lib/fixtures/keycloak_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestWithStandardTokenExchangeEnabled(t *testing.T) {
 	existingAttributes := map[string]string{
-		"client.secret.creation.time": "12345",
+		"client.secret.creation.time": "12345", // #nosec G101 -- Keycloak metadata key used in unit test, not a credential
 	}
 	client := gocloak.Client{
 		Attributes: &existingAttributes,
@@ -43,7 +43,7 @@ func TestWithStandardTokenExchangeEnabledInitializesAttributes(t *testing.T) {
 
 func TestWithDPoPBoundAccessTokens(t *testing.T) {
 	existingAttributes := map[string]string{
-		"client.secret.creation.time": "12345",
+		"client.secret.creation.time": "12345", // #nosec G101 -- Keycloak metadata key used in unit test, not a credential
 	}
 	client := gocloak.Client{
 		Attributes: &existingAttributes,

--- a/lib/fixtures/keycloak_test.go
+++ b/lib/fixtures/keycloak_test.go
@@ -1,0 +1,42 @@
+package fixtures
+
+import (
+	"testing"
+
+	"github.com/Nerzal/gocloak/v13"
+)
+
+func TestWithStandardTokenExchangeEnabled(t *testing.T) {
+	existingAttributes := map[string]string{
+		"client.secret.creation.time": "12345",
+	}
+	client := gocloak.Client{
+		Attributes: &existingAttributes,
+	}
+
+	updatedClient := withStandardTokenExchangeEnabled(client)
+
+	if updatedClient.Attributes == nil {
+		t.Fatal("expected attributes to be set")
+	}
+	if got := (*updatedClient.Attributes)[standardTokenExchangeEnabledAttribute]; got != "true" {
+		t.Fatalf("expected %s to be true, got %q", standardTokenExchangeEnabledAttribute, got)
+	}
+	if got := (*updatedClient.Attributes)["client.secret.creation.time"]; got != "12345" {
+		t.Fatalf("expected existing attribute to be preserved, got %q", got)
+	}
+	if _, ok := existingAttributes[standardTokenExchangeEnabledAttribute]; ok {
+		t.Fatal("expected original attributes map to remain unchanged")
+	}
+}
+
+func TestWithStandardTokenExchangeEnabledInitializesAttributes(t *testing.T) {
+	updatedClient := withStandardTokenExchangeEnabled(gocloak.Client{})
+
+	if updatedClient.Attributes == nil {
+		t.Fatal("expected attributes to be initialized")
+	}
+	if got := (*updatedClient.Attributes)[standardTokenExchangeEnabledAttribute]; got != "true" {
+		t.Fatalf("expected %s to be true, got %q", standardTokenExchangeEnabledAttribute, got)
+	}
+}

--- a/service/README.md
+++ b/service/README.md
@@ -72,7 +72,7 @@ For convenience, the `make toolcheck` script checks if you have the necessary de
 
 ### Provisioning Custom Keycloak and Policy Data
 
-To provision a custom Keycloak setup, create a yaml following the format of [the sample Keycloak config](service/cmd/keycloak_data.yaml). You can create different realms with separate users, clients, roles, and groups. Run the provisioning with `go run ./service provision keycloak -f <path-to-your-yaml-file>`.
+To provision a custom Keycloak setup, create a yaml following the format of [the sample Keycloak config](service/cmd/keycloak_data.yaml). You can create different realms with separate users, clients, roles, and groups. The `token_exchanges` entries enable Keycloak standard token exchange on the requester clients. Run the provisioning with `go run ./service provision keycloak -f <path-to-your-yaml-file>`.
 
 ## Developing a new platform service
 

--- a/service/entityresolution/integration/keycloak_test.go
+++ b/service/entityresolution/integration/keycloak_test.go
@@ -178,13 +178,13 @@ func (a *KeycloakTestAdapter) createKeycloakContainerConfig() internal.Container
 		Image:        "ghcr.io/opentdf/keycloak-standard:26.4.0",
 		ExposedPorts: []string{"8080/tcp"},
 		Env: map[string]string{
-			"KEYCLOAK_ADMIN":          a.config.AdminUser,
-			"KEYCLOAK_ADMIN_PASSWORD": a.config.AdminPass,
-			"KC_HTTP_ENABLED":         "true",
-			"KC_HOSTNAME_STRICT":      "false",
-			"KC_HEALTH_ENABLED":       "true",
-			"KC_METRICS_ENABLED":      "false",
-			"KC_LOG_LEVEL":            "WARN", // Reduce log noise for faster startup
+			"KC_BOOTSTRAP_ADMIN_USERNAME": a.config.AdminUser,
+			"KC_BOOTSTRAP_ADMIN_PASSWORD": a.config.AdminPass,
+			"KC_HTTP_ENABLED":             "true",
+			"KC_HOSTNAME_STRICT":          "false",
+			"KC_HEALTH_ENABLED":           "true",
+			"KC_METRICS_ENABLED":          "false",
+			"KC_LOG_LEVEL":                "WARN", // Reduce log noise for faster startup
 		},
 		Cmd:          []string{"start-dev"},
 		WaitStrategy: wait.ForListeningPort("8080/tcp").WithStartupTimeout(2 * time.Minute),
@@ -299,7 +299,7 @@ func (a *KeycloakTestAdapter) enableUnmanagedUserAttributes(ctx context.Context)
 		return fmt.Errorf("failed to get realm user profile config: %w", err)
 	}
 	var upConfig map[string]interface{}
-	if err := json.Unmarshal([]byte(realmUserProfileResp.String()), &upConfig); err != nil {
+	if err := json.Unmarshal(realmUserProfileResp.Body(), &upConfig); err != nil {
 		return fmt.Errorf("failed to parse realm user profile config: %w", err)
 	}
 	upConfig["unmanagedAttributePolicy"] = "ENABLED"

--- a/service/entityresolution/integration/keycloak_test.go
+++ b/service/entityresolution/integration/keycloak_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -174,7 +175,7 @@ func (a *KeycloakTestAdapter) TeardownTestData(ctx context.Context) error {
 // createKeycloakContainerConfig returns a Keycloak container configuration
 func (a *KeycloakTestAdapter) createKeycloakContainerConfig() internal.ContainerConfig {
 	return internal.ContainerConfig{
-		Image:        "quay.io/keycloak/keycloak:23.0",
+		Image:        "ghcr.io/opentdf/keycloak-standard:26.4.0",
 		ExposedPorts: []string{"8080/tcp"},
 		Env: map[string]string{
 			"KEYCLOAK_ADMIN":          a.config.AdminUser,
@@ -284,6 +285,27 @@ func (a *KeycloakTestAdapter) createTestRealm(ctx context.Context) error {
 			slog.String("id", realmID))
 	}
 
+	if err := a.enableUnmanagedUserAttributes(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *KeycloakTestAdapter) enableUnmanagedUserAttributes(ctx context.Context) error {
+	realmProfileURL := fmt.Sprintf("%s/admin/realms/%s/users/profile", a.config.AdminURL, a.config.Realm)
+	realmUserProfileResp, err := a.keycloakClient.GetRequestWithBearerAuth(ctx, a.adminToken.AccessToken).Get(realmProfileURL)
+	if err != nil {
+		return fmt.Errorf("failed to get realm user profile config: %w", err)
+	}
+	var upConfig map[string]interface{}
+	if err := json.Unmarshal([]byte(realmUserProfileResp.String()), &upConfig); err != nil {
+		return fmt.Errorf("failed to parse realm user profile config: %w", err)
+	}
+	upConfig["unmanagedAttributePolicy"] = "ENABLED"
+	if _, err := a.keycloakClient.GetRequestWithBearerAuth(ctx, a.adminToken.AccessToken).SetBody(upConfig).Put(realmProfileURL); err != nil {
+		return fmt.Errorf("failed to enable unmanaged user attributes: %w", err)
+	}
 	return nil
 }
 

--- a/test/integration/oauth/oauth_test.go
+++ b/test/integration/oauth/oauth_test.go
@@ -572,8 +572,6 @@ func setupStandardKeycloak(ctx context.Context, t *testing.T) (tc.Container, str
 		Env: map[string]string{
 			"KC_BOOTSTRAP_ADMIN_USERNAME": "admin",
 			"KC_BOOTSTRAP_ADMIN_PASSWORD": "admin", // #nosec G101 -- test-only Keycloak admin password
-			"KEYCLOAK_ADMIN":              "admin",
-			"KEYCLOAK_ADMIN_PASSWORD":     "admin", // #nosec G101 -- test-only Keycloak admin password
 		},
 
 		WaitingFor: wait.ForHTTP("/realms/master/.well-known/openid-configuration").

--- a/test/integration/oauth/oauth_test.go
+++ b/test/integration/oauth/oauth_test.go
@@ -217,7 +217,7 @@ func (s *OAuthSuite) TestGettingAccessTokenWithoutDPoPProofFails() {
 
 	req, err := http.NewRequest(http.MethodPost, s.keycloakEndpoint, strings.NewReader(formData.Encode()))
 	s.Require().NoError(err)
-	req.SetBasicAuth("opentdf-sdk", "secret")
+	req.SetBasicAuth("opentdf-sdk", "secret") // #nosec G101 -- test-only Keycloak client secret
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -570,9 +570,9 @@ func setupStandardKeycloak(ctx context.Context, t *testing.T) (tc.Container, str
 		},
 		Env: map[string]string{
 			"KC_BOOTSTRAP_ADMIN_USERNAME": "admin",
-			"KC_BOOTSTRAP_ADMIN_PASSWORD": "admin",
+			"KC_BOOTSTRAP_ADMIN_PASSWORD": "admin", // #nosec G101 -- test-only Keycloak admin password
 			"KEYCLOAK_ADMIN":              "admin",
-			"KEYCLOAK_ADMIN_PASSWORD":     "admin",
+			"KEYCLOAK_ADMIN_PASSWORD":     "admin", // #nosec G101 -- test-only Keycloak admin password
 		},
 
 		WaitingFor: wait.ForLog("Running the server"),
@@ -588,7 +588,7 @@ func setupStandardKeycloak(ctx context.Context, t *testing.T) (tc.Container, str
 	connectParams := fixtures.KeycloakConnectParams{
 		BasePath:         keycloakBase,
 		Username:         "admin",
-		Password:         "admin",
+		Password:         "admin", // #nosec G101 -- test-only Keycloak admin password
 		Realm:            realm,
 		Audience:         "opentdf",
 		AllowInsecureTLS: true,
@@ -620,7 +620,7 @@ func setupCustomKeycloakForCertExchange(ctx context.Context, t *testing.T) (tc.C
 			"KC_BOOTSTRAP_ADMIN_USERNAME":   "admin",
 			"KC_BOOTSTRAP_ADMIN_PASSWORD":   "admin",
 			"KEYCLOAK_ADMIN":                "admin",
-			"KEYCLOAK_ADMIN_PASSWORD":       "admin",
+			"KEYCLOAK_ADMIN_PASSWORD":       "admin", // #nosec G101 -- test-only Keycloak admin password
 			"KC_HTTPS_KEY_STORE_PASSWORD":   "password",
 			"KC_HTTPS_KEY_STORE_FILE":       "/truststore/truststore.jks",
 			"KC_HTTPS_CERTIFICATE_FILE":     "/etc/x509/tls/localhost.crt",

--- a/test/integration/oauth/oauth_test.go
+++ b/test/integration/oauth/oauth_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	standardKeycloakImage = "us-docker.pkg.dev/prj-infra-automation-ktbz/remote-proxy-quay/keycloak/keycloak:26.4.0"
+	standardKeycloakImage = "quay.io/keycloak/keycloak:26.4.0"
 	customKeycloakImage   = "ghcr.io/opentdf/keycloak:sha-8a6d35a"
 )
 

--- a/test/integration/oauth/oauth_test.go
+++ b/test/integration/oauth/oauth_test.go
@@ -509,10 +509,10 @@ func extractDPoPToken(r *http.Request, t *testing.T) jwt.Token {
 
 func setupKeycloak(ctx context.Context, t *testing.T) (tc.Container, string, string) {
 	containerReq := tc.ContainerRequest{
-		Image:        "ghcr.io/opentdf/keycloak:sha-8a6d35a",
+		Image:        "keycloak/keycloak:26.2",
 		ExposedPorts: []string{"8082/tcp", "8083/tcp"},
 		Cmd: []string{
-			"start-dev", "--http-port=8082", "--https-port=8083", "--features=preview", "--verbose",
+			"start-dev", "--http-port=8082", "--https-port=8083", "--verbose",
 			"-Djavax.net.ssl.trustStorePassword=password", "-Djavax.net.ssl.HostnameVerifier=AllowAll",
 			"-Djavax.net.debug=ssl",
 			"-Djavax.net.ssl.trustStore=/truststore/truststore.jks",
@@ -524,8 +524,8 @@ func setupKeycloak(ctx context.Context, t *testing.T) (tc.Container, string, str
 			{HostFilePath: "testdata/localhost.key", ContainerFilePath: "/etc/x509/tls/localhost.key", FileMode: int64(0o600)},
 		},
 		Env: map[string]string{
-			"KEYCLOAK_ADMIN":                "admin",
-			"KEYCLOAK_ADMIN_PASSWORD":       "admin",
+			"KC_BOOTSTRAP_ADMIN_USERNAME":   "admin",
+			"KC_BOOTSTRAP_ADMIN_PASSWORD":   "admin",
 			"KC_HTTPS_KEY_STORE_PASSWORD":   "password",
 			"KC_HTTPS_KEY_STORE_FILE":       "/truststore/truststore.jks",
 			"KC_HTTPS_CERTIFICATE_FILE":     "/etc/x509/tls/localhost.crt",

--- a/test/integration/oauth/oauth_test.go
+++ b/test/integration/oauth/oauth_test.go
@@ -12,8 +12,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,16 +32,31 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+const (
+	standardKeycloakImage = "us-docker.pkg.dev/prj-infra-automation-ktbz/remote-proxy-quay/keycloak/keycloak:26.4.0"
+	customKeycloakImage   = "ghcr.io/opentdf/keycloak:sha-8a6d35a"
+)
+
 type OAuthSuite struct {
+	suite.Suite
+	dpopJWK           jwk.Key
+	keycloakContainer tc.Container
+	keycloakEndpoint  string
+}
+
+type CertExchangeSuite struct {
 	suite.Suite
 	dpopJWK               jwk.Key
 	keycloakContainer     tc.Container
-	keycloakEndpoint      string
 	keycloakHTTPSEndpoint string
 }
 
 func TestOAuthTestSuite(t *testing.T) {
 	suite.Run(t, new(OAuthSuite))
+}
+
+func TestCertExchangeTestSuite(t *testing.T) {
+	suite.Run(t, new(CertExchangeSuite))
 }
 
 func (s *OAuthSuite) SetupSuite() {
@@ -55,20 +72,40 @@ func (s *OAuthSuite) SetupSuite() {
 	s.dpopJWK = dpopJWK
 	ctx := context.Background()
 
-	keycloak, idpEndpoint, idpHTTPSEndpoint := setupKeycloak(ctx, s.T())
+	keycloak, idpEndpoint := setupStandardKeycloak(ctx, s.T())
 	s.keycloakContainer = keycloak
 	s.keycloakEndpoint = idpEndpoint
-	s.keycloakHTTPSEndpoint = idpHTTPSEndpoint
 }
 
 func (s *OAuthSuite) TearDownSuite() {
 	_ = s.keycloakContainer.Terminate(context.Background())
 }
 
+func (s *CertExchangeSuite) SetupSuite() {
+	dpopKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	s.Require().NoError(err, "failed to generate dpop key")
+
+	dpopJWK, err := jwk.FromRaw(dpopKey)
+	s.Require().NoError(err)
+	s.Require().NoError(dpopJWK.Set("use", "sig"))
+	s.Require().NoError(dpopJWK.Set("alg", jwa.RS256.String()))
+
+	s.dpopJWK = dpopJWK
+	ctx := context.Background()
+
+	keycloak, idpHTTPSEndpoint := setupCustomKeycloakForCertExchange(ctx, s.T())
+	s.keycloakContainer = keycloak
+	s.keycloakHTTPSEndpoint = idpHTTPSEndpoint
+}
+
+func (s *CertExchangeSuite) TearDownSuite() {
+	_ = s.keycloakContainer.Terminate(context.Background())
+}
+
 //go:embed testdata/new-ca.crt
 var ca []byte
 
-func (s *OAuthSuite) TestCertExchangeFromKeycloak() {
+func (s *CertExchangeSuite) TestCertExchangeFromKeycloak() {
 	clientCredentials := oauth.ClientCredentials{
 		ClientID:   "opentdf-sdk",
 		ClientAuth: "secret",
@@ -172,6 +209,23 @@ func (s *OAuthSuite) TestGettingAccessTokenFromKeycloak() {
 	rolesList, ok := roles.([]interface{})
 	s.Require().True(ok)
 	s.Require().True(slices.Contains(rolesList, "opentdf-standard"), "missing the `opentdf-standard` role")
+}
+
+func (s *OAuthSuite) TestGettingAccessTokenWithoutDPoPProofFails() {
+	formData := url.Values{}
+	formData.Set("grant_type", "client_credentials")
+
+	req, err := http.NewRequest(http.MethodPost, s.keycloakEndpoint, strings.NewReader(formData.Encode()))
+	s.Require().NoError(err)
+	req.SetBasicAuth("opentdf-sdk", "secret")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.Require().GreaterOrEqual(resp.StatusCode, http.StatusBadRequest)
 }
 
 func (s *OAuthSuite) TestDoingTokenExchangeWithKeycloak() {
@@ -507,9 +561,48 @@ func extractDPoPToken(r *http.Request, t *testing.T) jwt.Token {
 	return clientTok
 }
 
-func setupKeycloak(ctx context.Context, t *testing.T) (tc.Container, string, string) {
+func setupStandardKeycloak(ctx context.Context, t *testing.T) (tc.Container, string) {
 	containerReq := tc.ContainerRequest{
-		Image:        "keycloak/keycloak:26.2",
+		Image:        standardKeycloakImage,
+		ExposedPorts: []string{"8082/tcp"},
+		Cmd: []string{
+			"start-dev", "--http-port=8082", "--verbose",
+		},
+		Env: map[string]string{
+			"KC_BOOTSTRAP_ADMIN_USERNAME": "admin",
+			"KC_BOOTSTRAP_ADMIN_PASSWORD": "admin",
+			"KEYCLOAK_ADMIN":              "admin",
+			"KEYCLOAK_ADMIN_PASSWORD":     "admin",
+		},
+
+		WaitingFor: wait.ForLog("Running the server"),
+	}
+
+	keycloak := startKeycloakContainer(ctx, t, containerReq)
+	port, err := keycloak.MappedPort(ctx, "8082")
+	require.NoError(t, err)
+	keycloakBase := "http://localhost:" + port.Port()
+
+	realm := "test"
+
+	connectParams := fixtures.KeycloakConnectParams{
+		BasePath:         keycloakBase,
+		Username:         "admin",
+		Password:         "admin",
+		Realm:            realm,
+		Audience:         "opentdf",
+		AllowInsecureTLS: true,
+	}
+
+	err = fixtures.SetupStandardKeycloak(ctx, connectParams)
+	require.NoError(t, err)
+
+	return keycloak, keycloakBase + "/realms/" + realm + "/protocol/openid-connect/token"
+}
+
+func setupCustomKeycloakForCertExchange(ctx context.Context, t *testing.T) (tc.Container, string) {
+	containerReq := tc.ContainerRequest{
+		Image:        customKeycloakImage,
 		ExposedPorts: []string{"8082/tcp", "8083/tcp"},
 		Cmd: []string{
 			"start-dev", "--http-port=8082", "--https-port=8083", "--verbose",
@@ -526,6 +619,8 @@ func setupKeycloak(ctx context.Context, t *testing.T) (tc.Container, string, str
 		Env: map[string]string{
 			"KC_BOOTSTRAP_ADMIN_USERNAME":   "admin",
 			"KC_BOOTSTRAP_ADMIN_PASSWORD":   "admin",
+			"KEYCLOAK_ADMIN":                "admin",
+			"KEYCLOAK_ADMIN_PASSWORD":       "admin",
 			"KC_HTTPS_KEY_STORE_PASSWORD":   "password",
 			"KC_HTTPS_KEY_STORE_FILE":       "/truststore/truststore.jks",
 			"KC_HTTPS_CERTIFICATE_FILE":     "/etc/x509/tls/localhost.crt",
@@ -536,22 +631,7 @@ func setupKeycloak(ctx context.Context, t *testing.T) (tc.Container, string, str
 		WaitingFor: wait.ForLog("Running the server"),
 	}
 
-	var providerType tc.ProviderType
-
-	if os.Getenv("TESTCONTAINERS_PODMAN") == "true" {
-		providerType = tc.ProviderPodman
-	} else {
-		providerType = tc.ProviderDocker
-	}
-
-	keycloak, err := tc.GenericContainer(ctx, tc.GenericContainerRequest{
-		ProviderType:     providerType,
-		ContainerRequest: containerReq,
-		Started:          true,
-	})
-	if err != nil {
-		t.Fatalf("error starting keycloak container: %v", err)
-	}
+	keycloak := startKeycloakContainer(ctx, t, containerReq)
 	port, err := keycloak.MappedPort(ctx, "8082")
 	require.NoError(t, err)
 	keycloakBase := "http://localhost:" + port.Port()
@@ -574,5 +654,26 @@ func setupKeycloak(ctx context.Context, t *testing.T) (tc.Container, string, str
 	err = fixtures.SetupKeycloak(ctx, connectParams)
 	require.NoError(t, err)
 
-	return keycloak, keycloakBase + "/realms/" + realm + "/protocol/openid-connect/token", keycloakHTTPSBase + "/realms/" + realm + "/protocol/openid-connect/token"
+	return keycloak, keycloakHTTPSBase + "/realms/" + realm + "/protocol/openid-connect/token"
+}
+
+func startKeycloakContainer(ctx context.Context, t *testing.T, containerReq tc.ContainerRequest) tc.Container {
+	var providerType tc.ProviderType
+
+	if os.Getenv("TESTCONTAINERS_PODMAN") == "true" {
+		providerType = tc.ProviderPodman
+	} else {
+		providerType = tc.ProviderDocker
+	}
+
+	keycloak, err := tc.GenericContainer(ctx, tc.GenericContainerRequest{
+		ProviderType:     providerType,
+		ContainerRequest: containerReq,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("error starting keycloak container: %v", err)
+	}
+
+	return keycloak
 }

--- a/test/integration/oauth/oauth_test.go
+++ b/test/integration/oauth/oauth_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	standardKeycloakImage = "quay.io/keycloak/keycloak:26.4.0"
+	standardKeycloakImage = "ghcr.io/opentdf/keycloak-standard:26.4.0"
 	customKeycloakImage   = "ghcr.io/opentdf/keycloak:sha-8a6d35a"
 )
 
@@ -293,12 +293,13 @@ func (s *OAuthSuite) TestDoingTokenExchangeWithKeycloak() {
 	s.Require().True(ok)
 	s.Require().Equal(exchangeCredentials.ClientID, azpClaim)
 
-	// verify that the exchanged token has a scope that is only allowed for the client that got the original token
-	scope, ok := tokenDetails.Get("scope")
-	s.Require().True(ok)
-	scopeString, ok := scope.(string)
-	s.Require().True(ok)
-	s.Require().Contains(scopeString, "testscope")
+	// Standard token exchange should issue the exchanged token for the requested
+	// audience without leaking scopes from the subject token.
+	if scope, ok := tokenDetails.Get("scope"); ok {
+		scopeString, ok := scope.(string)
+		s.Require().True(ok)
+		s.Require().NotContains(scopeString, "testscope")
+	}
 }
 
 func (s *OAuthSuite) TestClientSecretNoNonce() {
@@ -575,7 +576,12 @@ func setupStandardKeycloak(ctx context.Context, t *testing.T) (tc.Container, str
 			"KEYCLOAK_ADMIN_PASSWORD":     "admin", // #nosec G101 -- test-only Keycloak admin password
 		},
 
-		WaitingFor: wait.ForLog("Running the server"),
+		WaitingFor: wait.ForHTTP("/realms/master/.well-known/openid-configuration").
+			WithPort("8082/tcp").
+			WithStatusCodeMatcher(func(status int) bool {
+				return status == http.StatusOK
+			}).
+			WithStartupTimeout(2 * time.Minute),
 	}
 
 	keycloak := startKeycloakContainer(ctx, t, containerReq)
@@ -614,7 +620,7 @@ func setupCustomKeycloakForCertExchange(ctx context.Context, t *testing.T) (tc.C
 		Files: []tc.ContainerFile{
 			{HostFilePath: "testdata/new-ca.jks", ContainerFilePath: "/truststore/truststore.jks", FileMode: int64(0o644)},
 			{HostFilePath: "testdata/localhost.crt", ContainerFilePath: "/etc/x509/tls/localhost.crt", FileMode: int64(0o644)},
-			{HostFilePath: "testdata/localhost.key", ContainerFilePath: "/etc/x509/tls/localhost.key", FileMode: int64(0o600)},
+			{HostFilePath: "testdata/localhost.key", ContainerFilePath: "/etc/x509/tls/localhost.key", FileMode: int64(0o644)},
 		},
 		Env: map[string]string{
 			"KC_BOOTSTRAP_ADMIN_USERNAME":   "admin",
@@ -628,7 +634,7 @@ func setupCustomKeycloakForCertExchange(ctx context.Context, t *testing.T) (tc.C
 			"KC_HTTPS_CLIENT_AUTH":          "request",
 		},
 
-		WaitingFor: wait.ForLog("Running the server"),
+		WaitingFor: wait.ForLog("Running the server").WithStartupTimeout(2 * time.Minute),
 	}
 
 	keycloak := startKeycloakContainer(ctx, t, containerReq)

--- a/test/integration/oauth/oauth_test.go
+++ b/test/integration/oauth/oauth_test.go
@@ -215,7 +215,7 @@ func (s *OAuthSuite) TestGettingAccessTokenWithoutDPoPProofFails() {
 	formData := url.Values{}
 	formData.Set("grant_type", "client_credentials")
 
-	req, err := http.NewRequest(http.MethodPost, s.keycloakEndpoint, strings.NewReader(formData.Encode()))
+	req, err := http.NewRequestWithContext(s.T().Context(), http.MethodPost, s.keycloakEndpoint, strings.NewReader(formData.Encode()))
 	s.Require().NoError(err)
 	req.SetBasicAuth("opentdf-sdk", "secret") // #nosec G101 -- test-only Keycloak client secret
 	req.Header.Set("Accept", "application/json")
@@ -658,12 +658,9 @@ func setupCustomKeycloakForCertExchange(ctx context.Context, t *testing.T) (tc.C
 }
 
 func startKeycloakContainer(ctx context.Context, t *testing.T, containerReq tc.ContainerRequest) tc.Container {
-	var providerType tc.ProviderType
-
+	providerType := tc.ProviderDocker
 	if os.Getenv("TESTCONTAINERS_PODMAN") == "true" {
 		providerType = tc.ProviderPodman
-	} else {
-		providerType = tc.ProviderDocker
 	}
 
 	keycloak, err := tc.GenericContainer(ctx, tc.GenericContainerRequest{
@@ -671,9 +668,7 @@ func startKeycloakContainer(ctx context.Context, t *testing.T, containerReq tc.C
 		ContainerRequest: containerReq,
 		Started:          true,
 	})
-	if err != nil {
-		t.Fatalf("error starting keycloak container: %v", err)
-	}
+	require.NoError(t, err, "error starting keycloak container")
 
 	return keycloak
 }

--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -156,9 +156,9 @@ runs:
     - name: Download latest init-temp-keys.sh, docker-compose.yaml, and watch.sh
       shell: bash
       run: |
-        curl -sSfL https://raw.githubusercontent.com/opentdf/platform/refs/tags/pqc-enabled/.github/scripts/init-temp-keys.sh > otdf-test-platform/.github/scripts/init-temp-keys.sh
-        curl -sSfL https://raw.githubusercontent.com/opentdf/platform/refs/tags/pqc-enabled/docker-compose.yaml > otdf-test-platform/docker-compose.yaml
-        curl -sSfL https://raw.githubusercontent.com/opentdf/platform/refs/tags/pqc-enabled/.github/scripts/watch.sh > otdf-test-platform/.github/scripts/watch.sh
+        curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL https://raw.githubusercontent.com/opentdf/platform/refs/tags/pqc-enabled/.github/scripts/init-temp-keys.sh > otdf-test-platform/.github/scripts/init-temp-keys.sh
+        curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL https://raw.githubusercontent.com/opentdf/platform/refs/tags/pqc-enabled/docker-compose.yaml > otdf-test-platform/docker-compose.yaml
+        curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL https://raw.githubusercontent.com/opentdf/platform/refs/tags/pqc-enabled/.github/scripts/watch.sh > otdf-test-platform/.github/scripts/watch.sh
     - name: Set up go (platform's go version)
       id: setup-go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0

--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -297,18 +297,6 @@ runs:
       run: |
         yq e '.server.auth.dpop.enforce = true' -i opentdf.yaml
       working-directory: otdf-test-platform
-    - name: Overlay DPoP-capable Keycloak (26.2)
-      # The default docker-compose pins Keycloak 25 so downstream consumers stay on
-      # it; DPoP testing needs Keycloak 26.2 plus the admin-fine-grained-authz:v1
-      # feature flag, overlaid only when the nonce challenge flow is enabled.
-      shell: bash
-      if: ${{ inputs.dpop-challenge-enabled == 'true' }}
-      run: |
-        yq e '
-          (.services.keycloak.image = "keycloak/keycloak:26.2")
-          | (.services.keycloak.environment.KC_FEATURES = "preview,token-exchange,admin-fine-grained-authz:v1")
-        ' -i docker-compose.yaml
-      working-directory: otdf-test-platform
     - name: Configure logging
       shell: bash
       env:

--- a/tests-bdd/cukes/resources/keycloak_base.template
+++ b/tests-bdd/cukes/resources/keycloak_base.template
@@ -1,9 +1,7 @@
 # This template tracks service/cmd/keycloak_data.yaml. Only the templated
 # values (hostname/kcPort/platformPort/realm) and BDD-specific additions
-# marked inline (e.g., the `impersonation` client role on opentdf's
-# service account, used for RFC 8693 token-exchange in the encrypt/decrypt
-# scenarios) should differ from that file; when keycloak_data.yaml
-# changes, update this template to match.
+# marked inline should differ from that file; when keycloak_data.yaml changes,
+# update this template to match.
 baseUrl: &baseUrl http://{{.hostname}}:{{.kcPort}}
 serverBaseUrl: &serverBaseUrl http://{{.hostname}}:{{.platformPort}}
 customAudMapper: &customAudMapper
@@ -41,17 +39,16 @@ realms:
             - *customAudMapper
         sa_realm_roles:
           - opentdf-admin
-        # BDD-only: grant impersonation so the admin SDK can exchange its
-        # token for a user-scoped token in encrypt/decrypt scenarios.
-        sa_client_roles:
-          realm-management:
-            - impersonation
         copies: 10
       - client:
           clientID: opentdf-sdk
           enabled: true
           name: opentdf-sdk
           serviceAccountsEnabled: true
+          # BDD-only: encrypt/decrypt scenarios mint fixture-user tokens
+          # through the direct password grant because Keycloak standard token
+          # exchange does not support requested_subject impersonation.
+          directAccessGrantsEnabled: true
           clientAuthenticatorType: client-secret
           secret: secret
           protocolMappers:

--- a/tests-bdd/cukes/steps_encryption.go
+++ b/tests-bdd/cukes/steps_encryption.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	userTokenClientID     = "opentdf-sdk"
+	userTokenClientID     = "opentdf-sdk". //nolint:gosec // Test Credential
 	userTokenClientSecret = "secret"
 	bddUserPassword       = "testuser123"
 

--- a/tests-bdd/cukes/steps_encryption.go
+++ b/tests-bdd/cukes/steps_encryption.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	userTokenClientID     = "opentdf-sdk". //nolint:gosec // Test Credential
+	userTokenClientID     = "opentdf-sdk" //nolint:gosec // Test Credential
 	userTokenClientSecret = "secret"
 	bddUserPassword       = "testuser123"
 

--- a/tests-bdd/cukes/steps_encryption.go
+++ b/tests-bdd/cukes/steps_encryption.go
@@ -20,19 +20,9 @@ import (
 )
 
 const (
-	// Admin client used for both the platform SDK and as the exchanger in
-	// RFC 8693 user-impersonation token exchange. keycloak_base.template
-	// grants its service account the `impersonation` role on
-	// realm-management so it may obtain user-scoped tokens.
-	exchangeClientID     = "opentdf"
-	exchangeClientSecret = "secret"
-	// Target audience of the exchanged token; matches the token_exchanges
-	// policy wired in keycloak_base.template (start_client: opentdf,
-	// target_client: opentdf-sdk).
-	exchangeTargetClientID = "opentdf-sdk"
-	// Standard OAuth grant-type and token-type URNs from RFC 8693 — not credentials.
-	tokenExchangeGrant = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // URN identifier, not a credential
-	accessTokenType    = "urn:ietf:params:oauth:token-type:access_token"   //nolint:gosec // URN identifier, not a credential
+	userTokenClientID     = "opentdf-sdk"
+	userTokenClientSecret = "secret"
+	bddUserPassword       = "testuser123"
 
 	tokenEndpointTimeout = 10 * time.Second
 )
@@ -47,10 +37,9 @@ type decryptResult struct {
 
 type EncryptionStepDefinitions struct{}
 
-// userTokenForStoredAs mints a user-scoped SDK via RFC 8693 token exchange:
-// the admin client authenticates with client_credentials, then exchanges
-// that token for one representing the target user. Stashes the resulting
-// SDK under the given reference key.
+// userTokenForStoredAs mints a user-scoped SDK via password grant against
+// the BDD fixture user. Stashes the resulting SDK under the given reference
+// key.
 func (s *EncryptionStepDefinitions) userTokenForStoredAs(ctx context.Context, username, ref string) (context.Context, error) {
 	scenarioContext := GetPlatformScenarioContext(ctx)
 	localPlatformGlue, ok := (*scenarioContext.TestSuiteContext.PlatformGlue).(*LocalDevPlatformGlue)
@@ -65,13 +54,9 @@ func (s *EncryptionStepDefinitions) userTokenForStoredAs(ctx context.Context, us
 		scenarioContext.ScenarioOptions.KeycloakRealm,
 	)
 
-	adminToken, err := fetchAdminAccessToken(ctx, tokenURL)
+	token, err := fetchUserAccessToken(ctx, tokenURL, username)
 	if err != nil {
-		return ctx, fmt.Errorf("fetch admin token for exchange: %w", err)
-	}
-	token, err := exchangeForUserToken(ctx, tokenURL, adminToken.AccessToken, username)
-	if err != nil {
-		return ctx, fmt.Errorf("exchange admin token for user %q: %w", username, err)
+		return ctx, fmt.Errorf("fetch access token for user %q: %w", username, err)
 	}
 
 	userSDK, err := otdf.New(
@@ -186,36 +171,18 @@ func getDecryptResult(ctx context.Context, ref string) (*decryptResult, error) {
 	return result, nil
 }
 
-// fetchAdminAccessToken mints an admin service-account token via the
-// client_credentials grant against the exchange client.
-func fetchAdminAccessToken(ctx context.Context, tokenURL string) (*oauth2.Token, error) {
+// fetchUserAccessToken mints a token for a BDD fixture user through the
+// regular direct-access password grant. Keycloak standard token exchange
+// intentionally does not support requested_subject impersonation.
+func fetchUserAccessToken(ctx context.Context, tokenURL, username string) (*oauth2.Token, error) {
 	form := url.Values{
-		"grant_type":    {"client_credentials"},
-		"client_id":     {exchangeClientID},
-		"client_secret": {exchangeClientSecret},
+		"grant_type":    {"password"},
+		"client_id":     {userTokenClientID},
+		"client_secret": {userTokenClientSecret},
+		"username":      {username},
+		"password":      {bddUserPassword},
 	}
-	return postForTokenEndpoint(ctx, tokenURL, form, "client_credentials")
-}
-
-// exchangeForUserToken takes a valid admin token and asks Keycloak for a
-// user-scoped token via RFC 8693 token exchange with `requested_subject`.
-// Requires the exchange client to have the realm-management `impersonation`
-// role. `audience` routes the exchange through the opentdf->opentdf-sdk
-// policy configured in keycloak_base.template so the returned token is
-// minted for opentdf-sdk, matching the SDK's own token-exchange flow
-// (see sdk/auth/oauth/oauth.go).
-func exchangeForUserToken(ctx context.Context, tokenURL, adminAccessToken, username string) (*oauth2.Token, error) {
-	form := url.Values{
-		"grant_type":           {tokenExchangeGrant},
-		"client_id":            {exchangeClientID},
-		"client_secret":        {exchangeClientSecret},
-		"subject_token":        {adminAccessToken},
-		"subject_token_type":   {accessTokenType},
-		"requested_token_type": {accessTokenType},
-		"audience":             {exchangeTargetClientID},
-		"requested_subject":    {username},
-	}
-	return postForTokenEndpoint(ctx, tokenURL, form, "token-exchange")
+	return postForTokenEndpoint(ctx, tokenURL, form, "password")
 }
 
 // postForTokenEndpoint POSTs a token-endpoint form and decodes the standard

--- a/tests-bdd/cukes/steps_encryption.go
+++ b/tests-bdd/cukes/steps_encryption.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	userTokenClientID     = "opentdf-sdk" //nolint:gosec // Test Credential
-	userTokenClientSecret = "secret"
+	userTokenClientID     = "opentdf-sdk" //nolint:gosec // Test credential.
+	userTokenClientSecret = "secret"      //nolint:gosec // Test credential.
 	bddUserPassword       = "testuser123"
 
 	tokenEndpointTimeout = 10 * time.Second


### PR DESCRIPTION
## Summary
- Upgrade local/test standard Keycloak runtime paths to `ghcr.io/opentdf/keycloak-standard:26.4.0`, including `docker-compose.yaml`, OAuth testcontainers, and ERS Keycloak integration tests.
- Provision standard Keycloak token exchange by enabling `standard.token.exchange.enabled` on requester clients and adding a target-client audience mapper for exchanged tokens.
- Keep the custom OpenTDF Keycloak image only for the certificate-exchange/mTLS test path that still needs the custom providers.
- Update BDD encryption setup to use direct password-grant user tokens instead of admin impersonation token exchange.
- Split OAuth integration coverage for standard Keycloak and certificate-exchange Keycloak, including a negative DPoP-bound token test.
- Update ERS Keycloak setup for KC26 by enabling unmanaged user attributes in the test realm.
- Document the updated `token_exchanges` fixture behavior and bump the workspace toolchain to `go1.25.11` for current govulncheck coverage.

## Testing
- `go test ./lib/fixtures -run 'TestWith|TestDefaultProtocolMappers|TestExactClient' -count=1`
- `DOCKER_HOST=unix://$HOME/.colima/default/docker.sock TESTCONTAINERS_RYUK_DISABLED=true GOWORK=off go test ./oauth -count=1 -v` from `test/integration`
- `DOCKER_HOST=unix://$HOME/.colima/default/docker.sock TESTCONTAINERS_RYUK_DISABLED=true go test ./service/entityresolution/integration -run "TestKeycloak(UserAttributeSubjectMapping|EntityResolutionV2)$" -count=1 -v`
- Earlier validation on this branch:
  - `go test ./...` from `tests-bdd`
  - `GOWORK=off go test -run '^$' ./...` from `test/integration/oauth`
  - Compose smoke with local env port overrides, using the committed compose file image reference and no committed port changes.

## Related
- DSPX-3636
- Supports virtru-corp/data-security-platform#3450
- Supports virtru-corp/dsp-bundle#275


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for standard Keycloak token exchange and updated provisioning guidance.
  * Expanded OAuth integration coverage for certificate exchange and DPoP authentication.
  * BDD encryption/decryption scenarios now obtain user access tokens via direct password grant.
* **Bug Fixes**
  * Improved requester client matching/audience mapper setup and prevented scope leakage during token exchange.
  * Added coverage for failing access-token requests without DPoP proof.
  * Updated Keycloak container bootstrap to use the newer admin environment variables and upgraded to Keycloak 26.4.0.
* **Documentation**
  * Refreshed service README examples for standard token exchange behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->