### PR TITLE
feat(cli): add dynamic value mapping CRUD commands and e2e tests

### DIFF
--- a/otdfctl/cmd/policy/dynamicValueMappings.go
+++ b/otdfctl/cmd/policy/dynamicValueMappings.go
@@ -1,0 +1,423 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/evertras/bubble-table/table"
+	"github.com/google/uuid"
+	"github.com/opentdf/platform/otdfctl/cmd/common"
+	"github.com/opentdf/platform/otdfctl/pkg/cli"
+	"github.com/opentdf/platform/otdfctl/pkg/handlers"
+	"github.com/opentdf/platform/otdfctl/pkg/man"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/subjectmapping"
+	"github.com/spf13/cobra"
+)
+
+// parseDynamicValueMappingActions converts each flag value into an Action referenced by id (when a
+// UUID) or by name otherwise.
+func parseDynamicValueMappingActions(values []string) []*policy.Action {
+	actions := make([]*policy.Action, len(values))
+	for i, a := range values {
+		action := &policy.Action{}
+		if _, err := uuid.Parse(a); err != nil {
+			action.Name = a
+		} else {
+			action.Id = a
+		}
+		actions[i] = action
+	}
+	return actions
+}
+
+// parseDynamicValueMappingOperator validates the readable operator choice and returns its enum.
+// Only IN and IN_CONTAINS are supported; NOT_IN, UNSPECIFIED, and unknown values are rejected.
+func parseDynamicValueMappingOperator(operator string) policy.SubjectMappingOperatorEnum {
+	op := handlers.GetSubjectMappingOperatorFromChoice(operator)
+	if op != policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN &&
+		op != policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS {
+		cli.ExitWithError(fmt.Sprintf("Invalid --operator %q; must be one of %s", operator, strings.Join(handlers.DynamicValueMappingOperatorEnumChoices, ", ")), nil)
+	}
+	return op
+}
+
+func dynamicValueMappingRows(m *policy.DynamicValueMapping) [][]string {
+	actionsJSON, err := json.Marshal(m.GetActions())
+	if err != nil {
+		cli.ExitWithError("Error marshalling dynamic value mapping actions", err)
+	}
+	subjectSetsJSON, err := json.Marshal(m.GetSubjectConditionSet().GetSubjectSets())
+	if err != nil {
+		cli.ExitWithError("Error marshalling subject condition set", err)
+	}
+	return [][]string{
+		{"Id", m.GetId()},
+		{"Namespace", m.GetNamespace().GetFqn()},
+		{"Attribute Definition: Id", m.GetAttributeDefinition().GetId()},
+		{"Attribute Definition: FQN", m.GetAttributeDefinition().GetFqn()},
+		{"Resolver: Selector", m.GetValueResolver().GetSubjectExternalSelectorValue()},
+		{"Resolver: Operator", handlers.GetSubjectMappingOperatorChoiceFromEnum(m.GetValueResolver().GetOperator())},
+		{"Actions", string(actionsJSON)},
+		{"Subject Condition Set: Id", m.GetSubjectConditionSet().GetId()},
+		{"Subject Condition Set", string(subjectSetsJSON)},
+	}
+}
+
+func policyGetDynamicValueMapping(cmd *cobra.Command, args []string) {
+	c := cli.New(cmd, args)
+	h := common.NewHandler(c)
+	defer h.Close()
+
+	id := c.Flags.GetRequiredID("id")
+
+	mapping, err := h.GetDynamicValueMapping(cmd.Context(), id)
+	if err != nil {
+		cli.ExitWithError(fmt.Sprintf("Failed to find dynamic value mapping (%s)", id), err)
+	}
+
+	rows := dynamicValueMappingRows(mapping)
+	if mdRows := getMetadataRows(mapping.GetMetadata()); mdRows != nil {
+		rows = append(rows, mdRows...)
+	}
+
+	t := cli.NewTabular(rows...)
+	common.HandleSuccess(cmd, mapping.GetId(), t, mapping)
+}
+
+func policyListDynamicValueMappings(cmd *cobra.Command, args []string) {
+	c := cli.New(cmd, args)
+	h := common.NewHandler(c)
+	defer h.Close()
+
+	limit := c.Flags.GetRequiredInt32("limit")
+	offset := c.Flags.GetRequiredInt32("offset")
+	namespace := c.Flags.GetOptionalString("namespace")
+	attrDefID := c.Flags.GetOptionalID("attribute-definition-id")
+	sort := getSortOption(c)
+
+	resp, err := h.ListDynamicValueMappings(cmd.Context(), limit, offset, namespace, attrDefID, sort)
+	if err != nil {
+		cli.ExitWithError("Failed to list dynamic value mappings", err)
+	}
+
+	t := cli.NewTable(
+		cli.NewUUIDColumn(),
+		table.NewFlexColumn("namespace", "Namespace", cli.FlexColumnWidthFour),
+		table.NewFlexColumn("attr_definition_fqn", "Attribute Definition FQN", cli.FlexColumnWidthFour),
+		table.NewFlexColumn("selector", "Resolver Selector", cli.FlexColumnWidthThree),
+		table.NewFlexColumn("operator", "Resolver Operator", cli.FlexColumnWidthTwo),
+		table.NewFlexColumn("actions", "Actions", cli.FlexColumnWidthTwo),
+		table.NewFlexColumn("subject_condition_set_id", "Subject Condition Set: Id", cli.FlexColumnWidthFour),
+	)
+	rows := []table.Row{}
+	for _, dvm := range resp.GetDynamicValueMappings() {
+		actionsJSON, err := json.Marshal(dvm.GetActions())
+		if err != nil {
+			cli.ExitWithError("Error marshalling dynamic value mapping actions", err)
+		}
+		rows = append(rows, table.NewRow(table.RowData{
+			"id":                       dvm.GetId(),
+			"namespace":                dvm.GetNamespace().GetFqn(),
+			"attr_definition_fqn":      dvm.GetAttributeDefinition().GetFqn(),
+			"selector":                 dvm.GetValueResolver().GetSubjectExternalSelectorValue(),
+			"operator":                 handlers.GetSubjectMappingOperatorChoiceFromEnum(dvm.GetValueResolver().GetOperator()),
+			"actions":                  string(actionsJSON),
+			"subject_condition_set_id": dvm.GetSubjectConditionSet().GetId(),
+		}))
+	}
+	t = t.WithRows(rows)
+	t = cli.WithListPaginationFooter(t, resp.GetPagination())
+	common.HandleSuccess(cmd, "", t, resp)
+}
+
+func policyCreateDynamicValueMapping(cmd *cobra.Command, args []string) {
+	c := cli.New(cmd, args)
+	h := common.NewHandler(c)
+	defer h.Close()
+
+	attrDefID := c.Flags.GetOptionalID("attribute-definition-id")
+	attrDefFQN := c.Flags.GetOptionalString("attribute-definition-fqn")
+	selector := c.Flags.GetOptionalString("selector")
+	operator := c.Flags.GetOptionalString("operator")
+	actionFlagValues = c.Flags.GetStringSlice("action", actionFlagValues, cli.FlagsStringSliceOptions{Min: 0})
+	existingSCSID := c.Flags.GetOptionalID("subject-condition-set-id")
+	newScsJSON := c.Flags.GetOptionalString("subject-condition-set-new")
+	namespace := c.Flags.GetOptionalString("namespace")
+	metadataLabels = c.Flags.GetStringSlice("label", metadataLabels, cli.FlagsStringSliceOptions{Min: 0})
+
+	// validations
+	if attrDefID == "" && attrDefFQN == "" {
+		cli.ExitWithError("One of [--attribute-definition-id, --attribute-definition-fqn] is required", nil)
+	}
+	if attrDefID != "" && attrDefFQN != "" {
+		cli.ExitWithError("Only one of [--attribute-definition-id, --attribute-definition-fqn] may be provided", nil)
+	}
+	if selector == "" {
+		cli.ExitWithError("The resolver selector [--selector] is required", nil)
+	}
+	if operator == "" {
+		cli.ExitWithError("The resolver operator [--operator] is required", nil)
+	}
+	if len(actionFlagValues) == 0 {
+		cli.ExitWithError("At least one Action [--action] is required", nil)
+	}
+
+	resolver := &policy.DynamicValueResolver{
+		SubjectExternalSelectorValue: selector,
+		Operator:                     parseDynamicValueMappingOperator(operator),
+	}
+	actions := parseDynamicValueMappingActions(actionFlagValues)
+
+	var scs *subjectmapping.SubjectConditionSetCreate
+	if newScsJSON != "" {
+		ss, err := unmarshalSubjectSetsProto([]byte(newScsJSON))
+		if err != nil {
+			cli.ExitWithError("Error unmarshalling subject sets", err)
+		}
+		scs = &subjectmapping.SubjectConditionSetCreate{
+			SubjectSets: ss,
+		}
+	}
+
+	mapping, err := h.CreateDynamicValueMapping(cmd.Context(), attrDefID, attrDefFQN, resolver, actions, existingSCSID, scs, namespace, getMetadataMutable(metadataLabels))
+	if err != nil {
+		cli.ExitWithError("Failed to create dynamic value mapping", err)
+	}
+
+	rows := dynamicValueMappingRows(mapping)
+	if mdRows := getMetadataRows(mapping.GetMetadata()); mdRows != nil {
+		rows = append(rows, mdRows...)
+	}
+
+	t := cli.NewTabular(rows...)
+	common.HandleSuccess(cmd, mapping.GetId(), t, mapping)
+}
+
+func policyUpdateDynamicValueMapping(cmd *cobra.Command, args []string) {
+	c := cli.New(cmd, args)
+	h := common.NewHandler(c)
+	defer h.Close()
+
+	id := c.Flags.GetRequiredID("id")
+	selector := c.Flags.GetOptionalString("selector")
+	operator := c.Flags.GetOptionalString("operator")
+	actionFlagValues = c.Flags.GetStringSlice("action", actionFlagValues, cli.FlagsStringSliceOptions{Min: 0})
+	scsID := c.Flags.GetOptionalID("subject-condition-set-id")
+	metadataLabels = c.Flags.GetStringSlice("label", metadataLabels, cli.FlagsStringSliceOptions{Min: 0})
+
+	// The resolver is replaced as a whole and both of its fields are required, so --selector and
+	// --operator must be provided together (or both omitted to leave the resolver unchanged).
+	if (selector == "") != (operator == "") {
+		cli.ExitWithError("Both [--selector, --operator] must be provided together to replace the resolver", nil)
+	}
+	var resolver *policy.DynamicValueResolver
+	if selector != "" {
+		resolver = &policy.DynamicValueResolver{
+			SubjectExternalSelectorValue: selector,
+			Operator:                     parseDynamicValueMappingOperator(operator),
+		}
+	}
+
+	var actions []*policy.Action
+	if len(actionFlagValues) > 0 {
+		actions = parseDynamicValueMappingActions(actionFlagValues)
+	}
+
+	updated, err := h.UpdateDynamicValueMapping(
+		cmd.Context(),
+		id,
+		resolver,
+		scsID,
+		actions,
+		getMetadataMutable(metadataLabels),
+		getMetadataUpdateBehavior(),
+	)
+	if err != nil {
+		cli.ExitWithError("Failed to update dynamic value mapping", err)
+	}
+
+	rows := [][]string{{"Id", id}}
+	if mdRows := getMetadataRows(updated.GetMetadata()); mdRows != nil {
+		rows = append(rows, mdRows...)
+	}
+	t := cli.NewTabular(rows...)
+	common.HandleSuccess(cmd, id, t, updated)
+}
+
+func policyDeleteDynamicValueMapping(cmd *cobra.Command, args []string) {
+	c := cli.New(cmd, args)
+	h := common.NewHandler(c)
+	defer h.Close()
+
+	id := c.Flags.GetRequiredID("id")
+	force := c.Flags.GetOptionalBool("force")
+
+	dvm, err := h.GetDynamicValueMapping(cmd.Context(), id)
+	if err != nil {
+		cli.ExitWithError(fmt.Sprintf("Failed to find dynamic value mapping (%s)", id), err)
+	}
+
+	cli.ConfirmAction(cli.ActionDelete, "dynamic value mapping", dvm.GetId(), force)
+
+	deleted, err := h.DeleteDynamicValueMapping(cmd.Context(), id)
+	if err != nil {
+		cli.ExitWithError(fmt.Sprintf("Failed to delete dynamic value mapping (%s)", id), err)
+	}
+
+	rows := [][]string{{"Id", dvm.GetId()}}
+	if mdRows := getMetadataRows(deleted.GetMetadata()); mdRows != nil {
+		rows = append(rows, mdRows...)
+	}
+	t := cli.NewTabular(rows...)
+	common.HandleSuccess(cmd, id, t, deleted)
+}
+
+func initDynamicValueMappingsCommands() {
+	getDoc := man.Docs.GetCommand(
+		"policy/dynamic-value-mappings/get",
+		man.WithRun(policyGetDynamicValueMapping),
+	)
+	getDoc.Flags().StringP(
+		getDoc.GetDocFlag("id").Name,
+		getDoc.GetDocFlag("id").Shorthand,
+		getDoc.GetDocFlag("id").Default,
+		getDoc.GetDocFlag("id").Description,
+	)
+
+	listDoc := man.Docs.GetCommand(
+		"policy/dynamic-value-mappings/list",
+		man.WithRun(policyListDynamicValueMappings),
+	)
+	injectListPaginationFlags(listDoc)
+	injectListSortFlags(listDoc)
+	listDoc.Flags().StringP(
+		listDoc.GetDocFlag("namespace").Name,
+		listDoc.GetDocFlag("namespace").Shorthand,
+		listDoc.GetDocFlag("namespace").Default,
+		listDoc.GetDocFlag("namespace").Description,
+	)
+	listDoc.Flags().String(
+		listDoc.GetDocFlag("attribute-definition-id").Name,
+		listDoc.GetDocFlag("attribute-definition-id").Default,
+		listDoc.GetDocFlag("attribute-definition-id").Description,
+	)
+
+	createDoc := man.Docs.GetCommand(
+		"policy/dynamic-value-mappings/create",
+		man.WithRun(policyCreateDynamicValueMapping),
+	)
+	createDoc.Flags().StringP(
+		createDoc.GetDocFlag("attribute-definition-id").Name,
+		createDoc.GetDocFlag("attribute-definition-id").Shorthand,
+		createDoc.GetDocFlag("attribute-definition-id").Default,
+		createDoc.GetDocFlag("attribute-definition-id").Description,
+	)
+	createDoc.Flags().String(
+		createDoc.GetDocFlag("attribute-definition-fqn").Name,
+		createDoc.GetDocFlag("attribute-definition-fqn").Default,
+		createDoc.GetDocFlag("attribute-definition-fqn").Description,
+	)
+	createDoc.Flags().StringP(
+		createDoc.GetDocFlag("selector").Name,
+		createDoc.GetDocFlag("selector").Shorthand,
+		createDoc.GetDocFlag("selector").Default,
+		createDoc.GetDocFlag("selector").Description,
+	)
+	createDoc.Flags().StringP(
+		createDoc.GetDocFlag("operator").Name,
+		createDoc.GetDocFlag("operator").Shorthand,
+		createDoc.GetDocFlag("operator").Default,
+		createDoc.GetDocFlag("operator").Description,
+	)
+	createDoc.Flags().StringSliceVarP(
+		&actionFlagValues,
+		createDoc.GetDocFlag("action").Name,
+		createDoc.GetDocFlag("action").Shorthand,
+		[]string{},
+		createDoc.GetDocFlag("action").Description,
+	)
+	createDoc.Flags().String(
+		createDoc.GetDocFlag("subject-condition-set-id").Name,
+		createDoc.GetDocFlag("subject-condition-set-id").Default,
+		createDoc.GetDocFlag("subject-condition-set-id").Description,
+	)
+	createDoc.Flags().String(
+		createDoc.GetDocFlag("subject-condition-set-new").Name,
+		createDoc.GetDocFlag("subject-condition-set-new").Default,
+		createDoc.GetDocFlag("subject-condition-set-new").Description,
+	)
+	createDoc.Flags().StringP(
+		createDoc.GetDocFlag("namespace").Name,
+		createDoc.GetDocFlag("namespace").Shorthand,
+		createDoc.GetDocFlag("namespace").Default,
+		createDoc.GetDocFlag("namespace").Description,
+	)
+	injectLabelFlags(&createDoc.Command, false)
+
+	updateDoc := man.Docs.GetCommand(
+		"policy/dynamic-value-mappings/update",
+		man.WithRun(policyUpdateDynamicValueMapping),
+	)
+	updateDoc.Flags().StringP(
+		updateDoc.GetDocFlag("id").Name,
+		updateDoc.GetDocFlag("id").Shorthand,
+		updateDoc.GetDocFlag("id").Default,
+		updateDoc.GetDocFlag("id").Description,
+	)
+	updateDoc.Flags().StringP(
+		updateDoc.GetDocFlag("selector").Name,
+		updateDoc.GetDocFlag("selector").Shorthand,
+		updateDoc.GetDocFlag("selector").Default,
+		updateDoc.GetDocFlag("selector").Description,
+	)
+	updateDoc.Flags().StringP(
+		updateDoc.GetDocFlag("operator").Name,
+		updateDoc.GetDocFlag("operator").Shorthand,
+		updateDoc.GetDocFlag("operator").Default,
+		updateDoc.GetDocFlag("operator").Description,
+	)
+	updateDoc.Flags().StringSliceVarP(
+		&actionFlagValues,
+		updateDoc.GetDocFlag("action").Name,
+		updateDoc.GetDocFlag("action").Shorthand,
+		[]string{},
+		updateDoc.GetDocFlag("action").Description,
+	)
+	updateDoc.Flags().String(
+		updateDoc.GetDocFlag("subject-condition-set-id").Name,
+		updateDoc.GetDocFlag("subject-condition-set-id").Default,
+		updateDoc.GetDocFlag("subject-condition-set-id").Description,
+	)
+	injectLabelFlags(&updateDoc.Command, true)
+
+	deleteDoc := man.Docs.GetCommand(
+		"policy/dynamic-value-mappings/delete",
+		man.WithRun(policyDeleteDynamicValueMapping),
+	)
+	deleteDoc.Flags().StringP(
+		deleteDoc.GetDocFlag("id").Name,
+		deleteDoc.GetDocFlag("id").Shorthand,
+		deleteDoc.GetDocFlag("id").Default,
+		deleteDoc.GetDocFlag("id").Description,
+	)
+	deleteDoc.Flags().Bool(
+		deleteDoc.GetDocFlag("force").Name,
+		false,
+		deleteDoc.GetDocFlag("force").Description,
+	)
+
+	doc := man.Docs.GetCommand(
+		"policy/dynamic-value-mappings",
+		man.WithSubcommands(
+			createDoc,
+			getDoc,
+			listDoc,
+			updateDoc,
+			deleteDoc,
+		),
+	)
+	dynamicValueMappingCmd := &doc.Command
+	Cmd.AddCommand(dynamicValueMappingCmd)
+}

