### PR TITLE
feat(kas): support ML-KEM client session keys in rewrap

### DIFF
--- a/otdfctl/cmd/tdf/decrypt.go
+++ b/otdfctl/cmd/tdf/decrypt.go
@@ -39,6 +39,10 @@ func decryptRun(cmd *cobra.Command, args []string) {
 		sessionKeyAlgorithm = ocrypto.EC384Key
 	case string(ocrypto.EC521Key):
 		sessionKeyAlgorithm = ocrypto.EC521Key
+	case string(ocrypto.MLKEM768Key):
+		sessionKeyAlgorithm = ocrypto.MLKEM768Key
+	case string(ocrypto.MLKEM1024Key):
+		sessionKeyAlgorithm = ocrypto.MLKEM1024Key
 	default:
 		sessionKeyAlgorithm = ocrypto.RSA2048Key
 	}

--- a/otdfctl/docs/man/decrypt/_index.md
+++ b/otdfctl/docs/man/decrypt/_index.md
@@ -21,6 +21,8 @@ command:
         - ec:secp256r1
         - ec:secp384r1
         - ec:secp521r1
+        - mlkem:768
+        - mlkem:1024
       default: rsa:2048
     - name: with-assertion-verification-keys
       description: >
@@ -63,6 +65,8 @@ The session-key-algorithm specifies the algorithm to use for the session key. Th
 - ec:secp256r1
 - ec:secp384r1
 - ec:secp521r1
+- mlkem:768
+- mlkem:1024
 
 Example
 
@@ -70,6 +74,10 @@ Example
 # Decrypt a file using the ec:secp256r1 algorithm for the session key
 # EXPERIMENTAL
 otdfctl decrypt hello.txt --session-key-algorithm ec:secp256r1
