### PR TITLE
fix(ers): pass inline claims through multi-strategy context

### DIFF
--- a/service/entityresolution/multi-strategy/registration.go
+++ b/service/entityresolution/multi-strategy/registration.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentdf/platform/protocol/go/entityresolution"
 	"github.com/opentdf/platform/service/entityresolution/multi-strategy/types"
 	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/pkg/protohelper"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -110,12 +111,12 @@ func (ers *ERS) ResolveEntities(
 
 		// Add resolved claims
 		for claimName, claimValue := range result.Claims {
-			resultData[claimName] = StructPBCompatibleValue(claimValue)
+			resultData[claimName] = protohelper.StructPBCompatibleValue(claimValue)
 		}
 
 		// Add metadata with "metadata_" prefix
 		for metaKey, metaValue := range result.Metadata {
-			resultData[("metadata_" + metaKey)] = StructPBCompatibleValue(metaValue)
+			resultData[("metadata_" + metaKey)] = protohelper.StructPBCompatibleValue(metaValue)
 		}
 
 		// Convert to protobuf struct
@@ -445,29 +446,4 @@ func RegisterERS(config map[string]interface{}, logger *logger.Logger) (*ERS, se
 	}
 
 	return ers, nil
-}
-
-func StructPBCompatibleValue(value interface{}) interface{} {
-	switch v := value.(type) {
-	case []string:
-		result := make([]interface{}, len(v))
-		for i, item := range v {
-			result[i] = item
-		}
-		return result
-	case []interface{}:
-		result := make([]interface{}, len(v))
-		for i, item := range v {
-			result[i] = StructPBCompatibleValue(item)
-		}
-		return result
-	case map[string]interface{}:
-		result := make(map[string]interface{}, len(v))
-		for key, item := range v {
-			result[key] = StructPBCompatibleValue(item)
-		}
-		return result
-	default:
-		return value
-	}
 }

--- a/service/entityresolution/multi-strategy/registration.go
+++ b/service/entityresolution/multi-strategy/registration.go
@@ -55,6 +55,7 @@ func (ers *ERS) ResolveEntities(
 			continue
 		}
 
+		resolveCtx := ctx
 		var claimsMap types.JWTClaims
 		switch entity.GetEntityType().(type) {
 		case *authorization.Entity_Claims:
@@ -68,6 +69,7 @@ func (ers *ERS) ResolveEntities(
 				}
 				// Convert to map[string]interface{}
 				claimsMap = claimsStruct.AsMap()
+				resolveCtx = context.WithValue(ctx, types.JWTClaimsContextKey, claimsMap)
 			}
 		default:
 			entityBytes, err := protojson.Marshal(entity)
@@ -81,8 +83,7 @@ func (ers *ERS) ResolveEntities(
 		}
 
 		// Resolve entity using multi-strategy service
