### PR TITLE
fix: use existing pattern to support SEC1 format EC keys

### DIFF
--- a/lib/ocrypto/ec_key_pair.go
+++ b/lib/ocrypto/ec_key_pair.go
@@ -247,7 +247,15 @@ func ECPrivateKeyFromPem(privateECKeyInPem []byte) (*ecdh.PrivateKey, error) {
 	}
 
 	priv, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
+	switch {
+	case err == nil:
+	case strings.Contains(err.Error(), "use ParseECPrivateKey instead"):
+		// Check if it's in SEC1 / RFC 5915 encoding using the same pattern as `asym_decryption.go`: `FromPrivatePEMWithSalt`
+		priv, err = x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("ec x509.ParseECPrivateKey failed: %w", err)
+		}
+	default:
 		return nil, fmt.Errorf("ec x509.ParsePKCS8PrivateKey failed: %w", err)
 	}
 

--- a/lib/ocrypto/ec_key_pair_test.go
+++ b/lib/ocrypto/ec_key_pair_test.go
@@ -1,7 +1,13 @@
 package ocrypto
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -66,6 +72,55 @@ func TestECKeyPair(t *testing.T) {
 			t.Fatalf("did not fail as expected: NewECKeyPair(%d): %v", modeBad, err)
 		}
 	}
+}
+
+func TestECPrivateKeyFromPem(t *testing.T) {
+	curves := []struct {
+		name  string
+		curve elliptic.Curve
+	}{
+		{"P-256", elliptic.P256()},
+		{"P-384", elliptic.P384()},
+		{"P-521", elliptic.P521()},
+	}
+
+	for _, tc := range curves {
+		ecdsaKey, err := ecdsa.GenerateKey(tc.curve, rand.Reader)
+		require.NoError(t, err, "fail on ecdsa.GenerateKey for %s", tc.name)
+
+		// PKCS8 encoding ("BEGIN PRIVATE KEY"), e.g. `openssl genpkey`
+		pkcs8Bytes, err := x509.MarshalPKCS8PrivateKey(ecdsaKey)
+		require.NoError(t, err, "fail on x509.MarshalPKCS8PrivateKey for %s", tc.name)
+		pkcs8Pem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8Bytes})
+
+		// SEC1 / RFC 5915 encoding ("BEGIN EC PRIVATE KEY"), e.g. `openssl ecparam -genkey`
+		sec1Bytes, err := x509.MarshalECPrivateKey(ecdsaKey)
+		require.NoError(t, err, "fail on x509.MarshalECPrivateKey for %s", tc.name)
+		sec1Pem := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: sec1Bytes})
+
+		fromPKCS8, err := ECPrivateKeyFromPem(pkcs8Pem)
+		require.NoError(t, err, "fail on ECPrivateKeyFromPem with PKCS8 encoding for %s", tc.name)
+
+		fromSEC1, err := ECPrivateKeyFromPem(sec1Pem)
+		require.NoError(t, err, "fail on ECPrivateKeyFromPem with SEC1 encoding for %s", tc.name)
+
+		// Both encodings of the same key must yield the same ECDH key
+		require.True(t, fromPKCS8.Equal(fromSEC1),
+			"PKCS8 and SEC1 decodings of the same %s key differ", tc.name)
+	}
+
+	// Not PEM at all
+	_, err := ECPrivateKeyFromPem([]byte("not a pem"))
+	require.Error(t, err, "non-PEM input must be rejected")
+
+	// Valid PKCS8, but not an EC key
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "fail on rsa.GenerateKey")
+	rsaBytes, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	require.NoError(t, err, "fail on x509.MarshalPKCS8PrivateKey for RSA")
+	rsaPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: rsaBytes})
+	_, err = ECPrivateKeyFromPem(rsaPem)
+	require.Error(t, err, "non-EC PKCS8 key must be rejected")
 }
 
 func TestECRewrapKeyGenerate(t *testing.T) {


### PR DESCRIPTION
With a SEC1 EC key, the server starts cleanly because StandardCrypto parses EC keys lazily, then fails at request time in two places:
- https://github.com/opentdf/platform/blob/5bae1eb7a3b9d19d67845ac8239447eecf25e8ba/service/internal/security/in_process_provider.go#L190 FindKeyByID's key probe, which makes `GET /kas/v2/kas_public_key?algorithm=ec:secp256r1` return a misleading 404
- https://github.com/opentdf/platform/blob/5bae1eb7a3b9d19d67845ac8239447eecf25e8ba/service/internal/security/standard_crypto.go#L471 Decrypt's private key parser, which breaks EC rewraps

### Proposed Changes

* use existing pattern to support SEC1 format keys https://github.com/opentdf/platform/blob/21e95e04c9f5903dc4c437d12ea790bbbf20bbb1/lib/ocrypto/asym_decryption.go#L82-L83

### Checklist

- [X] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EC private key import compatibility by supporting both PKCS#8 and SEC1/RFC5915 PEM formats.
  * Preserved clear error handling for invalid PEM data and unsupported key types.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->