+
+# Decrypt a file using a pure ML-KEM-768 session key
+# EXPERIMENTAL
+otdfctl decrypt hello.txt --session-key-algorithm mlkem:768
 ```
 
 ### ZTDF Assertion Verification (experimental)

--- a/sdk/kas_client.go
+++ b/sdk/kas_client.go
@@ -183,10 +183,14 @@ func (k *KASClient) unwrap(ctx context.Context, requests ...*kas.UnsignedRewrapR
 		return nil, fmt.Errorf("error making rewrap request to kas: %w", err)
 	}
 
-	if ocrypto.IsECKeyType(k.sessionKey.GetKeyType()) {
+	switch {
+	case ocrypto.IsECKeyType(k.sessionKey.GetKeyType()):
 		return k.handleECKeyResponse(response)
+	case ocrypto.IsMLKEMKeyType(k.sessionKey.GetKeyType()):
+		return k.handleKEMKeyResponse(response)
+	default:
+		return k.handleRSAKeyResponse(response)
 	}
-	return k.handleRSAKeyResponse(response)
 }
 
 func (k *KASClient) handleECKeyResponse(response *kas.RewrapResponse) (map[string][]kaoResult, error) {
@@ -293,6 +297,42 @@ func (k *KASClient) processRSAResponse(response *kas.RewrapResponse, asymDecrypt
 			requiredObligationsForKAO := k.retrieveObligationsFromMetadata(kao.GetMetadata())
 			if kao.GetStatus() == statusPermit {
 				key, err := asymDecryption.Decrypt(kao.GetKasWrappedKey())
+				if err != nil {
+					kaoKeys = append(kaoKeys, kaoResult{KeyAccessObjectID: kao.GetKeyAccessObjectId(), Error: err, RequiredObligations: requiredObligationsForKAO})
+				} else {
+					kaoKeys = append(kaoKeys, kaoResult{KeyAccessObjectID: kao.GetKeyAccessObjectId(), SymmetricKey: key, RequiredObligations: requiredObligationsForKAO})
+				}
+			} else {
+				kaoKeys = append(kaoKeys, kaoResult{KeyAccessObjectID: kao.GetKeyAccessObjectId(), Error: errors.New(kao.GetError()), RequiredObligations: requiredObligationsForKAO})
+			}
+		}
+		policyResults[results.GetPolicyId()] = kaoKeys
+	}
+	return policyResults, nil
+}
+
+func (k *KASClient) handleKEMKeyResponse(response *kas.RewrapResponse) (map[string][]kaoResult, error) {
+	clientPrivateKey, err := k.sessionKey.PrivateKeyInPemFormat()
+	if err != nil {
+		return nil, fmt.Errorf("ocrypto.PrivateKeyInPemFormat failed: %w", err)
+	}
+
+	decryptor, err := ocrypto.FromPrivatePEM(clientPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("ocrypto.FromPrivatePEM failed: %w", err)
+	}
+
+	return k.processKEMResponse(response, decryptor)
+}
+
+func (k *KASClient) processKEMResponse(response *kas.RewrapResponse, decryptor ocrypto.PrivateKeyDecryptor) (map[string][]kaoResult, error) {
+	policyResults := make(map[string][]kaoResult)
+	for _, results := range response.GetResponses() {
+		var kaoKeys []kaoResult
+		for _, kao := range results.GetResults() {
+			requiredObligationsForKAO := k.retrieveObligationsFromMetadata(kao.GetMetadata())
+			if kao.GetStatus() == statusPermit {
+				key, err := decryptor.Decrypt(kao.GetKasWrappedKey())
 				if err != nil {
 					kaoKeys = append(kaoKeys, kaoResult{KeyAccessObjectID: kao.GetKeyAccessObjectId(), Error: err, RequiredObligations: requiredObligationsForKAO})
 				} else {

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -447,6 +447,15 @@ func (p *Provider) extractSRTBody(ctx context.Context, headers http.Header, in *
 		return nil, isV1, err400("clientPublicKey failure")
 	}
 
+	// Pure ML-KEM client session keys are SPKI-wrapped under the NIST ML-KEM
+	// OIDs (FIPS 203), which x509.ParsePKIXPublicKey does not recognize and
+	// would otherwise reject as a parse failure. Accept them here; whether
+	// ML-KEM rewrap is actually enabled is checked later in tdf3Rewrap.
+	if oid, _, kemErr := ocrypto.ParseKEMPublicSPKI(block.Bytes); kemErr == nil &&
+		(oid.Equal(ocrypto.OIDMLKEM768) || oid.Equal(ocrypto.OIDMLKEM1024)) {
+		return &requestBody, isV1, nil
+	}
+
 	// Try to parse the clientPublicKey
 	clientPublicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
@@ -1029,6 +1038,11 @@ func (p *Provider) tdf3Rewrap(ctx context.Context, requests []*kaspb.UnsignedRew
 			return "", results, nil
 		}
 	}
+	if ocrypto.IsMLKEMKeyType(asymEncrypt.KeyType()) && !p.Preview.MLKEMTDFEnabled {
+		p.Logger.ErrorContext(ctx, "ml-kem session key rewrap not enabled")
+		failAllKaos(requests, results, err400("invalid request"))
+		return "", results, nil
+	}
 
 	for _, pdpAccess := range pdpAccessResults {
 		policy := pdpAccess.Policy
@@ -1060,12 +1074,13 @@ func (p *Provider) tdf3Rewrap(ctx context.Context, requests []*kaspb.UnsignedRew
 
 			policyBinding := kao.GetKeyAccessObject().GetPolicyBinding().GetHash()
 			auditEventParams := audit.RewrapAuditEventParams{
-				Policy:        kasPolicy,
-				IsSuccess:     access,
-				TDFFormat:     "tdf3",
-				Algorithm:     req.GetAlgorithm(),
-				PolicyBinding: policyBinding,
-				KeyID:         kao.GetKeyAccessObject().GetKid(),
+				Policy:         kasPolicy,
+				IsSuccess:      access,
+				TDFFormat:      "tdf3",
+				Algorithm:      req.GetAlgorithm(),
+				PolicyBinding:  policyBinding,
+				KeyID:          kao.GetKeyAccessObject().GetKid(),
+				SessionKeyType: string(asymEncrypt.KeyType()),
 			}
 
 			if !access {

--- a/service/logger/audit/logger_test.go
+++ b/service/logger/audit/logger_test.go
@@ -36,10 +36,11 @@ var rewrapParams = RewrapAuditEventParams{
 			},
 		},
 	},
-	TDFFormat:     "test-tdf-format",
-	Algorithm:     "test-algorithm",
-	PolicyBinding: "test-policy-binding",
-	KeyID:         "r1",
+	TDFFormat:      "test-tdf-format",
+	Algorithm:      "test-algorithm",
+	PolicyBinding:  "test-policy-binding",
+	KeyID:          "r1",
+	SessionKeyType: "test-session-key-type",
 }
 
 var policyCRUDParams = PolicyEventParams{
@@ -171,6 +172,7 @@ func TestAuditRewrapSuccess(t *testing.T) {
 			},
 			"eventMetaData": {
 			  "algorithm": "%s",
+				"sessionKeyType": "%s",
 				"keyID": "%s",
 				"policyBinding": "%s",
 				"tdfFormat": "%s"
@@ -190,6 +192,7 @@ func TestAuditRewrapSuccess(t *testing.T) {
 		rewrapAttrsJSON,
 		TestActorID,
 		rewrapParams.Algorithm,
+		rewrapParams.SessionKeyType,
 		rewrapParams.KeyID,
 		rewrapParams.PolicyBinding,
 		rewrapParams.TDFFormat,
@@ -230,6 +233,7 @@ func TestAuditRewrapFailure(t *testing.T) {
 			},
 			"eventMetaData": {
 			  "algorithm": "%s",
+				"sessionKeyType": "%s",
 				"keyID": "%s",
 				"policyBinding": "%s",
 				"tdfFormat": "%s"
@@ -249,6 +253,7 @@ func TestAuditRewrapFailure(t *testing.T) {
 		rewrapAttrsJSON,
 		TestActorID,
 		rewrapParams.Algorithm,
+		rewrapParams.SessionKeyType,
 		rewrapParams.KeyID,
 		rewrapParams.PolicyBinding,
 		rewrapParams.TDFFormat,
@@ -568,6 +573,7 @@ func TestDeferredRewrapSuccess(t *testing.T) {
 			},
 			"eventMetaData": {
 			  "algorithm": "%s",
+				"sessionKeyType": "%s",
 				"keyID": "%s",
 				"policyBinding": "%s",
 				"tdfFormat": "%s"
@@ -587,6 +593,7 @@ func TestDeferredRewrapSuccess(t *testing.T) {
 		rewrapAttrsJSON,
 		TestActorID,
 		rewrapParams.Algorithm,
+		rewrapParams.SessionKeyType,
 		rewrapParams.KeyID,
 		rewrapParams.PolicyBinding,
 		rewrapParams.TDFFormat,
@@ -628,6 +635,7 @@ func TestDeferredRewrapCancelled(t *testing.T) {
 			},
 			"eventMetaData": {
 			  "algorithm": "%s",
+				"sessionKeyType": "%s",
 				"cancellation_error": "%s",
 				"keyID": "%s",
 				"policyBinding": "%s",
@@ -648,6 +656,7 @@ func TestDeferredRewrapCancelled(t *testing.T) {
 		rewrapAttrsJSON,
 		TestActorID,
 		rewrapParams.Algorithm,
+		rewrapParams.SessionKeyType,
 		"operation failed",
 		rewrapParams.KeyID,
 		rewrapParams.PolicyBinding,

--- a/service/logger/audit/rewrap.go
+++ b/service/logger/audit/rewrap.go
@@ -20,12 +20,13 @@ type KasAttribute struct {
 }
 
 type RewrapAuditEventParams struct {
-	Policy        KasPolicy
-	IsSuccess     bool
-	TDFFormat     string
-	Algorithm     string
-	PolicyBinding string
-	KeyID         string
+	Policy         KasPolicy
+	IsSuccess      bool
+	TDFFormat      string
+	Algorithm      string
+	PolicyBinding  string
+	KeyID          string
+	SessionKeyType string
 }
 
 func CreateRewrapAuditEvent(ctx context.Context, params RewrapAuditEventParams) (*EventObject, error) {
@@ -61,10 +62,11 @@ func CreateRewrapAuditEvent(ctx context.Context, params RewrapAuditEventParams) 
 			Attributes: make([]any, 0),
 		},
 		EventMetaData: auditEventMetadata{
-			"keyID":         params.KeyID,
-			"policyBinding": params.PolicyBinding,
-			"tdfFormat":     params.TDFFormat,
-			"algorithm":     params.Algorithm,
+			"keyID":          params.KeyID,
+			"policyBinding":  params.PolicyBinding,
+			"tdfFormat":      params.TDFFormat,
+			"algorithm":      params.Algorithm,
+			"sessionKeyType": params.SessionKeyType,
 		},
 		ClientInfo: eventClientInfo{
 			Platform:  "kas",

--- a/service/logger/audit/rewrap_test.go
+++ b/service/logger/audit/rewrap_test.go
@@ -25,13 +25,16 @@ func TestCreateRewrapAuditEventHappyPath(t *testing.T) {
 		},
 	}
 
+	sessionKeyType := "ec:secp256r1"
+
 	params := RewrapAuditEventParams{
-		Policy:        kasPolicy,
-		IsSuccess:     true,
-		TDFFormat:     TestTDFFormat,
-		Algorithm:     TestAlgorithm,
-		PolicyBinding: TestPolicyBinding,
-		KeyID:         keyID,
+		Policy:         kasPolicy,
+		IsSuccess:      true,
+		TDFFormat:      TestTDFFormat,
+		Algorithm:      TestAlgorithm,
+		PolicyBinding:  TestPolicyBinding,
+		KeyID:          keyID,
+		SessionKeyType: sessionKeyType,
 	}
 
 	event, err := CreateRewrapAuditEvent(createTestContext(t), params)
@@ -69,10 +72,11 @@ func TestCreateRewrapAuditEventHappyPath(t *testing.T) {
 	}
 
 	expectedEventMetaData := auditEventMetadata{
-		"keyID":         keyID,
-		"policyBinding": TestPolicyBinding,
-		"tdfFormat":     TestTDFFormat,
-		"algorithm":     TestAlgorithm,
+		"keyID":          keyID,
+		"policyBinding":  TestPolicyBinding,
+		"tdfFormat":      TestTDFFormat,
+		"algorithm":      TestAlgorithm,
+		"sessionKeyType": sessionKeyType,
 	}
 	if !reflect.DeepEqual(event.EventMetaData, expectedEventMetaData) {
 		t.Fatalf("event metadata did not match expected: got %+v, want %+v", event.EventMetaData, expectedEventMetaData)

--- a/spec/DSPX-4221.md
+++ b/spec/DSPX-4221.md
@@ -1,0 +1,40 @@
+---
+ticket: DSPX-4221
+title: Session Keys should support ML-KEM
+status: draft
+authors:
+    - dmihalcik@virtru.com
+branches:
+    - opentdf/platform:DSPX-4221-pq-sessions
+    - opentdf/java-sdk:DSPX-4221-pq-sessions
+    - opentdf/web-sdk:DSPX-4221-pq-sessions
+prs: []
+created: 2026-07-31T00:00:00Z
+updated: 2026-07-31T00:00:00Z
+jira_priority: Medium
+---
+
+
+# Session Keys should support ML-KEM
+
+## Summary
+Make sure all clients (and the server) support ML-KEM as the session encryption key (client generated key pair)
+
+## Problem / Motivation
+_Why does this work need to happen? What is the user/business pain?_
+
+## Proposed Solution
+_What will you build, at a functional level? Sketch the approach._
+
+## Inputs / Outputs / Contracts
+_Function signatures, data shapes, API contracts, CLI flags._
+
+## Edge Cases & Constraints
+_Boundary conditions, error states, performance limits, security considerations._
+
+## Out of Scope
+_What this work item explicitly does not cover._
+
+## Acceptance Criteria
+- [ ] _Clear, testable condition_
+- [ ] _…_

--- a/spec/DSPX-4221.md
+++ b/spec/DSPX-4221.md
@@ -1,40 +1,67 @@
 ---
 ticket: DSPX-4221
 title: Session Keys should support ML-KEM
-status: draft
+status: in-review
 authors:
     - dmihalcik@virtru.com
 branches:
     - opentdf/platform:DSPX-4221-pq-sessions
     - opentdf/java-sdk:DSPX-4221-pq-sessions
     - opentdf/web-sdk:DSPX-4221-pq-sessions
-prs: []
+    - opentdf/tests:DSPX-4221-pq-sessions
+prs:
+    - opentdf/platform#3814
+    - opentdf/tests#571
+    - opentdf/java-sdk#388
+    - opentdf/web-sdk#975
 created: 2026-07-31T00:00:00Z
-updated: 2026-07-31T00:00:00Z
+updated: 2026-08-01T00:00:00Z
 jira_priority: Medium
 ---
-
 
 # Session Keys should support ML-KEM
 
 ## Summary
-Make sure all clients (and the server) support ML-KEM as the session encryption key (client generated key pair)
+
+Make sure all clients (and the server) support ML-KEM as the session encryption key (client-generated key pair).
 
 ## Problem / Motivation
-_Why does this work need to happen? What is the user/business pain?_
+
+The rewrap "session key" is the ephemeral key pair a client generates and sends as `clientPublicKey` on a rewrap request, so KAS can wrap the response DEK back to the client. This is a separate concept from the KAS-managed TDF/KAO wrapping key (the `mechanism-mlkem`/`mechanism-xwing`/`mechanism-secpmlkem` features), which already supports post-quantum algorithms. Before this work, the session-key channel only supported RSA and EC: `extractSRTBody` parsed `clientPublicKey` with `x509.ParsePKIXPublicKey`, which doesn't recognize ML-KEM's SPKI OID and rejected it as a parse failure. That meant the rewrap *transport* remained a classical-crypto dependency even for a client and KAS that had otherwise fully adopted PQC-safe wrapping keys — a gap for future-proofing against a cryptographically-relevant quantum computer.
 
 ## Proposed Solution
-_What will you build, at a functional level? Sketch the approach._
+
+- **Platform (KAS)**: accept pure ML-KEM-768/1024 SPKI client public keys in `extractSRTBody`, gated behind `Preview.MLKEMTDFEnabled` (the same flag implied by `Preview.HybridTDFEnabled`, consistent with the existing EC gate). The wrap-to-client-key crypto itself needed no changes — `ocrypto.FromPublicPEMWithSalt` already dispatches ML-KEM/hybrid keys to the KEM encryptor, since it's shared with the KAS-managed-key path.
+- **Go SDK**: add an ML-KEM branch to `kas_client.go`'s `unwrap()` so the rewrap response can actually be decapsulated; expose `mlkem:768`/`mlkem:1024` on otdfctl's `--session-key-algorithm`.
+- **Java SDK**: extend the `KemProvider` SPI with `generateKeyPair`, and add the equivalent ML-KEM branch to `KASClient.unwrap()`.
+- **Web SDK**: already had a working ML-KEM session-key implementation client-side; testing surfaced (and this work fixed) a bug where the requested session-key algorithm was silently dropped and every decrypt negotiated RSA regardless of what was asked for.
+- **xtest**: a new `session-key-mlkem` feature flag and `test_session_key_mlkem_roundtrip`, which asserts against the KAS rewrap audit log's `sessionKeyType` field rather than just checking that decrypt succeeded — a successful roundtrip alone doesn't prove ML-KEM was actually negotiated, since a client silently falling back to RSA and a server responding in kind would still "work."
 
 ## Inputs / Outputs / Contracts
-_Function signatures, data shapes, API contracts, CLI flags._
+
+- Client sends `clientPublicKey` as a PEM-encoded SPKI public key on the rewrap request; the server infers the session-key type from the SPKI's algorithm OID (there is no explicit "key type" field on the request).
+- New CLI/API surface accepting `mlkem:768` / `mlkem:1024`:
+  - `otdfctl decrypt --session-key-algorithm mlkem:768`
+  - Go SDK: `sdk.WithSessionKeyType(ocrypto.MLKEM768Key)` (or `ocrypto.MLKEM1024Key`)
+  - Java cmdline: `--rewrap-key-type mlkem:768`
+  - Web SDK CLI: `--rewrapKeyType mlkem:768`
+- New audit field: `eventMetaData.sessionKeyType` on KAS rewrap audit events, recording the negotiated session-key type independently of anything the client reports about itself.
 
 ## Edge Cases & Constraints
-_Boundary conditions, error states, performance limits, security considerations._
+
+- Scope is limited to pure ML-KEM (768/1024); hybrid PQ/T session keys (X-Wing, secp+ML-KEM composites) are explicitly out of scope for this ticket.
+- Gated behind `Preview.MLKEMTDFEnabled`; a platform without that preview flag enabled rejects an ML-KEM `clientPublicKey` the same way it always rejected any non-RSA/EC key.
+- The session-key algorithm is independent of the TDF's own KAO wrapping mechanism: an RSA-wrapped TDF can be rewrapped over an ML-KEM session key (verified via `test_session_key_mlkem_roundtrip`, which deliberately uses a plain RSA-wrapped attribute).
 
 ## Out of Scope
-_What this work item explicitly does not cover._
+
+- Hybrid PQ/T session keys (X-Wing, NIST-hybrid EC+ML-KEM composites).
+- Changes to the KAO/TDF wrapping mechanism itself (`mechanism-mlkem`, etc.), which already existed before this work.
+- NanoTDF session keys.
 
 ## Acceptance Criteria
-- [ ] _Clear, testable condition_
-- [ ] _…_
+
+- [x] KAS rewrap accepts ML-KEM-768/1024 client session keys, gated by `Preview.MLKEMTDFEnabled`.
+- [x] Go SDK, Java SDK, and Web SDK can each generate an ML-KEM session key and successfully decrypt a rewrap response wrapped to it.
+- [x] Cross-SDK interop verified: any encrypt SDK paired with any decrypt SDK, for both `mlkem:768` and `mlkem:1024`.
+- [x] xtest coverage asserts the negotiated session-key type via the KAS audit log, not just roundtrip success.


### PR DESCRIPTION
## Summary

Part of DSPX-4221 (Session Keys should support ML-KEM). `rewrap`'s `clientPublicKey` — the client-generated ephemeral "session key" used to wrap the response DEK back to the client — only accepted RSA/EC keys. `extractSRTBody` parsed it with `x509.ParsePKIXPublicKey`, which doesn't recognize ML-KEM's SPKI OID and rejected it as a parse failure before the request ever reached the (already KEM-aware) wrap dispatch.

## Changes

- **`service/kas/access/rewrap.go`**: `extractSRTBody` now recognizes pure ML-KEM-768/1024 SPKI client public keys via `ocrypto.ParseKEMPublicSPKI`, mirroring the dispatch order `ocrypto.FromPublicPEMWithSalt` already uses internally. `tdf3Rewrap` gates the ML-KEM session-key path on `Preview.MLKEMTDFEnabled`, matching the existing EC gate (`Preview.ECTDFEnabled`). The wrap-to-client-key crypto itself needed no changes — `ocrypto.FromPublicPEMWithSalt` already dispatches ML-KEM/hybrid keys to the KEM encryptor, since it's shared with the KAS-managed-key (`mlkem-wrapped` KAO) path.
- **`sdk/kas_client.go`**: `unwrap()` only branched EC vs RSA; added an ML-KEM branch (`handleKEMKeyResponse`/`processKEMResponse`) so the Go SDK can decrypt a rewrap response wrapped to an ML-KEM session key. `sdk.WithSessionKeyType(ocrypto.MLKEM768Key / MLKEM1024Key)` already existed but previously caused a decrypt-time failure since `unwrap()` would try (and fail) to type-assert the KEM decryptor as RSA.
- **`otdfctl`**: `--session-key-algorithm` now accepts `mlkem:768`/`mlkem:1024` (the underlying `sdk.WithSessionKeyType` plumbing already supported these `ocrypto.KeyType` values, just not the CLI flag mapping); updated `docs/man/decrypt`.

### New audit field: `sessionKeyType`

A rewrap succeeding doesn't by itself prove which session-key type KAS actually used — nothing observable previously recorded it, so the companion xtest PR could only infer correctness indirectly from a successful decrypt (which would also pass if a client silently fell back to RSA). To make that test load-bearing:

- **`service/logger/audit/rewrap.go`**: `RewrapAuditEventParams` gains a `SessionKeyType` field, surfaced as `eventMetaData.sessionKeyType` on rewrap audit events.
- **`service/kas/access/rewrap.go`**: populates it from `asymEncrypt.KeyType()` (already computed for the `Preview.MLKEMTDFEnabled` gate above) when building each KAO's audit event.
- Updated the existing `service/logger/audit` unit tests for the new field.

## Scope

Deliberately limited to **pure ML-KEM** (768/1024), matching the ticket title and the existing `mechanism-mlkem` precedent — hybrid PQ/T session keys (X-Wing, secp+ML-KEM) are out of scope here.

## Test plan

```
go build ./service/... ./sdk/... ./otdfctl/...
go vet ./service/kas/... ./service/logger/... ./sdk/...
go test ./service/kas/... ./service/logger/... ./sdk/...
gofmt -l service/kas/access/rewrap.go service/logger/audit/rewrap.go service/logger/audit/rewrap_test.go service/logger/audit/logger_test.go sdk/kas_client.go otdfctl/cmd/tdf/decrypt.go
```
All pass, no regressions. Manually verified `otdfctl help decrypt` now lists `mlkem:768`/`mlkem:1024` for `--session-key-algorithm`.

## Related work

Companion PRs:
- opentdf/tests#571 — xtest coverage (`test_session_key_mlkem_roundtrip`), asserting on the new `sessionKeyType` audit field added here.
- opentdf/java-sdk#388 — Java SDK's rewrap-response decrypt path.

Ref: DSPX-4221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ML-KEM-768 and ML-KEM-1024 session-key algorithms in decryption and key rewrapping.
  * Added ML-KEM session-key options and usage examples to CLI documentation.
  * Added support for processing permitted wrapped keys and preserving obligation metadata.

* **Security & Auditing**
  * ML-KEM rewrapping is restricted when preview functionality is disabled.
  * Rewrap audit events now record the session-key type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->