--- a/otdfctl/cmd/policy/dynamicValueMappings.go
+++ b/otdfctl/cmd/policy/dynamicValueMappings.go
@@ -163,6 +163,9 @@ func policyCreateDynamicValueMapping(cmd *cobra.Command, args []string) {
 	if len(actionFlagValues) == 0 {
 		cli.ExitWithError("At least one Action [--action] is required", nil)
 	}
+	if existingSCSID != "" && newScsJSON != "" {
+		cli.ExitWithError("Only one of [--subject-condition-set-id, --subject-condition-set-new] may be provided", nil)
+	}
 
 	resolver := &policy.DynamicValueResolver{
 		SubjectExternalSelectorValue: selector,

--- a/otdfctl/cmd/policy/policy.go
+++ b/otdfctl/cmd/policy/policy.go
@@ -114,6 +114,7 @@ func InitCommands() {
 	initNamespacesCommands()
 	initSubjectConditionSetsCommands()
 	initSubjectMappingsCommands()
+	initDynamicValueMappingsCommands()
 	initObligationsCommands()
 	initResourceMappingsCommands()
 	initResourceMappingGroupsCommands()

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/_index.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/_index.md
@@ -1,0 +1,28 @@
+---
+title: Dynamic value mappings
+command:
+  name: dynamic-value-mappings
+  aliases:
+    - dvm
+    - dynamic-value-mapping
+    - dynamicvaluemappings
+---
+
+Dynamic Value Mappings entitle dynamically-requested Attribute Values under an Attribute Definition
+without pre-provisioning a Value and Subject Mapping for each discrete value.
+
+A Dynamic Value Mapping raises entitlement authority from a concrete Attribute Value up to the
+Attribute Definition. At decision time the mapping's resolver compares the requested resource value
+segment against a selector resolved from the Entity Representation (such as from an idP/LDAP), so a
+subject may be entitled to values that were never created in policy.
+
+A Dynamic Value Mapping (DVM) relates:
+    1. one Attribute Definition (see `attributes` command)
+    2. one dynamic value resolver (a selector plus a comparison operator)
+    3. one or more Actions (see `actions` command)
+    4. an optional static pre-gate Subject Condition Set (see `subject-condition-sets` command)
+
+Combination semantics: multiple dynamic value mappings on the same definition are OR-ed (any match
+entitles). When a static pre-gate Subject Condition Set is present, both the gate and the resolver
+must pass. A definition with a dynamic value mapping cannot also carry value-level subject mappings,
+and HIERARCHY definitions are not supported.

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
@@ -22,7 +22,7 @@ command:
         - IN
         - IN_CONTAINS
     - name: action
-      description: Each 'id' or 'name' of an Action to be entitled (i.e. 'create', 'read', 'update', 'delete')
+      description: Each 'id' or 'name' of an Action to be entitled (i.e. 'create', 'read', 'update', 'delete'). At least one is required.
     - name: subject-condition-set-id
       description: Known preexisting Subject Condition Set Id to use as a static pre-gate
     - name: subject-condition-set-new

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
@@ -1,0 +1,87 @@
+---
+title: Create a new dynamic value mapping
+command:
+  name: create
+  aliases:
+    - new
+    - add
+    - c
+  flags:
+    - name: attribute-definition-id
+      description: The ID of the Attribute Definition to scope the mapping to
+      shorthand: a
+    - name: attribute-definition-fqn
+      description: The FQN of the Attribute Definition to scope the mapping to
+    - name: selector
+      description: Selector for a field on the flattened Entity Representation (e.g. '.patientAssignments[]')
+      shorthand: s
+    - name: operator
+      description: How the requested resource value segment is compared against each entity selector value
+      shorthand: o
+      enum:
+        - IN
+        - IN_CONTAINS
+    - name: action
+      description: Each 'id' or 'name' of an Action to be entitled (i.e. 'create', 'read', 'update', 'delete')
+    - name: subject-condition-set-id
+      description: Known preexisting Subject Condition Set Id to use as a static pre-gate
+    - name: subject-condition-set-new
+      description: JSON array of Subject Sets to create a new static pre-gate Subject Condition Set associated with the created Dynamic Value Mapping
+    - name: namespace
+      description: Namespace ID or FQN
+      shorthand: n
+    - name: label
+      description: "Optional metadata 'labels' in the format: key=value"
+      shorthand: l
+---
+
+Create a Dynamic Value Mapping to entitle dynamically-requested Attribute Values under an Attribute
+Definition. At decision time the resolver compares the requested resource value segment against each
+value the `--selector` resolves from the Entity Representation, using the `--operator`.
+
+The `--operator` must be one of `IN` (exact match) or `IN_CONTAINS` (substring match, over-matches by
+design). `NOT_IN` is not supported because dynamic resolution is existential over the resolved entity
+values.
+
+Exactly one of `--attribute-definition-id` or `--attribute-definition-fqn` is required. A HIERARCHY
+Attribute Definition is not supported.
+
+Optionally provide a static pre-gate Subject Condition Set with either `--subject-condition-set-id`
+(existing) or `--subject-condition-set-new` (JSON to create a new one). When a gate is present, both
+the gate and the resolver must pass for entitlement.
+
+For more information about attribute definitions, see the `attributes` subcommand.
+
+For more information about subject condition sets, see the `subject-condition-sets` subcommand.
+
+## Examples
+
+Create a dynamic value mapping entitling 'read' where a patient assignment matches the requested value:
+```shell
+otdfctl policy dynamic-value-mappings create --attribute-definition-id 891cfe85-b381-4f85-9699-5f7dbfe2a9ab --selector '.patientAssignments[]' --operator IN --action read
+```
+
+Create a dynamic value mapping scoped by Attribute Definition FQN with a substring operator:
+```shell
+otdfctl policy dynamic-value-mappings create --attribute-definition-fqn https://hospital.co/attr/mrn --selector '.patientAssignments[]' --operator IN_CONTAINS --action read
+```
+
+Create a dynamic value mapping with a static pre-gate Subject Condition Set:
+```shell
+otdfctl policy dynamic-value-mappings create --attribute-definition-id 891cfe85-b381-4f85-9699-5f7dbfe2a9ab --selector '.patientAssignments[]' --operator IN --action read --subject-condition-set-new '[
+  {
+    "condition_groups": [
+      {
+        "conditions": [
+          {
+            "operator": 1,
+            "subject_external_values": ["clinician"],
+            "subject_external_selector_value": ".role"
+          }
+        ],
+        "boolean_operator": 1
+      }
+    ]
+  }
+]'
+```

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/delete.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/delete.md
@@ -1,0 +1,19 @@
+---
+title: Delete a dynamic value mapping
+command:
+  name: delete
+  aliases:
+    - d
+  flags:
+    - name: id
+      description: The ID of the dynamic value mapping to delete
+      shorthand: i
+      required: true
+      default: ''
+    - name: force
+      description: Force delete without interactive confirmation
+---
+
+Delete a Dynamic Value Mapping by its ID.
+
+For more information about dynamic value mappings, see the `dynamic-value-mappings` subcommand.

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/get.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/get.md
@@ -1,0 +1,17 @@
+---
+title: Get a dynamic value mapping
+command:
+  name: get
+  aliases:
+    - g
+  flags:
+    - name: id
+      description: The ID of the dynamic value mapping to get
+      shorthand: i
+      required: true
+      default: ''
+---
+
+Retrieve the specifics of a Dynamic Value Mapping by its ID.
+
+For more information about dynamic value mappings, see the `dynamic-value-mappings` subcommand.

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/list.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/list.md
@@ -1,0 +1,36 @@
+---
+title: List dynamic value mappings
+command:
+  name: list
+  aliases:
+    - l
+  flags:
+    - name: namespace
+      shorthand: n
+      description: Namespace ID or FQN to filter results
+    - name: attribute-definition-id
+      description: Attribute Definition ID to filter results
+    - name: limit
+      shorthand: l
+      description: Limit retrieved count
+    - name: offset
+      shorthand: o
+      description: Offset (page) quantity from start of the list
+    - name: sort
+      description: Sort list results by field
+    - name: order
+      description: Sort order direction. Accepted values are asc and desc
+---
+
+List Dynamic Value Mappings, optionally filtered by namespace or attribute definition.
+
+For more information about dynamic value mappings, see the `dynamic-value-mappings` subcommand.
+
+## Sort Options
+
+Use `--sort <field>` with optional `--order <direction>`. Either flag may be omitted.
+
+| Field | Description |
+| --- | --- |
+| created_at | Order by creation timestamp |
+| updated_at | Order by last update timestamp |

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/update.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/update.md
@@ -1,0 +1,48 @@
+---
+title: Update a dynamic value mapping
+command:
+  name: update
+  aliases:
+    - u
+  flags:
+    - name: id
+      description: The ID of the dynamic value mapping to update
+      shorthand: i
+      required: true
+    - name: selector
+      description: Replacement selector for a field on the flattened Entity Representation (requires --operator)
+      shorthand: s
+    - name: operator
+      description: Replacement comparison operator (requires --selector)
+      shorthand: o
+      enum:
+        - IN
+        - IN_CONTAINS
+    - name: action
+      description: Each 'id' or 'name' of an Action to be entitled (i.e. 'create', 'read', 'update', 'delete')
+    - name: subject-condition-set-id
+      description: Replacement static pre-gate Subject Condition Set Id
+      required: false
+    - name: label
+      description: "Optional metadata 'labels' in the format: key=value"
+      shorthand: l
+    - name: force-replace-labels
+      description: Destructively replace entire set of existing metadata 'labels' with any provided to this command
+      default: false
+---
+
+Update a Dynamic Value Mapping.
+
+`Actions` are updated in place, destructively replacing the current set. If you want to add or remove
+actions, provide the full set of actions on update.
+
+To replace the dynamic value resolver, provide both `--selector` and `--operator` together. Omit both
+to leave the resolver unchanged.
+
+For more information about dynamic value mappings, see the `dynamic-value-mappings` subcommand.
+
+## Example
+
+```shell
+otdfctl policy dynamic-value-mappings update --id 39866dd2-368b-41f6-b292-b4b68c01888b --action read
+```

--- a/otdfctl/e2e/dynamic-value-mapping.bats
+++ b/otdfctl/e2e/dynamic-value-mapping.bats
@@ -1,0 +1,229 @@
+#!/usr/bin/env bats
+
+# Tests for dynamic value mappings
+
+setup_file() {
+    export WITH_CREDS='--with-client-creds-file ./creds.json'
+    export HOST='--host http://localhost:8080'
+
+    export NS_NAME="dynamic-value-mappings-test.net"
+    export NS_FQN="https://$NS_NAME"
+    export NS_ID=$(./otdfctl $HOST $WITH_CREDS policy attributes namespaces create -n "$NS_NAME" --json | jq -r '.id')
+
+    # A non-hierarchy definition used by the happy-path tests
+    ATTR=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name attr1 --rule ANY_OF --json)
+    export DVM_ATTR_ID=$(echo "$ATTR" | jq -r '.id')
+    export DVM_ATTR_FQN=$(echo "$ATTR" | jq -r '.fqn')
+
+    # A HIERARCHY definition, unsupported by dynamic value mappings
+    export DVM_HIER_ATTR_ID=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name hierattr --rule HIERARCHY -v high -v low --json | jq -r '.id')
+
+    export SELECTOR='.patientAssignments[]'
+    export SCS_1='[{"condition_groups":[{"conditions":[{"operator":1,"subject_external_values":["clinician"],"subject_external_selector_value":".role"}],"boolean_operator":1}]}]'
+
+    export ACTION_READ_NAME='read'
+    export ACTION_CREATE_NAME='create'
+}
+
+setup() {
+    bats_load_library bats-support
+    bats_load_library bats-assert
+
+    # invoke binary with credentials
+    run_otdfctl_dvm () {
+      run sh -c "./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings $*"
+    }
+}
+
+teardown_file() {
+    # remove the created namespace with all underneath upon test suite completion
+    ./otdfctl $HOST $WITH_CREDS policy attributes namespaces unsafe delete --force --id "$NS_ID"
+
+    unset HOST WITH_CREDS NS_ID NS_FQN NS_NAME DVM_ATTR_ID DVM_ATTR_FQN DVM_HIER_ATTR_ID SELECTOR SCS_1
+}
+
+@test "Create dynamic value mapping" {
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
+        assert_success
+        assert_output --partial "Attribute Definition: Id"
+        assert_output --partial "Resolver: Selector"
+        assert_line --regexp "Resolver: Operator.*IN"
+        assert_line --regexp "Attribute Definition: Id.*$DVM_ATTR_ID"
+
+    # json shape
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN_CONTAINS --action "$ACTION_READ_NAME" --json
+        assert_success
+        [ "$(echo "$output" | jq -r '.attribute_definition.id')" = "$DVM_ATTR_ID" ]
+        [ "$(echo "$output" | jq -r '.value_resolver.subject_external_selector_value')" = "$SELECTOR" ]
+        # IN_CONTAINS enum serializes as 3
+        [ "$(echo "$output" | jq -r '.value_resolver.operator')" = "3" ]
+        [ "$(echo "$output" | jq -r '.actions[0].name')" = "$ACTION_READ_NAME" ]
+}
+
+@test "Create dynamic value mapping with a static pre-gate subject condition set" {
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json
+        assert_success
+        assert_not_equal "$(echo "$output" | jq -r '.subject_condition_set.id')" "null"
+        assert_not_equal "$(echo "$output" | jq -r '.subject_condition_set.id')" ""
+        assert_output --partial ".role"
+}
+
+@test "Create dynamic value mapping by attribute definition FQN" {
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-fqn "$DVM_ATTR_FQN" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json
+        assert_success
+        assert_equal "$(echo "$output" | jq -r '.attribute_definition.fqn')" "$DVM_ATTR_FQN"
+}
+
+@test "Create dynamic value mapping with namespace ID and FQN" {
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_ID" --json
+        assert_success
+        assert_equal "$(echo "$output" | jq -r '.namespace.id')" "$NS_ID"
+
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_FQN" --json
+        assert_success
+        assert_equal "$(echo "$output" | jq -r '.namespace.id')" "$NS_ID"
+}
+
+@test "Create dynamic value mapping rejects invalid input" {
+    # NOT_IN operator is rejected client-side
+    run_otdfctl_dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator NOT_IN --action "$ACTION_READ_NAME"
+        assert_failure
+        assert_output --partial "Invalid --operator"
+
+    # operator is required
+    run_otdfctl_dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --action "$ACTION_READ_NAME"
+        assert_failure
+        assert_output --partial "resolver operator [--operator] is required"
+
+    # an attribute definition reference is required
+    run_otdfctl_dvm create --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
+        assert_failure
+        assert_output --partial "[--attribute-definition-id, --attribute-definition-fqn] is required"
+
+    # an action is required
+    run_otdfctl_dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN
+        assert_failure
+        assert_output --partial "At least one Action [--action] is required"
+}
+
+@test "Create dynamic value mapping rejects a HIERARCHY definition" {
+    run_otdfctl_dvm create --attribute-definition-id "$DVM_HIER_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
+        assert_failure
+}
+
+@test "Create dynamic value mapping rejects coexistence with value subject mappings" {
+    coex_attr=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "coex_${BATS_TEST_NUMBER}_$RANDOM" --rule ANY_OF -v v1 --json)
+    coex_attr_id=$(echo "$coex_attr" | jq -r '.id')
+    coex_val_id=$(echo "$coex_attr" | jq -r '.values[0].id')
+
+    # attach a value-level subject mapping to the definition
+    ./otdfctl $HOST $WITH_CREDS policy subject-mappings create -a "$coex_val_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json
+
+    # a dynamic value mapping on the same definition must be rejected by the server
+    run_otdfctl_dvm create --attribute-definition-id "$coex_attr_id" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
+        assert_failure
+}
+
+@test "Get dynamic value mapping" {
+    run ./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json
+        assert_success
+        created=$(echo "$output" | jq -r '.id')
+        assert_not_equal "$created" "null"
+        assert_not_equal "$created" ""
+
+    # table
+    run_otdfctl_dvm get --id "$created"
+        assert_success
+        assert_line --regexp "Id.*$created"
+        assert_line --regexp "Attribute Definition: Id.*$DVM_ATTR_ID"
+        assert_line --regexp "Resolver: Operator.*IN"
+
+    # json
+    run_otdfctl_dvm get --id "$created" --json
+        assert_success
+        [ "$(echo "$output" | jq -r '.id')" = "$created" ]
+        [ "$(echo "$output" | jq -r '.value_resolver.subject_external_selector_value')" = "$SELECTOR" ]
+}
+
+@test "List dynamic value mappings" {
+    created=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json | jq -r '.id')
+
+    run_otdfctl_dvm list
+        assert_success
+        assert_output --partial "$created"
+        assert_output --partial "Total"
+        assert_line --regexp "Current Offset.*0"
+
+    run_otdfctl_dvm list --json
+        assert_success
+        assert_equal "$(echo "$output" | jq -r --arg id "$created" '.dynamic_value_mappings[] | select(.id == $id) | .id')" "$created"
+        total=$(echo "$output" | jq -r '.pagination.total')
+        [[ "$total" -ge 1 ]]
+
+    # filter by attribute definition id
+    run_otdfctl_dvm list --attribute-definition-id "$DVM_ATTR_ID" --json
+        assert_success
+        assert_equal "$(echo "$output" | jq -r --arg id "$DVM_ATTR_ID" '[.dynamic_value_mappings[] | select(.attribute_definition.id != $id)] | length')" "0"
+}
+
+@test "List dynamic value mappings supports namespace filter" {
+    created=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_ID" --json | jq -r '.id')
+
+    run_otdfctl_dvm list --namespace "$NS_ID" --json
+        assert_success
+        assert_equal "$(echo "$output" | jq -r --arg id "$created" '.dynamic_value_mappings[] | select(.id == $id) | .id')" "$created"
+        assert_equal "$(echo "$output" | jq -r --arg ns "$NS_ID" '[.dynamic_value_mappings[] | select(.namespace.id != $ns)] | length')" "0"
+
+    run_otdfctl_dvm list --namespace "$NS_FQN" --json
+        assert_success
+        assert_equal "$(echo "$output" | jq -r --arg id "$created" '.dynamic_value_mappings[] | select(.id == $id) | .id')" "$created"
+}
+
+@test "List dynamic value mappings supports sort and order flags" {
+    sort_attr=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "sort_dvm_${BATS_TEST_NUMBER}_$RANDOM" --rule ANY_OF --json | jq -r '.id')
+    dvm_a=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$sort_attr" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_ID" --json | jq -r '.id')
+    dvm_b=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$sort_attr" --selector "$SELECTOR" --operator IN --action "$ACTION_CREATE_NAME" --namespace "$NS_ID" --json | jq -r '.id')
+
+    run_otdfctl_dvm list --namespace "$NS_ID" --sort created_at --order asc --limit 500 --json
+        assert_success
+        assert_equal "$(echo "$output" | jq -r --arg a "$dvm_a" --arg b "$dvm_b" '[.dynamic_value_mappings[] | select(.id == $a or .id == $b) | .id] | join(",")')" "$dvm_a,$dvm_b"
+
+    run_otdfctl_dvm list --namespace "$NS_ID" --sort created_at --order desc --limit 500 --json
+        assert_success
+        assert_equal "$(echo "$output" | jq -r --arg a "$dvm_a" --arg b "$dvm_b" '[.dynamic_value_mappings[] | select(.id == $a or .id == $b) | .id] | join(",")')" "$dvm_b,$dvm_a"
+}
+
+@test "Update a dynamic value mapping" {
+    created=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json | jq -r '.id')
+
+    # replace the actions
+    run_otdfctl_dvm update --id "$created" --action "$ACTION_CREATE_NAME" --json
+        assert_success
+        assert_equal "$(echo "$output" | jq -r '.id')" "$created"
+
+    run_otdfctl_dvm get --id "$created" --json
+        assert_success
+        [ "$(echo "$output" | jq -r '.actions[0].name')" = "$ACTION_CREATE_NAME" ]
+
+    # replace the resolver (selector + operator together)
+    run_otdfctl_dvm update --id "$created" --selector ".newSelector[]" --operator IN_CONTAINS --json
+        assert_success
+
+    run_otdfctl_dvm get --id "$created" --json
+        assert_success
+        [ "$(echo "$output" | jq -r '.value_resolver.subject_external_selector_value')" = ".newSelector[]" ]
+        [ "$(echo "$output" | jq -r '.value_resolver.operator')" = "3" ]
+
+    # selector and operator must be provided together
+    run_otdfctl_dvm update --id "$created" --selector ".onlySelector[]"
+        assert_failure
+        assert_output --partial "Both [--selector, --operator] must be provided together"
+}
+
+@test "Delete dynamic value mapping" {
+    to_delete=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json | jq -r '.id')
+
+    run_otdfctl_dvm delete --id "$to_delete" --force
+        assert_success
+        assert_line --regexp "Id.*$to_delete"
+}

