### PR TITLE
chore(ci): update e2e test environments to Keycloak 26.4

### DIFF
--- a/.github/scripts/init-temp-keys.cmd
+++ b/.github/scripts/init-temp-keys.cmd
@@ -21,4 +21,4 @@ set hostKeyDir=%hostKeyDir%/keys
 set "hostKeyDir=%hostKeyDir:\=/%"
 
 openssl pkcs12 -export -in keys/keycloak-ca.pem -inkey keys/keycloak-ca-private.pem -out keys/ca.p12 -nodes -passout pass:password
-docker run -v %hostKeyDir%:/keys --entrypoint keytool keycloak/keycloak:25.0 -importkeystore -srckeystore /keys/ca.p12 -srcstoretype PKCS12 -destkeystore /keys/ca.jks -deststoretype JKS -srcstorepass "password" -deststorepass "password" -noprompt
+docker run -v %hostKeyDir%:/keys --entrypoint keytool keycloak/keycloak:26.4 -importkeystore -srckeystore /keys/ca.p12 -srcstoretype PKCS12 -destkeystore /keys/ca.jks -deststoretype JKS -srcstorepass "password" -deststorepass "password" -noprompt

--- a/.github/scripts/init-temp-keys.sh
+++ b/.github/scripts/init-temp-keys.sh
@@ -79,7 +79,7 @@ docker run \
   -v $(pwd)/keys:/keys \
   --entrypoint keytool \
   --user $(id -u):$(id -g) \
-  keycloak/keycloak:25.0 \
+  keycloak/keycloak:26.4 \
   -importkeystore \
   -srckeystore /keys/ca.p12 \
   -srcstoretype PKCS12 \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: changeme
       #KC_HOSTNAME_URL: http://localhost:8888/auth
+      KC_FEATURES: dpop
       KC_HEALTH_ENABLED: "true"
       KC_HTTPS_KEY_STORE_PASSWORD: "password"
       KC_HTTPS_KEY_STORE_FILE: "/truststore/truststore.jks"

