### PR TITLE
fix(ers): Add postgres_object output transformation for JSON/JSONB results

### DIFF
--- a/service/entityresolution/multi-strategy/README.md
+++ b/service/entityresolution/multi-strategy/README.md
@@ -129,6 +129,7 @@ services:
 | Transformation | Input | Output | Use Case |
 |---------------|-------|---------|----------|
 | `postgres_array` | `"{apple,banana,cherry}"` | `["apple", "banana", "cherry"]` | PostgreSQL arrays |
+| `postgres_object` | `[]byte`, `string`, or `map[string]any` holding a JSON object (e.g. `'{"dept":"eng","level":3}'`) | `map[string]any{"dept":"eng","level":3}` | PostgreSQL `json`/`jsonb` columns surfaced as structured claims. `nil`, empty `[]byte`, and empty `string` normalize to `{}`; any other input type is an error. |
 
 ### LDAP-Specific Transformations
 

--- a/service/entityresolution/multi-strategy/output_mapper.go
+++ b/service/entityresolution/multi-strategy/output_mapper.go
@@ -1,6 +1,7 @@
 package multistrategy
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -155,8 +156,44 @@ func (om *OutputMapper) applyTransformation(value interface{}, transformation st
 	case "trim":
 		return om.transformTrim(value)
 
+	case "postgres_object":
+		return om.transformPostgresObject(value)
+
 	default:
 		return nil, fmt.Errorf("unknown transformation: %s", transformation)
+	}
+}
+
+// transformPostgresObject converts a Postgres JSON/JSONB query result into a map[string]any.
+// Postgres drivers may return JSON/JSONB values as []byte, string, or an already-parsed map.
+func (om *OutputMapper) transformPostgresObject(value interface{}) (interface{}, error) {
+	if value == nil {
+		return map[string]any{}, nil
+	}
+
+	switch v := value.(type) {
+	case map[string]any:
+		return v, nil
+	case []byte:
+		if len(v) == 0 {
+			return map[string]any{}, nil
+		}
+		result := map[string]any{}
+		if err := json.Unmarshal(v, &result); err != nil {
+			return nil, fmt.Errorf("postgres_object transformation failed to unmarshal []byte: %w", err)
+		}
+		return result, nil
+	case string:
+		if v == "" {
+			return map[string]any{}, nil
+		}
+		result := map[string]any{}
+		if err := json.Unmarshal([]byte(v), &result); err != nil {
+			return nil, fmt.Errorf("postgres_object transformation failed to unmarshal string: %w", err)
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("postgres_object transformation requires []byte, string, or map[string]any input, got %T", value)
 	}
 }
 

--- a/service/entityresolution/multi-strategy/output_mapper.go
+++ b/service/entityresolution/multi-strategy/output_mapper.go
@@ -40,7 +40,8 @@ func (om *OutputMapper) MapResult(rawResult *types.RawResult, outputMappings []t
 	}
 
 	// Apply output mappings
-	for _, mapping := range outputMappings {
+	appliedTransformations := make([]string, len(outputMappings))
+	for i, mapping := range outputMappings {
 		if err := om.applyMapping(rawResult, entityResult, mapping); err != nil {
 			return nil, types.WrapMultiStrategyError(
 				types.ErrorTypeMapping,
@@ -53,10 +54,12 @@ func (om *OutputMapper) MapResult(rawResult *types.RawResult, outputMappings []t
 				},
 			)
 		}
+		appliedTransformations[i] = mapping.Transformation
 	}
 
 	// Add mapping metadata
 	entityResult.Metadata["output_mappings_applied"] = len(outputMappings)
+	entityResult.Metadata["output_mappings_applied_transformations"] = strings.Join(appliedTransformations, ",")
 	entityResult.Metadata["claims_mapped"] = len(entityResult.Claims)
 
 	return entityResult, nil

--- a/service/entityresolution/multi-strategy/output_mapper.go
+++ b/service/entityresolution/multi-strategy/output_mapper.go
@@ -176,6 +176,9 @@ func (om *OutputMapper) transformPostgresObject(value interface{}) (interface{},
 
 	switch v := value.(type) {
 	case map[string]any:
+		if v == nil {
+			return map[string]any{}, nil
+		}
 		return v, nil
 	case []byte:
 		if len(v) == 0 {
@@ -185,6 +188,9 @@ func (om *OutputMapper) transformPostgresObject(value interface{}) (interface{},
 		if err := json.Unmarshal(v, &result); err != nil {
 			return nil, fmt.Errorf("postgres_object transformation failed to unmarshal []byte: %w", err)
 		}
+		if result == nil {
+			return map[string]any{}, nil
+		}
 		return result, nil
 	case string:
 		if v == "" {
@@ -193,6 +199,9 @@ func (om *OutputMapper) transformPostgresObject(value interface{}) (interface{},
 		result := map[string]any{}
 		if err := json.Unmarshal([]byte(v), &result); err != nil {
 			return nil, fmt.Errorf("postgres_object transformation failed to unmarshal string: %w", err)
+		}
+		if result == nil {
+			return map[string]any{}, nil
 		}
 		return result, nil
 	default:

--- a/service/entityresolution/multi-strategy/output_mapper_test.go
+++ b/service/entityresolution/multi-strategy/output_mapper_test.go
@@ -1,0 +1,106 @@
+package multistrategy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestOutputMapper_transformPostgresObject(t *testing.T) {
+	om := NewOutputMapper()
+
+	var typedNilMap map[string]any
+
+	tests := []struct {
+		name     string
+		input    any
+		expected any
+		hasError bool
+	}{
+		{
+			name:     "nil input returns empty map",
+			input:    nil,
+			expected: map[string]any{},
+		},
+		{
+			name:     "typed nil map[string]any returns empty map",
+			input:    typedNilMap,
+			expected: map[string]any{},
+		},
+		{
+			name:     "already parsed map returned as-is",
+			input:    map[string]any{"foo": "bar", "n": float64(1)},
+			expected: map[string]any{"foo": "bar", "n": float64(1)},
+		},
+		{
+			name:     "empty []byte returns empty map",
+			input:    []byte{},
+			expected: map[string]any{},
+		},
+		{
+			name:     "empty string returns empty map",
+			input:    "",
+			expected: map[string]any{},
+		},
+		{
+			name:     "JSON null []byte returns empty map",
+			input:    []byte(`null`),
+			expected: map[string]any{},
+		},
+		{
+			name:     "JSON null string returns empty map",
+			input:    `null`,
+			expected: map[string]any{},
+		},
+		{
+			name:     "valid JSON []byte is unmarshaled",
+			input:    []byte(`{"foo":"bar","n":1}`),
+			expected: map[string]any{"foo": "bar", "n": float64(1)},
+		},
+		{
+			name:     "valid JSON string is unmarshaled",
+			input:    `{"foo":"bar","nested":{"k":"v"}}`,
+			expected: map[string]any{"foo": "bar", "nested": map[string]any{"k": "v"}},
+		},
+		{
+			name:     "invalid JSON []byte returns error",
+			input:    []byte(`{not json`),
+			hasError: true,
+		},
+		{
+			name:     "invalid JSON string returns error",
+			input:    `{not json`,
+			hasError: true,
+		},
+		{
+			name:     "JSON array []byte is not an object and returns error",
+			input:    []byte(`[1,2,3]`),
+			hasError: true,
+		},
+		{
+			name:     "unsupported type returns error",
+			input:    42,
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := om.transformPostgresObject(tt.input)
+
+			if tt.hasError {
+				if err == nil {
+					t.Fatalf("expected error but got none (result=%v)", result)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("transformPostgresObject(%v) = %v, expected %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Proposed Changes

closes #3802 

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `postgres_object` transformation to convert PostgreSQL JSON/JSONB inputs into structured objects.
  * Output metadata now records the specific transformations applied (as a comma-joined list) while keeping existing mapping counts intact.
* **Documentation**
  * Updated multi-strategy transformation documentation to include `postgres_object` input/output and error behavior.
* **Tests**
  * Added coverage for `postgres_object` across valid inputs, empty/null cases, and invalid/unsupported data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->