### PR TITLE
chore(ers): expand multi-strategy ERS BDD coverage

### DIFF
--- a/tests-bdd/features/claims-ldap-fallback-ers.feature
+++ b/tests-bdd/features/claims-ldap-fallback-ers.feature
@@ -1,13 +1,14 @@
 @claims-ldap-fallback-ers @stateless
-Feature: Claims-to-LDAP fallback via condition-based strategy routing
-  Validate that condition-based strategy selection correctly routes entity
-  resolution: a claims strategy with condition "department exists" is skipped
-  when the entity lacks a department claim, and the LDAP strategy with
-  condition "userName exists" matches and provides the department from LDAP.
+Feature: Claims-to-LDAP fallback via continue failure strategy
+  Validate that failure_strategy "continue" allows LDAP to resolve entities
+  after the claims strategy fails. The claims strategy condition "userName
+  exists" matches user_name entities, but the claims provider fails because
+  JWTClaimsContextKey is only populated for Entity_Claims — not Entity_UserName.
+  Under "continue", this error is ignored and the LDAP strategy succeeds.
 
-  This demonstrates the fallback pattern where claims serve as a fast path
-  (when claims already contain the needed attributes) and LDAP acts as the
-  fallback (when claims are incomplete).
+  Also validates the claims fast path: when an Entity_Claims entity carries
+  the needed attributes inline, the claims strategy succeeds directly without
+  needing LDAP.
 
   Background:
     Given an LDAP directory with test users
@@ -19,7 +20,7 @@ Feature: Claims-to-LDAP fallback via condition-based strategy routing
       entity_type: subject
       conditions:
         jwt_claims:
-          - claim: department
+          - claim: userName
             operator: exists
       output_mapping:
         - source_claim: department
