### PR TITLE
fix(ers): use pgx for postgres providers

### DIFF
--- a/service/entityresolution/integration/multistrategy_comprehensive_test.go
+++ b/service/entityresolution/integration/multistrategy_comprehensive_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
-	_ "github.com/lib/pq" // PostgreSQL driver
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -156,7 +155,7 @@ func TestMultiStrategy_SQLOnly(t *testing.T) {
 	// Retry connection to handle container startup timing
 	var db *sql.DB
 	for i := 0; i < 10; i++ {
-		db, err = sql.Open("postgres", connStr)
+		db, err = sql.Open("pgx/v5", connStr)
 		if err != nil {
 			time.Sleep(500 * time.Millisecond)
 			continue

--- a/service/entityresolution/multi-strategy/providers/sql/sql_provider.go
+++ b/service/entityresolution/multi-strategy/providers/sql/sql_provider.go
@@ -6,11 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	// Database drivers would be imported here:
-	// _ "github.com/lib/pq"           // PostgreSQL driver
-	// _ "github.com/go-sql-driver/mysql" // MySQL driver
-	// _ "github.com/mattn/go-sqlite3" // SQLite driver
-
+	// Register pgx as a database/sql driver for PostgreSQL ERS providers.
+	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/opentdf/platform/service/entityresolution/multi-strategy/types"
 )
 
@@ -44,8 +41,14 @@ func NewProvider(ctx context.Context, name string, config Config) (*Provider, er
 		)
 	}
 
+	// Keep "postgres" as the configuration value while using pgx internally.
+	databaseDriver := config.Driver
+	if databaseDriver == "postgres" {
+		databaseDriver = "pgx/v5"
+	}
+
 	// Open database connection
-	db, err := sql.Open(config.Driver, connStr)
+	db, err := sql.Open(databaseDriver, connStr)
 	if err != nil {
 		return nil, types.WrapMultiStrategyError(
 			types.ErrorTypeProvider,

--- a/service/entityresolution/multi-strategy/providers/sql/sql_provider_test.go
+++ b/service/entityresolution/multi-strategy/providers/sql/sql_provider_test.go
@@ -1,0 +1,21 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProviderUsesPGXForPostgres(t *testing.T) {
+	config := DefaultConfig()
+	config.Host = "127.0.0.1"
+	config.Port = 0
+	config.Database = "test"
+
+	_, err := NewProvider(t.Context(), "postgres", config)
+	require.Error(t, err)
+
+	var parseError *pgconn.ParseConfigError
+	require.ErrorAs(t, err, &parseError)
+}

--- a/service/go.mod
+++ b/service/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lestrrat-go/jwx/v2 v2.1.6
-	github.com/lib/pq v1.10.9
 	github.com/mattn/go-sqlite3 v1.14.48
 	github.com/open-policy-agent/opa v1.5.1
 	github.com/opentdf/platform/lib/fixtures v0.6.0

--- a/service/go.sum
+++ b/service/go.sum
@@ -223,8 +223,6 @@ github.com/lestrrat-go/jwx/v2 v2.1.6 h1:hxM1gfDILk/l5ylers6BX/Eq1m/pnxe9NBwW6lVf
 github.com/lestrrat-go/jwx/v2 v2.1.6/go.mod h1:Y722kU5r/8mV7fYDifjug0r8FK8mZdw0K0GpJw/l8pU=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
-github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
-github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 h1:PpXWgLPs+Fqr325bN2FD2ISlRRztXibcX6e8f5FR5Dc=
 github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=


### PR DESCRIPTION
### Proposed Changes

- Keep `driver: postgres` as the ERS configuration contract.
- Register pgx v5 and select its `database/sql` driver internally for PostgreSQL providers.
- Remove the test-only `lib/pq` registration and dependency.
- Add focused coverage that verifies `postgres` reaches the pgx configuration path.

This is a narrower alternative to #3543. It fixes #3539 without exposing pgx driver names or adding PostgreSQL aliases to user configuration.

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation (not needed; configuration remains unchanged)

### Testing Instructions

- `cd service && go test ./entityresolution/multi-strategy/... -race`
- `cd service && go test ./entityresolution/multi-strategy/providers/sql -race -count=1`
- `cd sdk && go test -run TestREADMECodeBlocks`
- `cd service && golangci-lint run -c ../.golangci.yaml --new-from-rev=origin/main`

The PostgreSQL container test is wired to pgx v5 but requires Docker to execute.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL connection handling for SQL-based integrations.
  * PostgreSQL configurations now use the updated database driver consistently.
  * Added validation to ensure connection errors are reported correctly.

* **Tests**
  * Added coverage for PostgreSQL provider initialization and configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->