### PR TITLE
fix(ers): update test assertion for attempted_strategies type after structpb coercion

### DIFF
--- a/service/entityresolution/integration/multistrategy_comprehensive_test.go
+++ b/service/entityresolution/integration/multistrategy_comprehensive_test.go
@@ -551,14 +551,23 @@ func TestMultiStrategy_ClaimsThenLDAPFallback(t *testing.T) {
 		t.Fatalf("Expected LDAP search_filter for alice, got %v", got)
 	}
 
-	attemptedStrategies, ok := result.Metadata["attempted_strategies"].([]string)
-	if !ok {
-		t.Fatalf("Expected attempted_strategies to be []string, got %T", result.Metadata["attempted_strategies"])
-	}
-
 	expectedStrategies := []string{"claims_direct_lookup", "ldap_directory_lookup"}
-	if !reflect.DeepEqual(attemptedStrategies, expectedStrategies) {
-		t.Fatalf("Expected attempted_strategies %v, got %v", expectedStrategies, attemptedStrategies)
+	switch v := result.Metadata["attempted_strategies"].(type) {
+	case []string:
+		if !reflect.DeepEqual(v, expectedStrategies) {
+			t.Fatalf("Expected attempted_strategies %v, got %v", expectedStrategies, v)
+		}
+	case []interface{}:
+		if len(v) != len(expectedStrategies) {
+			t.Fatalf("Expected %d attempted_strategies, got %d: %v", len(expectedStrategies), len(v), v)
+		}
+		for i, expected := range expectedStrategies {
+			if got, ok := v[i].(string); !ok || got != expected {
+				t.Fatalf("Expected attempted_strategies[%d] = %q, got %v", i, expected, v[i])
+			}
+		}
+	default:
+		t.Fatalf("Expected attempted_strategies to be []string or []interface{}, got %T", result.Metadata["attempted_strategies"])
 	}
 }
 

--- a/service/entityresolution/integration/multistrategy_comprehensive_test.go
+++ b/service/entityresolution/integration/multistrategy_comprehensive_test.go
@@ -560,8 +560,8 @@ func TestMultiStrategy_ClaimsThenLDAPFallback(t *testing.T) {
 		t.Fatalf("Expected %d attempted_strategies, got %d: %v", len(expectedStrategies), len(attemptedStrategies), attemptedStrategies)
 	}
 	for i, expected := range expectedStrategies {
-		got, ok := attemptedStrategies[i].(string)
-		if !ok || got != expected {
+		got, isStr := attemptedStrategies[i].(string)
+		if !isStr || got != expected {
 			t.Fatalf("Expected attempted_strategies[%d] = %q, got %v", i, expected, attemptedStrategies[i])
 		}
 	}

--- a/service/entityresolution/integration/multistrategy_comprehensive_test.go
+++ b/service/entityresolution/integration/multistrategy_comprehensive_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -552,22 +551,19 @@ func TestMultiStrategy_ClaimsThenLDAPFallback(t *testing.T) {
 	}
 
 	expectedStrategies := []string{"claims_direct_lookup", "ldap_directory_lookup"}
-	switch v := result.Metadata["attempted_strategies"].(type) {
-	case []string:
-		if !reflect.DeepEqual(v, expectedStrategies) {
-			t.Fatalf("Expected attempted_strategies %v, got %v", expectedStrategies, v)
+	attemptedStrategies, ok := result.Metadata["attempted_strategies"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected attempted_strategies to be []interface{}, got %T", result.Metadata["attempted_strategies"])
+	}
+
+	if len(attemptedStrategies) != len(expectedStrategies) {
+		t.Fatalf("Expected %d attempted_strategies, got %d: %v", len(expectedStrategies), len(attemptedStrategies), attemptedStrategies)
+	}
+	for i, expected := range expectedStrategies {
+		got, ok := attemptedStrategies[i].(string)
+		if !ok || got != expected {
+			t.Fatalf("Expected attempted_strategies[%d] = %q, got %v", i, expected, attemptedStrategies[i])
 		}
-	case []interface{}:
-		if len(v) != len(expectedStrategies) {
-			t.Fatalf("Expected %d attempted_strategies, got %d: %v", len(expectedStrategies), len(v), v)
-		}
-		for i, expected := range expectedStrategies {
-			if got, ok := v[i].(string); !ok || got != expected {
-				t.Fatalf("Expected attempted_strategies[%d] = %q, got %v", i, expected, v[i])
-			}
-		}
-	default:
-		t.Fatalf("Expected attempted_strategies to be []string or []interface{}, got %T", result.Metadata["attempted_strategies"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- `TestMultiStrategy_ClaimsThenLDAPFallback` fails after the `[]string` → `[]interface{}` coercion in the service code because the test assertion only accepts `[]string`
- Updated the assertion to accept both `[]string` and `[]interface{}` for `attempted_strategies` metadata

## Context

Found while running integration tests locally on macOS (Colima). The structpb coercion fix in this PR correctly changes the internal type, but the comprehensive test at `multistrategy_comprehensive_test.go:554` was not updated to match.

## Test plan

- [x] `TestMultiStrategy_ClaimsThenLDAPFallback` passes locally (was failing before this fix)
- [x] All 23 multi-strategy integration tests pass (0 skipped, 0 failed)