### PR TITLE
fix(ers): Add postgres_object_array output transformation for JSON/JSONB array results

### DIFF
--- a/service/entityresolution/multi-strategy/output_mapper.go
+++ b/service/entityresolution/multi-strategy/output_mapper.go
@@ -162,6 +162,9 @@ func (om *OutputMapper) applyTransformation(value interface{}, transformation st
 	case "postgres_object":
 		return om.transformPostgresObject(value)
 
+	case "postgres_object_array":
+		return om.transformPostgresObjectArray(value)
+
 	default:
 		return nil, fmt.Errorf("unknown transformation: %s", transformation)
 	}
@@ -206,6 +209,63 @@ func (om *OutputMapper) transformPostgresObject(value interface{}) (interface{},
 		return result, nil
 	default:
 		return nil, fmt.Errorf("postgres_object transformation requires []byte, string, or map[string]any input, got %T", value)
+	}
+}
+
+// transformPostgresObjectArray converts a Postgres JSON/JSONB array-of-objects query result into a []map[string]any.
+// Postgres drivers may return JSON/JSONB array values as []byte, string, an already-parsed []map[string]any,
+// or a []any whose elements are per-element convertible via transformPostgresObject.
+func (om *OutputMapper) transformPostgresObjectArray(value interface{}) (interface{}, error) {
+	if value == nil {
+		return []map[string]any{}, nil
+	}
+
+	switch v := value.(type) {
+	case []map[string]any:
+		if v == nil {
+			return []map[string]any{}, nil
+		}
+		return v, nil
+	case []any:
+		result := make([]map[string]any, 0, len(v))
+		for i, elem := range v {
+			transformed, err := om.transformPostgresObject(elem)
+			if err != nil {
+				return nil, fmt.Errorf("postgres_object_array transformation failed at index %d: %w", i, err)
+			}
+			m, ok := transformed.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("postgres_object_array transformation produced unexpected type at index %d: %T", i, transformed)
+			}
+			result = append(result, m)
+		}
+		return result, nil
+	case []byte:
+		if len(v) == 0 {
+			return []map[string]any{}, nil
+		}
+		result := []map[string]any{}
+		if err := json.Unmarshal(v, &result); err != nil {
+			return nil, fmt.Errorf("postgres_object_array transformation failed to unmarshal []byte: %w", err)
+		}
+		if result == nil {
+			return []map[string]any{}, nil
+		}
+		return result, nil
+	case string:
+		if v == "" {
+			return []map[string]any{}, nil
+		}
+		result := []map[string]any{}
+		if err := json.Unmarshal([]byte(v), &result); err != nil {
+			return nil, fmt.Errorf("postgres_object_array transformation failed to unmarshal string: %w", err)
+		}
+		if result == nil {
+			return []map[string]any{}, nil
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("postgres_object_array transformation requires []byte, string, []any, or []map[string]any input, got %T", value)
 	}
 }
 

--- a/service/entityresolution/multi-strategy/output_mapper_test.go
+++ b/service/entityresolution/multi-strategy/output_mapper_test.go
@@ -104,3 +104,163 @@ func TestOutputMapper_transformPostgresObject(t *testing.T) {
 		})
 	}
 }
