### PR TITLE
feat(sdk): add AccessToken accessor to SDK

### DIFF
--- a/sdk/access_token_test.go
+++ b/sdk/access_token_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccessToken_ReturnsTokenFromSource(t *testing.T) {
 	s := &SDK{tokenSource: FakeAccessTokenSource{accessToken: "test-token"}}
 
-	tok, err := s.AccessToken(context.Background())
+	tok, err := s.Auth().AccessToken(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, auth.AccessToken("test-token"), tok)
 }
@@ -20,7 +20,15 @@ func TestAccessToken_ReturnsTokenFromSource(t *testing.T) {
 func TestAccessToken_NoTokenSource(t *testing.T) {
 	s := &SDK{}
 
-	tok, err := s.AccessToken(context.Background())
+	tok, err := s.Auth().AccessToken(context.Background())
 	require.ErrorIs(t, err, ErrNoAccessTokenSource)
+	assert.Empty(t, tok)
+}
+
+func TestAccessToken_EmptyToken(t *testing.T) {
+	s := &SDK{tokenSource: FakeAccessTokenSource{accessToken: ""}}
+
+	tok, err := s.Auth().AccessToken(context.Background())
+	require.ErrorIs(t, err, ErrAccessTokenInvalid)
 	assert.Empty(t, tok)
 }

--- a/sdk/access_token_test.go
+++ b/sdk/access_token_test.go
@@ -1,0 +1,26 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opentdf/platform/sdk/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessToken_ReturnsTokenFromSource(t *testing.T) {
+	s := &SDK{tokenSource: FakeAccessTokenSource{accessToken: "test-token"}}
+
+	tok, err := s.AccessToken(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, auth.AccessToken("test-token"), tok)
+}
+
+func TestAccessToken_NoTokenSource(t *testing.T) {
+	s := &SDK{}
+
+	tok, err := s.AccessToken(context.Background())
+	require.ErrorIs(t, err, ErrNoAccessTokenSource)
+	assert.Empty(t, tok)
+}

--- a/sdk/access_token_test.go
+++ b/sdk/access_token_test.go
@@ -2,8 +2,10 @@ package sdk
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
+	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/opentdf/platform/sdk/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,4 +33,41 @@ func TestAccessToken_EmptyToken(t *testing.T) {
 	tok, err := s.Auth().AccessToken(context.Background())
 	require.ErrorIs(t, err, ErrAccessTokenInvalid)
 	assert.Empty(t, tok)
+}
+
+type recordCtxKey struct{}
+
+// recordingTokenSource captures what AccessToken forwards to it so tests can assert
+// the context and HTTP client are passed through. It records a context value rather
+// than the context itself (avoiding a context.Context struct field) and the client
+// pointer for identity comparison.
+type recordingTokenSource struct {
+	token       string
+	gotCtxValue any
+	gotClient   *http.Client
+}
+
+func (r *recordingTokenSource) AccessToken(ctx context.Context, client *http.Client) (auth.AccessToken, error) {
+	r.gotCtxValue = ctx.Value(recordCtxKey{})
+	r.gotClient = client
+	return auth.AccessToken(r.token), nil
+}
+
+func (r *recordingTokenSource) MakeToken(func(jwk.Key) ([]byte, error)) ([]byte, error) {
+	return nil, nil
+}
+
+func TestAccessToken_ForwardsContextAndClient(t *testing.T) {
+	ctx := context.WithValue(context.Background(), recordCtxKey{}, "value")
+	client := &http.Client{}
+
+	rec := &recordingTokenSource{token: "test-token"}
+	s := &SDK{tokenSource: rec}
+	s.httpClient = client
+
+	tok, err := s.Auth().AccessToken(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, auth.AccessToken("test-token"), tok)
+	assert.Equal(t, "value", rec.gotCtxValue, "context should be forwarded unchanged")
+	assert.Same(t, client, rec.gotClient, "http client should be forwarded unchanged")
 }

--- a/sdk/auth_client.go
+++ b/sdk/auth_client.go
@@ -1,0 +1,34 @@
+package sdk
+
+import (
+	"context"
+
+	"github.com/opentdf/platform/sdk/auth"
+)
+
+// Auth returns an AuthClient for authentication-related operations.
+func (s *SDK) Auth() *AuthClient {
+	return &AuthClient{sdk: s}
+}
+
+// AuthClient groups authentication operations for the SDK.
+type AuthClient struct {
+	sdk *SDK
+}
+
+// AccessToken returns a valid access token for the SDK's configured credentials.
+// It returns ErrNoAccessTokenSource if the SDK was created without credentials, and
+// ErrAccessTokenInvalid if the token source returns an empty token.
+func (a *AuthClient) AccessToken(ctx context.Context) (auth.AccessToken, error) {
+	if a.sdk.tokenSource == nil {
+		return "", ErrNoAccessTokenSource
+	}
+	token, err := a.sdk.tokenSource.AccessToken(ctx, a.sdk.httpClient)
+	if err != nil {
+		return "", err
+	}
+	if token == "" {
+		return "", ErrAccessTokenInvalid
+	}
+	return token, nil
+}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -45,6 +45,7 @@ const (
 	ErrPlatformTokenEndpointNotFound = Error("token_endpoint not found in well-known idp configuration")
 	ErrPlatformEndpointNotFound      = Error("platform_endpoint not found in well-known configuration")
 	ErrAccessTokenInvalid            = Error("access token is invalid")
+	ErrNoAccessTokenSource           = Error("no access token source configured; SDK was created without credentials")
 	ErrWellKnowConfigEmpty           = Error("well-known configuration is empty")
 	ErrAttributeNotFound             = Error("attribute not found")
 )
@@ -303,6 +304,15 @@ func buildIDPTokenSource(c *config) (auth.AccessTokenSource, error) {
 
 func (s SDK) Close() error {
 	return nil
+}
+
+// AccessToken returns a valid access token for the SDK's configured credentials.
+// It returns ErrNoAccessTokenSource if the SDK was constructed without credentials.
+func (s *SDK) AccessToken(ctx context.Context) (auth.AccessToken, error) {
+	if s.tokenSource == nil {
+		return "", ErrNoAccessTokenSource
+	}
+	return s.tokenSource.AccessToken(ctx, s.httpClient)
 }
 
 // Logger returns the configured slog.Logger for this SDK instance

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -306,15 +306,6 @@ func (s SDK) Close() error {
 	return nil
 }
 
-// AccessToken returns a valid access token for the SDK's configured credentials.
-// It returns ErrNoAccessTokenSource if the SDK was constructed without credentials.
-func (s *SDK) AccessToken(ctx context.Context) (auth.AccessToken, error) {
-	if s.tokenSource == nil {
-		return "", ErrNoAccessTokenSource
-	}
-	return s.tokenSource.AccessToken(ctx, s.httpClient)
-}
-
 // Logger returns the configured slog.Logger for this SDK instance
 func (s SDK) Logger() *slog.Logger {
 	return s.logger


### PR DESCRIPTION
### Proposed Changes

* Add a public `AccessToken(ctx context.Context) (auth.AccessToken, error)` method on the `SDK` that returns a valid access token from the configured `tokenSource`, passing the SDK's own HTTP client (the same client the auth interceptor uses).
* Return a new `ErrNoAccessTokenSource` sentinel when the SDK was constructed without credentials (nil token source) instead of panicking. Uncredentialed clients are a supported configuration (`buildIDPTokenSource` returns nil in that case).

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

- `cd sdk && go test . -race -run TestAccessToken`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access-token retrieval through the SDK’s authentication interface.
  * Supports configured token sources and reports clear errors when credentials are unavailable or invalid.

* **Tests**
  * Added coverage for successful token retrieval, missing token sources, and empty tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->