--- a/service/entityresolution/integration/keycloak_test.go
+++ b/service/entityresolution/integration/keycloak_test.go
@@ -180,6 +180,7 @@ func (a *KeycloakTestAdapter) createKeycloakContainerConfig() internal.Container
 		Env: map[string]string{
 			"KC_BOOTSTRAP_ADMIN_USERNAME": a.config.AdminUser,
 			"KC_BOOTSTRAP_ADMIN_PASSWORD": a.config.AdminPass,
+			"KC_FEATURES":                 "dpop",
 			"KC_HTTP_ENABLED":             "true",
 			"KC_HOSTNAME_STRICT":          "false",
 			"KC_HEALTH_ENABLED":           "true",

--- a/test/integration/oauth/oauth_test.go
+++ b/test/integration/oauth/oauth_test.go
@@ -34,7 +34,6 @@ import (
 
 const (
 	standardKeycloakImage = "ghcr.io/opentdf/keycloak-standard:26.4.0"
-	customKeycloakImage   = "ghcr.io/opentdf/keycloak:sha-8a6d35a"
 )
 
 type OAuthSuite struct {
@@ -572,6 +571,7 @@ func setupStandardKeycloak(ctx context.Context, t *testing.T) (tc.Container, str
 		Env: map[string]string{
 			"KC_BOOTSTRAP_ADMIN_USERNAME": "admin",
 			"KC_BOOTSTRAP_ADMIN_PASSWORD": "admin", // #nosec G101 -- test-only Keycloak admin password
+			"KC_FEATURES":                 "dpop",
 		},
 
 		WaitingFor: wait.ForHTTP("/realms/master/.well-known/openid-configuration").
@@ -606,7 +606,7 @@ func setupStandardKeycloak(ctx context.Context, t *testing.T) (tc.Container, str
 
 func setupCustomKeycloakForCertExchange(ctx context.Context, t *testing.T) (tc.Container, string) {
 	containerReq := tc.ContainerRequest{
-		Image:        customKeycloakImage,
+		Image:        standardKeycloakImage,
 		ExposedPorts: []string{"8082/tcp", "8083/tcp"},
 		Cmd: []string{
 			"start-dev", "--http-port=8082", "--https-port=8083", "--verbose",
@@ -622,9 +622,8 @@ func setupCustomKeycloakForCertExchange(ctx context.Context, t *testing.T) (tc.C
 		},
 		Env: map[string]string{
 			"KC_BOOTSTRAP_ADMIN_USERNAME":   "admin",
-			"KC_BOOTSTRAP_ADMIN_PASSWORD":   "admin",
-			"KEYCLOAK_ADMIN":                "admin",
-			"KEYCLOAK_ADMIN_PASSWORD":       "admin", // #nosec G101 -- test-only Keycloak admin password
+			"KC_BOOTSTRAP_ADMIN_PASSWORD":   "admin", // #nosec G101 -- test-only Keycloak admin password
+			"KC_FEATURES":                   "dpop",
 			"KC_HTTPS_KEY_STORE_PASSWORD":   "password",
 			"KC_HTTPS_KEY_STORE_FILE":       "/truststore/truststore.jks",
 			"KC_HTTPS_CERTIFICATE_FILE":     "/etc/x509/tls/localhost.crt",
@@ -632,7 +631,15 @@ func setupCustomKeycloakForCertExchange(ctx context.Context, t *testing.T) (tc.C
 			"KC_HTTPS_CLIENT_AUTH":          "request",
 		},
 
-		WaitingFor: wait.ForLog("Running the server").WithStartupTimeout(2 * time.Minute),
+		// Wait on an actual HTTP response rather than the "Running the server" log line:
+		// in Keycloak 26.4 that message is printed (as the dev-mode warning) before the HTTP
+		// connector is accepting connections, which races the admin login below.
+		WaitingFor: wait.ForHTTP("/realms/master/.well-known/openid-configuration").
+			WithPort("8082/tcp").
+			WithStatusCodeMatcher(func(status int) bool {
+				return status == http.StatusOK
+			}).
+			WithStartupTimeout(2 * time.Minute),
 	}
 
 	keycloak := startKeycloakContainer(ctx, t, containerReq)

--- a/test/start-up-with-containers/action.yaml
+++ b/test/start-up-with-containers/action.yaml
@@ -7,6 +7,14 @@ inputs:
     required: false
     description: 'The ref to check out for the platform'
     default: 'main'
+  bootstrap-ref:
+    required: false
+    description: >-
+      Ref of opentdf/platform to fetch the bootstrap files (docker-compose.yaml,
+      init-temp-keys.sh, watch.sh) from. These files are executed, so this is
+      restricted to an allowlist: [main, pqc-enabled]. Defaults to
+      the pqc-enabled tag.
+    default: 'pqc-enabled'
   extra-keys:
     required: false
     description: A JSON array containing extra keys for the KAS to load. Each object should have 'kid', 'alg', 'private', and 'cert' fields.
@@ -55,6 +63,7 @@ runs:
       shell: bash
       env:
         PLATFORM_REF: ${{ inputs.platform-ref }}
+        BOOTSTRAP_REF: ${{ inputs.bootstrap-ref }}
         EXTRA_KEYS: ${{ inputs.extra-keys }}
         EC_TDF_ENABLED: ${{ inputs.ec-tdf-enabled }}
         PQC_ENABLED: ${{ inputs.pqc-enabled }}
@@ -69,6 +78,18 @@ runs:
           echo "Error: platform-ref must contain only alphanumeric characters, dots, underscores, hyphens, and forward slashes."
           exit 1
         fi
+
+        # Validate bootstrap-ref against an explicit allowlist. The bootstrap files
+        # (docker-compose.yaml, init-temp-keys.sh, watch.sh) are executed, so only
+        # vetted refs are permitted rather than an arbitrary branch/tag.
+        case "${BOOTSTRAP_REF}" in
+          main|pqc-enabled)
+            ;;
+          *)
+            echo "Error: bootstrap-ref must be one of: main, pqc-enabled."
+            exit 1
+            ;;
+        esac
 
         # Validate extra-keys (must be a valid JSON array)
         if ! jq -e 'type == "array"' <<< "${EXTRA_KEYS}" > /dev/null 2>&1; then
@@ -155,10 +176,14 @@ runs:
         persist-credentials: false
     - name: Download latest init-temp-keys.sh, docker-compose.yaml, and watch.sh
       shell: bash
+      env:
+        BOOTSTRAP_REF: ${{ inputs.bootstrap-ref }}
       run: |
-        curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL https://raw.githubusercontent.com/opentdf/platform/refs/tags/pqc-enabled/.github/scripts/init-temp-keys.sh > otdf-test-platform/.github/scripts/init-temp-keys.sh
-        curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL https://raw.githubusercontent.com/opentdf/platform/refs/tags/pqc-enabled/docker-compose.yaml > otdf-test-platform/docker-compose.yaml
-        curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL https://raw.githubusercontent.com/opentdf/platform/refs/tags/pqc-enabled/.github/scripts/watch.sh > otdf-test-platform/.github/scripts/watch.sh
+        # Bare ref form resolves branches, tags, and SHAs (e.g. the default pqc-enabled tag).
+        base="https://raw.githubusercontent.com/opentdf/platform/${BOOTSTRAP_REF}"
+        curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL "${base}/.github/scripts/init-temp-keys.sh" > otdf-test-platform/.github/scripts/init-temp-keys.sh
+        curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL "${base}/docker-compose.yaml" > otdf-test-platform/docker-compose.yaml
+        curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL "${base}/.github/scripts/watch.sh" > otdf-test-platform/.github/scripts/watch.sh
     - name: Set up go (platform's go version)
       id: setup-go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0


### PR DESCRIPTION
## Summary

Updates all test/CI/e2e Keycloak targets to **26.4+**. The runtime image (`ghcr.io/opentdf/keycloak-standard:26.4.0`) was already at 26.4; this cleans up the remaining stale/orphaned targets.

Fixes DSPX-4190

### Changes
- **Keytool image `25.0 → 26.4`** in `.github/scripts/init-temp-keys.sh` and `init-temp-keys.cmd` (used only as a `keytool` entrypoint to build the truststore).
- **Retire the orphaned custom image**: the cert-exchange OAuth test was the sole user of the SHA-pinned `ghcr.io/opentdf/keycloak:sha-8a6d35a` (no semver tag, no public source repo). Repointed `setupCustomKeycloakForCertExchange` at `keycloak-standard:26.4.0`, dropped the redundant legacy `KEYCLOAK_ADMIN*` env vars, and switched its readiness probe from `wait.ForLog("Running the server")` to an HTTP check — on 26.4 that log line is printed before the HTTP connector accepts connections, which raced the admin login (`EOF`).
- **Enable DPoP explicitly** via `KC_FEATURES: dpop` in `docker-compose.yaml` (covers the `start-up-with-containers` action + BDD suite transitively) and in the OAuth + ERS test containers. DPoP is supported/default-on in 26.4; set explicitly for robustness. The `opentdf-dpop` client attribute is unchanged.
- **`start-up-with-containers` action: new `bootstrap-ref` input.** The action overlays `docker-compose.yaml` / `init-temp-keys.sh` / `watch.sh` by fetching them from a hardcoded `pqc-enabled` tag (independent of `platform-ref`). Added a `bootstrap-ref` input (default `pqc-enabled`, so existing behavior is unchanged) so those bootstrap files can be pulled from any branch/tag/SHA — letting downstream e2e workflows test infra changes like this one from a PR branch before the tag is moved.

### Testing
Run against `keycloak-standard:26.4.0` (local Docker):
- `TestOAuthTestSuite` — pass, including both DPoP tests and standard token exchange.
- `TestCertExchangeTestSuite` — pass; X.509 cert-exchange flow works on the standard image (validates dropping the custom image).
- `service/entityresolution/integration/...` — pass with the DPoP env addition.
- `make fmt` / `gofmt` clean; remaining lint findings are pre-existing and unrelated.

To exercise cross-repo e2e workflows on this branch, reference the action at this branch and set both refs:
```yaml
uses: opentdf/platform/test/start-up-with-containers@DSPX-4190
with:
  bootstrap-ref: DSPX-4190   # pull docker-compose.yaml + init-temp-keys.sh (26.4 + dpop) from this branch
  platform-ref: DSPX-4190    # optional: use branch service code too
```

### Notes
- gocloak was **not** bumped — v13.9.0 works fine against 26.4 across all suites.
- Follow-up DSPX-4191 tracks migrating the legacy Python KAS / virtru-corp consumers off the custom `tdf_claims` mapper so the custom image can be fully retired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Demonstration of Proof-of-Possession (DPoP) support for Keycloak-based authentication.
  * Added configurable bootstrap sources, allowing startup files to be selected from approved release tracks.

* **Bug Fixes**
  * Updated Keycloak tooling and container configuration to version 26.4 for improved compatibility.
  * Improved integration-test startup checks by validating OpenID configuration availability rather than relying on log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->