--- a/otdfctl/e2e/dynamic-value-mapping.bats
+++ b/otdfctl/e2e/dynamic-value-mapping.bats
@@ -112,12 +112,16 @@ teardown_file() {
 }
 
 @test "Create dynamic value mapping rejects coexistence with value subject mappings" {
-    coex_attr=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "coex_${BATS_TEST_NUMBER}_$RANDOM" --rule ANY_OF -v v1 --json)
-    coex_attr_id=$(echo "$coex_attr" | jq -r '.id')
-    coex_val_id=$(echo "$coex_attr" | jq -r '.values[0].id')
+    run ./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "coex_${BATS_TEST_NUMBER}_$RANDOM" --rule ANY_OF -v v1 --json
+    assert_success
+    coex_attr_id=$(echo "$output" | jq -r '.id')
+    coex_val_id=$(echo "$output" | jq -r '.values[0].id')
+    assert_not_equal "$coex_attr_id" ""
+    assert_not_equal "$coex_val_id" ""
 
     # attach a value-level subject mapping to the definition
-    ./otdfctl $HOST $WITH_CREDS policy subject-mappings create -a "$coex_val_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json
+    run ./otdfctl $HOST $WITH_CREDS policy subject-mappings create -a "$coex_val_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json
+    assert_success
 
     # a dynamic value mapping on the same definition must be rejected by the server
     run_otdfctl_dvm create --attribute-definition-id "$coex_attr_id" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