+
+func TestOutputMapper_transformPostgresObjectArray(t *testing.T) {
+	om := NewOutputMapper()
+
+	var typedNilSliceMap []map[string]any
+	var typedNilSliceAny []any
+
+	tests := []struct {
+		name     string
+		input    any
+		expected any
+		hasError bool
+	}{
+		{
+			name:     "nil input returns empty slice",
+			input:    nil,
+			expected: []map[string]any{},
+		},
+		{
+			name:     "typed nil []map[string]any returns empty slice",
+			input:    typedNilSliceMap,
+			expected: []map[string]any{},
+		},
+		{
+			name:     "typed nil []any returns empty slice",
+			input:    typedNilSliceAny,
+			expected: []map[string]any{},
+		},
+		{
+			name:     "already parsed []map[string]any returned as-is",
+			input:    []map[string]any{{"a": float64(1)}, {"b": "x"}},
+			expected: []map[string]any{{"a": float64(1)}, {"b": "x"}},
+		},
+		{
+			name:     "empty []map[string]any returned as-is",
+			input:    []map[string]any{},
+			expected: []map[string]any{},
+		},
+		{
+			name:     "empty []byte returns empty slice",
+			input:    []byte{},
+			expected: []map[string]any{},
+		},
+		{
+			name:     "empty string returns empty slice",
+			input:    "",
+			expected: []map[string]any{},
+		},
+		{
+			name:     "JSON null []byte returns empty slice",
+			input:    []byte(`null`),
+			expected: []map[string]any{},
+		},
+		{
+			name:     "JSON null string returns empty slice",
+			input:    `null`,
+			expected: []map[string]any{},
+		},
+		{
+			name:     "empty JSON array []byte returns empty slice",
+			input:    []byte(`[]`),
+			expected: []map[string]any{},
+		},
+		{
+			name:     "empty JSON array string returns empty slice",
+			input:    `[]`,
+			expected: []map[string]any{},
+		},
+		{
+			name:     "valid JSON []byte is unmarshaled",
+			input:    []byte(`[{"foo":"bar"},{"n":1}]`),
+			expected: []map[string]any{{"foo": "bar"}, {"n": float64(1)}},
+		},
+		{
+			name:     "valid JSON string is unmarshaled",
+			input:    `[{"a":1},{"nested":{"k":"v"}}]`,
+			expected: []map[string]any{{"a": float64(1)}, {"nested": map[string]any{"k": "v"}}},
+		},
+		{
+			name: "[]any of parsed maps is coerced",
+			input: []any{
+				map[string]any{"a": float64(1)},
+				map[string]any{"b": "x"},
+			},
+			expected: []map[string]any{{"a": float64(1)}, {"b": "x"}},
+		},
+		{
+			name: "[]any of JSON []byte elements is coerced",
+			input: []any{
+				[]byte(`{"a":1}`),
+				[]byte(`{"b":"x"}`),
+			},
+			expected: []map[string]any{{"a": float64(1)}, {"b": "x"}},
+		},
+		{
+			name: "[]any of JSON string elements is coerced",
+			input: []any{
+				`{"a":1}`,
+				`{"b":"x"}`,
+			},
+			expected: []map[string]any{{"a": float64(1)}, {"b": "x"}},
+		},
+		{
+			name:     "[]any with nil element becomes empty object",
+			input:    []any{nil, map[string]any{"a": float64(1)}},
+			expected: []map[string]any{{}, {"a": float64(1)}},
+		},
+		{
+			name:     "[]any with unsupported element type returns error",
+			input:    []any{42},
+			hasError: true,
+		},
+		{
+			name:     "invalid JSON []byte returns error",
+			input:    []byte(`[not json`),
+			hasError: true,
+		},
+		{
+			name:     "invalid JSON string returns error",
+			input:    `[not json`,
+			hasError: true,
+		},
+		{
+			name:     "JSON object []byte is not an array and returns error",
+			input:    []byte(`{"a":1}`),
+			hasError: true,
+		},
+		{
+			name:     "JSON array of scalars returns error",
+			input:    []byte(`[1,2,3]`),
+			hasError: true,
+		},
+		{
+			name:     "unsupported type returns error",
+			input:    42,
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := om.transformPostgresObjectArray(tt.input)
+
+			if tt.hasError {
+				if err == nil {
+					t.Fatalf("expected error but got none (result=%v)", result)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("transformPostgresObjectArray(%v) = %v, expected %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Proposed Changes

closes #3813 

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added support for converting PostgreSQL object arrays into structured object lists.
  * Improved handling of empty, null, JSON, and mixed-value array formats.
  * Added clearer validation errors for invalid array elements and unsupported input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->