### PR TITLE
feat(authz): dynamic value mapping and direct entitlement e2e coverage

### DIFF
--- a/otdfctl/cmd/policy/dynamicValueMappings.go
+++ b/otdfctl/cmd/policy/dynamicValueMappings.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opentdf/platform/otdfctl/pkg/cli"
 	"github.com/opentdf/platform/otdfctl/pkg/handlers"
 	"github.com/opentdf/platform/otdfctl/pkg/man"
+	"github.com/opentdf/platform/otdfctl/pkg/utils"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/subjectmapping"
 	"github.com/spf13/cobra"
@@ -94,10 +95,10 @@ func policyListDynamicValueMappings(cmd *cobra.Command, args []string) {
 	limit := c.Flags.GetRequiredInt32("limit")
 	offset := c.Flags.GetRequiredInt32("offset")
 	namespace := c.Flags.GetOptionalString("namespace")
-	attrDefID := c.Flags.GetOptionalID("attribute-definition-id")
+	attribute := c.Flags.GetOptionalString("attribute")
 	sort := getSortOption(c)
 
-	resp, err := h.ListDynamicValueMappings(cmd.Context(), limit, offset, namespace, attrDefID, sort)
+	resp, err := h.ListDynamicValueMappings(cmd.Context(), limit, offset, namespace, attribute, sort)
 	if err != nil {
 		cli.ExitWithError("Failed to list dynamic value mappings", err)
 	}
@@ -137,22 +138,17 @@ func policyCreateDynamicValueMapping(cmd *cobra.Command, args []string) {
 	h := common.NewHandler(c)
 	defer h.Close()
 
-	attrDefID := c.Flags.GetOptionalID("attribute-definition-id")
-	attrDefFQN := c.Flags.GetOptionalString("attribute-definition-fqn")
+	attribute := c.Flags.GetOptionalString("attribute")
 	selector := c.Flags.GetOptionalString("selector")
 	operator := c.Flags.GetOptionalString("operator")
 	actionFlagValues = c.Flags.GetStringSlice("action", actionFlagValues, cli.FlagsStringSliceOptions{Min: 0})
-	existingSCSID := c.Flags.GetOptionalID("subject-condition-set-id")
-	newScsJSON := c.Flags.GetOptionalString("subject-condition-set-new")
+	subjectConditionSet := c.Flags.GetOptionalString("subject-condition-set")
 	namespace := c.Flags.GetOptionalString("namespace")
 	metadataLabels = c.Flags.GetStringSlice("label", metadataLabels, cli.FlagsStringSliceOptions{Min: 0})
 
 	// validations
-	if attrDefID == "" && attrDefFQN == "" {
-		cli.ExitWithError("One of [--attribute-definition-id, --attribute-definition-fqn] is required", nil)
-	}
-	if attrDefID != "" && attrDefFQN != "" {
-		cli.ExitWithError("Only one of [--attribute-definition-id, --attribute-definition-fqn] may be provided", nil)
+	if attribute == "" {
+		cli.ExitWithError("The Attribute Definition reference [--attribute] is required", nil)
 	}
 	if selector == "" {
 		cli.ExitWithError("The resolver selector [--selector] is required", nil)
@@ -163,9 +159,6 @@ func policyCreateDynamicValueMapping(cmd *cobra.Command, args []string) {
 	if len(actionFlagValues) == 0 {
 		cli.ExitWithError("At least one Action [--action] is required", nil)
 	}
-	if existingSCSID != "" && newScsJSON != "" {
-		cli.ExitWithError("Only one of [--subject-condition-set-id, --subject-condition-set-new] may be provided", nil)
-	}
 
 	resolver := &policy.DynamicValueResolver{
 		SubjectExternalSelectorValue: selector,
@@ -173,18 +166,25 @@ func policyCreateDynamicValueMapping(cmd *cobra.Command, args []string) {
 	}
 	actions := parseDynamicValueMappingActions(actionFlagValues)
 
+	// The static pre-gate accepts either an existing Subject Condition Set (referenced by UUID) or a
+	// JSON array of Subject Sets to create a new one.
+	var existingSCSID string
 	var scs *subjectmapping.SubjectConditionSetCreate
-	if newScsJSON != "" {
-		ss, err := unmarshalSubjectSetsProto([]byte(newScsJSON))
-		if err != nil {
-			cli.ExitWithError("Error unmarshalling subject sets", err)
-		}
-		scs = &subjectmapping.SubjectConditionSetCreate{
-			SubjectSets: ss,
+	if subjectConditionSet != "" {
+		if utils.ClassifyString(subjectConditionSet) == utils.StringTypeUUID {
+			existingSCSID = subjectConditionSet
+		} else {
+			ss, err := unmarshalSubjectSetsProto([]byte(subjectConditionSet))
+			if err != nil {
+				cli.ExitWithError("Error unmarshalling subject sets", err)
+			}
+			scs = &subjectmapping.SubjectConditionSetCreate{
+				SubjectSets: ss,
+			}
 		}
 	}
 
-	mapping, err := h.CreateDynamicValueMapping(cmd.Context(), attrDefID, attrDefFQN, resolver, actions, existingSCSID, scs, namespace, getMetadataMutable(metadataLabels))
+	mapping, err := h.CreateDynamicValueMapping(cmd.Context(), attribute, resolver, actions, existingSCSID, scs, namespace, getMetadataMutable(metadataLabels))
 	if err != nil {
 		cli.ExitWithError("Failed to create dynamic value mapping", err)
 	}
@@ -211,10 +211,8 @@ func policyUpdateDynamicValueMapping(cmd *cobra.Command, args []string) {
 	metadataLabels = c.Flags.GetStringSlice("label", metadataLabels, cli.FlagsStringSliceOptions{Min: 0})
 
 	// The resolver is replaced as a whole and both of its fields are required, so --selector and
-	// --operator must be provided together (or both omitted to leave the resolver unchanged).
-	if (selector == "") != (operator == "") {
-		cli.ExitWithError("Both [--selector, --operator] must be provided together to replace the resolver", nil)
-	}
+	// --operator must be provided together (or both omitted to leave the resolver unchanged). This
+	// pairing is enforced by MarkFlagsRequiredTogether when the command is wired up.
 	var resolver *policy.DynamicValueResolver
 	if selector != "" {
 		resolver = &policy.DynamicValueResolver{
@@ -301,10 +299,11 @@ func initDynamicValueMappingsCommands() {
 		listDoc.GetDocFlag("namespace").Default,
 		listDoc.GetDocFlag("namespace").Description,
 	)
-	listDoc.Flags().String(
-		listDoc.GetDocFlag("attribute-definition-id").Name,
-		listDoc.GetDocFlag("attribute-definition-id").Default,
-		listDoc.GetDocFlag("attribute-definition-id").Description,
+	listDoc.Flags().StringP(
+		listDoc.GetDocFlag("attribute").Name,
+		listDoc.GetDocFlag("attribute").Shorthand,
+		listDoc.GetDocFlag("attribute").Default,
+		listDoc.GetDocFlag("attribute").Description,
 	)
 
 	createDoc := man.Docs.GetCommand(
@@ -312,15 +311,10 @@ func initDynamicValueMappingsCommands() {
 		man.WithRun(policyCreateDynamicValueMapping),
 	)
 	createDoc.Flags().StringP(
-		createDoc.GetDocFlag("attribute-definition-id").Name,
-		createDoc.GetDocFlag("attribute-definition-id").Shorthand,
-		createDoc.GetDocFlag("attribute-definition-id").Default,
-		createDoc.GetDocFlag("attribute-definition-id").Description,
-	)
-	createDoc.Flags().String(
-		createDoc.GetDocFlag("attribute-definition-fqn").Name,
-		createDoc.GetDocFlag("attribute-definition-fqn").Default,
-		createDoc.GetDocFlag("attribute-definition-fqn").Description,
+		createDoc.GetDocFlag("attribute").Name,
+		createDoc.GetDocFlag("attribute").Shorthand,
+		createDoc.GetDocFlag("attribute").Default,
+		createDoc.GetDocFlag("attribute").Description,
 	)
 	createDoc.Flags().StringP(
 		createDoc.GetDocFlag("selector").Name,
@@ -342,14 +336,9 @@ func initDynamicValueMappingsCommands() {
 		createDoc.GetDocFlag("action").Description,
 	)
 	createDoc.Flags().String(
-		createDoc.GetDocFlag("subject-condition-set-id").Name,
-		createDoc.GetDocFlag("subject-condition-set-id").Default,
-		createDoc.GetDocFlag("subject-condition-set-id").Description,
-	)
-	createDoc.Flags().String(
-		createDoc.GetDocFlag("subject-condition-set-new").Name,
-		createDoc.GetDocFlag("subject-condition-set-new").Default,
-		createDoc.GetDocFlag("subject-condition-set-new").Description,
+		createDoc.GetDocFlag("subject-condition-set").Name,
+		createDoc.GetDocFlag("subject-condition-set").Default,
+		createDoc.GetDocFlag("subject-condition-set").Description,
 	)
 	createDoc.Flags().StringP(
 		createDoc.GetDocFlag("namespace").Name,
@@ -393,6 +382,8 @@ func initDynamicValueMappingsCommands() {
 		updateDoc.GetDocFlag("subject-condition-set-id").Default,
 		updateDoc.GetDocFlag("subject-condition-set-id").Description,
 	)
+	// The resolver is replaced as a whole; both fields are required together to replace it.
+	updateDoc.MarkFlagsRequiredTogether("selector", "operator")
 	injectLabelFlags(&updateDoc.Command, true)
 
 	deleteDoc := man.Docs.GetCommand(

--- a/otdfctl/cmd/policy/dynamicValueMappings.go
+++ b/otdfctl/cmd/policy/dynamicValueMappings.go
@@ -33,13 +33,24 @@ func parseDynamicValueMappingActions(values []string) []*policy.Action {
 	return actions
 }
 
-// parseDynamicValueMappingOperator validates the readable operator choice and returns its enum.
-// Only IN and IN_CONTAINS are supported; NOT_IN, UNSPECIFIED, and unknown values are rejected.
-func parseDynamicValueMappingOperator(operator string) policy.SubjectMappingOperatorEnum {
+// validateDynamicValueMappingOperator validates the readable operator choice and returns its enum.
+// Only IN and IN_CONTAINS are supported; NOT_IN, UNSPECIFIED, and unknown values are rejected with
+// an error.
+func validateDynamicValueMappingOperator(operator string) (policy.SubjectMappingOperatorEnum, error) {
 	op := handlers.GetSubjectMappingOperatorFromChoice(operator)
 	if op != policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN &&
 		op != policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS {
-		cli.ExitWithError(fmt.Sprintf("Invalid --operator %q; must be one of %s", operator, strings.Join(handlers.DynamicValueMappingOperatorEnumChoices, ", ")), nil)
+		return op, fmt.Errorf("invalid --operator %q; must be one of %s", operator, strings.Join(handlers.DynamicValueMappingOperatorEnumChoices, ", "))
+	}
+	return op, nil
+}
+
+// parseDynamicValueMappingOperator validates the readable operator choice and returns its enum,
+// exiting with an error on an unsupported operator.
+func parseDynamicValueMappingOperator(operator string) policy.SubjectMappingOperatorEnum {
+	op, err := validateDynamicValueMappingOperator(operator)
+	if err != nil {
+		cli.ExitWithError(err.Error(), nil)
 	}
 	return op
 }

--- a/otdfctl/cmd/policy/dynamicValueMappings_test.go
+++ b/otdfctl/cmd/policy/dynamicValueMappings_test.go
@@ -1,0 +1,108 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDynamicValueMappingActions(t *testing.T) {
+	uuid1 := "891cfe85-b381-4f85-9699-5f7dbfe2a9ab"
+	uuid2 := "3c51a593-cd4d-4b74-9f97-3b3b6b0a6f21"
+
+	tests := []struct {
+		name  string
+		input []string
+		want  []*policy.Action
+	}{
+		{
+			name:  "empty slice",
+			input: []string{},
+			want:  []*policy.Action{},
+		},
+		{
+			name:  "name reference",
+			input: []string{"read"},
+			want:  []*policy.Action{{Name: "read"}},
+		},
+		{
+			name:  "uuid reference",
+			input: []string{uuid1},
+			want:  []*policy.Action{{Id: uuid1}},
+		},
+		{
+			name:  "mixed ids and names",
+			input: []string{uuid1, "read", uuid2, "create"},
+			want: []*policy.Action{
+				{Id: uuid1},
+				{Name: "read"},
+				{Id: uuid2},
+				{Name: "create"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDynamicValueMappingActions(tt.input)
+			require.Len(t, got, len(tt.want))
+			for i, action := range got {
+				require.Equal(t, tt.want[i].GetId(), action.GetId())
+				require.Equal(t, tt.want[i].GetName(), action.GetName())
+			}
+		})
+	}
+}
+
+func TestValidateDynamicValueMappingOperator(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    policy.SubjectMappingOperatorEnum
+		wantErr bool
+	}{
+		{
+			name:  "IN accepted",
+			input: "IN",
+			want:  policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+		},
+		{
+			name:  "IN_CONTAINS accepted",
+			input: "IN_CONTAINS",
+			want:  policy.SubjectMappingOperatorEnum_SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS,
+		},
+		{
+			name:    "NOT_IN rejected",
+			input:   "NOT_IN",
+			wantErr: true,
+		},
+		{
+			name:    "UNSPECIFIED rejected",
+			input:   "UNSPECIFIED",
+			wantErr: true,
+		},
+		{
+			name:    "unknown rejected",
+			input:   "SOMETHING_ELSE",
+			wantErr: true,
+		},
+		{
+			name:    "empty rejected",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateDynamicValueMappingOperator(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
@@ -7,11 +7,9 @@ command:
     - add
     - c
   flags:
-    - name: attribute-definition-id
-      description: The ID of the Attribute Definition to scope the mapping to
+    - name: attribute
+      description: URI or ID of the Attribute Definition to scope the mapping to
       shorthand: a
-    - name: attribute-definition-fqn
-      description: The FQN of the Attribute Definition to scope the mapping to
     - name: selector
       description: Selector for a field on the flattened Entity Representation (e.g. '.patientAssignments[]')
       shorthand: s
@@ -23,10 +21,8 @@ command:
         - IN_CONTAINS
     - name: action
       description: Each 'id' or 'name' of an Action to be entitled (i.e. 'create', 'read', 'update', 'delete'). At least one is required.
-    - name: subject-condition-set-id
-      description: Known preexisting Subject Condition Set Id to use as a static pre-gate
-    - name: subject-condition-set-new
-      description: JSON array of Subject Sets to create a new static pre-gate Subject Condition Set associated with the created Dynamic Value Mapping
+    - name: subject-condition-set
+      description: "Static pre-gate Subject Condition Set: either a known preexisting Subject Condition Set ID, or a JSON array of Subject Sets to create a new one"
     - name: namespace
       description: Namespace ID or FQN
       shorthand: n
@@ -43,12 +39,12 @@ The `--operator` must be one of `IN` (exact match) or `IN_CONTAINS` (substring m
 design). `NOT_IN` is not supported because dynamic resolution is existential over the resolved entity
 values.
 
-Exactly one of `--attribute-definition-id` or `--attribute-definition-fqn` is required. A HIERARCHY
-Attribute Definition is not supported.
+The `--attribute` flag is required and accepts either the URI (FQN) or ID of the Attribute
+Definition to scope the mapping to. A HIERARCHY Attribute Definition is not supported.
 
-Optionally provide a static pre-gate Subject Condition Set with either `--subject-condition-set-id`
-(existing) or `--subject-condition-set-new` (JSON to create a new one). When a gate is present, both
-the gate and the resolver must pass for entitlement.
+Optionally provide a static pre-gate Subject Condition Set with `--subject-condition-set`, which
+accepts either an existing Subject Condition Set ID or a JSON array of Subject Sets to create a new
+one. When a gate is present, both the gate and the resolver must pass for entitlement.
 
 For more information about attribute definitions, see the `attributes` subcommand.
 
@@ -58,17 +54,17 @@ For more information about subject condition sets, see the `subject-condition-se
 
 Create a dynamic value mapping entitling 'read' where a patient assignment matches the requested value:
 ```shell
-otdfctl policy dynamic-value-mappings create --attribute-definition-id 891cfe85-b381-4f85-9699-5f7dbfe2a9ab --selector '.patientAssignments[]' --operator IN --action read
+otdfctl policy dynamic-value-mappings create --attribute 891cfe85-b381-4f85-9699-5f7dbfe2a9ab --selector '.patientAssignments[]' --operator IN --action read
 ```
 
 Create a dynamic value mapping scoped by Attribute Definition FQN with a substring operator:
 ```shell
-otdfctl policy dynamic-value-mappings create --attribute-definition-fqn https://hospital.co/attr/mrn --selector '.patientAssignments[]' --operator IN_CONTAINS --action read
+otdfctl policy dynamic-value-mappings create --attribute https://hospital.co/attr/mrn --selector '.patientAssignments[]' --operator IN_CONTAINS --action read
 ```
 
 Create a dynamic value mapping with a static pre-gate Subject Condition Set:
 ```shell
-otdfctl policy dynamic-value-mappings create --attribute-definition-id 891cfe85-b381-4f85-9699-5f7dbfe2a9ab --selector '.patientAssignments[]' --operator IN --action read --subject-condition-set-new '[
+otdfctl policy dynamic-value-mappings create --attribute 891cfe85-b381-4f85-9699-5f7dbfe2a9ab --selector '.patientAssignments[]' --operator IN --action read --subject-condition-set '[
   {
     "condition_groups": [
       {

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
@@ -53,16 +53,19 @@ For more information about subject condition sets, see the `subject-condition-se
 ## Examples
 
 Create a dynamic value mapping entitling 'read' where a patient assignment matches the requested value:
+
 ```shell
 otdfctl policy dynamic-value-mappings create --attribute 891cfe85-b381-4f85-9699-5f7dbfe2a9ab --selector '.patientAssignments[]' --operator IN --action read
 ```
 
 Create a dynamic value mapping scoped by Attribute Definition FQN with a substring operator:
+
 ```shell
 otdfctl policy dynamic-value-mappings create --attribute https://hospital.co/attr/mrn --selector '.patientAssignments[]' --operator IN_CONTAINS --action read
 ```
 
 Create a dynamic value mapping with a static pre-gate Subject Condition Set:
+
 ```shell
 otdfctl policy dynamic-value-mappings create --attribute 891cfe85-b381-4f85-9699-5f7dbfe2a9ab --selector '.patientAssignments[]' --operator IN --action read --subject-condition-set '[
   {

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/delete.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/delete.md
@@ -17,3 +17,15 @@ command:
 Delete a Dynamic Value Mapping by its ID.
 
 For more information about dynamic value mappings, see the `dynamic-value-mappings` subcommand.
+
+## Examples
+
+Delete a dynamic value mapping by ID (prompts for confirmation):
+```shell
+otdfctl policy dynamic-value-mappings delete --id 3c51a593-cd4d-4b74-9f97-3b3b6b0a6f21
+```
+
+Delete without the interactive confirmation:
+```shell
+otdfctl policy dynamic-value-mappings delete --id 3c51a593-cd4d-4b74-9f97-3b3b6b0a6f21 --force
+```

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/delete.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/delete.md
@@ -21,11 +21,13 @@ For more information about dynamic value mappings, see the `dynamic-value-mappin
 ## Examples
 
 Delete a dynamic value mapping by ID (prompts for confirmation):
+
 ```shell
 otdfctl policy dynamic-value-mappings delete --id 3c51a593-cd4d-4b74-9f97-3b3b6b0a6f21
 ```
 
 Delete without the interactive confirmation:
+
 ```shell
 otdfctl policy dynamic-value-mappings delete --id 3c51a593-cd4d-4b74-9f97-3b3b6b0a6f21 --force
 ```

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/get.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/get.md
@@ -15,3 +15,15 @@ command:
 Retrieve the specifics of a Dynamic Value Mapping by its ID.
 
 For more information about dynamic value mappings, see the `dynamic-value-mappings` subcommand.
+
+## Examples
+
+Get a dynamic value mapping by ID:
+```shell
+otdfctl policy dynamic-value-mappings get --id 3c51a593-cd4d-4b74-9f97-3b3b6b0a6f21
+```
+
+Get a dynamic value mapping as JSON:
+```shell
+otdfctl policy dynamic-value-mappings get --id 3c51a593-cd4d-4b74-9f97-3b3b6b0a6f21 --json
+```

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/get.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/get.md
@@ -19,11 +19,13 @@ For more information about dynamic value mappings, see the `dynamic-value-mappin
 ## Examples
 
 Get a dynamic value mapping by ID:
+
 ```shell
 otdfctl policy dynamic-value-mappings get --id 3c51a593-cd4d-4b74-9f97-3b3b6b0a6f21
 ```
 
 Get a dynamic value mapping as JSON:
+
 ```shell
 otdfctl policy dynamic-value-mappings get --id 3c51a593-cd4d-4b74-9f97-3b3b6b0a6f21 --json
 ```

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/list.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/list.md
@@ -8,8 +8,9 @@ command:
     - name: namespace
       shorthand: n
       description: Namespace ID or FQN to filter results
-    - name: attribute-definition-id
-      description: Attribute Definition ID to filter results
+    - name: attribute
+      shorthand: a
+      description: URI or ID of the Attribute Definition to filter results
     - name: limit
       shorthand: l
       description: Limit retrieved count

--- a/otdfctl/e2e/dynamic-value-mapping.bats
+++ b/otdfctl/e2e/dynamic-value-mapping.bats
@@ -43,7 +43,7 @@ teardown_file() {
 }
 
 @test "Create dynamic value mapping" {
-    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
         assert_success
         assert_output --partial "Attribute Definition: Id"
         assert_output --partial "Resolver: Selector"
@@ -51,7 +51,7 @@ teardown_file() {
         assert_line --regexp "Attribute Definition: Id.*$DVM_ATTR_ID"
 
     # json shape
-    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN_CONTAINS --action "$ACTION_READ_NAME" --json
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN_CONTAINS --action "$ACTION_READ_NAME" --json
         assert_success
         [ "$(echo "$output" | jq -r '.attribute_definition.id')" = "$DVM_ATTR_ID" ]
         [ "$(echo "$output" | jq -r '.value_resolver.subject_external_selector_value')" = "$SELECTOR" ]
@@ -61,7 +61,7 @@ teardown_file() {
 }
 
 @test "Create dynamic value mapping with a static pre-gate subject condition set" {
-    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --subject-condition-set "$SCS_1" --json
         assert_success
         assert_not_equal "$(echo "$output" | jq -r '.subject_condition_set.id')" "null"
         assert_not_equal "$(echo "$output" | jq -r '.subject_condition_set.id')" ""
@@ -69,45 +69,45 @@ teardown_file() {
 }
 
 @test "Create dynamic value mapping by attribute definition FQN" {
-    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-fqn "$DVM_ATTR_FQN" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute "$DVM_ATTR_FQN" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json
         assert_success
         assert_equal "$(echo "$output" | jq -r '.attribute_definition.fqn')" "$DVM_ATTR_FQN"
 }
 
 @test "Create dynamic value mapping with namespace ID and FQN" {
-    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_ID" --json
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_ID" --json
         assert_success
         assert_equal "$(echo "$output" | jq -r '.namespace.id')" "$NS_ID"
 
-    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_FQN" --json
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mappings create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_FQN" --json
         assert_success
         assert_equal "$(echo "$output" | jq -r '.namespace.id')" "$NS_ID"
 }
 
 @test "Create dynamic value mapping rejects invalid input" {
     # NOT_IN operator is rejected client-side
-    run_otdfctl_dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator NOT_IN --action "$ACTION_READ_NAME"
+    run_otdfctl_dvm create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator NOT_IN --action "$ACTION_READ_NAME"
         assert_failure
         assert_output --partial "Invalid --operator"
 
     # operator is required
-    run_otdfctl_dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --action "$ACTION_READ_NAME"
+    run_otdfctl_dvm create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --action "$ACTION_READ_NAME"
         assert_failure
         assert_output --partial "resolver operator [--operator] is required"
 
     # an attribute definition reference is required
     run_otdfctl_dvm create --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
         assert_failure
-        assert_output --partial "[--attribute-definition-id, --attribute-definition-fqn] is required"
+        assert_output --partial "Attribute Definition reference [--attribute] is required"
 
     # an action is required
-    run_otdfctl_dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN
+    run_otdfctl_dvm create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN
         assert_failure
         assert_output --partial "At least one Action [--action] is required"
 }
 
 @test "Create dynamic value mapping rejects a HIERARCHY definition" {
-    run_otdfctl_dvm create --attribute-definition-id "$DVM_HIER_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
+    run_otdfctl_dvm create --attribute "$DVM_HIER_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
         assert_failure
 }
 
@@ -120,17 +120,17 @@ teardown_file() {
     assert_not_equal "$coex_val_id" ""
 
     # attach a value-level subject mapping to the definition
-    run ./otdfctl $HOST $WITH_CREDS policy subject-mappings create -a "$coex_val_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json
+    run ./otdfctl $HOST $WITH_CREDS policy subject-mappings create -a "$coex_val_id" --action "$ACTION_READ_NAME" --subject-condition-set "$SCS_1" --json
     assert_success
 
     # a dynamic value mapping on the same definition must be rejected by the server
-    run_otdfctl_dvm create --attribute-definition-id "$coex_attr_id" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
+    run_otdfctl_dvm create --attribute "$coex_attr_id" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
         assert_failure
 }
 
 @test "Get dynamic value mapping" {
     # exercise the singular 'dynamic-value-mapping' alias here
-    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mapping create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json
+    run ./otdfctl $HOST $WITH_CREDS policy dynamic-value-mapping create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json
         assert_success
         created=$(echo "$output" | jq -r '.id')
         assert_not_equal "$created" "null"
@@ -151,7 +151,7 @@ teardown_file() {
 }
 
 @test "List dynamic value mappings" {
-    created=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json | jq -r '.id')
+    created=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json | jq -r '.id')
 
     run_otdfctl_dvm list
         assert_success
@@ -166,13 +166,19 @@ teardown_file() {
         [[ "$total" -ge 1 ]]
 
     # filter by attribute definition id
-    run_otdfctl_dvm list --attribute-definition-id "$DVM_ATTR_ID" --json
+    run_otdfctl_dvm list --attribute "$DVM_ATTR_ID" --json
         assert_success
+        assert_equal "$(echo "$output" | jq -r --arg id "$DVM_ATTR_ID" '[.dynamic_value_mappings[] | select(.attribute_definition.id != $id)] | length')" "0"
+
+    # filter by attribute definition FQN (resolved to its ID client-side)
+    run_otdfctl_dvm list --attribute "$DVM_ATTR_FQN" --json
+        assert_success
+        assert_equal "$(echo "$output" | jq -r --arg id "$created" '.dynamic_value_mappings[] | select(.id == $id) | .id')" "$created"
         assert_equal "$(echo "$output" | jq -r --arg id "$DVM_ATTR_ID" '[.dynamic_value_mappings[] | select(.attribute_definition.id != $id)] | length')" "0"
 }
 
 @test "List dynamic value mappings supports namespace filter" {
-    created=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_ID" --json | jq -r '.id')
+    created=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_ID" --json | jq -r '.id')
 
     run_otdfctl_dvm list --namespace "$NS_ID" --json
         assert_success
@@ -186,8 +192,8 @@ teardown_file() {
 
 @test "List dynamic value mappings supports sort and order flags" {
     sort_attr=$(./otdfctl $HOST $WITH_CREDS policy attributes create --namespace "$NS_ID" --name "sort_dvm_${BATS_TEST_NUMBER}_$RANDOM" --rule ANY_OF --json | jq -r '.id')
-    dvm_a=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$sort_attr" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_ID" --json | jq -r '.id')
-    dvm_b=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$sort_attr" --selector "$SELECTOR" --operator IN --action "$ACTION_CREATE_NAME" --namespace "$NS_ID" --json | jq -r '.id')
+    dvm_a=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute "$sort_attr" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --namespace "$NS_ID" --json | jq -r '.id')
+    dvm_b=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute "$sort_attr" --selector "$SELECTOR" --operator IN --action "$ACTION_CREATE_NAME" --namespace "$NS_ID" --json | jq -r '.id')
 
     run_otdfctl_dvm list --namespace "$NS_ID" --sort created_at --order asc --limit 500 --json
         assert_success
@@ -199,7 +205,7 @@ teardown_file() {
 }
 
 @test "Update a dynamic value mapping" {
-    created=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json | jq -r '.id')
+    created=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json | jq -r '.id')
 
     # replace the actions
     run_otdfctl_dvm update --id "$created" --action "$ACTION_CREATE_NAME" --json
@@ -219,14 +225,14 @@ teardown_file() {
         [ "$(echo "$output" | jq -r '.value_resolver.subject_external_selector_value')" = ".newSelector[]" ]
         [ "$(echo "$output" | jq -r '.value_resolver.operator')" = "3" ]
 
-    # selector and operator must be provided together
+    # selector and operator must be provided together (enforced by cobra flag grouping)
     run_otdfctl_dvm update --id "$created" --selector ".onlySelector[]"
         assert_failure
-        assert_output --partial "Both [--selector, --operator] must be provided together"
+        assert_output --partial "if any flags in the group [selector operator] are set they must all be set"
 }
 
 @test "Delete dynamic value mapping" {
-    to_delete=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute-definition-id "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json | jq -r '.id')
+    to_delete=$(./otdfctl $HOST $WITH_CREDS policy dvm create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME" --json | jq -r '.id')
 
     run_otdfctl_dvm delete --id "$to_delete" --force
         assert_success

--- a/otdfctl/e2e/dynamic-value-mapping.bats
+++ b/otdfctl/e2e/dynamic-value-mapping.bats
@@ -120,7 +120,7 @@ teardown_file() {
     assert_not_equal "$coex_val_id" ""
 
     # attach a value-level subject mapping to the definition
-    run ./otdfctl $HOST $WITH_CREDS policy subject-mappings create -a "$coex_val_id" --action "$ACTION_READ_NAME" --subject-condition-set "$SCS_1" --json
+    run ./otdfctl $HOST $WITH_CREDS policy subject-mappings create -a "$coex_val_id" --action "$ACTION_READ_NAME" --subject-condition-set-new "$SCS_1" --json
     assert_success
 
     # a dynamic value mapping on the same definition must be rejected by the server

--- a/otdfctl/e2e/dynamic-value-mapping.bats
+++ b/otdfctl/e2e/dynamic-value-mapping.bats
@@ -88,7 +88,7 @@ teardown_file() {
     # NOT_IN operator is rejected client-side
     run_otdfctl_dvm create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator NOT_IN --action "$ACTION_READ_NAME"
         assert_failure
-        assert_output --partial "Invalid --operator"
+        assert_output --partial "invalid --operator"
 
     # operator is required
     run_otdfctl_dvm create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --action "$ACTION_READ_NAME"

--- a/otdfctl/pkg/handlers/dynamicvaluemappings.go
+++ b/otdfctl/pkg/handlers/dynamicvaluemappings.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/opentdf/platform/protocol/go/common"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/protocol/go/policy/dynamicvaluemapping"
@@ -14,6 +15,15 @@ import (
 // values, so a negative operator is not supported.
 var DynamicValueMappingOperatorEnumChoices = []string{SubjectMappingOperatorIn, SubjectMappingOperatorInContains}
 
+// getAttributeDefinitionIDAndFQN splits a single attribute definition reference into its ID and FQN
+// components: a UUID is treated as an ID, anything else as an FQN. Mirrors getNamespaceIDAndFQN.
+func getAttributeDefinitionIDAndFQN(attribute string) (string, string) {
+	if _, err := uuid.Parse(attribute); err != nil {
+		return "", attribute
+	}
+	return attribute, ""
+}
+
 func (h Handler) GetDynamicValueMapping(ctx context.Context, id string) (*policy.DynamicValueMapping, error) {
 	resp, err := h.sdk.DynamicValueMapping.GetDynamicValueMapping(ctx, &dynamicvaluemapping.GetDynamicValueMappingRequest{
 		Id: id,
@@ -21,7 +31,7 @@ func (h Handler) GetDynamicValueMapping(ctx context.Context, id string) (*policy
 	return resp.GetDynamicValueMapping(), err
 }
 
-func (h Handler) ListDynamicValueMappings(ctx context.Context, limit, offset int32, namespace, attrDefID string, sort SortOption) (*dynamicvaluemapping.ListDynamicValueMappingsResponse, error) {
+func (h Handler) ListDynamicValueMappings(ctx context.Context, limit, offset int32, namespace, attribute string, sort SortOption) (*dynamicvaluemapping.ListDynamicValueMappingsResponse, error) {
 	req := &dynamicvaluemapping.ListDynamicValueMappingsRequest{
 		Pagination: &policy.PageRequest{
 			Limit:  limit,
@@ -29,8 +39,17 @@ func (h Handler) ListDynamicValueMappings(ctx context.Context, limit, offset int
 		},
 	}
 	req.NamespaceId, req.NamespaceFqn = getNamespaceIDAndFQN(namespace)
-	if attrDefID != "" {
-		req.AttributeDefinitionId = attrDefID
+	// The list request filters by Attribute Definition ID only, so resolve an FQN to its ID client-side.
+	if attribute != "" {
+		if _, err := uuid.Parse(attribute); err == nil {
+			req.AttributeDefinitionId = attribute
+		} else {
+			attr, err := h.GetAttribute(ctx, attribute)
+			if err != nil {
+				return nil, err
+			}
+			req.AttributeDefinitionId = attr.GetId()
+		}
 	}
 	if !sort.IsZero() {
 		allowedFields := map[string]dynamicvaluemapping.SortDynamicValueMappingsType{
@@ -47,7 +66,8 @@ func (h Handler) ListDynamicValueMappings(ctx context.Context, limit, offset int
 }
 
 // Creates and returns the created dynamic value mapping
-func (h Handler) CreateDynamicValueMapping(ctx context.Context, attrDefID, attrDefFQN string, resolver *policy.DynamicValueResolver, actions []*policy.Action, existingSCSID string, newSCS *subjectmapping.SubjectConditionSetCreate, namespace string, m *common.MetadataMutable) (*policy.DynamicValueMapping, error) {
+func (h Handler) CreateDynamicValueMapping(ctx context.Context, attribute string, resolver *policy.DynamicValueResolver, actions []*policy.Action, existingSCSID string, newSCS *subjectmapping.SubjectConditionSetCreate, namespace string, m *common.MetadataMutable) (*policy.DynamicValueMapping, error) {
+	attrDefID, attrDefFQN := getAttributeDefinitionIDAndFQN(attribute)
 	req := &dynamicvaluemapping.CreateDynamicValueMappingRequest{
 		AttributeDefinitionId:         attrDefID,
 		AttributeDefinitionFqn:        attrDefFQN,

--- a/otdfctl/pkg/handlers/dynamicvaluemappings_test.go
+++ b/otdfctl/pkg/handlers/dynamicvaluemappings_test.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAttributeDefinitionIDAndFQN(t *testing.T) {
+	uuid := "891cfe85-b381-4f85-9699-5f7dbfe2a9ab"
+	fqn := "https://hospital.co/attr/mrn"
+
+	tests := []struct {
+		name    string
+		input   string
+		wantID  string
+		wantFQN string
+	}{
+		{
+			name:   "uuid is treated as an id",
+			input:  uuid,
+			wantID: uuid,
+		},
+		{
+			name:    "fqn is treated as an fqn",
+			input:   fqn,
+			wantFQN: fqn,
+		},
+		{
+			name:    "non-uuid string is treated as an fqn",
+			input:   "not-a-uuid",
+			wantFQN: "not-a-uuid",
+		},
+		{
+			name:  "empty string yields empty id and fqn",
+			input: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotFQN := getAttributeDefinitionIDAndFQN(tt.input)
+			require.Equal(t, tt.wantID, gotID)
+			require.Equal(t, tt.wantFQN, gotFQN)
+		})
+	}
+}

--- a/service/entityresolution/claims/v2/entity_resolution.go
+++ b/service/entityresolution/claims/v2/entity_resolution.go
@@ -31,12 +31,12 @@ type EntityResolutionServiceV2 struct {
 	trace.Tracer
 }
 
-type ClaimsConfig struct {
+type Config struct {
 	AllowDirectEntitlements bool `mapstructure:"allow_direct_entitlements" json:"allow_direct_entitlements" default:"false"`
 }
 
 func RegisterClaimsERS(cfg config.ServiceConfig, logger *logger.Logger) (EntityResolutionServiceV2, serviceregistry.HandlerServer) {
-	var inputConfig ClaimsConfig
+	var inputConfig Config
 	if err := mapstructure.Decode(cfg, &inputConfig); err != nil {
 		logger.Error("failed to decode claims entity resolution configuration", slog.Any("error", err))
 		log.Fatalf("Failed to decode claims entity resolution configuration: %v", err)

--- a/service/entityresolution/claims/v2/entity_resolution.go
+++ b/service/entityresolution/claims/v2/entity_resolution.go
@@ -178,9 +178,11 @@ func parseDirectEntitlementsFromClaims(entityStruct *structpb.Struct) ([]*entity
 }
 
 func parseDirectEntitlementFQN(entry map[string]interface{}) (string, error) {
+	// Attribute value FQNs are case-insensitive in policy and the PDP lowercases resource FQNs
+	// before matching, so normalize here to avoid a mixed-case claim being missed and denied.
 	if raw, ok := entry["attribute_value_fqn"]; ok {
 		if fqn, fqnOK := raw.(string); fqnOK {
-			fqn = strings.TrimSpace(fqn)
+			fqn = strings.ToLower(strings.TrimSpace(fqn))
 			if fqn != "" {
 				return fqn, nil
 			}
@@ -188,7 +190,7 @@ func parseDirectEntitlementFQN(entry map[string]interface{}) (string, error) {
 	}
 	if raw, ok := entry["attributeValueFqn"]; ok {
 		if fqn, fqnOK := raw.(string); fqnOK {
-			fqn = strings.TrimSpace(fqn)
+			fqn = strings.ToLower(strings.TrimSpace(fqn))
 			if fqn != "" {
 				return fqn, nil
 			}

--- a/service/entityresolution/claims/v2/entity_resolution.go
+++ b/service/entityresolution/claims/v2/entity_resolution.go
@@ -2,11 +2,15 @@ package claims
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"log/slog"
 	"strconv"
+	"strings"
 
 	"connectrpc.com/connect"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/opentdf/platform/protocol/go/entity"
 	entityresolutionV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
@@ -22,17 +26,30 @@ import (
 
 type EntityResolutionServiceV2 struct {
 	entityresolutionV2.UnimplementedEntityResolutionServiceServer
-	logger *logger.Logger
+	logger                  *logger.Logger
+	allowDirectEntitlements bool
 	trace.Tracer
 }
 
-func RegisterClaimsERS(_ config.ServiceConfig, logger *logger.Logger) (EntityResolutionServiceV2, serviceregistry.HandlerServer) {
-	claimsSVC := EntityResolutionServiceV2{logger: logger}
+type ClaimsConfig struct {
+	AllowDirectEntitlements bool `mapstructure:"allow_direct_entitlements" json:"allow_direct_entitlements" default:"false"`
+}
+
+func RegisterClaimsERS(cfg config.ServiceConfig, logger *logger.Logger) (EntityResolutionServiceV2, serviceregistry.HandlerServer) {
+	var inputConfig ClaimsConfig
+	if err := mapstructure.Decode(cfg, &inputConfig); err != nil {
+		logger.Error("failed to decode claims entity resolution configuration", slog.Any("error", err))
+		log.Fatalf("Failed to decode claims entity resolution configuration: %v", err)
+	}
+	claimsSVC := EntityResolutionServiceV2{
+		logger:                  logger,
+		allowDirectEntitlements: inputConfig.AllowDirectEntitlements,
+	}
 	return claimsSVC, nil
 }
 
 func (s EntityResolutionServiceV2) ResolveEntities(ctx context.Context, req *connect.Request[entityresolutionV2.ResolveEntitiesRequest]) (*connect.Response[entityresolutionV2.ResolveEntitiesResponse], error) {
-	resp, err := EntityResolution(ctx, req.Msg, s.logger)
+	resp, err := EntityResolution(ctx, req.Msg, s.logger, s.allowDirectEntitlements)
 	return connect.NewResponse(&resp), err
 }
 
@@ -63,13 +80,14 @@ func CreateEntityChainsFromTokens(
 }
 
 func EntityResolution(_ context.Context,
-	req *entityresolutionV2.ResolveEntitiesRequest, logger *logger.Logger,
+	req *entityresolutionV2.ResolveEntitiesRequest, logger *logger.Logger, allowDirectEntitlements bool,
 ) (entityresolutionV2.ResolveEntitiesResponse, error) {
 	payload := req.GetEntities()
 	var resolvedEntities []*entityresolutionV2.EntityRepresentation
 
 	for idx, ident := range payload {
 		entityStruct := &structpb.Struct{}
+		var directEntitlements []*entityresolutionV2.DirectEntitlement
 		switch ident.GetEntityType().(type) {
 		case *entity.Entity_Claims:
 			claims := ident.GetClaims()
@@ -77,6 +95,13 @@ func EntityResolution(_ context.Context,
 				err := claims.UnmarshalTo(entityStruct)
 				if err != nil {
 					return entityresolutionV2.ResolveEntitiesResponse{}, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("error unpacking anypb.Any to structpb.Struct: %w", err))
+				}
+			}
+			if allowDirectEntitlements {
+				var err error
+				directEntitlements, err = parseDirectEntitlementsFromClaims(entityStruct)
+				if err != nil {
+					return entityresolutionV2.ResolveEntitiesResponse{}, connect.NewError(connect.CodeInvalidArgument, err)
 				}
 			}
 		default:
@@ -95,12 +120,119 @@ func EntityResolution(_ context.Context,
 		resolvedEntities = append(
 			resolvedEntities,
 			&entityresolutionV2.EntityRepresentation{
-				OriginalId:      originialID,
-				AdditionalProps: []*structpb.Struct{entityStruct},
+				OriginalId:         originialID,
+				AdditionalProps:    []*structpb.Struct{entityStruct},
+				DirectEntitlements: directEntitlements,
 			},
 		)
 	}
 	return entityresolutionV2.ResolveEntitiesResponse{EntityRepresentations: resolvedEntities}, nil
+}
+
+func parseDirectEntitlementsFromClaims(entityStruct *structpb.Struct) ([]*entityresolutionV2.DirectEntitlement, error) {
+	if entityStruct == nil {
+		return nil, nil
+	}
+	claims := entityStruct.AsMap()
+	rawEntitlements, ok := claims["direct_entitlements"]
+	if !ok {
+		rawEntitlements, ok = claims["directEntitlements"]
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	entitlementList, entitlementsOK := rawEntitlements.([]interface{})
+	if !entitlementsOK {
+		return nil, errors.New("direct_entitlements must be an array")
+	}
+
+	out := make([]*entityresolutionV2.DirectEntitlement, 0, len(entitlementList))
+	for idx, entry := range entitlementList {
+		entryMap, entryOK := entry.(map[string]interface{})
+		if !entryOK {
+			return nil, fmt.Errorf("direct_entitlements[%d] must be an object", idx)
+		}
+
+		fqn, err := parseDirectEntitlementFQN(entryMap)
+		if err != nil {
+			return nil, fmt.Errorf("direct_entitlements[%d] %w", idx, err)
+		}
+
+		rawActions, actionsOK := entryMap["actions"]
+		if !actionsOK {
+			return nil, fmt.Errorf("direct_entitlements[%d] missing actions", idx)
+		}
+		actions, err := parseDirectEntitlementActions(rawActions)
+		if err != nil {
+			return nil, fmt.Errorf("direct_entitlements[%d] invalid actions: %w", idx, err)
+		}
+
+		out = append(out, &entityresolutionV2.DirectEntitlement{
+			AttributeValueFqn: fqn,
+			Actions:           actions,
+		})
+	}
+
+	return out, nil
+}
+
+func parseDirectEntitlementFQN(entry map[string]interface{}) (string, error) {
+	if raw, ok := entry["attribute_value_fqn"]; ok {
+		if fqn, fqnOK := raw.(string); fqnOK {
+			fqn = strings.TrimSpace(fqn)
+			if fqn != "" {
+				return fqn, nil
+			}
+		}
+	}
+	if raw, ok := entry["attributeValueFqn"]; ok {
+		if fqn, fqnOK := raw.(string); fqnOK {
+			fqn = strings.TrimSpace(fqn)
+			if fqn != "" {
+				return fqn, nil
+			}
+		}
+	}
+	return "", errors.New("missing attribute_value_fqn")
+}
+
+func parseDirectEntitlementActions(raw interface{}) ([]string, error) {
+	actions := make([]string, 0)
+	switch typed := raw.(type) {
+	case []interface{}:
+		for _, action := range typed {
+			actionStr, ok := action.(string)
+			if !ok {
+				return nil, errors.New("action must be a string")
+			}
+			actionStr = strings.TrimSpace(strings.ToLower(actionStr))
+			if actionStr != "" {
+				actions = append(actions, actionStr)
+			}
+		}
+	case []string:
+		for _, action := range typed {
+			action = strings.TrimSpace(strings.ToLower(action))
+			if action != "" {
+				actions = append(actions, action)
+			}
+		}
+	case string:
+		for _, action := range strings.Split(typed, ",") {
+			action = strings.TrimSpace(strings.ToLower(action))
+			if action != "" {
+				actions = append(actions, action)
+			}
+		}
+	default:
+		return nil, errors.New("actions must be an array or string")
+	}
+
+	if len(actions) == 0 {
+		return nil, errors.New("no actions provided")
+	}
+	return actions, nil
 }
 
 func getEntitiesFromToken(jwtString string) ([]*entity.Entity, error) {

--- a/service/entityresolution/claims/v2/entity_resolution.go
+++ b/service/entityresolution/claims/v2/entity_resolution.go
@@ -32,7 +32,7 @@ type EntityResolutionServiceV2 struct {
 }
 
 type Config struct {
-	AllowDirectEntitlements bool `mapstructure:"allow_direct_entitlements" json:"allow_direct_entitlements" default:"false"`
+	AllowDirectEntitlements bool `mapstructure:"allow_direct_entitlements" json:"allow_direct_entitlements"`
 }
 
 func RegisterClaimsERS(cfg config.ServiceConfig, logger *logger.Logger) (EntityResolutionServiceV2, serviceregistry.HandlerServer) {

--- a/service/entityresolution/claims/v2/entity_resolution.go
+++ b/service/entityresolution/claims/v2/entity_resolution.go
@@ -38,7 +38,6 @@ type Config struct {
 func RegisterClaimsERS(cfg config.ServiceConfig, logger *logger.Logger) (EntityResolutionServiceV2, serviceregistry.HandlerServer) {
 	var inputConfig Config
 	if err := mapstructure.Decode(cfg, &inputConfig); err != nil {
-		logger.Error("failed to decode claims entity resolution configuration", slog.Any("error", err))
 		log.Fatalf("Failed to decode claims entity resolution configuration: %v", err)
 	}
 	claimsSVC := EntityResolutionServiceV2{

--- a/service/entityresolution/claims/v2/entity_resolution_test.go
+++ b/service/entityresolution/claims/v2/entity_resolution_test.go
@@ -22,7 +22,7 @@ func Test_ClientResolveEntity(t *testing.T) {
 	req := entityresolutionV2.ResolveEntitiesRequest{}
 	req.Entities = validBody
 
-	resp, reserr := claims.EntityResolution(t.Context(), &req, logger.CreateTestLogger())
+	resp, reserr := claims.EntityResolution(t.Context(), &req, logger.CreateTestLogger(), false)
 
 	require.NoError(t, reserr)
 
@@ -44,7 +44,7 @@ func Test_EmailResolveEntity(t *testing.T) {
 	req := entityresolutionV2.ResolveEntitiesRequest{}
 	req.Entities = validBody
 
-	resp, reserr := claims.EntityResolution(t.Context(), &req, logger.CreateTestLogger())
+	resp, reserr := claims.EntityResolution(t.Context(), &req, logger.CreateTestLogger(), false)
 
 	require.NoError(t, reserr)
 
@@ -78,7 +78,7 @@ func Test_ClaimsResolveEntity(t *testing.T) {
 	req := entityresolutionV2.ResolveEntitiesRequest{}
 	req.Entities = validBody
 
-	resp, reserr := claims.EntityResolution(t.Context(), &req, logger.CreateTestLogger())
+	resp, reserr := claims.EntityResolution(t.Context(), &req, logger.CreateTestLogger(), false)
 
 	require.NoError(t, reserr)
 
@@ -91,6 +91,65 @@ func Test_ClaimsResolveEntity(t *testing.T) {
 	propMap := entityRepresentations[0].GetAdditionalProps()[0].AsMap()
 	assert.Equal(t, "bar", propMap["foo"])
 	assert.EqualValues(t, 42, propMap["baz"])
+}
+
+func Test_ClaimsResolveEntityDirectEntitlements(t *testing.T) {
+	customclaims := map[string]interface{}{
+		"direct_entitlements": []interface{}{
+			map[string]interface{}{
+				"attribute_value_fqn": "https://example.com/attr/department/value/eng",
+				"actions":             []interface{}{"read", "update"},
+			},
+		},
+	}
+	structClaims, err := structpb.NewStruct(customclaims)
+	require.NoError(t, err)
+
+	anyClaims, err := anypb.New(structClaims)
+	require.NoError(t, err)
+
+	var validBody []*entity.Entity
+	validBody = append(validBody, &entity.Entity{EphemeralId: "1234", EntityType: &entity.Entity_Claims{Claims: anyClaims}})
+
+	req := entityresolutionV2.ResolveEntitiesRequest{Entities: validBody}
+
+	resp, reserr := claims.EntityResolution(t.Context(), &req, logger.CreateTestLogger(), true)
+	require.NoError(t, reserr)
+
+	entityRepresentations := resp.GetEntityRepresentations()
+	require.Len(t, entityRepresentations, 1)
+
+	entitlements := entityRepresentations[0].GetDirectEntitlements()
+	require.Len(t, entitlements, 1)
+	assert.Equal(t, "https://example.com/attr/department/value/eng", entitlements[0].GetAttributeValueFqn())
+	assert.ElementsMatch(t, []string{"read", "update"}, entitlements[0].GetActions())
+}
+
+func Test_ClaimsResolveEntityDirectEntitlementsDisabled(t *testing.T) {
+	customclaims := map[string]interface{}{
+		"direct_entitlements": []interface{}{
+			map[string]interface{}{
+				"attribute_value_fqn": "https://example.com/attr/department/value/eng",
+				"actions":             []interface{}{"read"},
+			},
+		},
+	}
+	structClaims, err := structpb.NewStruct(customclaims)
+	require.NoError(t, err)
+
+	anyClaims, err := anypb.New(structClaims)
+	require.NoError(t, err)
+
+	req := entityresolutionV2.ResolveEntitiesRequest{Entities: []*entity.Entity{
+		{EphemeralId: "1234", EntityType: &entity.Entity_Claims{Claims: anyClaims}},
+	}}
+
+	resp, reserr := claims.EntityResolution(t.Context(), &req, logger.CreateTestLogger(), false)
+	require.NoError(t, reserr)
+
+	entityRepresentations := resp.GetEntityRepresentations()
+	require.Len(t, entityRepresentations, 1)
+	assert.Empty(t, entityRepresentations[0].GetDirectEntitlements())
 }
 
 func Test_JWTToEntityChainClaims(t *testing.T) {

--- a/service/entityresolution/claims/v2/entity_resolution_test.go
+++ b/service/entityresolution/claims/v2/entity_resolution_test.go
@@ -3,6 +3,7 @@ package claims_test
 import (
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/opentdf/platform/protocol/go/entity"
 	entityresolutionV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
 	claims "github.com/opentdf/platform/service/entityresolution/claims/v2"
@@ -150,6 +151,93 @@ func Test_ClaimsResolveEntityDirectEntitlementsDisabled(t *testing.T) {
 	entityRepresentations := resp.GetEntityRepresentations()
 	require.Len(t, entityRepresentations, 1)
 	assert.Empty(t, entityRepresentations[0].GetDirectEntitlements())
+}
+
+func Test_ClaimsResolveEntityDirectEntitlementsFQNNormalized(t *testing.T) {
+	customclaims := map[string]interface{}{
+		"direct_entitlements": []interface{}{
+			map[string]interface{}{
+				"attribute_value_fqn": "https://Example.com/attr/Department/value/ENG",
+				"actions":             []interface{}{"Read"},
+			},
+		},
+	}
+	structClaims, err := structpb.NewStruct(customclaims)
+	require.NoError(t, err)
+	anyClaims, err := anypb.New(structClaims)
+	require.NoError(t, err)
+
+	req := entityresolutionV2.ResolveEntitiesRequest{Entities: []*entity.Entity{
+		{EphemeralId: "1234", EntityType: &entity.Entity_Claims{Claims: anyClaims}},
+	}}
+
+	resp, reserr := claims.EntityResolution(t.Context(), &req, logger.CreateTestLogger(), true)
+	require.NoError(t, reserr)
+
+	entitlements := resp.GetEntityRepresentations()[0].GetDirectEntitlements()
+	require.Len(t, entitlements, 1)
+	// FQN is lowercased to match how the PDP normalizes resource FQNs; actions are lowercased too.
+	assert.Equal(t, "https://example.com/attr/department/value/eng", entitlements[0].GetAttributeValueFqn())
+	assert.ElementsMatch(t, []string{"read"}, entitlements[0].GetActions())
+}
+
+func Test_ClaimsResolveEntityDirectEntitlementsMalformed(t *testing.T) {
+	testCases := []struct {
+		name   string
+		claims map[string]interface{}
+	}{
+		{
+			name:   "direct_entitlements not an array",
+			claims: map[string]interface{}{"direct_entitlements": "not-an-array"},
+		},
+		{
+			name: "entry missing attribute_value_fqn",
+			claims: map[string]interface{}{"direct_entitlements": []interface{}{
+				map[string]interface{}{"actions": []interface{}{"read"}},
+			}},
+		},
+		{
+			name: "entry missing actions",
+			claims: map[string]interface{}{"direct_entitlements": []interface{}{
+				map[string]interface{}{"attribute_value_fqn": "https://example.com/attr/department/value/eng"},
+			}},
+		},
+		{
+			name: "entry with empty actions",
+			claims: map[string]interface{}{"direct_entitlements": []interface{}{
+				map[string]interface{}{
+					"attribute_value_fqn": "https://example.com/attr/department/value/eng",
+					"actions":             []interface{}{},
+				},
+			}},
+		},
+		{
+			name: "entry with non-string action",
+			claims: map[string]interface{}{"direct_entitlements": []interface{}{
+				map[string]interface{}{
+					"attribute_value_fqn": "https://example.com/attr/department/value/eng",
+					"actions":             []interface{}{42},
+				},
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			structClaims, err := structpb.NewStruct(tc.claims)
+			require.NoError(t, err)
+			anyClaims, err := anypb.New(structClaims)
+			require.NoError(t, err)
+
+			req := entityresolutionV2.ResolveEntitiesRequest{Entities: []*entity.Entity{
+				{EphemeralId: "1234", EntityType: &entity.Entity_Claims{Claims: anyClaims}},
+			}}
+
+			_, reserr := claims.EntityResolution(t.Context(), &req, logger.CreateTestLogger(), true)
+			require.Error(t, reserr)
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(reserr))
+		})
+	}
 }
 
 func Test_JWTToEntityChainClaims(t *testing.T) {

--- a/tests-bdd/cukes/resources/platform.direct_entitlements.template
+++ b/tests-bdd/cukes/resources/platform.direct_entitlements.template
@@ -1,0 +1,112 @@
+# BDD platform template for direct entitlement decisioning.
+# Tracks platform.template but runs the claims ERS (so direct_entitlements
+# supplied on the entity representation are honored) and enables the
+# experimental allow_direct_entitlements flag on both the authorization and
+# entityresolution services.
+logger:
+  level: debug
+  type: text
+  output: stderr
+mode: all
+db:
+  host: {{ .pgHost }}
+  port: {{ .pgPort }}
+  database: {{ .pgDatabase }}
+  user: postgres
+  password: changeme
+  schema: otdf
+services:
+  authorization:
+    allow_direct_entitlements: true
+  kas:
+    registered_kas_uri: http://{{ .hostname }}:{{ .platformPort }}
+    preview:
+      ec_tdf_enabled: false
+      key_management: false
+    root_key: a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1 # For local development testing only
+    keyring:
+      - kid: e1
+        alg: ec:secp256r1
+      - kid: e1
+        alg: ec:secp256r1
+        legacy: true
+      - kid: r1
+        alg: rsa:2048
+      - kid: r1
+        alg: rsa:2048
+        legacy: true
+  entityresolution:
+    mode: claims
+    allow_direct_entitlements: true
+server:
+  public_hostname: {{ .hostname }}
+  tls:
+    enabled: false
+    cert: ./keys/platform.crt
+    key: ./keys/platform-key.pem
+  auth:
+    enabled: true
+    enforceDPoP: false
+    audience: "http://{{ .hostname }}:{{ .platformPort }}"
+    issuer: http://{{ .hostname }}:{{ .kcPort }}/auth/realms/{{ .authRealm }}
+    policy:
+      username_claim:
+      groups_claim:
+      client_id_claim:
+      extension: |
+        g, opentdf-admin, role:admin
+        g, opentdf-standard, role:standard
+      csv:
+      model:
+  trace:
+    enabled: false
+    provider:
+      name: file
+      file:
+        path: "./traces/traces.log"
+        prettyPrint: true
+        maxSize: 50
+        maxBackups: 5
+        maxAge: 14
+        compress: true
+  cors:
+    enabled: true
+    allowedorigins:
+      - "*"
+    allowedmethods:
+      - GET
+      - POST
+      - PATCH
+      - PUT
+      - DELETE
+      - OPTIONS
+    allowedheaders:
+      - Accept
+      - Accept-Encoding
+      - Authorization
+      - Connect-Protocol-Version
+      - Content-Length
+      - Content-Type
+      - Dpop
+      - X-CSRF-Token
+      - X-Requested-With
+      - X-Rewrap-Additional-Context
+    exposedheaders:
+      - Link
+    allowcredentials: true
+    maxage: 3600
+  grpc:
+    reflectionEnabled: true
+  cryptoProvider:
+    type: standard
+    standard:
+      keys:
+        - kid: r1
+          alg: rsa:2048
+          private: {{ .platformKeysDir }}/kas-private.pem
+          cert: {{ .platformKeysDir }}/kas-cert.pem
+        - kid: e1
+          alg: ec:secp256r1
+          private: {{ .platformKeysDir }}/kas-ec-private.pem
+          cert: {{ .platformKeysDir }}/kas-ec-cert.pem
+  port: {{ .platformPort }}

--- a/tests-bdd/cukes/resources/platform.dynamic_value_mappings.template
+++ b/tests-bdd/cukes/resources/platform.dynamic_value_mappings.template
@@ -1,0 +1,118 @@
+# BDD platform template for dynamic value mapping decisioning.
+# Tracks platform.template; the only functional addition is enabling the
+# experimental allow_dynamic_value_mappings flag on the authorization service.
+logger:
+  level: debug
+  type: text
+  output: stderr
+mode: all
+db:
+  host: {{ .pgHost }}
+  port: {{ .pgPort }}
+  database: {{ .pgDatabase }}
+  user: postgres
+  password: changeme
+  schema: otdf
+services:
+  authorization:
+    allow_dynamic_value_mappings: true
+  kas:
+    registered_kas_uri: http://{{ .hostname }}:{{ .platformPort }}
+    preview:
+      ec_tdf_enabled: false
+      key_management: false
+    root_key: a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1 # For local development testing only
+    keyring:
+      - kid: e1
+        alg: ec:secp256r1
+      - kid: e1
+        alg: ec:secp256r1
+        legacy: true
+      - kid: r1
+        alg: rsa:2048
+      - kid: r1
+        alg: rsa:2048
+        legacy: true
+  entityresolution:
+    log_level: info
+    url: http://{{ .hostname }}:{{ .kcPort }}/auth
+    clientid: "tdf-entity-resolution"
+    clientsecret: "secret"
+    realm: "{{ .authRealm }}"
+    legacykeycloak: true
+    inferid:
+      from:
+        email: true
+        username: true
+server:
+  public_hostname: {{ .hostname }}
+  tls:
+    enabled: false
+    cert: ./keys/platform.crt
+    key: ./keys/platform-key.pem
+  auth:
+    enabled: true
+    enforceDPoP: false
+    audience: "http://{{ .hostname }}:{{ .platformPort }}"
+    issuer: http://{{ .hostname }}:{{ .kcPort }}/auth/realms/{{ .authRealm }}
+    policy:
+      username_claim:
+      groups_claim:
+      client_id_claim:
+      extension: |
+        g, opentdf-admin, role:admin
+        g, opentdf-standard, role:standard
+      csv:
+      model:
+  trace:
+    enabled: false
+    provider:
+      name: file
+      file:
+        path: "./traces/traces.log"
+        prettyPrint: true
+        maxSize: 50
+        maxBackups: 5
+        maxAge: 14
+        compress: true
+  cors:
+    enabled: true
+    allowedorigins:
+      - "*"
+    allowedmethods:
+      - GET
+      - POST
+      - PATCH
+      - PUT
+      - DELETE
+      - OPTIONS
+    allowedheaders:
+      - Accept
+      - Accept-Encoding
+      - Authorization
+      - Connect-Protocol-Version
+      - Content-Length
+      - Content-Type
+      - Dpop
+      - X-CSRF-Token
+      - X-Requested-With
+      - X-Rewrap-Additional-Context
+    exposedheaders:
+      - Link
+    allowcredentials: true
+    maxage: 3600
+  grpc:
+    reflectionEnabled: true
+  cryptoProvider:
+    type: standard
+    standard:
+      keys:
+        - kid: r1
+          alg: rsa:2048
+          private: {{ .platformKeysDir }}/kas-private.pem
+          cert: {{ .platformKeysDir }}/kas-cert.pem
+        - kid: e1
+          alg: ec:secp256r1
+          private: {{ .platformKeysDir }}/kas-ec-private.pem
+          cert: {{ .platformKeysDir }}/kas-ec-cert.pem
+  port: {{ .platformPort }}

--- a/tests-bdd/cukes/steps_directentitlements.go
+++ b/tests-bdd/cukes/steps_directentitlements.go
@@ -1,0 +1,201 @@
+package cukes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cucumber/godog"
+	"github.com/opentdf/platform/protocol/go/entity"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type DirectEntitlementsStepDefinitions struct{}
+
+const (
+	directEntitlementColumnAttributeFQN = "attribute_value_fqn"
+	directEntitlementColumnActions      = "actions"
+)
+
+// thereIsAClaimsSubjectEntityReferencedAsWithDirectEntitlements records a claims subject entity
+// whose claims carry direct_entitlements, so the claims ERS (with allow_direct_entitlements) emits
+// them on the entity representation for the PDP.
+func (s *DirectEntitlementsStepDefinitions) thereIsAClaimsSubjectEntityReferencedAsWithDirectEntitlements(ctx context.Context, referenceID string, tbl *godog.Table) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	directEntitlements, err := parseDirectEntitlementsTable(tbl)
+	if err != nil {
+		return ctx, err
+	}
+
+	claims := map[string]interface{}{
+		"direct_entitlements": directEntitlements,
+	}
+	structClaims, err := structpb.NewStruct(claims)
+	if err != nil {
+		return ctx, err
+	}
+	anyClaims, err := anypb.New(structClaims)
+	if err != nil {
+		return ctx, err
+	}
+
+	subjectEntity := &entity.Entity{
+		EphemeralId: referenceID,
+		Category:    entity.Entity_CATEGORY_SUBJECT,
+		EntityType:  &entity.Entity_Claims{Claims: anyClaims},
+	}
+	scenarioContext.RecordObject(referenceID, subjectEntity)
+	return ctx, nil
+}
+
+// iAddClaimsToSubjectEntityWith merges additional claims into an existing claims subject entity so a
+// subject mapping can also apply alongside direct entitlements.
+func (s *DirectEntitlementsStepDefinitions) iAddClaimsToSubjectEntityWith(ctx context.Context, referenceID string, tbl *godog.Table) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	entityObj, ok := scenarioContext.GetObject(referenceID).(*entity.Entity)
+	if !ok || entityObj == nil {
+		return ctx, fmt.Errorf("entity %s not found or invalid type", referenceID)
+	}
+	if entityObj.GetClaims() == nil {
+		return ctx, errors.New("entity does not contain claims")
+	}
+
+	claimsStruct := &structpb.Struct{}
+	if err := entityObj.GetClaims().UnmarshalTo(claimsStruct); err != nil {
+		return ctx, err
+	}
+	claimsMap := claimsStruct.AsMap()
+
+	updates, err := parseClaimsTable(tbl)
+	if err != nil {
+		return ctx, err
+	}
+	for key, value := range updates {
+		claimsMap[key] = value
+	}
+
+	updatedStruct, err := structpb.NewStruct(claimsMap)
+	if err != nil {
+		return ctx, err
+	}
+	anyClaims, err := anypb.New(updatedStruct)
+	if err != nil {
+		return ctx, err
+	}
+
+	entityObj.EntityType = &entity.Entity_Claims{Claims: anyClaims}
+	scenarioContext.RecordObject(referenceID, entityObj)
+	return ctx, nil
+}
+
+func parseDirectEntitlementsTable(tbl *godog.Table) ([]interface{}, error) {
+	if tbl == nil || len(tbl.Rows) == 0 {
+		return nil, errors.New("direct entitlements table is empty")
+	}
+
+	cellMap := map[string]int{}
+	for ci, cell := range tbl.Rows[0].Cells {
+		cellMap[cell.Value] = ci
+	}
+
+	attrIdx, ok := cellMap[directEntitlementColumnAttributeFQN]
+	if !ok {
+		return nil, fmt.Errorf("direct entitlements table requires column %s", directEntitlementColumnAttributeFQN)
+	}
+	actionsIdx, ok := cellMap[directEntitlementColumnActions]
+	if !ok {
+		return nil, fmt.Errorf("direct entitlements table requires column %s", directEntitlementColumnActions)
+	}
+
+	out := make([]interface{}, 0, len(tbl.Rows)-1)
+	for ri, row := range tbl.Rows {
+		if ri == 0 {
+			continue
+		}
+		attrFQN := strings.TrimSpace(row.Cells[attrIdx].Value)
+		if attrFQN == "" {
+			return nil, errors.New("direct entitlements require attribute_value_fqn values")
+		}
+
+		rawActions := ""
+		if actionsIdx < len(row.Cells) {
+			rawActions = row.Cells[actionsIdx].Value
+		}
+		actions := make([]interface{}, 0)
+		for _, action := range strings.Split(rawActions, ",") {
+			action = strings.TrimSpace(action)
+			if action == "" {
+				continue
+			}
+			actions = append(actions, strings.ToLower(action))
+		}
+		if len(actions) == 0 {
+			return nil, fmt.Errorf("direct entitlement for %s requires actions", attrFQN)
+		}
+
+		out = append(out, map[string]interface{}{
+			"attribute_value_fqn": attrFQN,
+			"actions":             actions,
+		})
+	}
+
+	if len(out) == 0 {
+		return nil, errors.New("direct entitlements table has no rows")
+	}
+
+	return out, nil
+}
+
+func parseClaimsTable(tbl *godog.Table) (map[string]interface{}, error) {
+	if tbl == nil || len(tbl.Rows) == 0 {
+		return nil, errors.New("claims table is empty")
+	}
+
+	cellMap := map[string]int{}
+	for ci, cell := range tbl.Rows[0].Cells {
+		cellMap[cell.Value] = ci
+	}
+
+	nameIdx, ok := cellMap["name"]
+	if !ok {
+		return nil, errors.New("claims table requires column name")
+	}
+	valueIdx, ok := cellMap["value"]
+	if !ok {
+		return nil, errors.New("claims table requires column value")
+	}
+
+	out := map[string]interface{}{}
+	for ri, row := range tbl.Rows {
+		if ri == 0 {
+			continue
+		}
+		key := strings.TrimSpace(row.Cells[nameIdx].Value)
+		if key == "" {
+			return nil, errors.New("claims table requires name values")
+		}
+		rawValue := ""
+		if valueIdx < len(row.Cells) {
+			rawValue = strings.TrimSpace(row.Cells[valueIdx].Value)
+		}
+
+		var parsed interface{}
+		if rawValue != "" {
+			if err := json.Unmarshal([]byte(rawValue), &parsed); err != nil {
+				parsed = rawValue
+			}
+		}
+		out[key] = parsed
+	}
+
+	return out, nil
+}
+
+func RegisterDirectEntitlementsStepDefinitions(ctx *godog.ScenarioContext) {
+	stepDefinitions := &DirectEntitlementsStepDefinitions{}
+	ctx.Step(`^there is a claims subject entity referenced as "([^"]*)" with direct entitlements:$`, stepDefinitions.thereIsAClaimsSubjectEntityReferencedAsWithDirectEntitlements)
+	ctx.Step(`^I add claims to subject entity "([^"]*)" with:$`, stepDefinitions.iAddClaimsToSubjectEntityWith)
+}

--- a/tests-bdd/cukes/steps_dynamicvaluemappings.go
+++ b/tests-bdd/cukes/steps_dynamicvaluemappings.go
@@ -1,0 +1,90 @@
+package cukes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cucumber/godog"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/dynamicvaluemapping"
+)
+
+type DynamicValueMappingsStepDefinitions struct{}
+
+// iSendARequestToCreateDynamicValueMapping creates one dynamic value mapping per data row via the
+// SDK. Supported columns: attribute_definition_fqn, selector, operator (IN|IN_CONTAINS),
+// standard actions, custom actions, condition_set_name (optional static pre-gate), reference_id.
+func (s *DynamicValueMappingsStepDefinitions) iSendARequestToCreateDynamicValueMapping(ctx context.Context, tbl *godog.Table) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	scenarioContext.ClearError()
+
+	cellIndexMap := make(map[int]string)
+	requests := []*dynamicvaluemapping.CreateDynamicValueMappingRequest{}
+	referenceIDs := []string{}
+
+	for ri, r := range tbl.Rows {
+		req := &dynamicvaluemapping.CreateDynamicValueMappingRequest{}
+		resolver := &policy.DynamicValueResolver{}
+		var standardActions *string
+		var customActions *string
+		referenceID := ""
+		for ci, c := range r.Cells {
+			if ri == 0 {
+				cellIndexMap[ci] = c.Value
+				continue
+			}
+			value := strings.TrimSpace(c.Value)
+			switch cellIndexMap[ci] {
+			case "attribute_definition_fqn":
+				req.AttributeDefinitionFqn = value
+			case "selector":
+				resolver.SubjectExternalSelectorValue = value
+			case "operator":
+				op, ok := policy.SubjectMappingOperatorEnum_value["SUBJECT_MAPPING_OPERATOR_ENUM_"+strings.ToUpper(value)]
+				if !ok {
+					return ctx, fmt.Errorf("invalid dynamic value resolver operator: %s", value)
+				}
+				resolver.Operator = policy.SubjectMappingOperatorEnum(op)
+			case "condition_set_name":
+				scs, ok := scenarioContext.GetObject(value).(*policy.SubjectConditionSet)
+				if !ok {
+					return ctx, fmt.Errorf("unable to get condition set for %s", value)
+				}
+				req.ExistingSubjectConditionSetId = scs.GetId()
+			case "standard actions":
+				standardActions = &c.Value
+			case "custom actions":
+				customActions = &c.Value
+			case "reference_id":
+				referenceID = value
+			default:
+				return ctx, fmt.Errorf("invalid dynamic value mapping column: %s", cellIndexMap[ci])
+			}
+		}
+		if ri > 0 {
+			req.ValueResolver = resolver
+			req.Actions = GetActionsFromValues(standardActions, customActions)
+			requests = append(requests, req)
+			referenceIDs = append(referenceIDs, referenceID)
+		}
+	}
+
+	for i, req := range requests {
+		resp, err := scenarioContext.SDK.DynamicValueMapping.CreateDynamicValueMapping(ctx, req)
+		scenarioContext.SetError(err)
+		if err != nil {
+			return ctx, err
+		}
+		if resp != nil && referenceIDs[i] != "" {
+			scenarioContext.RecordObject(referenceIDs[i], resp.GetDynamicValueMapping())
+		}
+	}
+
+	return ctx, nil
+}
+
+func RegisterDynamicValueMappingsStepDefinitions(ctx *godog.ScenarioContext) {
+	stepDefinitions := &DynamicValueMappingsStepDefinitions{}
+	ctx.Step(`^I send a request to create a dynamic value mapping with:$`, stepDefinitions.iSendARequestToCreateDynamicValueMapping)
+}

--- a/tests-bdd/features/direct-entitlements.feature
+++ b/tests-bdd/features/direct-entitlements.feature
@@ -1,0 +1,66 @@
+@direct-entitlements
+Feature: Direct entitlements decisioning
+  Validates direct entitlement evaluation through the AuthorizationV2 PDP (the
+  same decision path KAS rewrap invokes). A direct entitlement is carried on the
+  entity representation by the claims ERS and grants a subject an action on an
+  attribute value without a subject mapping. Requires allow_direct_entitlements.
+
+  Background:
+    Given a local platform with platform template "cukes/resources/platform.direct_entitlements.template" and keycloak template "cukes/resources/keycloak_base.template"
+    And I submit a request to create a namespace with name "example.com" and reference id "ns1"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values     |
+      | ns1          | department | anyOf | eng,hr     |
+      | ns1          | project    | allOf | alpha,beta |
+    Then the response should be successful
+
+  Scenario: Direct entitlement permits a matching action
+    Given there is a claims subject entity referenced as "alice" with direct entitlements:
+      | attribute_value_fqn                           | actions |
+      | https://example.com/attr/department/value/eng | read    |
+    When I send a decision request for entity chain "alice" for "read" action on resource "https://example.com/attr/department/value/eng"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response
+
+  Scenario: Direct entitlement denies an action mismatch
+    Given there is a claims subject entity referenced as "alice" with direct entitlements:
+      | attribute_value_fqn                           | actions |
+      | https://example.com/attr/department/value/eng | read    |
+    When I send a decision request for entity chain "alice" for "update" action on resource "https://example.com/attr/department/value/eng"
+    Then the response should be successful
+    And I should get a "DENY" decision response
+
+  Scenario: Direct entitlement denies when the entitled value differs
+    Given there is a claims subject entity referenced as "alice" with direct entitlements:
+      | attribute_value_fqn                           | actions |
+      | https://example.com/attr/department/value/eng | read    |
+    When I send a decision request for entity chain "alice" for "read" action on resource "https://example.com/attr/department/value/hr"
+    Then the response should be successful
+    And I should get a "DENY" decision response
+
+  Scenario: Direct entitlement permits a synthetic value not pre-provisioned in policy
+    Given there is a claims subject entity referenced as "alice" with direct entitlements:
+      | attribute_value_fqn                               | actions |
+      | https://example.com/attr/department/value/finance | read    |
+    When I send a decision request for entity chain "alice" for "read" action on resource "https://example.com/attr/department/value/finance"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response
+
+  Scenario: Subject mapping and direct entitlement together satisfy an ALL_OF resource
+    Given there is a claims subject entity referenced as "alice" with direct entitlements:
+      | attribute_value_fqn                            | actions |
+      | https://example.com/attr/project/value/beta    | read    |
+    And I add claims to subject entity "alice" with:
+      | name       | value                 |
+      | attributes | {"project":["alpha"]} |
+    And a condition group referenced as "cg_project_alpha" with an "or" operator with conditions:
+      | selector_value        | operator | values |
+      | .attributes.project[] | in       | alpha  |
+    And a subject set referenced as "ss_project_alpha" containing the condition groups "cg_project_alpha"
+    And I send a request to create a subject condition set referenced as "scs_project_alpha" containing subject sets "ss_project_alpha"
+    And I send a request to create a subject mapping with:
+      | reference_id     | attribute_value                              | condition_set_name | standard actions | custom actions |
+      | sm_project_alpha | https://example.com/attr/project/value/alpha | scs_project_alpha  | read             |                |
+    When I send a decision request for entity chain "alice" for "read" action on resource "https://example.com/attr/project/value/alpha,https://example.com/attr/project/value/beta"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response

--- a/tests-bdd/features/dynamic-value-mappings.feature
+++ b/tests-bdd/features/dynamic-value-mappings.feature
@@ -15,9 +15,14 @@ Feature: Encrypt and decrypt with dynamic value mappings
       | name       | value       |
       | department | ["finance"] |
       | clearance  | ["alpha"]   |
+    And a user exists with username "carol" and email "carol@example.com" and the following attributes:
+      | name       | value           |
+      | department | ["engineering"] |
+      | clearance  | ["beta"]        |
     And a local platform with platform template "cukes/resources/platform.dynamic_value_mappings.template" and keycloak template "cukes/resources/keycloak_base.template"
     And a user token for "alice" stored as "alice_tok"
     And a user token for "bob" stored as "bob_tok"
+    And a user token for "carol" stored as "carol_tok"
     And I submit a request to create a namespace with name "example.com" and reference id "ns1"
     And I send a request to create an attribute with:
       | namespace_id | name      | rule  | values             |
@@ -60,7 +65,10 @@ Feature: Encrypt and decrypt with dynamic value mappings
     And the response should be successful
     When I encrypt plaintext "gated engineering" with attributes "https://example.com/attr/team/value/engineering" stored as "tdf_gated"
     And using token "alice_tok", decrypt "tdf_gated" stored as "alice_gated"
+    And using token "carol_tok", decrypt "tdf_gated" stored as "carol_gated"
     Then the decryption stored as "alice_gated" should succeed with plaintext "gated engineering"
+    # carol matches the mapping (department engineering) but fails the static pre-gate (no clearance alpha)
+    And the decryption stored as "carol_gated" should be denied
 
   Scenario: ALL_OF multi-value requires entitlement to every bound value
     Given I send a request to create a dynamic value mapping with:

--- a/tests-bdd/features/dynamic-value-mappings.feature
+++ b/tests-bdd/features/dynamic-value-mappings.feature
@@ -1,0 +1,74 @@
+@dynamic-value-mappings
+Feature: Encrypt and decrypt with dynamic value mappings
+  Validates that a Dynamic Value Mapping entitles a subject to decrypt a TDF
+  bound to an attribute value under the mapped definition, without a per-value
+  subject mapping. Entitlement is resolved at decision time by comparing the
+  requested resource value segment against a selector on the entity
+  representation (keycloak ERS). Requires allow_dynamic_value_mappings.
+
+  Background:
+    Given a user exists with username "alice" and email "alice@example.com" and the following attributes:
+      | name       | value            |
+      | department | ["engineering"]  |
+      | clearance  | ["alpha","beta"] |
+    And a user exists with username "bob" and email "bob@example.com" and the following attributes:
+      | name       | value       |
+      | department | ["finance"] |
+      | clearance  | ["alpha"]   |
+    And a local platform with platform template "cukes/resources/platform.dynamic_value_mappings.template" and keycloak template "cukes/resources/keycloak_base.template"
+    And a user token for "alice" stored as "alice_tok"
+    And a user token for "bob" stored as "bob_tok"
+    And I submit a request to create a namespace with name "example.com" and reference id "ns1"
+    And I send a request to create an attribute with:
+      | namespace_id | name      | rule  | values             |
+      | ns1          | team      | anyOf | engineering,finance |
+      | ns1          | project   | anyOf | engineer            |
+      | ns1          | clearance | allOf | alpha,beta          |
+    Then the response should be successful
+
+  Scenario: IN operator permits an exact department match and denies others
+    Given I send a request to create a dynamic value mapping with:
+      | attribute_definition_fqn      | selector               | operator | standard actions | reference_id |
+      | https://example.com/attr/team | .attributes.department[] | IN       | read             | dvm_team     |
+    And the response should be successful
+    When I encrypt plaintext "team engineering" with attributes "https://example.com/attr/team/value/engineering" stored as "tdf_in"
+    And using token "alice_tok", decrypt "tdf_in" stored as "alice_in"
+    And using token "bob_tok", decrypt "tdf_in" stored as "bob_in"
+    Then the decryption stored as "alice_in" should succeed with plaintext "team engineering"
+    And the decryption stored as "bob_in" should be denied
+
+  Scenario: IN_CONTAINS operator permits a substring match
+    Given I send a request to create a dynamic value mapping with:
+      | attribute_definition_fqn         | selector               | operator    | standard actions | reference_id |
+      | https://example.com/attr/project | .attributes.department[] | IN_CONTAINS | read             | dvm_project  |
+    And the response should be successful
+    When I encrypt plaintext "substring match" with attributes "https://example.com/attr/project/value/engineer" stored as "tdf_contains"
+    And using token "alice_tok", decrypt "tdf_contains" stored as "alice_contains"
+    And using token "bob_tok", decrypt "tdf_contains" stored as "bob_contains"
+    Then the decryption stored as "alice_contains" should succeed with plaintext "substring match"
+    And the decryption stored as "bob_contains" should be denied
+
+  Scenario: Static pre-gate must also pass for entitlement
+    Given a condition group referenced as "cg_alpha" with an "or" operator with conditions:
+      | selector_value        | operator | values |
+      | .attributes.clearance[] | in       | alpha  |
+    And a subject set referenced as "ss_alpha" containing the condition groups "cg_alpha"
+    And I send a request to create a subject condition set referenced as "scs_alpha" containing subject sets "ss_alpha"
+    And I send a request to create a dynamic value mapping with:
+      | attribute_definition_fqn      | selector               | operator | standard actions | condition_set_name | reference_id |
+      | https://example.com/attr/team | .attributes.department[] | IN       | read             | scs_alpha          | dvm_gated    |
+    And the response should be successful
+    When I encrypt plaintext "gated engineering" with attributes "https://example.com/attr/team/value/engineering" stored as "tdf_gated"
+    And using token "alice_tok", decrypt "tdf_gated" stored as "alice_gated"
+    Then the decryption stored as "alice_gated" should succeed with plaintext "gated engineering"
+
+  Scenario: ALL_OF multi-value requires entitlement to every bound value
+    Given I send a request to create a dynamic value mapping with:
+      | attribute_definition_fqn           | selector              | operator | standard actions | reference_id  |
+      | https://example.com/attr/clearance | .attributes.clearance[] | IN       | read             | dvm_clearance |
+    And the response should be successful
+    When I encrypt plaintext "all of clearance" with attributes "https://example.com/attr/clearance/value/alpha,https://example.com/attr/clearance/value/beta" stored as "tdf_allof"
+    And using token "alice_tok", decrypt "tdf_allof" stored as "alice_allof"
+    And using token "bob_tok", decrypt "tdf_allof" stored as "bob_allof"
+    Then the decryption stored as "alice_allof" should succeed with plaintext "all of clearance"
+    And the decryption stored as "bob_allof" should be denied

--- a/tests-bdd/go.mod
+++ b/tests-bdd/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/opentdf/platform/lib/fixtures v0.3.0
 	github.com/opentdf/platform/lib/identifier v0.0.2
-	github.com/opentdf/platform/lib/ocrypto v0.10.0
-	github.com/opentdf/platform/protocol/go v0.30.0
-	github.com/opentdf/platform/sdk v0.17.0
+	github.com/opentdf/platform/lib/ocrypto v0.14.0
+	github.com/opentdf/platform/protocol/go v0.37.0
+	github.com/opentdf/platform/sdk v0.25.0
 	github.com/opentdf/platform/service v0.7.2
 	github.com/spf13/pflag v1.0.10
 	github.com/testcontainers/testcontainers-go v0.42.0
@@ -22,7 +22,7 @@ require (
 )
 
 require (
-	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250613105001-9f2d3c737feb.1 // indirect
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1 // indirect
 	buf.build/go/protovalidate v0.13.1 // indirect
 	cel.dev/expr v0.25.1 // indirect
 	connectrpc.com/grpchealth v1.4.0 // indirect
@@ -31,7 +31,7 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/DefangLabs/secret-detector v0.0.0-20250403165618-22662109213e // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Nerzal/gocloak/v13 v13.9.0 // indirect
@@ -47,6 +47,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/compose-spec/compose-go/v2 v2.10.2 // indirect
 	github.com/containerd/console v1.0.5 // indirect
 	github.com/containerd/containerd/api v1.10.0 // indirect

--- a/tests-bdd/go.sum
+++ b/tests-bdd/go.sum
@@ -1,5 +1,5 @@
-buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250613105001-9f2d3c737feb.1 h1:AUL6VF5YWL01j/1H/DQbPUSDkEwYqwVCNw7yhbpOxSQ=
-buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250613105001-9f2d3c737feb.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1 h1:s6hzCXtND/ICdGPTMGk7C+/BFlr2Jg5GyH0NKf4XGXg=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
 buf.build/go/protovalidate v0.13.1 h1:6loHDTWdY/1qmqmt1MijBIKeN4T9Eajrqb9isT1W1s8=
 buf.build/go/protovalidate v0.13.1/go.mod h1:C/QcOn/CjXRn5udUwYBiLs8y1TGy7RS+GOSKqjS77aU=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
@@ -22,8 +22,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/DefangLabs/secret-detector v0.0.0-20250403165618-22662109213e h1:rd4bOvKmDIx0WeTv9Qz+hghsgyjikFiPrseXHlKepO0=
 github.com/DefangLabs/secret-detector v0.0.0-20250403165618-22662109213e/go.mod h1:blbwPQh4DTlCZEfk1BLU4oMIhLda2U+A840Uag9DsZw=
-github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
-github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -459,12 +459,12 @@ github.com/opentdf/platform/lib/flattening v0.1.3 h1:IuOm/wJVXNrzOV676Ticgr0wyBk
 github.com/opentdf/platform/lib/flattening v0.1.3/go.mod h1:Gs/T+6FGZKk9OAdz2Jf1R8CTGeNRYrq1lZGDeYT3hrY=
 github.com/opentdf/platform/lib/identifier v0.0.2 h1:h3zR+IZ/4/X5UOYUp/aTA0OcX1QqsmgSiqjaM0uttFE=
 github.com/opentdf/platform/lib/identifier v0.0.2/go.mod h1:/tHnLlSVOq3qmbIYSvKrtuZchQfagenv4wG5twl4oRs=
-github.com/opentdf/platform/lib/ocrypto v0.10.0 h1:7dn/z/1qH3p+gWCrfOoU7hj9XF/p5N+b2JBJuWF9aK0=
-github.com/opentdf/platform/lib/ocrypto v0.10.0/go.mod h1:WASkoHreqgTFImB/gJW42VTdpi9AkgkmaW19y/fU+Ew=
-github.com/opentdf/platform/protocol/go v0.30.0 h1:mdYTPpbnSdTPYO7XKixK7a4mDf6RpRaF7J4dZCw0Qq8=
-github.com/opentdf/platform/protocol/go v0.30.0/go.mod h1:aiEmtYytvQtbiexZGAKYMe2mYTBPZqbNSh+OXmtrtkA=
-github.com/opentdf/platform/sdk v0.17.0 h1:ApVa0/yB5M2wbqu3s0FxlXo17C1ojuul3tsQW1BGpyk=
-github.com/opentdf/platform/sdk v0.17.0/go.mod h1:U4Ndr/Pr0c3rYik/JGfymT86I2InPIANX7WiFcvr2Pw=
+github.com/opentdf/platform/lib/ocrypto v0.14.0 h1:qAIOFpz72/QDhYC0oLRXgA5uEnyv1xqkc7kvWQSRFcY=
+github.com/opentdf/platform/lib/ocrypto v0.14.0/go.mod h1:TLaMvVE1aTqrgW8AZz0ZuxX/ZpI7l5IQOHyX99fdKl0=
+github.com/opentdf/platform/protocol/go v0.37.0 h1:gA4zlfxbswhEadlK/0L/UYpRjiT166EClbcJQEdYcZ0=
+github.com/opentdf/platform/protocol/go v0.37.0/go.mod h1:6A0vQJ5D4ZTLReWAp8Y/7jTFzlYCmL/IfMJWDHZS6M0=
+github.com/opentdf/platform/sdk v0.25.0 h1:SuHHgdFzaklDCx8zP3p9d06tDgeCbCuNhU/cUKjFd6w=
+github.com/opentdf/platform/sdk v0.25.0/go.mod h1:kl4a4PoV3YoumaL5LTJzdB+SZINyCo4A9IdnLZN9aM4=
 github.com/opentdf/platform/service v0.7.2 h1:GICI2R8yFxiQu10vsS/1c69vN3CLJpkchk9pCLv9vs4=
 github.com/opentdf/platform/service v0.7.2/go.mod h1:Fs2s0SqIWzlcL6fXxYkD9yLf7G/ChjSUi0g/OKtLQ+A=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=

--- a/tests-bdd/platform_test.go
+++ b/tests-bdd/platform_test.go
@@ -110,6 +110,7 @@ func runTests() int {
 			cukes.RegisterSmokeStepDefinitions(ctx, platformCukesContext)
 			cukes.RegisterAuthorizationStepDefinitions(ctx)
 			cukes.RegisterSubjectMappingsStepsDefinitions(ctx)
+			cukes.RegisterDynamicValueMappingsStepDefinitions(ctx)
 			cukes.RegisterRegisteredResourcesStepDefinitions(ctx)
 			cukes.RegisterObligationsStepDefinitions(ctx, platformCukesContext)
 			cukes.RegisterKasRegistryStepDefinitions(ctx)

--- a/tests-bdd/platform_test.go
+++ b/tests-bdd/platform_test.go
@@ -111,6 +111,7 @@ func runTests() int {
 			cukes.RegisterAuthorizationStepDefinitions(ctx)
 			cukes.RegisterSubjectMappingsStepsDefinitions(ctx)
 			cukes.RegisterDynamicValueMappingsStepDefinitions(ctx)
+			cukes.RegisterDirectEntitlementsStepDefinitions(ctx)
 			cukes.RegisterRegisteredResourcesStepDefinitions(ctx)
 			cukes.RegisterObligationsStepDefinitions(ctx, platformCukesContext)
 			cukes.RegisterKasRegistryStepDefinitions(ctx)


### PR DESCRIPTION
### Proposed Changes

* Add claims-ERS support for direct entitlements: parse `direct_entitlements` from entity claims into `EntityRepresentation.DirectEntitlements`, gated by the experimental `allow_direct_entitlements` flag (`service/entityresolution/claims/v2`). Ported from the earlier direct-entitlement work.
* Add BDD e2e coverage for dynamic value mappings via full TDF encrypt/decrypt (keycloak ERS): a new platform template with `allow_dynamic_value_mappings` enabled, a `create a dynamic value mapping` SDK step, and scenarios covering `IN`, `IN_CONTAINS`, a static pre-gate subject condition set, and ALL_OF multi-value (allow + deny).
* Add BDD e2e coverage for direct entitlements via `GetDecision` PERMIT/DENY (the same AuthorizationV2 PDP path KAS rewrap uses, claims ERS): a new platform template with `allow_direct_entitlements` enabled, claims-entity steps, and scenarios covering action match/mismatch, a value not pre-provisioned in policy, and a subject-mapping + direct-entitlement combination.

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

- `cd service && go test ./entityresolution/claims/...`
- Build the BDD platform image and run the two features:
  - `docker build -t platform-cukes .`
  - `cd tests-bdd && PLATFORM_IMAGE=platform-cukes:latest go test -tags cukes -v -run TestFeatures . --godog.tags="@dynamic-value-mappings,@direct-entitlements"`
  - Verified locally: 9 scenarios (9 passed), 106 steps (106 passed).

> Stacked on the otdfctl dynamic-value-mapping CLI branch; base is set accordingly so the diff is limited to this work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claims-based entity resolution can optionally extract and normalize `direct_entitlements` (behind a configuration flag).
  * Added BDD coverage and scenarios for direct-entitlements decisioning and dynamic value mappings.
  * Updated dynamic value mappings CLI management for create/list/get/update/delete flows.
* **Bug Fixes**
  * Malformed `direct_entitlements` now produce clearer invalid-argument errors; FQN/action values are normalized.
* **Tests**
  * Expanded unit and end-to-end BDD suites, including new step definitions and platform templates.
* **Documentation**
  * Refreshed `otdfctl` man pages/examples to match updated dynamic value mappings CLI flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->