@@ -52,7 +53,7 @@ Feature: Claims-to-LDAP fallback via condition-based strategy routing
       """
     And a local platform with inline ERS configuration
 
-  Scenario: Entity without department claim falls back to LDAP — engineering user gets PERMIT
+  Scenario: Claims fails for user_name, continue allows LDAP fallback — engineering user gets PERMIT
     Given I submit a request to create a namespace with name "fallback.test" and reference id "ns_fb"
     And I send a request to create an attribute with:
       | namespace_id | name       | rule  | values                         |
@@ -72,7 +73,7 @@ Feature: Claims-to-LDAP fallback via condition-based strategy routing
     Then the response should be successful
     And I should get a "PERMIT" decision response
 
-  Scenario: Entity without department claim falls back to LDAP — operations user gets DENY
+  Scenario: Claims fails for user_name, LDAP resolves non-engineering department — DENY
     Given I submit a request to create a namespace with name "fallback-deny.test" and reference id "ns_fb_deny"
     And I send a request to create an attribute with:
       | namespace_id | name       | rule  | values                         |
@@ -91,3 +92,26 @@ Feature: Claims-to-LDAP fallback via condition-based strategy routing
     When I send a decision request for entity chain "eve_fb" for "read" action on resource "https://fallback-deny.test/attr/department/value/engineering"
     Then the response should be successful
     And I should get a "DENY" decision response
+
+  Scenario: Entity_Claims with department skips LDAP — claims fast path PERMIT
+    Given I submit a request to create a namespace with name "fastpath.test" and reference id "ns_fp"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values                         |
+      | ns_fp        | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_fp" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_fp" containing the condition groups "cg_fp"
+    And I send a request to create a subject condition set referenced as "scs_fp" containing subject sets "ss_fp"
+    And I send a request to create a subject mapping with:
+      | reference_id | attribute_value                                          | condition_set_name | standard actions | custom actions |
+      | sm_fp        | https://fastpath.test/attr/department/value/engineering  | scs_fp             | read             |                |
+    Then the response should be successful
+    Given there is a claims subject entity referenced as "alice_fp" with claims:
+      """
+      {"userName":"alice","department":"engineering"}
+      """
+    When I send a decision request for entity chain "alice_fp" for "read" action on resource "https://fastpath.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response

--- a/tests-bdd/features/claims-ldap-fallback-ers.feature
+++ b/tests-bdd/features/claims-ldap-fallback-ers.feature
@@ -1,0 +1,93 @@
+@claims-ldap-fallback-ers @stateless
+Feature: Claims-to-LDAP fallback via condition-based strategy routing
+  Validate that condition-based strategy selection correctly routes entity
+  resolution: a claims strategy with condition "department exists" is skipped
+  when the entity lacks a department claim, and the LDAP strategy with
+  condition "userName exists" matches and provides the department from LDAP.
+
+  This demonstrates the fallback pattern where claims serve as a fast path
+  (when claims already contain the needed attributes) and LDAP acts as the
+  fallback (when claims are incomplete).
+
+  Background:
+    Given an LDAP directory with test users
+    And an ERS configuration with mode "multi-strategy" and failure strategy "continue"
+    And an ERS provider "jwt_claims" of type "claims"
+    And an ERS provider "ldap_directory" of type "ldap" connected to the LDAP directory
+    And an ERS mapping strategy "claims_with_department" using provider "jwt_claims"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: department
+            operator: exists
+      output_mapping:
+        - source_claim: department
+          claim_name: department
+        - source_claim: userName
+          claim_name: username
+      """
+    And an ERS mapping strategy "ldap_department_lookup" using provider "ldap_directory"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: userName
+            operator: exists
+      ldap_search:
+        base_dn: "ou=users,dc=opentdf,dc=test"
+        filter: "(&(objectClass=inetOrgPerson)(uid={username}))"
+        scope: subtree
+        attributes: ["uid", "mail", "departmentNumber"]
+      input_mapping:
+        - jwt_claim: userName
+          parameter: username
+      output_mapping:
+        - source_attribute: departmentNumber
+          claim_name: department
+        - source_attribute: mail
+          claim_name: email
+        - source_attribute: uid
+          claim_name: username
+      """
+    And a local platform with inline ERS configuration
+
+  Scenario: Entity without department claim falls back to LDAP — engineering user gets PERMIT
+    Given I submit a request to create a namespace with name "fallback.test" and reference id "ns_fb"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values                         |
+      | ns_fb        | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_fb" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_fb" containing the condition groups "cg_fb"
+    And I send a request to create a subject condition set referenced as "scs_fb" containing subject sets "ss_fb"
+    And I send a request to create a subject mapping with:
+      | reference_id | attribute_value                                         | condition_set_name | standard actions | custom actions |
+      | sm_fb        | https://fallback.test/attr/department/value/engineering | scs_fb             | read             |                |
+    Then the response should be successful
+    Given there is a "user_name" subject entity with value "diana" and referenced as "diana_fb"
+    When I send a decision request for entity chain "diana_fb" for "read" action on resource "https://fallback.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response
+
+  Scenario: Entity without department claim falls back to LDAP — operations user gets DENY
+    Given I submit a request to create a namespace with name "fallback-deny.test" and reference id "ns_fb_deny"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values                         |
+      | ns_fb_deny   | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_fb_deny" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_fb_deny" containing the condition groups "cg_fb_deny"
+    And I send a request to create a subject condition set referenced as "scs_fb_deny" containing subject sets "ss_fb_deny"
+    And I send a request to create a subject mapping with:
+      | reference_id | attribute_value                                              | condition_set_name | standard actions | custom actions |
+      | sm_fb_deny   | https://fallback-deny.test/attr/department/value/engineering | scs_fb_deny        | read             |                |
+    Then the response should be successful
+    Given there is a "user_name" subject entity with value "eve" and referenced as "eve_fb"
+    When I send a decision request for entity chain "eve_fb" for "read" action on resource "https://fallback-deny.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "DENY" decision response

--- a/tests-bdd/features/claims-only-ers.feature
+++ b/tests-bdd/features/claims-only-ers.feature
@@ -1,0 +1,68 @@
+@claims-only-ers @stateless
+Feature: Claims-only ERS resolution (no LDAP)
+  Validate that Entity_Claims entities carrying claims inline can be resolved
+  by a claims-only multi-strategy ERS without needing LDAP.
+
+  Background:
+    And an ERS configuration with mode "multi-strategy" and failure strategy "continue"
+    And an ERS provider "jwt_claims" of type "claims"
+    And an ERS mapping strategy "claims_department" using provider "jwt_claims"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: department
+            operator: exists
+      output_mapping:
+        - source_claim: department
+          claim_name: department
+        - source_claim: userName
+          claim_name: username
+      """
+    And a local platform with inline ERS configuration
+
+  Scenario: Claims entity with engineering department gets PERMIT
+    Given I submit a request to create a namespace with name "claims-only.test" and reference id "ns_claims"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values                         |
+      | ns_claims    | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_claims" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_claims" containing the condition groups "cg_claims"
+    And I send a request to create a subject condition set referenced as "scs_claims" containing subject sets "ss_claims"
+    And I send a request to create a subject mapping with:
+      | reference_id | attribute_value                                            | condition_set_name | standard actions | custom actions |
+      | sm_claims    | https://claims-only.test/attr/department/value/engineering | scs_claims         | read             |                |
+    Then the response should be successful
+    Given there is a claims subject entity referenced as "diana_claims" with claims:
+      """
+      {"userName":"diana","department":"engineering"}
+      """
+    When I send a decision request for entity chain "diana_claims" for "read" action on resource "https://claims-only.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response
+
+  Scenario: Claims entity with marketing department gets DENY for engineering resource
+    Given I submit a request to create a namespace with name "claims-deny.test" and reference id "ns_claims_deny"
+    And I send a request to create an attribute with:
+      | namespace_id   | name       | rule  | values                         |
+      | ns_claims_deny | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_claims_deny" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_claims_deny" containing the condition groups "cg_claims_deny"
+    And I send a request to create a subject condition set referenced as "scs_claims_deny" containing subject sets "ss_claims_deny"
+    And I send a request to create a subject mapping with:
+      | reference_id   | attribute_value                                           | condition_set_name | standard actions | custom actions |
+      | sm_claims_deny | https://claims-deny.test/attr/department/value/engineering | scs_claims_deny    | read             |                |
+    Then the response should be successful
+    Given there is a claims subject entity referenced as "bob_claims" with claims:
+      """
+      {"userName":"bob","department":"marketing"}
+      """
+    When I send a decision request for entity chain "bob_claims" for "read" action on resource "https://claims-deny.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "DENY" decision response