@@ -125,7 +129,8 @@ teardown_file() {
 }
 
 @test "Get dynamic value mapping" {
-    run ./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json
+    # exercise the singular 'dynamic-value-mapping' alias here
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mapping create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json
         assert_success
         created=$(echo "$output" | jq -r '.id')
         assert_not_equal "$created" "null"
@@ -226,4 +231,8 @@ teardown_file() {
     run_otdfctl_dvm delete --id "$to_delete" --force
         assert_success
         assert_line --regexp "Id.*$to_delete"
+
+    # deletion must persist
+    run_otdfctl_dvm get --id "$to_delete"
+        assert_failure
 }

--- a/otdfctl/pkg/handlers/dynamicvaluemappings.go
+++ b/otdfctl/pkg/handlers/dynamicvaluemappings.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/opentdf/platform/protocol/go/common"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/dynamicvaluemapping"
+	"github.com/opentdf/platform/protocol/go/policy/subjectmapping"
+)
+
+// DynamicValueMappingOperatorEnumChoices are the operators supported by a dynamic value resolver.
+// NOT_IN and UNSPECIFIED are excluded: dynamic resolution is existential over the resolved entity
+// values, so a negative operator is not supported.
+var DynamicValueMappingOperatorEnumChoices = []string{SubjectMappingOperatorIn, SubjectMappingOperatorInContains}
+
+func (h Handler) GetDynamicValueMapping(ctx context.Context, id string) (*policy.DynamicValueMapping, error) {
+	resp, err := h.sdk.DynamicValueMapping.GetDynamicValueMapping(ctx, &dynamicvaluemapping.GetDynamicValueMappingRequest{
+		Id: id,
+	})
+	return resp.GetDynamicValueMapping(), err
+}
+
+func (h Handler) ListDynamicValueMappings(ctx context.Context, limit, offset int32, namespace, attrDefID string, sort SortOption) (*dynamicvaluemapping.ListDynamicValueMappingsResponse, error) {
+	req := &dynamicvaluemapping.ListDynamicValueMappingsRequest{
+		Pagination: &policy.PageRequest{
+			Limit:  limit,
+			Offset: offset,
+		},
+	}
+	req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
+	if attrDefID != "" {
+		req.AttributeDefinitionId = attrDefID
+	}
+	if !sort.IsZero() {
+		allowedFields := map[string]dynamicvaluemapping.SortDynamicValueMappingsType{
+			"created_at": dynamicvaluemapping.SortDynamicValueMappingsType_SORT_DYNAMIC_VALUE_MAPPINGS_TYPE_CREATED_AT,
+			"updated_at": dynamicvaluemapping.SortDynamicValueMappingsType_SORT_DYNAMIC_VALUE_MAPPINGS_TYPE_UPDATED_AT,
+		}
+		field, err := sortField("dynamic value mappings", sort, allowedFields)
+		if err != nil {
+			return nil, err
+		}
+		req.Sort = []*dynamicvaluemapping.DynamicValueMappingsSort{{Field: field, Direction: sort.Direction}}
+	}
+	return h.sdk.DynamicValueMapping.ListDynamicValueMappings(ctx, req)
+}
+
+// Creates and returns the created dynamic value mapping
+func (h Handler) CreateDynamicValueMapping(ctx context.Context, attrDefID, attrDefFQN string, resolver *policy.DynamicValueResolver, actions []*policy.Action, existingSCSID string, newSCS *subjectmapping.SubjectConditionSetCreate, namespace string, m *common.MetadataMutable) (*policy.DynamicValueMapping, error) {
+	req := &dynamicvaluemapping.CreateDynamicValueMappingRequest{
+		AttributeDefinitionId:         attrDefID,
+		AttributeDefinitionFqn:        attrDefFQN,
+		ValueResolver:                 resolver,
+		Actions:                       actions,
+		ExistingSubjectConditionSetId: existingSCSID,
+		NewSubjectConditionSet:        newSCS,
+		Metadata:                      m,
+	}
+	req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
+	resp, err := h.sdk.DynamicValueMapping.CreateDynamicValueMapping(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return h.GetDynamicValueMapping(ctx, resp.GetDynamicValueMapping().GetId())
+}
+
+// Updates and returns the updated dynamic value mapping
+func (h Handler) UpdateDynamicValueMapping(ctx context.Context, id string, resolver *policy.DynamicValueResolver, scsID string, actions []*policy.Action, m *common.MetadataMutable, behavior common.MetadataUpdateEnum) (*policy.DynamicValueMapping, error) {
+	_, err := h.sdk.DynamicValueMapping.UpdateDynamicValueMapping(ctx, &dynamicvaluemapping.UpdateDynamicValueMappingRequest{
+		Id:                     id,
+		ValueResolver:          resolver,
+		SubjectConditionSetId:  scsID,
+		Actions:                actions,
+		Metadata:               m,
+		MetadataUpdateBehavior: behavior,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return h.GetDynamicValueMapping(ctx, id)
+}
+
+func (h Handler) DeleteDynamicValueMapping(ctx context.Context, id string) (*policy.DynamicValueMapping, error) {
+	resp, err := h.sdk.DynamicValueMapping.DeleteDynamicValueMapping(ctx, &dynamicvaluemapping.DeleteDynamicValueMappingRequest{
+		Id: id,
+	})
+	return resp.GetDynamicValueMapping(), err
+}


### PR DESCRIPTION
### Proposed Changes

* Add a `policy dynamic-value-mappings` command group to `otdfctl` (aliases `dvm`, `dynamic-value-mapping`) with `create`, `get`, `list`, `update`, and `delete`, mirroring the `subject-mappings` pattern. Wraps the `DynamicValueMapping` SDK client with a new handler, cobra commands, and man docs.
* Validate the resolver operator client-side (only `IN` / `IN_CONTAINS`; reject `NOT_IN` and unspecified), require exactly one of `--attribute-definition-id` / `--attribute-definition-fqn`, and require `--selector` and `--operator` together on update.
* Add an end-to-end bats suite (`otdfctl/e2e/dynamic-value-mapping.bats`) covering CRUD (table + `--json`), static-gate create, namespace id/fqn, sort/filter, and error/rejection cases (NOT_IN, missing operator/definition/action, HIERARCHY definition, value-subject-mapping coexistence).

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation

### Testing Instructions

- `cd otdfctl && golangci-lint run ./... && go test ./...`
- Start and provision a local platform, then run the e2e suite:
  `cd otdfctl && make test-bats` (or `bats ./e2e/dynamic-value-mapping.bats`).
  Verified locally: all 13 tests pass against a live platform.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI support to create, retrieve, list, update, and delete dynamic value mappings.
  * Added filtering, pagination, sorting, metadata labels, resolver configuration, actions, and optional subject-condition gates.
  * Added validation for supported operators and required option combinations.
* **Documentation**
  * Added command reference pages with usage, flags, constraints, and examples.
* **Tests**
  * Added end-to-end coverage for lifecycle operations, validation, filtering, sorting, and JSON/table output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->