-		ctxWithClaims := context.WithValue(ctx, types.JWTClaimsContextKey, claimsMap)
-		result, err := ers.service.ResolveEntity(ctxWithClaims, entityID, claimsMap)
+		result, err := ers.service.ResolveEntity(resolveCtx, entityID, claimsMap)
 		if err != nil {
 			ers.logger.Error("failed to resolve entity",
 				slog.String("entity_id", entityID),

--- a/service/entityresolution/multi-strategy/registration.go
+++ b/service/entityresolution/multi-strategy/registration.go
@@ -80,7 +80,8 @@ func (ers *ERS) ResolveEntities(
 		}
 
 		// Resolve entity using multi-strategy service
-		result, err := ers.service.ResolveEntity(ctx, entityID, claimsMap)
+		ctxWithClaims := context.WithValue(ctx, types.JWTClaimsContextKey, claimsMap)
+		result, err := ers.service.ResolveEntity(ctxWithClaims, entityID, claimsMap)
 		if err != nil {
 			ers.logger.Error("failed to resolve entity",
 				slog.String("entity_id", entityID),
@@ -109,12 +110,12 @@ func (ers *ERS) ResolveEntities(
 
 		// Add resolved claims
 		for claimName, claimValue := range result.Claims {
-			resultData[claimName] = claimValue
+			resultData[claimName] = structPBCompatibleValue(claimValue)
 		}
 
 		// Add metadata with "metadata_" prefix
 		for metaKey, metaValue := range result.Metadata {
-			resultData[("metadata_" + metaKey)] = metaValue
+			resultData[("metadata_" + metaKey)] = structPBCompatibleValue(metaValue)
 		}
 
 		// Convert to protobuf struct
@@ -444,4 +445,29 @@ func RegisterERS(config map[string]interface{}, logger *logger.Logger) (*ERS, se
 	}
 
 	return ers, nil
+}
+
+func structPBCompatibleValue(value interface{}) interface{} {
+	switch v := value.(type) {
+	case []string:
+		result := make([]interface{}, len(v))
+		for i, item := range v {
+			result[i] = item
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(v))
+		for i, item := range v {
+			result[i] = structPBCompatibleValue(item)
+		}
+		return result
+	case map[string]interface{}:
+		result := make(map[string]interface{}, len(v))
+		for key, item := range v {
+			result[key] = structPBCompatibleValue(item)
+		}
+		return result
+	default:
+		return value
+	}
 }

--- a/service/entityresolution/multi-strategy/registration.go
+++ b/service/entityresolution/multi-strategy/registration.go
@@ -110,12 +110,12 @@ func (ers *ERS) ResolveEntities(
 
 		// Add resolved claims
 		for claimName, claimValue := range result.Claims {
-			resultData[claimName] = structPBCompatibleValue(claimValue)
+			resultData[claimName] = StructPBCompatibleValue(claimValue)
 		}
 
 		// Add metadata with "metadata_" prefix
 		for metaKey, metaValue := range result.Metadata {
-			resultData[("metadata_" + metaKey)] = structPBCompatibleValue(metaValue)
+			resultData[("metadata_" + metaKey)] = StructPBCompatibleValue(metaValue)
 		}
 
 		// Convert to protobuf struct
@@ -447,7 +447,7 @@ func RegisterERS(config map[string]interface{}, logger *logger.Logger) (*ERS, se
 	return ers, nil
 }
 
-func structPBCompatibleValue(value interface{}) interface{} {
+func StructPBCompatibleValue(value interface{}) interface{} {
 	switch v := value.(type) {
 	case []string:
 		result := make([]interface{}, len(v))
@@ -458,13 +458,13 @@ func structPBCompatibleValue(value interface{}) interface{} {
 	case []interface{}:
 		result := make([]interface{}, len(v))
 		for i, item := range v {
-			result[i] = structPBCompatibleValue(item)
+			result[i] = StructPBCompatibleValue(item)
 		}
 		return result
 	case map[string]interface{}:
 		result := make(map[string]interface{}, len(v))
 		for key, item := range v {
-			result[key] = structPBCompatibleValue(item)
+			result[key] = StructPBCompatibleValue(item)
 		}
 		return result
 	default:

--- a/service/entityresolution/multi-strategy/registration_test.go
+++ b/service/entityresolution/multi-strategy/registration_test.go
@@ -1,0 +1,102 @@
+package multistrategy
+
+import (
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/opentdf/platform/protocol/go/authorization"
+	"github.com/opentdf/platform/protocol/go/entityresolution"
+	"github.com/opentdf/platform/service/entityresolution/multi-strategy/types"
+	"github.com/opentdf/platform/service/logger"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestResolveEntities_ClaimsProviderUsesInlineClaimsContext(t *testing.T) {
+	t.Helper()
+
+	erService, err := NewERS(t.Context(), types.MultiStrategyConfig{
+		Providers: map[string]types.ProviderConfig{
+			"jwt": {
+				Type:       "claims",
+				Connection: map[string]interface{}{},
+			},
+		},
+		MappingStrategies: []types.MappingStrategy{
+			{
+				Name:       "claims_passthrough",
+				Provider:   "jwt",
+				EntityType: types.EntityTypeSubject,
+				Conditions: types.StrategyConditions{
+					JWTClaims: []types.JWTClaimCondition{
+						{
+							Claim:    "sub",
+							Operator: "exists",
+						},
+					},
+				},
+				OutputMapping: []types.OutputMapping{
+					{
+						SourceClaim: "sub",
+						ClaimName:   "subject",
+					},
+					{
+						SourceClaim: "email",
+						ClaimName:   "email_address",
+					},
+				},
+			},
+		},
+	}, logger.CreateTestLogger())
+	if err != nil {
+		t.Fatalf("NewERS() error = %v", err)
+	}
+
+	claimsStruct, err := structpb.NewStruct(map[string]interface{}{
+		"sub":   "diana",
+		"email": "diana@example.com",
+	})
+	if err != nil {
+		t.Fatalf("structpb.NewStruct() error = %v", err)
+	}
+
+	claimsAny, err := anypb.New(claimsStruct)
+	if err != nil {
+		t.Fatalf("anypb.New() error = %v", err)
+	}
+
+	resp, err := erService.ResolveEntities(t.Context(), connect.NewRequest(&entityresolution.ResolveEntitiesRequest{
+		Entities: []*authorization.Entity{
+			{
+				Id:         "diana-claims",
+				EntityType: &authorization.Entity_Claims{Claims: claimsAny},
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("ResolveEntities() error = %v", err)
+	}
+
+	if got := len(resp.Msg.GetEntityRepresentations()); got != 1 {
+		t.Fatalf("expected 1 entity representation, got %d", got)
+	}
+
+	props := resp.Msg.GetEntityRepresentations()[0].GetAdditionalProps()
+	if len(props) != 1 {
+		t.Fatalf("expected 1 additional props entry, got %d", len(props))
+	}
+
+	result := props[0].AsMap()
+	if got := result["subject"]; got != "diana" {
+		t.Fatalf("expected subject diana, got %v", got)
+	}
+	if got := result["email_address"]; got != "diana@example.com" {
+		t.Fatalf("expected email_address diana@example.com, got %v", got)
+	}
+	if got := result["metadata_source"]; got != "jwt_claims" {
+		t.Fatalf("expected metadata_source jwt_claims, got %v", got)
+	}
+	if _, hasError := result["error"]; hasError {
+		t.Fatalf("expected successful resolution, got error payload: %v", result["error"])
+	}
+}

--- a/service/entityresolution/multi-strategy/registration_test.go
+++ b/service/entityresolution/multi-strategy/registration_test.go
@@ -100,3 +100,58 @@ func TestResolveEntities_ClaimsProviderUsesInlineClaimsContext(t *testing.T) {
 		t.Fatalf("expected successful resolution, got error payload: %v", result["error"])
 	}
 }
+
+func TestResolveEntities_UserNameEntityDoesNotSeedClaimsContext(t *testing.T) {
+	t.Helper()
+
+	erService, err := NewERS(t.Context(), types.MultiStrategyConfig{
+		Providers: map[string]types.ProviderConfig{
+			"jwt": {
+				Type:       "claims",
+				Connection: map[string]interface{}{},
+			},
+		},
+		FailureStrategy: types.FailureStrategyContinue,
+		MappingStrategies: []types.MappingStrategy{
+			{
+				Name:       "claims_passthrough",
+				Provider:   "jwt",
+				EntityType: types.EntityTypeSubject,
+				Conditions: types.StrategyConditions{
+					JWTClaims: []types.JWTClaimCondition{{Claim: "userName", Operator: "exists"}},
+				},
+				OutputMapping: []types.OutputMapping{{SourceClaim: "userName", ClaimName: "username"}},
+			},
+		},
+	}, logger.CreateTestLogger())
+	if err != nil {
+		t.Fatalf("NewERS() error = %v", err)
+	}
+
+	resp, err := erService.ResolveEntities(t.Context(), connect.NewRequest(&entityresolution.ResolveEntitiesRequest{
+		Entities: []*authorization.Entity{{
+			Id:         "alice-user-name",
+			EntityType: &authorization.Entity_UserName{UserName: "alice"},
+		}},
+	}))
+	if err != nil {
+		t.Fatalf("ResolveEntities() error = %v", err)
+	}
+
+	if got := len(resp.Msg.GetEntityRepresentations()); got != 1 {
+		t.Fatalf("expected 1 entity representation, got %d", got)
+	}
+
+	props := resp.Msg.GetEntityRepresentations()[0].GetAdditionalProps()
+	if len(props) != 1 {
+		t.Fatalf("expected 1 additional props entry, got %d", len(props))
+	}
+
+	result := props[0].AsMap()
+	if _, hasError := result["error"]; !hasError {
+		t.Fatalf("expected claims provider to fail without middleware claims for user_name entity, got %v", result)
+	}
+	if got := result["entity_id"]; got != "alice-user-name" {
+		t.Fatalf("expected entity_id alice-user-name, got %v", got)
+	}
+}

--- a/service/entityresolution/multi-strategy/v2/registration.go
+++ b/service/entityresolution/multi-strategy/v2/registration.go
@@ -124,7 +124,7 @@ func (ers *ERSV2) ResolveEntities(
 
 		// Add metadata with "metadata_" prefix
 		for metaKey, metaValue := range result.Metadata {
-			resultData[("metadata_" + metaKey)] = structPBCompatibleValue(metaValue)
+			resultData[("metadata_" + metaKey)] = multistrategy.StructPBCompatibleValue(metaValue)
 		}
 
 		// Convert to protobuf struct
@@ -478,29 +478,4 @@ func extractClaimNames(claims types.JWTClaims) []string {
 		names = append(names, name)
 	}
 	return names
-}
-
-func structPBCompatibleValue(value interface{}) interface{} {
-	switch v := value.(type) {
-	case []string:
-		result := make([]interface{}, len(v))
-		for i, item := range v {
-			result[i] = item
-		}
-		return result
-	case []interface{}:
-		result := make([]interface{}, len(v))
-		for i, item := range v {
-			result[i] = structPBCompatibleValue(item)
-		}
-		return result
-	case map[string]interface{}:
-		result := make(map[string]interface{}, len(v))
-		for key, item := range v {
-			result[key] = structPBCompatibleValue(item)
-		}
-		return result
-	default:
-		return value
-	}
 }

--- a/service/entityresolution/multi-strategy/v2/registration.go
+++ b/service/entityresolution/multi-strategy/v2/registration.go
@@ -89,7 +89,8 @@ func (ers *ERSV2) ResolveEntities(
 		}
 
 		// Resolve entity using multi-strategy service
-		result, err := ers.service.ResolveEntity(ctx, entityID, claimsMap)
+		ctxWithClaims := context.WithValue(ctx, types.JWTClaimsContextKey, claimsMap)
+		result, err := ers.service.ResolveEntity(ctxWithClaims, entityID, claimsMap)
 		if err != nil {
 			ers.logger.Error("failed to resolve entity",
 				slog.String("entity_id", entityID),
@@ -123,7 +124,7 @@ func (ers *ERSV2) ResolveEntities(
 
 		// Add metadata with "metadata_" prefix
 		for metaKey, metaValue := range result.Metadata {
-			resultData[("metadata_" + metaKey)] = metaValue
+			resultData[("metadata_" + metaKey)] = structPBCompatibleValue(metaValue)
 		}
 
 		// Convert to protobuf struct
@@ -477,4 +478,29 @@ func extractClaimNames(claims types.JWTClaims) []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+func structPBCompatibleValue(value interface{}) interface{} {
+	switch v := value.(type) {
+	case []string:
+		result := make([]interface{}, len(v))
+		for i, item := range v {
+			result[i] = item
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(v))
+		for i, item := range v {
+			result[i] = structPBCompatibleValue(item)
+		}
+		return result
+	case map[string]interface{}:
+		result := make(map[string]interface{}, len(v))
+		for key, item := range v {
+			result[key] = structPBCompatibleValue(item)
+		}
+		return result
+	default:
+		return value
+	}
 }

--- a/service/entityresolution/multi-strategy/v2/registration.go
+++ b/service/entityresolution/multi-strategy/v2/registration.go
@@ -16,6 +16,7 @@ import (
 	multistrategy "github.com/opentdf/platform/service/entityresolution/multi-strategy"
 	"github.com/opentdf/platform/service/entityresolution/multi-strategy/types"
 	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/pkg/protohelper"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -124,7 +125,7 @@ func (ers *ERSV2) ResolveEntities(
 
 		// Add metadata with "metadata_" prefix
 		for metaKey, metaValue := range result.Metadata {
-			resultData[("metadata_" + metaKey)] = multistrategy.StructPBCompatibleValue(metaValue)
+			resultData[("metadata_" + metaKey)] = protohelper.StructPBCompatibleValue(metaValue)
 		}
 
 		// Convert to protobuf struct

--- a/service/entityresolution/multi-strategy/v2/registration.go
+++ b/service/entityresolution/multi-strategy/v2/registration.go
@@ -64,6 +64,7 @@ func (ers *ERSV2) ResolveEntities(
 			ers.logger.Warn("empty entity ID in request; using generated ID", slog.String("entity_id", entityID))
 		}
 
+		resolveCtx := ctx
 		var claimsMap types.JWTClaims
 		switch entityV2.GetEntityType().(type) {
 		case *entity.Entity_Claims:
@@ -77,6 +78,7 @@ func (ers *ERSV2) ResolveEntities(
 				}
 				// Convert to map[string]interface{}
 				claimsMap = claimsStruct.AsMap()
+				resolveCtx = context.WithValue(ctx, types.JWTClaimsContextKey, claimsMap)
 			}
 		default:
 			entityBytes, err := protojson.Marshal(entityV2)
@@ -90,8 +92,7 @@ func (ers *ERSV2) ResolveEntities(
 		}
 
 		// Resolve entity using multi-strategy service
-		ctxWithClaims := context.WithValue(ctx, types.JWTClaimsContextKey, claimsMap)
-		result, err := ers.service.ResolveEntity(ctxWithClaims, entityID, claimsMap)
+		result, err := ers.service.ResolveEntity(resolveCtx, entityID, claimsMap)
 		if err != nil {
 			ers.logger.Error("failed to resolve entity",
 				slog.String("entity_id", entityID),

--- a/service/entityresolution/multi-strategy/v2/registration_test.go
+++ b/service/entityresolution/multi-strategy/v2/registration_test.go
@@ -1,7 +1,6 @@
 package multistrategy
 
 import (
-	"context"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -137,16 +136,7 @@ func TestERSV2_ResolveEntities_PopulatesRepresentations(t *testing.T) {
 		},
 	})
 
-	// The claims provider reads JWT claims from ctx (see
-	// providers/claims/claims_provider.go). In production, upstream callers
-	// (admin API middleware, JustInTimePDP) populate this before invoking
-	// the handler; we mirror that here so the strategy actually succeeds
-	// and we exercise the serialization path where the bug lives.
-	ctx := context.WithValue(t.Context(), types.JWTClaimsContextKey, types.JWTClaims{
-		"sub":   "alice",
-		"email": "alice@example.com",
-	})
-	resp, err := ers.ResolveEntities(ctx, req)
+	resp, err := ers.ResolveEntities(t.Context(), req)
 	if err != nil {
 		t.Fatalf("ResolveEntities returned error: %v", err)
 	}
@@ -187,5 +177,95 @@ func TestERSV2_ResolveEntities_PopulatesRepresentations(t *testing.T) {
 	}
 	if got := list.GetValues()[0].GetStringValue(); got != "jwt_strategy" {
 		t.Errorf("metadata_attempted_strategies[0] = %q, want %q", got, "jwt_strategy")
+	}
+}
+
+func TestResolveEntities_ClaimsProviderUsesInlineClaimsContext(t *testing.T) {
+	t.Helper()
+
+	erService, err := NewERSV2(t.Context(), types.MultiStrategyConfig{
+		Providers: map[string]types.ProviderConfig{
+			"jwt": {
+				Type:       "claims",
+				Connection: map[string]interface{}{},
+			},
+		},
+		MappingStrategies: []types.MappingStrategy{
+			{
+				Name:       "claims_passthrough",
+				Provider:   "jwt",
+				EntityType: types.EntityTypeSubject,
+				Conditions: types.StrategyConditions{
+					JWTClaims: []types.JWTClaimCondition{
+						{
+							Claim:    "sub",
+							Operator: "exists",
+						},
+					},
+				},
+				OutputMapping: []types.OutputMapping{
+					{
+						SourceClaim: "sub",
+						ClaimName:   "subject",
+					},
+					{
+						SourceClaim: "email",
+						ClaimName:   "email_address",
+					},
+				},
+			},
+		},
+	}, logger.CreateTestLogger())
+	if err != nil {
+		t.Fatalf("NewERSV2() error = %v", err)
+	}
+
+	claimsStruct, err := structpb.NewStruct(map[string]interface{}{
+		"sub":   "diana",
+		"email": "diana@example.com",
+	})
+	if err != nil {
+		t.Fatalf("structpb.NewStruct() error = %v", err)
+	}
+
+	claimsAny, err := anypb.New(claimsStruct)
+	if err != nil {
+		t.Fatalf("anypb.New() error = %v", err)
+	}
+
+	resp, err := erService.ResolveEntities(t.Context(), connect.NewRequest(&ersV2.ResolveEntitiesRequest{
+		Entities: []*entity.Entity{
+			{
+				EphemeralId: "diana-claims",
+				EntityType:  &entity.Entity_Claims{Claims: claimsAny},
+				Category:    entity.Entity_CATEGORY_SUBJECT,
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("ResolveEntities() error = %v", err)
+	}
+
+	if got := len(resp.Msg.GetEntityRepresentations()); got != 1 {
+		t.Fatalf("expected 1 entity representation, got %d", got)
+	}
+
+	props := resp.Msg.GetEntityRepresentations()[0].GetAdditionalProps()
+	if len(props) != 1 {
+		t.Fatalf("expected 1 additional props entry, got %d", len(props))
+	}
+
+	result := props[0].AsMap()
+	if got := result["subject"]; got != "diana" {
+		t.Fatalf("expected subject diana, got %v", got)
+	}
+	if got := result["email_address"]; got != "diana@example.com" {
+		t.Fatalf("expected email_address diana@example.com, got %v", got)
+	}
+	if got := result["metadata_source"]; got != "jwt_claims" {
+		t.Fatalf("expected metadata_source jwt_claims, got %v", got)
+	}
+	if _, hasError := result["error"]; hasError {
+		t.Fatalf("expected successful resolution, got error payload: %v", result["error"])
 	}
 }

--- a/service/entityresolution/multi-strategy/v2/registration_test.go
+++ b/service/entityresolution/multi-strategy/v2/registration_test.go
@@ -269,3 +269,59 @@ func TestResolveEntities_ClaimsProviderUsesInlineClaimsContext(t *testing.T) {
 		t.Fatalf("expected successful resolution, got error payload: %v", result["error"])
 	}
 }
+
+func TestResolveEntities_UserNameEntityDoesNotSeedClaimsContext(t *testing.T) {
+	t.Helper()
+
+	erService, err := NewERSV2(t.Context(), types.MultiStrategyConfig{
+		Providers: map[string]types.ProviderConfig{
+			"jwt": {
+				Type:       "claims",
+				Connection: map[string]interface{}{},
+			},
+		},
+		FailureStrategy: types.FailureStrategyContinue,
+		MappingStrategies: []types.MappingStrategy{
+			{
+				Name:       "claims_passthrough",
+				Provider:   "jwt",
+				EntityType: types.EntityTypeSubject,
+				Conditions: types.StrategyConditions{
+					JWTClaims: []types.JWTClaimCondition{{Claim: "userName", Operator: "exists"}},
+				},
+				OutputMapping: []types.OutputMapping{{SourceClaim: "userName", ClaimName: "username"}},
+			},
+		},
+	}, logger.CreateTestLogger())
+	if err != nil {
+		t.Fatalf("NewERSV2() error = %v", err)
+	}
+
+	resp, err := erService.ResolveEntities(t.Context(), connect.NewRequest(&ersV2.ResolveEntitiesRequest{
+		Entities: []*entity.Entity{{
+			EphemeralId: "alice-user-name",
+			EntityType:  &entity.Entity_UserName{UserName: "alice"},
+			Category:    entity.Entity_CATEGORY_SUBJECT,
+		}},
+	}))
+	if err != nil {
+		t.Fatalf("ResolveEntities() error = %v", err)
+	}
+
+	if got := len(resp.Msg.GetEntityRepresentations()); got != 1 {
+		t.Fatalf("expected 1 entity representation, got %d", got)
+	}
+
+	props := resp.Msg.GetEntityRepresentations()[0].GetAdditionalProps()
+	if len(props) != 1 {
+		t.Fatalf("expected 1 additional props entry, got %d", len(props))
+	}
+
+	result := props[0].AsMap()
+	if _, hasError := result["error"]; !hasError {
+		t.Fatalf("expected claims provider to fail without middleware claims for user_name entity, got %v", result)
+	}
+	if got := result["entity_id"]; got != "alice-user-name" {
+		t.Fatalf("expected entity_id alice-user-name, got %v", got)
+	}
+}

--- a/service/pkg/protohelper/structpb.go
+++ b/service/pkg/protohelper/structpb.go
@@ -1,0 +1,29 @@
+package protohelper
+
+// StructPBCompatibleValue normalizes Go values into shapes accepted by structpb.NewStruct.
+// In particular, it recursively converts []string into []interface{} while preserving
+// nested []interface{} and map[string]interface{} values.
+func StructPBCompatibleValue(value interface{}) interface{} {
+	switch v := value.(type) {
+	case []string:
+		result := make([]interface{}, len(v))
+		for i, item := range v {
+			result[i] = item
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(v))
+		for i, item := range v {
+			result[i] = StructPBCompatibleValue(item)
+		}
+		return result
+	case map[string]interface{}:
+		result := make(map[string]interface{}, len(v))
+		for key, item := range v {
+			result[key] = StructPBCompatibleValue(item)
+		}
+		return result
+	default:
+		return value
+	}
+}

--- a/service/pkg/protohelper/structpb_test.go
+++ b/service/pkg/protohelper/structpb_test.go
@@ -1,0 +1,37 @@
+package protohelper
+
+import (
+	"reflect"
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestStructPBCompatibleValue(t *testing.T) {
+	input := map[string]interface{}{
+		"attempted_strategies": []string{"claims", "ldap"},
+		"nested": map[string]interface{}{
+			"values": []interface{}{
+				"ok",
+				[]string{"a", "b"},
+				map[string]interface{}{"inner": []string{"x", "y"}},
+			},
+		},
+	}
+
+	normalized := StructPBCompatibleValue(input)
+
+	normalizedMap, ok := normalized.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected normalized result to be map[string]interface{}, got %T", normalized)
+	}
+
+	expectedStrategies := []interface{}{"claims", "ldap"}
+	if !reflect.DeepEqual(normalizedMap["attempted_strategies"], expectedStrategies) {
+		t.Fatalf("expected attempted_strategies %v, got %v", expectedStrategies, normalizedMap["attempted_strategies"])
+	}
+
+	if _, err := structpb.NewStruct(normalizedMap); err != nil {
+		t.Fatalf("expected normalized map to be structpb-compatible, got error: %v", err)
+	}
+}

--- a/tests-bdd/cukes/steps_authorization.go
+++ b/tests-bdd/cukes/steps_authorization.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type AuthorizationServiceStepDefinitions struct{}
@@ -21,14 +22,18 @@ const (
 )
 
 func ConvertInterfaceToAny(jsonData []byte) (*anypb.Any, error) {
-	// Create an empty Any
+	// First allow callers to provide a native Any JSON payload.
 	anyMsg := &anypb.Any{}
+	if err := protojson.Unmarshal(jsonData, anyMsg); err == nil {
+		return anyMsg, nil
+	}
 
-	// Use protojson's Unmarshal which handles @type automatically
-	if err := protojson.Unmarshal(jsonData, anyMsg); err != nil {
+	// For claims entities in BDD, plain JSON objects are the ergonomic input.
+	claimsStruct := &structpb.Struct{}
+	if err := protojson.Unmarshal(jsonData, claimsStruct); err != nil {
 		return nil, err
 	}
-	return anyMsg, nil
+	return anypb.New(claimsStruct)
 }
 
 func GetActionsFromValues(standardActions *string, customActions *string) []*policy.Action {
@@ -96,6 +101,16 @@ func (s *AuthorizationServiceStepDefinitions) thereIsAEnvEntityWithValueAndRefer
 func (s *AuthorizationServiceStepDefinitions) thereIsASubjectEntityWithValueAndReferencedAs(ctx context.Context, entityIDType string, entityIDValue string, referenceID string) (context.Context, error) {
 	scenarioContext := GetPlatformScenarioContext(ctx)
 	entity, err := s.createEntity(referenceID, "SUBJECT", entityIDType, entityIDValue)
+	if err != nil {
+		return ctx, err
+	}
+	scenarioContext.RecordObject(referenceID, entity)
+	return ctx, nil
+}
+
+func (s *AuthorizationServiceStepDefinitions) thereIsAClaimsSubjectEntityReferencedAsWithClaims(ctx context.Context, referenceID string, doc *godog.DocString) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	entity, err := s.createEntity(referenceID, "SUBJECT", "claims", doc.Content)
 	if err != nil {
 		return ctx, err
 	}
@@ -468,6 +483,7 @@ func (s *AuthorizationServiceStepDefinitions) theDecisionResponseForResourceShou
 func RegisterAuthorizationStepDefinitions(ctx *godog.ScenarioContext) {
 	stepDefinitions := AuthorizationServiceStepDefinitions{}
 	ctx.Step(`^there is a "([^"]*)" subject entity with value "([^"]*)" and referenced as "([^"]*)"$`, stepDefinitions.thereIsASubjectEntityWithValueAndReferencedAs)
+	ctx.Step(`^there is a claims subject entity referenced as "([^"]*)" with claims:$`, stepDefinitions.thereIsAClaimsSubjectEntityReferencedAsWithClaims)
 	ctx.Step(`^there is a "([^"]*)" environment entity with value "([^"]*)" and referenced as "([^"]*)"$`, stepDefinitions.thereIsAEnvEntityWithValueAndReferencedAs)
 	ctx.Step(`^I send a decision request for entity chain "([^"]*)" for "([^"]*)" action on resource "([^"]*)"$`, stepDefinitions.iSendADecisionRequestForEntityChainForActionOnResource)
 	ctx.Step(`^I send a decision request for entity chain "([^"]*)" for "([^"]*)" action on resource "([^"]*)" with fulfillable obligations "([^"]*)"$`, stepDefinitions.iSendADecisionRequestForEntityChainForActionOnResourceWithFulfillableObligations)

--- a/tests-bdd/cukes/steps_authorization_test.go
+++ b/tests-bdd/cukes/steps_authorization_test.go
@@ -1,0 +1,27 @@
+package cukes
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestConvertInterfaceToAny_PlainClaimsJSON(t *testing.T) {
+	anyMsg, err := ConvertInterfaceToAny([]byte(`{"userName":"diana","department":"engineering"}`))
+	if err != nil {
+		t.Fatalf("ConvertInterfaceToAny() error = %v", err)
+	}
+
+	var claimsStruct structpb.Struct
+	if err := anyMsg.UnmarshalTo(&claimsStruct); err != nil {
+		t.Fatalf("UnmarshalTo(structpb.Struct) error = %v", err)
+	}
+
+	claims := claimsStruct.AsMap()
+	if got := claims["userName"]; got != "diana" {
+		t.Fatalf("expected userName diana, got %v", got)
+	}
+	if got := claims["department"]; got != "engineering" {
+		t.Fatalf("expected department engineering, got %v", got)
+	}
+}

--- a/tests-bdd/features/multi-strategy-ers-claims.feature
+++ b/tests-bdd/features/multi-strategy-ers-claims.feature
@@ -1,0 +1,70 @@
+@claims-only-ers @stateless
+Feature: Multi-strategy ERS direct claims resolution
+  Validate that multi-strategy ERS resolves inline claims entities through the full
+  SDK -> Connect RPC -> platform -> ERS stack. This specifically covers the
+  ResolveEntities path used by authorization decisions when subject entities carry
+  claims directly instead of relying on LDAP lookup.
+
+  Background:
+    Given an ERS configuration with mode "multi-strategy" and failure strategy "fail-fast"
+    And an ERS provider "jwt_claims" of type "claims"
+    And an ERS mapping strategy "claims_passthrough" using provider "jwt_claims"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: userName
+            operator: exists
+      output_mapping:
+        - source_claim: userName
+          claim_name: username
+        - source_claim: department
+          claim_name: department
+      """
+    And a local platform with inline ERS configuration
+
+  Scenario: Inline claims engineering user gets PERMIT
+    Given I submit a request to create a namespace with name "claims-permit.test" and reference id "ns_claims_permit"
+    And I send a request to create an attribute with:
+      | namespace_id      | name       | rule  | values                         |
+      | ns_claims_permit  | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_claims_eng" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_claims_eng" containing the condition groups "cg_claims_eng"
+    And I send a request to create a subject condition set referenced as "scs_claims_eng" containing subject sets "ss_claims_eng"
+    And I send a request to create a subject mapping with:
+      | reference_id  | attribute_value                                              | condition_set_name | standard actions | custom actions |
+      | sm_claims_eng | https://claims-permit.test/attr/department/value/engineering | scs_claims_eng     | read             |                |
+    Then the response should be successful
+    Given there is a claims subject entity referenced as "diana_claims" with claims:
+      """
+      {"userName":"diana","department":"engineering"}
+      """
+    When I send a decision request for entity chain "diana_claims" for "read" action on resource "https://claims-permit.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response
+
+  Scenario: Inline claims marketing user gets DENY for engineering resource
+    Given I submit a request to create a namespace with name "claims-deny.test" and reference id "ns_claims_deny"
+    And I send a request to create an attribute with:
+      | namespace_id    | name       | rule  | values                         |
+      | ns_claims_deny  | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_claims_eng2" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_claims_eng2" containing the condition groups "cg_claims_eng2"
+    And I send a request to create a subject condition set referenced as "scs_claims_eng2" containing subject sets "ss_claims_eng2"
+    And I send a request to create a subject mapping with:
+      | reference_id   | attribute_value                                            | condition_set_name | standard actions | custom actions |
+      | sm_claims_eng2 | https://claims-deny.test/attr/department/value/engineering | scs_claims_eng2    | read             |                |
+    Then the response should be successful
+    Given there is a claims subject entity referenced as "bob_claims" with claims:
+      """
+      {"userName":"bob","department":"marketing"}
+      """
+    When I send a decision request for entity chain "bob_claims" for "read" action on resource "https://claims-deny.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "DENY" decision response


### PR DESCRIPTION
## Summary
- pass inline ResolveEntities claims through `types.JWTClaimsContextKey` before calling the multi-strategy service
- add regression tests for both v1 and v2 claims-only ResolveEntities paths
- normalize result values before building protobuf structs so metadata/claim arrays serialize cleanly

## Testing
- go test ./entityresolution/multi-strategy/...
- golangci-lint run ./entityresolution/multi-strategy/...
- cd sdk && go test -run TestREADMECodeBlocks

Fixes #3790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-strategy entity resolution now supports inline JWT claims, including claim-to-entity field mapping and metadata.
  * Added BDD support and end-to-end scenarios for claims-based authorization, including permitted and denied access outcomes.

* **Bug Fixes**
  * Improved normalization of claim and metadata values for reliable response formatting.
  * Claims context is only applied when provided by a claims entity.

* **Tests**
  * Added unit and integration coverage for claims resolution, mappings, metadata, and authorization decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->