### PR TITLE
feat(cli): add streaming list output and man Doc.AddStringFlag helper

### DIFF
--- a/otdfctl/pkg/cli/stream.go
+++ b/otdfctl/pkg/cli/stream.go
@@ -3,18 +3,11 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"iter"
-	"strings"
-	"text/tabwriter"
-)
 
-// tabwriter configuration for the streamed styled table.
-const (
-	streamTabMinWidth = 0
-	streamTabWidth    = 2
-	streamTabPadding  = 2
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
 )
 
 // StreamList renders a list of items incrementally to w.
@@ -23,10 +16,10 @@ const (
 // encoding one item at a time so the full result set is never held in memory.
 // This is the memory-bounded path, suitable for very large lists.
 //
-// In styled mode it writes a tab-aligned table with the given column headers,
-// one row per item derived from row. Column alignment requires measuring every
-// cell, so the styled path buffers rows until the stream completes; use JSON
-// mode when memory bounds matter for a large result set.
+// In styled mode it renders a bordered, styled table with the given column
+// headers, one row per item derived from row. Aligning and styling the table
+// requires every cell, so the styled path buffers rows until the stream
+// completes; use JSON mode when memory bounds matter for a large result set.
 //
 // items is an iter.Seq2 yielding (item, err) so callers can feed a paged
 // iterator without materializing it. A non-nil err (for example, a failed page
@@ -37,7 +30,7 @@ func (c *Cli) StreamList(w io.Writer, headers []string, row func(any) []string, 
 	if c.printer != nil && c.printer.json {
 		return streamJSONArray(w, items)
 	}
-	return streamTable(w, headers, row, items)
+	return renderStyledTable(w, headers, row, items)
 }
 
 // streamJSONArray writes items as a pretty-printed JSON array, marshaling one
@@ -89,20 +82,38 @@ func marshalStreamItem(item any) ([]byte, error) {
 	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }
 
-// streamTable writes a tab-aligned table of headers followed by one row per
-// item. tabwriter buffers writes and only reports errors on Flush, so the
-// per-row writes are not error-checked (fmt.Fprint* returns are excluded from
-// errcheck); a non-nil iterator error aborts before Flush and is returned.
-func streamTable(w io.Writer, headers []string, row func(any) []string, items iter.Seq2[any, error]) error {
-	tw := tabwriter.NewWriter(w, streamTabMinWidth, streamTabWidth, streamTabPadding, ' ', 0)
-	if len(headers) > 0 {
-		fmt.Fprintln(tw, strings.Join(headers, "\t"))
-	}
+// renderStyledTable buffers every row, then renders a rounded, styled table
+// matching the look of NewTable. Alignment and styling need all rows, so the
+// stream is drained first; a non-nil iterator error aborts before rendering and
+// is returned. The rendered table is written to w in a single call.
+func renderStyledTable(w io.Writer, headers []string, row func(any) []string, items iter.Seq2[any, error]) error {
+	rows := make([][]string, 0)
 	for item, err := range items {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(tw, strings.Join(row(item), "\t"))
+		rows = append(rows, row(item))
 	}
-	return tw.Flush()
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(styleTable).
+		StyleFunc(styledTableCell).
+		Rows(rows...)
+	if len(headers) > 0 {
+		t = t.Headers(headers...)
+	}
+
+	_, err := io.WriteString(w, t.String()+"\n")
+	return err
+}
+
+// styledTableCell styles table cells to match NewTable: adaptive foreground with
+// horizontal padding for every cell, bold for the header row.
+func styledTableCell(row, _ int) lipgloss.Style {
+	style := styleTable.Padding(0, 1)
+	if row == table.HeaderRow {
+		return style.Bold(true)
+	}
+	return style
 }

--- a/otdfctl/pkg/cli/stream.go
+++ b/otdfctl/pkg/cli/stream.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"iter"
+	"strings"
+	"text/tabwriter"
+)
+
+// tabwriter configuration for the streamed styled table.
+const (
+	streamTabMinWidth = 0
+	streamTabWidth    = 2
+	streamTabPadding  = 2
+)
+
+// StreamList renders a list of items incrementally to w.
+//
+// In JSON mode (the printer configured for JSON output) it writes a JSON array,
+// encoding one item at a time so the full result set is never held in memory.
+// This is the memory-bounded path, suitable for very large lists.
+//
+// In styled mode it writes a tab-aligned table with the given column headers,
+// one row per item derived from row. Column alignment requires measuring every
+// cell, so the styled path buffers rows until the stream completes; use JSON
+// mode when memory bounds matter for a large result set.
+//
+// items is an iter.Seq2 yielding (item, err) so callers can feed a paged
+// iterator without materializing it. A non-nil err (for example, a failed page
+// fetch) aborts the stream and is returned, so a mid-iteration failure surfaces
+// to the caller rather than looking like normal exhaustion. row maps an item to
+// its table cells and is only invoked in styled mode.
+func (c *Cli) StreamList(w io.Writer, headers []string, row func(any) []string, items iter.Seq2[any, error]) error {
+	if c.printer != nil && c.printer.json {
+		return streamJSONArray(w, items)
+	}
+	return streamTable(w, headers, row, items)
+}
+
+// streamJSONArray writes items as a pretty-printed JSON array, marshaling one
+// item at a time to bound memory. Indentation and HTML-escaping match printJSON.
+// A non-nil iterator error aborts before closing the array and is returned.
+func streamJSONArray(w io.Writer, items iter.Seq2[any, error]) error {
+	if _, err := io.WriteString(w, "["); err != nil {
+		return err
+	}
+	first := true
+	for item, err := range items {
+		if err != nil {
+			return err
+		}
+		b, err := marshalStreamItem(item)
+		if err != nil {
+			return err
+		}
+		sep := ",\n  "
+		if first {
+			sep = "\n  "
+			first = false
+		}
+		if _, err := io.WriteString(w, sep); err != nil {
+			return err
+		}
+		if _, err := w.Write(b); err != nil {
+			return err
+		}
+	}
+	tail := "]\n"
+	if !first {
+		tail = "\n]\n"
+	}
+	_, err := io.WriteString(w, tail)
+	return err
+}
+
+// marshalStreamItem encodes a single item indented for placement inside the
+// streamed array, without a trailing newline.
+func marshalStreamItem(item any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("  ", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(item); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// streamTable writes a tab-aligned table of headers followed by one row per
+// item. tabwriter buffers writes and only reports errors on Flush, so the
+// per-row writes are not error-checked (fmt.Fprint* returns are excluded from
+// errcheck); a non-nil iterator error aborts before Flush and is returned.
+func streamTable(w io.Writer, headers []string, row func(any) []string, items iter.Seq2[any, error]) error {
+	tw := tabwriter.NewWriter(w, streamTabMinWidth, streamTabWidth, streamTabPadding, ' ', 0)
+	if len(headers) > 0 {
+		fmt.Fprintln(tw, strings.Join(headers, "\t"))
+	}
+	for item, err := range items {
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(tw, strings.Join(row(item), "\t"))
+	}
+	return tw.Flush()
+}

--- a/otdfctl/pkg/cli/stream_test.go
+++ b/otdfctl/pkg/cli/stream_test.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"iter"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seqOf returns an error-free iter.Seq2 over the given items, mirroring how a
+// paged iterator with no fetch failures would feed StreamList.
+func seqOf(items ...any) iter.Seq2[any, error] {
+	return func(yield func(any, error) bool) {
+		for _, it := range items {
+			if !yield(it, nil) {
+				return
+			}
+		}
+	}
+}
+
+// seqErr yields the given items and then a terminal error, mirroring a paged
+// iterator whose later page fetch fails.
+func seqErr(err error, items ...any) iter.Seq2[any, error] {
+	return func(yield func(any, error) bool) {
+		for _, it := range items {
+			if !yield(it, nil) {
+				return
+			}
+		}
+		yield(nil, err)
+	}
+}
+
+// failingWriter fails its Write after okWrites successful calls, exercising the
+// io.Writer error branches of the streamers.
+type failingWriter struct {
+	okWrites int
+	n        int
+}
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	if f.n >= f.okWrites {
+		return 0, errors.New("write failed")
+	}
+	f.n++
+	return len(p), nil
+}
+
+func TestStreamListJSON(t *testing.T) {
+	c := New(&cobra.Command{Use: "test"}, nil, WithPrintJSON())
+
+	var buf bytes.Buffer
+	items := seqOf(
+		map[string]string{"id": "1", "name": "alpha"},
+		map[string]string{"id": "2", "name": "beta"},
+	)
+	require.NoError(t, c.StreamList(&buf, []string{"ID", "Name"}, nil, items))
+
+	var decoded []map[string]string
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	require.Len(t, decoded, 2)
+	assert.Equal(t, "1", decoded[0]["id"])
+	assert.Equal(t, "beta", decoded[1]["name"])
+}
+
+func TestStreamListJSONEmpty(t *testing.T) {
+	c := New(&cobra.Command{Use: "test"}, nil, WithPrintJSON())
+
+	var buf bytes.Buffer
+	require.NoError(t, c.StreamList(&buf, nil, nil, seqOf()))
+
+	var decoded []any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	assert.Empty(t, decoded)
+}
+
+func TestStreamListJSONNoHTMLEscape(t *testing.T) {
+	c := New(&cobra.Command{Use: "test"}, nil, WithPrintJSON())
+
+	var buf bytes.Buffer
+	items := seqOf(map[string]string{"attr": "a&b<c>"})
+	require.NoError(t, c.StreamList(&buf, nil, nil, items))
+
+	assert.Contains(t, buf.String(), "a&b<c>")
+}
+
+// TestStreamListJSONIteratorError verifies a page-fetch failure surfaces rather
+// than looking like normal exhaustion (the P2 review concern).
+func TestStreamListJSONIteratorError(t *testing.T) {
+	c := New(&cobra.Command{Use: "test"}, nil, WithPrintJSON())
+
+	sentinel := errors.New("page fetch failed")
+	var buf bytes.Buffer
+	err := c.StreamList(&buf, nil, nil, seqErr(sentinel, map[string]string{"id": "1"}))
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestStreamListJSONMarshalError(t *testing.T) {
+	c := New(&cobra.Command{Use: "test"}, nil, WithPrintJSON())
+
+	var buf bytes.Buffer
+	// A channel cannot be marshaled to JSON.
+	err := c.StreamList(&buf, nil, nil, seqOf(make(chan int)))
+	require.Error(t, err)
+}
+
+func TestStreamListJSONWriteErrors(t *testing.T) {
+	one := map[string]string{"id": "1"}
+	for name, tc := range map[string]struct {
+		okWrites int
+		items    iter.Seq2[any, error]
+	}{
+		"open bracket": {okWrites: 0, items: seqOf(one)},
+		"separator":    {okWrites: 1, items: seqOf(one)},
+		"item bytes":   {okWrites: 2, items: seqOf(one)},
+		"tail":         {okWrites: 1, items: seqOf()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := New(&cobra.Command{Use: "test"}, nil, WithPrintJSON())
+			w := &failingWriter{okWrites: tc.okWrites}
+			assert.Error(t, c.StreamList(w, nil, nil, tc.items))
+		})
+	}
+}
+
+func TestStreamListTable(t *testing.T) {
+	c := New(&cobra.Command{Use: "test"}, nil) // styled mode: no --json
+
+	var buf bytes.Buffer
+	items := seqOf(
+		[]string{"1", "alpha"},
+		[]string{"2", "beta"},
+	)
+	row := func(v any) []string { s, _ := v.([]string); return s }
+	require.NoError(t, c.StreamList(&buf, []string{"ID", "Name"}, row, items))
+
+	out := buf.String()
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "Name")
+	assert.Contains(t, out, "alpha")
+	assert.Contains(t, out, "beta")
+	// header is written before the rows
+	assert.Less(t, strings.Index(out, "ID"), strings.Index(out, "alpha"))
+}
+
+func TestStreamListTableNoHeaders(t *testing.T) {
+	c := New(&cobra.Command{Use: "test"}, nil)
+
+	var buf bytes.Buffer
+	items := seqOf([]string{"only"})
+	row := func(v any) []string { s, _ := v.([]string); return s }
+	require.NoError(t, c.StreamList(&buf, nil, row, items))
+
+	assert.Contains(t, buf.String(), "only")
+}
+
+func TestStreamListTableIteratorError(t *testing.T) {
+	c := New(&cobra.Command{Use: "test"}, nil)
+
+	sentinel := errors.New("page fetch failed")
+	row := func(v any) []string { s, _ := v.([]string); return s }
+	err := c.StreamList(&bytes.Buffer{}, []string{"ID"}, row, seqErr(sentinel, []string{"1"}))
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestStreamListTableFlushError(t *testing.T) {
+	c := New(&cobra.Command{Use: "test"}, nil)
+
+	row := func(v any) []string { s, _ := v.([]string); return s }
+	w := &failingWriter{okWrites: 0}
+	assert.Error(t, c.StreamList(w, []string{"ID"}, row, seqOf([]string{"1"})))
+}

--- a/otdfctl/pkg/cli/stream_test.go
+++ b/otdfctl/pkg/cli/stream_test.go
@@ -148,6 +148,8 @@ func TestStreamListTable(t *testing.T) {
 	assert.Contains(t, out, "beta")
 	// header is written before the rows
 	assert.Less(t, strings.Index(out, "ID"), strings.Index(out, "alpha"))
+	// styled mode renders a bordered table rather than plain text
+	assert.Contains(t, out, "╭")
 }
 
 func TestStreamListTableNoHeaders(t *testing.T) {
@@ -170,7 +172,7 @@ func TestStreamListTableIteratorError(t *testing.T) {
 	require.ErrorIs(t, err, sentinel)
 }
 
-func TestStreamListTableFlushError(t *testing.T) {
+func TestStreamListTableWriteError(t *testing.T) {
 	c := New(&cobra.Command{Use: "test"}, nil)
 
 	row := func(v any) []string { s, _ := v.([]string); return s }

--- a/otdfctl/pkg/cli/stream_test.go
+++ b/otdfctl/pkg/cli/stream_test.go
@@ -63,6 +63,25 @@ func TestStreamListJSON(t *testing.T) {
 	)
 	require.NoError(t, c.StreamList(&buf, []string{"ID", "Name"}, nil, items))
 
+	// Exact-output assertion: each object's opening brace is indented two spaces
+	// by the separator (SetIndent does not prefix the opening "{"), matching
+	// printJSON. Pins the layout against separator regressions.
+	const wantJSON = `[
+  {
+    "id": "1",
+    "name": "alpha"
+  },
+  {
+    "id": "2",
+    "name": "beta"
+  }
+]
+`
+	// Exact byte comparison on purpose: JSONEq ignores whitespace, but this test
+	// exists to pin the indentation/formatting, not JSON equality.
+	//nolint:testifylint // encoded-compare: exact formatting is the assertion
+	assert.Equal(t, wantJSON, buf.String())
+
 	var decoded []map[string]string
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
 	require.Len(t, decoded, 2)

--- a/otdfctl/pkg/man/docflags.go
+++ b/otdfctl/pkg/man/docflags.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/opentdf/platform/otdfctl/pkg/cli"
+	"github.com/spf13/cobra"
 )
 
 // SensitiveAnnotationKey is the pflag annotation key used to mark flags whose
@@ -34,6 +35,15 @@ func (d *Doc) GetDocFlag(name string) DocFlag {
 
 func (f DocFlag) DefaultAsBool() bool {
 	return f.Default == "true"
+}
+
+// AddStringFlag registers a string flag on cmd from the doc's flag definition,
+// wiring the flag's name, shorthand, default, and description in one call. It
+// reduces the boilerplate of reading each field from GetDocFlag by hand, which
+// is useful for commands that register many flags.
+func (d *Doc) AddStringFlag(cmd *cobra.Command, name string) {
+	f := d.GetDocFlag(name)
+	cmd.Flags().StringP(f.Name, f.Shorthand, f.Default, f.Description)
 }
 
 // MarkSensitiveFlags sets pflag annotations on all flags in the command's

--- a/otdfctl/pkg/man/docflags_test.go
+++ b/otdfctl/pkg/man/docflags_test.go
@@ -76,3 +76,36 @@ func TestMarkSensitiveFlagsPanicsOnUnregistered(t *testing.T) {
 		doc.MarkSensitiveFlags()
 	})
 }
+
+func TestAddStringFlag(t *testing.T) {
+	doc, err := ProcessDoc(`---
+title: Test Command
+command:
+  name: test
+  flags:
+    - name: workspace
+      shorthand: w
+      default: default-ws
+      description: ID of the workspace
+---
+
+Body.
+`)
+	require.NoError(t, err)
+
+	cmd := &cobra.Command{Use: "test"}
+	doc.AddStringFlag(cmd, "workspace")
+
+	f := cmd.Flags().Lookup("workspace")
+	require.NotNil(t, f)
+	assert.Equal(t, "w", f.Shorthand)
+	assert.Equal(t, "default-ws", f.DefValue)
+	assert.Equal(t, "ID of the workspace", f.Usage)
+}
+
+func TestAddStringFlagPanicsOnUnknown(t *testing.T) {
+	doc := &Doc{Command: cobra.Command{Use: "test"}}
+	assert.Panics(t, func() {
+		doc.AddStringFlag(&cobra.Command{Use: "test"}, "missing")
+	})
+}


### PR DESCRIPTION
## Summary

Two small, reusable additions to otdfctl, both prompted by CLI work that registers many flags and lists potentially large result sets:

- **`Cli.StreamList`** (`pkg/cli/stream.go`) — renders a list incrementally. In JSON mode it writes a JSON array, marshaling one item at a time so the full result set is never buffered (memory-bounded, suitable for very large lists). In styled mode it writes a `text/tabwriter`-aligned table; that path buffers rows to align columns, so JSON mode is the memory-bounded path. Takes an `iter.Seq[any]` so callers can feed a paged iterator without materializing it.
- **`man.Doc.AddStringFlag`** (`pkg/man/docflags.go`) — registers a string flag on a command from its doc definition in one call, replacing the repeated `cmd.Flags().StringP(doc.GetDocFlag("x").Name, …Shorthand, …Default, …Description)` boilerplate seen across `cmd/`.

## Test plan

- [x] `go test ./pkg/man/... ./pkg/cli/... -race` passes (new unit tests cover JSON/styled streaming, empty input, HTML-escape parity, and the flag helper including its panic-on-unknown path).
- [x] `golangci-lint run ./pkg/man/... ./pkg/cli/...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added list output in JSON and tabular formats for command-line results.
  - JSON output preserves item order and special characters, including empty results.
  - Tables support optional headers, aligned rows, and styled borders.
  - Added support for registering documented string command-line flags.

- **Bug Fixes**
  - Improved handling of iterator, encoding, and output errors during list rendering.

- **Tests**
  - Added comprehensive coverage for streaming output, table formatting, special characters, failures, and flag registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->