### PR TITLE
feat(core): add generic audit transaction recorder

### DIFF
--- a/service/logger/audit/context.go
+++ b/service/logger/audit/context.go
@@ -14,6 +14,7 @@ type contextKey struct{}
 type auditTransaction struct {
 	ContextData
 	events []pendingEvent
+	closed bool
 	mu     sync.Mutex
 }
 

--- a/service/logger/audit/enrichment.go
+++ b/service/logger/audit/enrichment.go
@@ -11,8 +11,11 @@ import (
 	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
 )
 
-func (a *Logger) buildLogEntry(ctx context.Context, event *EventObject) map[string]any {
-	entry := event.emittedPayloadMap()
+func (a *Logger) buildRecordedLogEntry(ctx context.Context, event RecordedEvent) map[string]any {
+	entry, ok := normalizeAuditValue(event).(map[string]any)
+	if !ok {
+		panic("normalized recorded audit payload must be a map")
+	}
 	a.applyJWTClaimEnrichment(ctx, entry)
 	return entry
 }

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -87,6 +87,11 @@ func (a *Logger) With(key string, value string) *Logger {
 
 // addEvent appends a pending audit event to the transaction
 func (tx *auditTransaction) addEvent(verb Verb, event RecordedEvent) error {
+	snapshot := cloneRecordedEvent(event)
+	return tx.addSnapshot(verb, snapshot)
+}
+
+func (tx *auditTransaction) addSnapshot(verb Verb, event RecordedEvent) error {
 	tx.mu.Lock()
 	defer tx.mu.Unlock()
 	if tx.closed {
@@ -94,7 +99,7 @@ func (tx *auditTransaction) addEvent(verb Verb, event RecordedEvent) error {
 	}
 	tx.events = append(tx.events, pendingEvent{
 		verb:  verb,
-		event: cloneRecordedEvent(event),
+		event: event,
 	})
 	return nil
 }
@@ -189,7 +194,11 @@ func (a *Logger) Record(ctx context.Context, verb Verb, event RecordedEvent) err
 	if !ok || tx == nil {
 		return ErrNoTransaction
 	}
-	return tx.addEvent(verb, event)
+	snapshot, err := snapshotRecordedEvent(event)
+	if err != nil {
+		return err
+	}
+	return tx.addSnapshot(verb, snapshot)
 }
 
 func (a *Logger) rewrapBase(ctx context.Context, eventParams RewrapAuditEventParams) {

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -25,7 +25,7 @@ const (
 // pendingEvent represents a single audit event waiting to be logged
 type pendingEvent struct {
 	verb  Verb
-	event *EventObject
+	event RecordedEvent
 }
 
 var logLevelNames = map[slog.Leveler]string{
@@ -86,13 +86,17 @@ func (a *Logger) With(key string, value string) *Logger {
 }
 
 // addEvent appends a pending audit event to the transaction
-func (tx *auditTransaction) addEvent(verb Verb, event *EventObject) {
+func (tx *auditTransaction) addEvent(verb Verb, event RecordedEvent) error {
 	tx.mu.Lock()
 	defer tx.mu.Unlock()
+	if tx.closed {
+		return ErrTransactionClosed
+	}
 	tx.events = append(tx.events, pendingEvent{
 		verb:  verb,
-		event: event,
+		event: cloneRecordedEvent(event),
 	})
+	return nil
 }
 
 // logClose completes an audit transaction and emits all recorded events.
@@ -100,23 +104,30 @@ func (tx *auditTransaction) addEvent(verb Verb, event *EventObject) {
 // Otherwise, events are logged with their originally recorded success/failure status.
 func (tx *auditTransaction) logClose(ctx context.Context, auditLogger *Logger, success bool, err error) {
 	tx.mu.Lock()
-	defer tx.mu.Unlock()
-	for _, event := range tx.events {
+	if tx.closed {
+		tx.mu.Unlock()
+		return
+	}
+	tx.closed = true
+	events := tx.events
+	tx.events = nil
+	tx.mu.Unlock()
+	for _, event := range events {
 		auditEvent := event.event
 
 		if !success {
-			auditEvent.Action.Result = ActionResultCancel
+			auditEvent.Action.Result = ActionResultCancel.String()
 		}
 
 		if err != nil {
 			if auditEvent.EventMetaData == nil {
-				auditEvent.EventMetaData = make(auditEventMetadata)
+				auditEvent.EventMetaData = make(map[string]any)
 			}
 			auditEvent.EventMetaData["cancellation_error"] = err.Error()
 		}
 
 		//nolint:sloglint // audit message is always just the verb
-		auditLogger.logger.Log(ctx, LevelAudit, string(event.verb), slog.Any("audit", auditLogger.buildLogEntry(ctx, auditEvent)))
+		auditLogger.logger.Log(ctx, LevelAudit, string(event.verb), slog.Any("audit", auditLogger.buildRecordedLogEntry(ctx, auditEvent)))
 	}
 }
 
@@ -163,7 +174,22 @@ func LogAuditEvent(ctx context.Context, verb Verb, event *EventObject) {
 	if event == nil {
 		panic("nil audit event provided")
 	}
-	tx.addEvent(verb, event)
+	if err := tx.addEvent(verb, recordedEventFromLegacy(*event)); err != nil {
+		panic(err)
+	}
+}
+
+// Record adds an externally constructed event to the current request audit
+// transaction. The event is deeply snapshotted before Record returns.
+func (a *Logger) Record(ctx context.Context, verb Verb, event RecordedEvent) error {
+	if a == nil || verb == "" {
+		return ErrInvalidEvent
+	}
+	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
+	if !ok || tx == nil {
+		return ErrNoTransaction
+	}
+	return tx.addEvent(verb, event)
 }
 
 func (a *Logger) rewrapBase(ctx context.Context, eventParams RewrapAuditEventParams) {

--- a/service/logger/audit/recorded_event.go
+++ b/service/logger/audit/recorded_event.go
@@ -1,0 +1,206 @@
+package audit
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+var (
+	// ErrNoTransaction indicates that the context is not managed by the audit interceptor.
+	ErrNoTransaction = errors.New("audit transaction missing from context")
+	// ErrTransactionClosed indicates that the request audit lifecycle has already completed.
+	ErrTransactionClosed = errors.New("audit transaction already closed")
+	// ErrInvalidEvent indicates that a recorded event is not valid.
+	ErrInvalidEvent = errors.New("invalid audit event")
+)
+
+// RecordedEvent is the generic, externally constructible audit event recorded by
+// injected services. String-valued types keep the upstream contract independent
+// of service-specific object and action taxonomies.
+type RecordedEvent struct {
+	Object        RecordedObject     `json:"object"`
+	Action        RecordedAction     `json:"action"`
+	Actor         RecordedActor      `json:"actor"`
+	EventMetaData map[string]any     `json:"eventMetaData" audit:"extensible"`
+	ClientInfo    RecordedClientInfo `json:"clientInfo"`
+	Original      map[string]any     `json:"original,omitempty" audit:"extensible"`
+	Updated       map[string]any     `json:"updated,omitempty" audit:"extensible"`
+	RequestID     uuid.UUID          `json:"requestID" audit:"reserved"`
+	Timestamp     string             `json:"timestamp" audit:"reserved"`
+}
+
+type RecordedObject struct {
+	Type       string                   `json:"type" audit:"reserved"`
+	ID         string                   `json:"id"`
+	Name       string                   `json:"name,omitempty"`
+	Attributes RecordedObjectAttributes `json:"attributes,omitempty"`
+}
+
+type RecordedObjectAttributes struct {
+	Assertions  []string `json:"assertions,omitempty"`
+	Attrs       []string `json:"attrs,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
+}
+
+type RecordedAction struct {
+	Type   string `json:"type" audit:"reserved"`
+	Result string `json:"result" audit:"reserved"`
+}
+
+type RecordedActor struct {
+	ID         string `json:"id" audit:"reserved"`
+	Attributes []any  `json:"attributes"`
+}
+
+type RecordedClientInfo struct {
+	UserAgent string `json:"userAgent" audit:"reserved"`
+	Platform  string `json:"platform" audit:"reserved"`
+	RequestIP string `json:"requestIP" audit:"reserved"`
+}
+
+// Recorder records audit events in the current request transaction.
+type Recorder interface {
+	Record(context.Context, Verb, RecordedEvent) error
+}
+
+func cloneRecordedEvent(event RecordedEvent) RecordedEvent {
+	cloned, ok := normalizeAuditValue(event).(map[string]any)
+	if !ok {
+		panic("normalized recorded audit event must be a map")
+	}
+	return recordedEventFromMap(cloned)
+}
+
+func recordedEventFromMap(event map[string]any) RecordedEvent {
+	return RecordedEvent{
+		Object: RecordedObject{
+			Type:       nestedString(event, "object", "type"),
+			ID:         nestedString(event, "object", "id"),
+			Name:       nestedString(event, "object", "name"),
+			Attributes: recordedObjectAttributesFromMap(nestedMap(event, "object", "attributes")),
+		},
+		Action: RecordedAction{
+			Type:   nestedString(event, "action", "type"),
+			Result: nestedString(event, "action", "result"),
+		},
+		Actor: RecordedActor{
+			ID:         nestedString(event, "actor", "id"),
+			Attributes: nestedAnySlice(event, "actor", "attributes"),
+		},
+		EventMetaData: nestedMap(event, "eventMetaData"),
+		ClientInfo: RecordedClientInfo{
+			UserAgent: nestedString(event, "clientInfo", "userAgent"),
+			Platform:  nestedString(event, "clientInfo", "platform"),
+			RequestIP: nestedString(event, "clientInfo", "requestIP"),
+		},
+		Original:  nestedMap(event, "original"),
+		Updated:   nestedMap(event, "updated"),
+		RequestID: nestedUUID(event, "requestID"),
+		Timestamp: nestedString(event, "timestamp"),
+	}
+}
+
+func recordedObjectAttributesFromMap(attributes map[string]any) RecordedObjectAttributes {
+	return RecordedObjectAttributes{
+		Assertions:  stringSlice(attributes["assertions"]),
+		Attrs:       stringSlice(attributes["attrs"]),
+		Permissions: stringSlice(attributes["permissions"]),
+	}
+}
+
+func nestedMap(root map[string]any, path ...string) map[string]any {
+	var current any = root
+	for _, part := range path {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil
+		}
+		current = object[part]
+	}
+	object, _ := current.(map[string]any)
+	return object
+}
+
+func nestedString(root map[string]any, path ...string) string {
+	var current any = root
+	for _, part := range path {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = object[part]
+	}
+	value, _ := current.(string)
+	return value
+}
+
+func nestedAnySlice(root map[string]any, path ...string) []any {
+	var current any = root
+	for _, part := range path {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil
+		}
+		current = object[part]
+	}
+	value, _ := current.([]any)
+	return value
+}
+
+func nestedUUID(root map[string]any, path ...string) uuid.UUID {
+	value := nestedString(root, path...)
+	parsed, _ := uuid.Parse(value)
+	return parsed
+}
+
+func stringSlice(value any) []string {
+	items, ok := value.([]any)
+	if !ok {
+		if strings, stringsOK := value.([]string); stringsOK {
+			return strings
+		}
+		return nil
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if stringItem, stringOK := item.(string); stringOK {
+			result = append(result, stringItem)
+		}
+	}
+	return result
+}
+
+func recordedEventFromLegacy(event EventObject) RecordedEvent {
+	return RecordedEvent{
+		Object: RecordedObject{
+			Type: event.Object.Type.String(),
+			ID:   event.Object.ID,
+			Name: event.Object.Name,
+			Attributes: RecordedObjectAttributes{
+				Assertions:  event.Object.Attributes.Assertions,
+				Attrs:       event.Object.Attributes.Attrs,
+				Permissions: event.Object.Attributes.Permissions,
+			},
+		},
+		Action: RecordedAction{
+			Type:   event.Action.Type.String(),
+			Result: event.Action.Result.String(),
+		},
+		Actor: RecordedActor{
+			ID:         event.Actor.ID,
+			Attributes: event.Actor.Attributes,
+		},
+		EventMetaData: event.EventMetaData,
+		ClientInfo: RecordedClientInfo{
+			UserAgent: event.ClientInfo.UserAgent,
+			Platform:  event.ClientInfo.Platform,
+			RequestIP: event.ClientInfo.RequestIP,
+		},
+		Original:  event.Original,
+		Updated:   event.Updated,
+		RequestID: event.RequestID,
+		Timestamp: event.Timestamp,
+	}
+}

--- a/service/logger/audit/recorded_event.go
+++ b/service/logger/audit/recorded_event.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -94,7 +95,9 @@ func snapshotRecordedEvent(event RecordedEvent) (RecordedEvent, error) {
 			snapshotErr = fmt.Errorf("%w: %w", ErrInvalidEvent, err)
 			return
 		}
-		if err := json.Unmarshal(encoded, &snapshot); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(encoded))
+		decoder.UseNumber()
+		if err := decoder.Decode(&snapshot); err != nil {
 			snapshotErr = fmt.Errorf("%w: %w", ErrInvalidEvent, err)
 		}
 	}()

--- a/service/logger/audit/recorded_event.go
+++ b/service/logger/audit/recorded_event.go
@@ -2,7 +2,9 @@ package audit
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 )
@@ -31,6 +33,7 @@ type RecordedEvent struct {
 	Timestamp     string             `json:"timestamp" audit:"reserved"`
 }
 
+// RecordedObject identifies the resource affected by an audit action.
 type RecordedObject struct {
 	Type       string                   `json:"type" audit:"reserved"`
 	ID         string                   `json:"id"`
@@ -38,22 +41,26 @@ type RecordedObject struct {
 	Attributes RecordedObjectAttributes `json:"attributes,omitempty"`
 }
 
+// RecordedObjectAttributes contains optional policy attributes for a resource.
 type RecordedObjectAttributes struct {
 	Assertions  []string `json:"assertions,omitempty"`
 	Attrs       []string `json:"attrs,omitempty"`
 	Permissions []string `json:"permissions,omitempty"`
 }
 
+// RecordedAction describes the operation and its result.
 type RecordedAction struct {
 	Type   string `json:"type" audit:"reserved"`
 	Result string `json:"result" audit:"reserved"`
 }
 
+// RecordedActor identifies the principal performing the operation.
 type RecordedActor struct {
 	ID         string `json:"id" audit:"reserved"`
 	Attributes []any  `json:"attributes"`
 }
 
+// RecordedClientInfo describes the client and service recording the event.
 type RecordedClientInfo struct {
 	UserAgent string `json:"userAgent" audit:"reserved"`
 	Platform  string `json:"platform" audit:"reserved"`
@@ -71,6 +78,27 @@ func cloneRecordedEvent(event RecordedEvent) RecordedEvent {
 		panic("normalized recorded audit event must be a map")
 	}
 	return recordedEventFromMap(cloned)
+}
+
+func snapshotRecordedEvent(event RecordedEvent) (RecordedEvent, error) {
+	var snapshot RecordedEvent
+	var snapshotErr error
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				snapshotErr = fmt.Errorf("%w: event snapshot panic: %v", ErrInvalidEvent, recovered)
+			}
+		}()
+		encoded, err := json.Marshal(event)
+		if err != nil {
+			snapshotErr = fmt.Errorf("%w: %w", ErrInvalidEvent, err)
+			return
+		}
+		if err := json.Unmarshal(encoded, &snapshot); err != nil {
+			snapshotErr = fmt.Errorf("%w: %w", ErrInvalidEvent, err)
+		}
+	}()
+	return snapshot, snapshotErr
 }
 
 func recordedEventFromMap(event map[string]any) RecordedEvent {

--- a/service/logger/audit/recorded_event_external_test.go
+++ b/service/logger/audit/recorded_event_external_test.go
@@ -1,0 +1,27 @@
+package audit_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/opentdf/platform/service/logger/audit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalRecorderAPI(t *testing.T) {
+	ctx := audit.ContextWithActorID(t.Context(), "actor-1")
+	logger := audit.CreateAuditLogger(*slog.New(slog.DiscardHandler))
+
+	event := audit.RecordedEvent{
+		Object: audit.RecordedObject{Type: "external_resource", ID: "resource-1"},
+		Action: audit.RecordedAction{Type: "read", Result: "success"},
+		Actor:  audit.RecordedActor{ID: "actor-1"},
+		ClientInfo: audit.RecordedClientInfo{
+			Platform: "external-service",
+		},
+	}
+
+	var recorder audit.Recorder = logger
+	require.NoError(t, recorder.Record(context.WithoutCancel(ctx), audit.Verb("external read"), event))
+}

--- a/service/logger/audit/recorded_event_test.go
+++ b/service/logger/audit/recorded_event_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -72,6 +73,19 @@ func TestRecordReturnsInvalidEventForPanickingValue(t *testing.T) {
 
 	err := logger.Record(ctx, Verb("read"), event)
 	require.ErrorIs(t, err, ErrInvalidEvent)
+}
+
+func TestRecordPreservesLargeNumericMetadata(t *testing.T) {
+	logger, buffer := createTestLogger()
+	ctx := createTestContext(t)
+	event := RecordedEvent{EventMetaData: map[string]any{"sequence": uint64(math.MaxUint64)}}
+	require.NoError(t, logger.Record(ctx, Verb("read"), event))
+
+	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
+	require.True(t, ok)
+	require.Equal(t, json.Number("18446744073709551615"), tx.events[0].event.EventMetaData["sequence"])
+	tx.logClose(ctx, logger, true, nil)
+	require.Contains(t, buffer.String(), `"sequence":18446744073709551615`)
 }
 
 type panickingJSONValue struct{}

--- a/service/logger/audit/recorded_event_test.go
+++ b/service/logger/audit/recorded_event_test.go
@@ -65,6 +65,21 @@ func TestRecordReturnsTypedErrors(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidEvent)
 }
 
+func TestRecordReturnsInvalidEventForPanickingValue(t *testing.T) {
+	logger, _ := createTestLogger()
+	ctx := createTestContext(t)
+	event := RecordedEvent{EventMetaData: map[string]any{"bad": panickingJSONValue{}}}
+
+	err := logger.Record(ctx, Verb("read"), event)
+	require.ErrorIs(t, err, ErrInvalidEvent)
+}
+
+type panickingJSONValue struct{}
+
+func (panickingJSONValue) MarshalJSON() ([]byte, error) {
+	panic("cannot serialize")
+}
+
 func TestRecordCancellationDoesNotMutateCaller(t *testing.T) {
 	logger, buffer := createTestLogger()
 	ctx := createTestContext(t)

--- a/service/logger/audit/recorded_event_test.go
+++ b/service/logger/audit/recorded_event_test.go
@@ -1,0 +1,89 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordEmitsGenericEventWithDefaultWireShape(t *testing.T) {
+	event := RecordedEvent{
+		Object: RecordedObject{
+			Type: "external_resource",
+			ID:   "resource-1",
+		},
+		Action: RecordedAction{
+			Type:   "share",
+			Result: "success",
+		},
+		Actor: RecordedActor{
+			ID:         "actor-1",
+			Attributes: []any{"member"},
+		},
+		EventMetaData: map[string]any{"owner": map[string]any{"id": "org-1"}},
+		ClientInfo: RecordedClientInfo{
+			Platform: "external-service",
+		},
+	}
+
+	logEntry, _ := doWithLogger(t, nil, func(ctx context.Context, logger *Logger) {
+		require.NoError(t, logger.Record(ctx, Verb("share"), event))
+		event.Object.ID = "mutated"
+		event.Actor.Attributes[0] = "mutated"
+		owner, ok := event.EventMetaData["owner"].(map[string]any)
+		require.True(t, ok)
+		owner["id"] = "mutated"
+	})
+
+	require.Equal(t, "share", logEntry.Msg)
+	payload := decodeAuditPayload(t, logEntry.Audit)
+	require.Equal(t, "resource-1", nestedString(payload, "object", "id"))
+	require.Equal(t, []any{"member"}, nestedAnySlice(payload, "actor", "attributes"))
+	require.Equal(t, "org-1", nestedString(payload, "eventMetaData", "owner", "id"))
+}
+
+func TestRecordReturnsTypedErrors(t *testing.T) {
+	logger, _ := createTestLogger()
+	event := RecordedEvent{Object: RecordedObject{Type: "external_resource"}}
+
+	err := logger.Record(t.Context(), Verb("read"), event)
+	require.ErrorIs(t, err, ErrNoTransaction)
+	require.ErrorIs(t, logger.Record(createTestContext(t), "", event), ErrInvalidEvent)
+
+	ctx := createTestContext(t)
+	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
+	require.True(t, ok)
+	tx.logClose(ctx, logger, true, nil)
+	err = logger.Record(ctx, Verb("read"), event)
+	require.ErrorIs(t, err, ErrTransactionClosed)
+
+	var nilLogger *Logger
+	err = nilLogger.Record(ctx, Verb("read"), event)
+	require.ErrorIs(t, err, ErrInvalidEvent)
+}
+
+func TestRecordCancellationDoesNotMutateCaller(t *testing.T) {
+	logger, buffer := createTestLogger()
+	ctx := createTestContext(t)
+	event := RecordedEvent{
+		Action:        RecordedAction{Type: "write", Result: "success"},
+		EventMetaData: map[string]any{"existing": true},
+	}
+	require.NoError(t, logger.Record(ctx, Verb("write"), event))
+
+	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
+	require.True(t, ok)
+	tx.logClose(ctx, logger, false, errors.New("request failed"))
+
+	entry, _ := extractLogEntry(t, buffer)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(entry.Audit, &payload))
+	require.Equal(t, ActionResultCancel.String(), nestedString(payload, "action", "result"))
+	require.Equal(t, "request failed", nestedString(payload, "eventMetaData", "cancellation_error"))
+	require.Equal(t, "success", event.Action.Result)
+	_, present := event.EventMetaData["cancellation_error"]
+	require.False(t, present)
+}


### PR DESCRIPTION
### Proposed Changes

- add an externally constructible, string-valued `RecordedEvent` contract for injected services
- add non-panicking `Logger.Record` errors for missing, closed, and invalid transactions/events
- snapshot inputs before transaction locking to prevent caller mutation, reentrant deadlocks, and numeric precision loss
- close transactions exactly once while preserving the existing `AUDIT` / `msg` / `audit` output contract

This is PR 1 of 2 for PEP-5181. PR #3817 adds finalized-event processing and startup injection on top of this recorder.

### Design and compatibility

- no SaaS-DSP or Audit API types enter upstream
- legacy `LogAuditEvent` retains its panic behavior for source compatibility
- `audit.jwt_claim_mappings` remains supported
- ordinary returned Connect errors retain current behavior; changing transaction outcome semantics is follow-up work

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation

### Testing Instructions

- `cd service && go test -race ./logger/audit ./pkg/config ./pkg/server ./internal/server`
- `cd service && golangci-lint run --new-from-rev=origin/main ./logger/audit/... ./logger/... ./pkg/server/...`
- `cd sdk && go test -run TestREADMECodeBlocks`
- `git diff --check origin/main...HEAD`

Repository-wide `make lint` is blocked locally by an invalid Buf API token. Repository-wide `make test` reaches environment-dependent Keycloak/Docker suites that are unavailable locally; the focused race suites above pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured audit event recording with support for resource, action, actor, and client metadata.
  * Added a public recording interface for submitting audit events.
* **Bug Fixes**
  * Prevented events from being recorded after a transaction is closed.
  * Improved event isolation and validation to avoid unintended data changes or invalid audit entries.
* **Tests**
  * Added coverage for external recording workflows, cancellation handling, validation, serialization, and metadata preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->