--- a/tests-bdd/features/claims-only-ers.feature
+++ b/tests-bdd/features/claims-only-ers.feature
@@ -4,7 +4,7 @@ Feature: Claims-only ERS resolution (no LDAP)
   by a claims-only multi-strategy ERS without needing LDAP.
 
   Background:
-    And an ERS configuration with mode "multi-strategy" and failure strategy "continue"
+    Given an ERS configuration with mode "multi-strategy" and failure strategy "continue"
     And an ERS provider "jwt_claims" of type "claims"
     And an ERS mapping strategy "claims_department" using provider "jwt_claims"
       """

--- a/tests-bdd/features/multi-strategy-ers-failfast.feature
+++ b/tests-bdd/features/multi-strategy-ers-failfast.feature
@@ -2,14 +2,18 @@
 Feature: Multi-strategy ERS fail-fast behavior
   Validate that failure_strategy "fail-fast" stops entity resolution at the first
   strategy error, preventing fallback to subsequent strategies. This contrasts
-  with the "continue" behavior tested in multi-strategy-ers.feature where the
-  same user (alice) gets PERMIT because LDAP succeeds after claims fails.
+  with the "continue" behavior tested in claims-ldap-fallback-ers.feature where
+  the same user gets PERMIT because LDAP succeeds after claims fails.
 
   The claims_passthrough strategy fails for user_name entities because the
   claims provider requires inline claims via JWTClaimsContextKey, which is
   only populated for Entity_Claims entities — not for Entity_UserName. Under
   "fail-fast", this error aborts resolution immediately — LDAP never
   executes — so the entity has no .department claim and gets DENY.
+
+  When an Entity_Claims entity is used, the claims provider succeeds and
+  fail-fast does not trigger — proving fail-fast only blocks on actual errors,
+  not universally.
 
   Background:
     Given an LDAP directory with test users
@@ -26,6 +30,8 @@ Feature: Multi-strategy ERS fail-fast behavior
       output_mapping:
         - source_claim: userName
           claim_name: username
+        - source_claim: department
+          claim_name: department
       """
     And an ERS mapping strategy "ldap_by_username" using provider "ldap_directory"
       """
@@ -71,3 +77,26 @@ Feature: Multi-strategy ERS fail-fast behavior
     When I send a decision request for entity chain "alice_ff" for "read" action on resource "https://eng-failfast.test/attr/department/value/engineering"
     Then the response should be successful
     And I should get a "DENY" decision response
+
+  Scenario: Entity_Claims succeeds under fail-fast — claims provider does not error
+    Given I submit a request to create a namespace with name "ff-claims.test" and reference id "ns_ff_claims"
+    And I send a request to create an attribute with:
+      | namespace_id  | name       | rule  | values                         |
+      | ns_ff_claims  | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_ff_claims" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_ff_claims" containing the condition groups "cg_ff_claims"
+    And I send a request to create a subject condition set referenced as "scs_ff_claims" containing subject sets "ss_ff_claims"
+    And I send a request to create a subject mapping with:
+      | reference_id  | attribute_value                                            | condition_set_name | standard actions | custom actions |
+      | sm_ff_claims  | https://ff-claims.test/attr/department/value/engineering   | scs_ff_claims      | read             |                |
+    Then the response should be successful
+    Given there is a claims subject entity referenced as "diana_ff" with claims:
+      """
+      {"userName":"diana","department":"engineering"}
+      """
+    When I send a decision request for entity chain "diana_ff" for "read" action on resource "https://ff-claims.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response

--- a/tests-bdd/features/multi-strategy-ers-failfast.feature
+++ b/tests-bdd/features/multi-strategy-ers-failfast.feature
@@ -1,0 +1,73 @@
+@multi-strategy-ers-failfast @stateless
+Feature: Multi-strategy ERS fail-fast behavior
+  Validate that failure_strategy "fail-fast" stops entity resolution at the first
+  strategy error, preventing fallback to subsequent strategies. This contrasts
+  with the "continue" behavior tested in multi-strategy-ers.feature where the
+  same user (alice) gets PERMIT because LDAP succeeds after claims fails.
+
+  The claims_passthrough strategy fails for user_name entities because the
+  claims provider requires inline claims via JWTClaimsContextKey, which is
+  only populated for Entity_Claims entities — not for Entity_UserName. Under
+  "fail-fast", this error aborts resolution immediately — LDAP never
+  executes — so the entity has no .department claim and gets DENY.
+
+  Background:
+    Given an LDAP directory with test users
+    And an ERS configuration with mode "multi-strategy" and failure strategy "fail-fast"
+    And an ERS provider "jwt_claims" of type "claims"
+    And an ERS provider "ldap_directory" of type "ldap" connected to the LDAP directory
+    And an ERS mapping strategy "claims_passthrough" using provider "jwt_claims"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: userName
+            operator: exists
+      output_mapping:
+        - source_claim: userName
+          claim_name: username
+      """
+    And an ERS mapping strategy "ldap_by_username" using provider "ldap_directory"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: userName
+            operator: exists
+      ldap_search:
+        base_dn: "ou=users,dc=opentdf,dc=test"
+        filter: "(&(objectClass=inetOrgPerson)(uid={username}))"
+        scope: subtree
+        attributes: ["uid", "mail", "departmentNumber"]
+      input_mapping:
+        - jwt_claim: userName
+          parameter: username
+      output_mapping:
+        - source_attribute: departmentNumber
+          claim_name: department
+        - source_attribute: mail
+          claim_name: email
+        - source_attribute: uid
+          claim_name: username
+      """
+    And a local platform with inline ERS configuration
+
+  Scenario: Fail-fast prevents LDAP fallback — engineering user gets DENY
+    Given I submit a request to create a namespace with name "eng-failfast.test" and reference id "ns_eng_ff"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values                         |
+      | ns_eng_ff    | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_eng_ff" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_eng_ff" containing the condition groups "cg_eng_ff"
+    And I send a request to create a subject condition set referenced as "scs_eng_ff" containing subject sets "ss_eng_ff"
+    And I send a request to create a subject mapping with:
+      | reference_id | attribute_value                                             | condition_set_name | standard actions | custom actions |
+      | sm_eng_ff    | https://eng-failfast.test/attr/department/value/engineering | scs_eng_ff         | read             |                |
+    Then the response should be successful
+    Given there is a "user_name" subject entity with value "alice" and referenced as "alice_ff"
+    When I send a decision request for entity chain "alice_ff" for "read" action on resource "https://eng-failfast.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "DENY" decision response


### PR DESCRIPTION
## Summary

> **Blocked by #3794** — `@claims-only-ers` scenarios will fail until the #3790 fix lands. The other two features (`@multi-strategy-ers-failfast`, `@claims-ldap-fallback-ers`) pass independently.

Expands multi-strategy ERS BDD test coverage (DSPX-4100) with three new feature files:

- **`@multi-strategy-ers-failfast`** — Demonstrates that `failure_strategy: "fail-fast"` stops entity resolution at the first strategy error, preventing LDAP fallback. Alice gets DENY (vs PERMIT under `continue` in the existing feature).

- **`@claims-ldap-fallback-ers`** — Validates condition-based strategy routing: a claims strategy with condition `department exists` is skipped when the entity lacks department, and the LDAP strategy with condition `userName exists` provides it via fallback. Covers both PERMIT (engineering user via LDAP) and DENY (operations user via LDAP).

- **`@claims-only-ers`** — Validates that `Entity_Claims` entities carrying inline claims can be resolved by a claims-only multi-strategy ERS without LDAP. Currently fails due to #3790; will pass once #3794 merges.

Also adds a DocString-based step definition for creating claims entities with embedded JSON.

### Test results

| Tag | Scenarios | Result |
|-----|-----------|--------|
| `@multi-strategy-ers-failfast` | 1 | ✅ Pass |
| `@claims-ldap-fallback-ers` | 2 | ✅ All pass |
| `@claims-only-ers` | 2 | ⏳ Blocked by #3794 |
| `@multi-strategy-ers` (existing) | 3 | ✅ All pass (no regression) |

### Related

- #3790 — `ResolveEntities` does not populate `JWTClaimsContextKey` for claims provider
- #3794 — Fix for #3790 (once merged, `@claims-only-ers` should pass)
- #3797 — Condition operator BDD coverage (merged)
- PR #3767 — Initial multi-strategy ERS BDD tests (merged)

## Test plan

- [ ] CI: `@multi-strategy-ers-failfast` and `@claims-ldap-fallback-ers` pass
- [ ] CI: `@claims-only-ers` expected to fail until #3794 merges
- [ ] After #3794 merges: rebase, reconcile overlapping step definitions, all scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for claims-based access decisions.
  * Added stateless claims-only access scenarios.
  * Added coverage for fallback from claims to LDAP when claims are unavailable.
  * Added validation that fail-fast behavior prevents fallback after a claims resolution error.
  * Verified expected permit and deny outcomes for engineering and non-engineering access scenarios across supported resolution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->