### PR TITLE
feat(core): process finalized audit emissions

### DIFF
--- a/service/logger/audit/README.md
+++ b/service/logger/audit/README.md
@@ -1,0 +1,48 @@
+# Extending audit recording
+
+Injected services can record generic, typed audit events through the same
+request transaction used by built-in OpenTDF services:
+
+```go
+err := params.Logger.Audit.Record(ctx, audit.Verb("read"), audit.RecordedEvent{
+	Object: audit.RecordedObject{Type: "document", ID: documentID},
+	Action: audit.RecordedAction{Type: "read", Result: "success"},
+	Actor:  audit.RecordedActor{ID: actorID},
+})
+```
+
+`Record` returns an error when the context has no active audit transaction or
+the transaction has already closed. It snapshots the event before returning,
+so later caller mutation cannot change the emitted record. The legacy
+`LogAuditEvent` API retains its panic behavior for compatibility.
+
+Applications embedding Platform can install one instance-scoped processor:
+
+```go
+server.Start(server.WithAuditProcessor(audit.ProcessorFunc(
+	func(ctx context.Context, event audit.FinalizedEvent) (audit.ProcessResult, error) {
+		return audit.ProcessResult{Emissions: []audit.Emission{{
+			Level:   audit.LevelAudit,
+			Message: string(event.Verb),
+			Attrs:   []slog.Attr{slog.Any("audit", event.Audit)},
+		}}}, nil
+	},
+)))
+```
+
+Processors receive a deep snapshot after request finalization and configured
+JWT claim enrichment. They may return one or many ordered emissions. Producing
+no output requires `Drop: true`; an accidental empty result, an error, or a
+panic emits the unchanged default event once and writes an operational error.
+Processors are shared across requests and must be concurrency-safe.
+
+The default processor preserves the existing JSON shape:
+
+```json
+{"level":"AUDIT","msg":"read","audit":{}}
+```
+
+JWT claim mappings enrich caller and request context. They must not establish
+resource ownership or tenant partitioning. Processors should derive ownership
+from authoritative resource fields supplied by the service; `FinalizedEvent.Event`
+retains those pre-enrichment fields for that purpose.

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -33,8 +33,31 @@ var logLevelNames = map[slog.Leveler]string{
 }
 
 type Logger struct {
-	logger *slog.Logger
-	config Config
+	logger      *slog.Logger
+	diagnostics *slog.Logger
+	processor   Processor
+	config      Config
+}
+
+// Option configures an audit logger at construction time.
+type Option func(*Logger)
+
+// WithProcessor configures the finalized-event processor.
+func WithProcessor(processor Processor) Option {
+	return func(logger *Logger) {
+		if processor != nil {
+			logger.processor = processor
+		}
+	}
+}
+
+// WithDiagnosticLogger routes processor failures to an operational logger.
+func WithDiagnosticLogger(diagnostics *slog.Logger) Option {
+	return func(logger *Logger) {
+		if diagnostics != nil {
+			logger.diagnostics = diagnostics
+		}
+	}
 }
 
 // Used to support custom log levels showing up with custom labels as well
@@ -56,10 +79,16 @@ func ReplaceAttrAuditLevel(_ []string, a slog.Attr) slog.Attr {
 	return a
 }
 
-func CreateAuditLogger(logger slog.Logger) *Logger {
-	return &Logger{
-		logger: &logger,
+func CreateAuditLogger(logger slog.Logger, options ...Option) *Logger {
+	auditLogger := &Logger{
+		logger:      &logger,
+		diagnostics: slog.Default(),
+		processor:   defaultProcessor{},
 	}
+	for _, option := range options {
+		option(auditLogger)
+	}
+	return auditLogger
 }
 
 func cloneConfig(cfg Config) Config {
@@ -78,11 +107,30 @@ func (a *Logger) ApplyConfig(cfg Config) error {
 }
 
 func (a *Logger) With(key string, value string) *Logger {
+	diagnostics := a.diagnostics
+	if diagnostics == nil {
+		diagnostics = slog.Default()
+	}
+	processor := a.processor
+	if processor == nil {
+		processor = defaultProcessor{}
+	}
 	return &Logger{
 		//nolint:sloglint // custom logger should support key/value pairs in With attributes
 		logger: a.logger.With(key, value),
-		config: cloneConfig(a.config),
+		//nolint:sloglint // mirror the same scoped attributes on operational diagnostics
+		diagnostics: diagnostics.With(key, value),
+		processor:   processor,
+		config:      cloneConfig(a.config),
 	}
+}
+
+// Processor returns the immutable processor configured for this logger.
+func (a *Logger) Processor() Processor {
+	if a.processor == nil {
+		return defaultProcessor{}
+	}
+	return a.processor
 }
 
 // addEvent appends a pending audit event to the transaction
@@ -126,8 +174,12 @@ func (tx *auditTransaction) logClose(ctx context.Context, auditLogger *Logger, s
 			auditEvent.EventMetaData["cancellation_error"] = err.Error()
 		}
 
-		//nolint:sloglint // audit message is always just the verb
-		auditLogger.logger.Log(ctx, LevelAudit, string(event.verb), slog.Any("audit", auditLogger.buildRecordedLogEntry(ctx, auditEvent)))
+		finalized := FinalizedEvent{
+			Verb:  event.verb,
+			Event: cloneRecordedEvent(auditEvent),
+			Audit: auditLogger.buildRecordedLogEntry(ctx, auditEvent),
+		}
+		auditLogger.processAndEmit(ctx, finalized)
 	}
 }
 
@@ -166,6 +218,10 @@ func (a *Logger) GetDecisionV2(ctx context.Context, eventParams GetDecisionV2Eve
 	LogAuditEvent(ctx, VerbDecision, event)
 }
 
+// LogAuditEvent records a legacy OpenTDF event and retains its historical panic
+// behavior when no transaction exists or the event is nil.
+//
+// Deprecated: Use (*Logger).Record for externally supplied events.
 func LogAuditEvent(ctx context.Context, verb Verb, event *EventObject) {
 	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
 	if !ok {
@@ -209,4 +265,30 @@ func (a *Logger) policyCrudBase(ctx context.Context, isSuccess bool, eventParams
 		return
 	}
 	LogAuditEvent(ctx, VerbPolicyCRUD, auditEvent)
+}
+
+func (a *Logger) processAndEmit(ctx context.Context, event FinalizedEvent) {
+	processor := a.processor
+	if processor == nil {
+		processor = defaultProcessor{}
+	}
+	result, err := processEvent(ctx, processor, event)
+	if err == nil {
+		err = validateProcessResult(result)
+	}
+	if err != nil {
+		diagnostics := a.diagnostics
+		if diagnostics == nil {
+			diagnostics = slog.Default()
+		}
+		diagnostics.ErrorContext(ctx, "audit processor failed; emitting default event", slog.Any("error", err))
+		result, _ = defaultProcessor{}.Process(ctx, event)
+	}
+	if result.Drop {
+		return
+	}
+	for _, emission := range result.Emissions {
+		//nolint:sloglint // processor-defined audit messages are intentionally dynamic
+		a.logger.LogAttrs(ctx, emission.Level, emission.Message, emission.Attrs...)
+	}
 }

--- a/service/logger/audit/processor.go
+++ b/service/logger/audit/processor.go
@@ -1,0 +1,99 @@
+package audit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+)
+
+// ErrInvalidProcessResult indicates that a processor result cannot be emitted safely.
+var ErrInvalidProcessResult = errors.New("invalid audit processor result")
+
+// FinalizedEvent is the immutable processor input after request outcome and
+// configured JWT enrichment have been applied. Event retains the authoritative
+// producer fields; Audit is the enriched default OpenTDF payload.
+type FinalizedEvent struct {
+	Verb  Verb
+	Event RecordedEvent
+	Audit map[string]any
+}
+
+// Emission describes one slog record produced by an audit processor.
+type Emission struct {
+	Level   slog.Level
+	Message string
+	Attrs   []slog.Attr
+}
+
+// ProcessResult contains all emissions for one finalized event. Drop must be
+// explicitly true to intentionally produce no output.
+type ProcessResult struct {
+	Emissions []Emission
+	Drop      bool
+}
+
+// Processor transforms finalized audit events. Implementations may be called
+// concurrently and must not mutate their input or retain aliases to it.
+type Processor interface {
+	Process(context.Context, FinalizedEvent) (ProcessResult, error)
+}
+
+// ProcessorFunc adapts a function to Processor.
+type ProcessorFunc func(context.Context, FinalizedEvent) (ProcessResult, error)
+
+func (f ProcessorFunc) Process(ctx context.Context, event FinalizedEvent) (ProcessResult, error) {
+	return f(ctx, event)
+}
+
+type defaultProcessor struct{}
+
+func (defaultProcessor) Process(_ context.Context, event FinalizedEvent) (ProcessResult, error) {
+	return ProcessResult{Emissions: []Emission{{
+		Level:   LevelAudit,
+		Message: string(event.Verb),
+		Attrs:   []slog.Attr{slog.Any("audit", event.Audit)},
+	}}}, nil
+}
+
+func processEvent(ctx context.Context, processor Processor, event FinalizedEvent) (ProcessResult, error) {
+	var result ProcessResult
+	var processErr error
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				processErr = fmt.Errorf("audit processor panic: %v", recovered)
+				result = ProcessResult{}
+			}
+		}()
+		result, processErr = processor.Process(context.WithoutCancel(ctx), cloneFinalizedEvent(event))
+	}()
+	return result, processErr
+}
+
+func validateProcessResult(result ProcessResult) error {
+	if result.Drop {
+		if len(result.Emissions) != 0 {
+			return fmt.Errorf("%w: drop cannot include emissions", ErrInvalidProcessResult)
+		}
+		return nil
+	}
+	if len(result.Emissions) == 0 {
+		return fmt.Errorf("%w: empty emissions require explicit drop", ErrInvalidProcessResult)
+	}
+	for idx, emission := range result.Emissions {
+		if emission.Level < LevelAudit {
+			return fmt.Errorf("%w: emission %d level %s is filtered by the audit handler", ErrInvalidProcessResult, idx, emission.Level)
+		}
+	}
+	return nil
+}
+
+func cloneFinalizedEvent(event FinalizedEvent) FinalizedEvent {
+	auditMap, _ := normalizeAuditValue(event.Audit).(map[string]any)
+	return FinalizedEvent{
+		Verb:  event.Verb,
+		Event: cloneRecordedEvent(event.Event),
+		Audit: auditMap,
+	}
+}

--- a/service/logger/audit/processor_test.go
+++ b/service/logger/audit/processor_test.go
@@ -1,0 +1,180 @@
+package audit
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func createProcessorTestLogger(processor Processor) (*Logger, *bytes.Buffer, *bytes.Buffer) {
+	var auditBuffer bytes.Buffer
+	var diagnosticBuffer bytes.Buffer
+	auditHandler := slog.NewJSONHandler(&auditBuffer, &slog.HandlerOptions{
+		Level:       LevelAudit,
+		ReplaceAttr: ReplaceAttrAuditLevel,
+	})
+	diagnosticHandler := slog.NewJSONHandler(&diagnosticBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := CreateAuditLogger(
+		*slog.New(auditHandler),
+		WithProcessor(processor),
+		WithDiagnosticLogger(slog.New(diagnosticHandler)),
+	)
+	return logger, &auditBuffer, &diagnosticBuffer
+}
+
+func recordedTestEvent() RecordedEvent {
+	return RecordedEvent{
+		Object: RecordedObject{Type: "resource", ID: "resource-1"},
+		Action: RecordedAction{Type: "read", Result: "success"},
+		EventMetaData: map[string]any{
+			"owner": map[string]any{"id": "org-1"},
+		},
+	}
+}
+
+func closeRecordedEvent(t *testing.T, logger *Logger) {
+	t.Helper()
+	ctx := createTestContext(t)
+	require.NoError(t, logger.Record(ctx, Verb("read"), recordedTestEvent()))
+	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
+	require.True(t, ok)
+	tx.logClose(ctx, logger, true, nil)
+}
+
+func decodeJSONLines(t *testing.T, buffer *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var entries []map[string]any
+	scanner := bufio.NewScanner(bytes.NewReader(buffer.Bytes()))
+	for scanner.Scan() {
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal(scanner.Bytes(), &entry))
+		entries = append(entries, entry)
+	}
+	require.NoError(t, scanner.Err())
+	return entries
+}
+
+func TestProcessorEmitsManyInOrder(t *testing.T) {
+	processor := ProcessorFunc(func(_ context.Context, event FinalizedEvent) (ProcessResult, error) {
+		require.Equal(t, "org-1", nestedString(event.Audit, "eventMetaData", "owner", "id"))
+		return ProcessResult{Emissions: []Emission{
+			{Level: LevelAudit, Message: "partition-1", Attrs: []slog.Attr{slog.String("message", "one")}},
+			{Level: LevelAudit, Message: "partition-2", Attrs: []slog.Attr{slog.String("message", "two")}},
+		}}, nil
+	})
+	logger, auditBuffer, diagnosticBuffer := createProcessorTestLogger(processor)
+
+	closeRecordedEvent(t, logger)
+
+	entries := decodeJSONLines(t, auditBuffer)
+	require.Len(t, entries, 2)
+	require.Equal(t, "partition-1", entries[0]["msg"])
+	require.Equal(t, "one", entries[0]["message"])
+	require.Equal(t, "partition-2", entries[1]["msg"])
+	require.Equal(t, "two", entries[1]["message"])
+	require.Empty(t, diagnosticBuffer.String())
+}
+
+func TestDefaultProcessorPreservesOuterWireContract(t *testing.T) {
+	logger, auditBuffer, diagnosticBuffer := createProcessorTestLogger(defaultProcessor{})
+	closeRecordedEvent(t, logger)
+
+	entries := decodeJSONLines(t, auditBuffer)
+	require.Len(t, entries, 1)
+	require.ElementsMatch(t, []string{"time", "level", "msg", "audit"}, mapKeys(entries[0]))
+	require.Equal(t, LevelAuditStr, entries[0]["level"])
+	require.Equal(t, "read", entries[0]["msg"])
+	require.Empty(t, diagnosticBuffer.String())
+}
+
+func TestProcessorSeparatesAuthoritativeEventFromJWTEnrichment(t *testing.T) {
+	token, rawToken := createTestJWTForAudit(t)
+	processor := ProcessorFunc(func(ctx context.Context, event FinalizedEvent) (ProcessResult, error) {
+		require.Equal(t, "resource-1", event.Event.Object.ID)
+		require.Equal(t, "jwt-user", nestedString(event.Audit, "object", "id"))
+		return defaultProcessor{}.Process(ctx, event)
+	})
+	logger, _, diagnosticBuffer := createProcessorTestLogger(processor)
+	require.NoError(t, logger.ApplyConfig(Config{JWTClaimMappings: []JWTClaimMapping{{Claim: "sub", Path: "object.id"}}}))
+	ctx := ctxAuth.ContextWithAuthNInfo(createTestContext(t), nil, token, rawToken)
+	require.NoError(t, logger.Record(ctx, Verb("read"), recordedTestEvent()))
+	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
+	require.True(t, ok)
+	tx.logClose(ctx, logger, true, nil)
+	require.Empty(t, diagnosticBuffer.String())
+}
+
+func mapKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func TestProcessorExplicitDrop(t *testing.T) {
+	processor := ProcessorFunc(func(context.Context, FinalizedEvent) (ProcessResult, error) {
+		return ProcessResult{Drop: true}, nil
+	})
+	logger, auditBuffer, diagnosticBuffer := createProcessorTestLogger(processor)
+
+	closeRecordedEvent(t, logger)
+
+	require.Empty(t, auditBuffer.String())
+	require.Empty(t, diagnosticBuffer.String())
+}
+
+func TestProcessorFailuresFallBackWithoutMutation(t *testing.T) {
+	testCases := map[string]Processor{
+		"error": ProcessorFunc(func(_ context.Context, event FinalizedEvent) (ProcessResult, error) {
+			object, ok := event.Audit["object"].(map[string]any)
+			require.True(t, ok)
+			object["id"] = "mutated"
+			return ProcessResult{}, errors.New("conversion failed")
+		}),
+		"panic": ProcessorFunc(func(context.Context, FinalizedEvent) (ProcessResult, error) {
+			panic("conversion panic")
+		}),
+		"implicit empty": ProcessorFunc(func(context.Context, FinalizedEvent) (ProcessResult, error) {
+			return ProcessResult{}, nil
+		}),
+		"drop with emission": ProcessorFunc(func(context.Context, FinalizedEvent) (ProcessResult, error) {
+			return ProcessResult{Drop: true, Emissions: []Emission{{Level: LevelAudit}}}, nil
+		}),
+		"filtered level": ProcessorFunc(func(context.Context, FinalizedEvent) (ProcessResult, error) {
+			return ProcessResult{Emissions: []Emission{{Level: slog.LevelError, Message: "filtered"}}}, nil
+		}),
+	}
+
+	for name, processor := range testCases {
+		t.Run(name, func(t *testing.T) {
+			logger, auditBuffer, diagnosticBuffer := createProcessorTestLogger(processor)
+			closeRecordedEvent(t, logger)
+
+			entries := decodeJSONLines(t, auditBuffer)
+			require.Len(t, entries, 1)
+			require.Equal(t, "read", entries[0]["msg"])
+			auditPayload, ok := entries[0]["audit"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "resource-1", nestedString(auditPayload, "object", "id"))
+			require.Contains(t, diagnosticBuffer.String(), "audit processor failed; emitting default event")
+		})
+	}
+}
+
+func TestLoggerWithRetainsProcessor(t *testing.T) {
+	processor := ProcessorFunc(func(context.Context, FinalizedEvent) (ProcessResult, error) {
+		return ProcessResult{Drop: true}, nil
+	})
+	logger, _, _ := createProcessorTestLogger(processor)
+
+	child := logger.With("namespace", "external")
+	require.NotNil(t, child.Processor())
+}

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -40,13 +40,31 @@ type Config struct {
 	Type   string `mapstructure:"type" json:"type" default:"json"`
 }
 
+// Option configures a Logger at construction time.
+type Option func(*loggerOptions)
+
+type loggerOptions struct {
+	auditProcessor audit.Processor
+}
+
+// WithAuditProcessor configures the processor used by the audit logger.
+func WithAuditProcessor(processor audit.Processor) Option {
+	return func(options *loggerOptions) {
+		options.auditProcessor = processor
+	}
+}
+
 const (
 	LevelTrace = slog.Level(-8)
 )
 
-func NewLogger(config Config) (*Logger, error) {
+func NewLogger(config Config, options ...Option) (*Logger, error) {
 	var sLogger *slog.Logger
 	logger := new(Logger)
+	loggerOpts := loggerOptions{}
+	for _, option := range options {
+		option(&loggerOpts)
+	}
 
 	w, err := getWriter(config)
 	if err != nil {
@@ -83,7 +101,11 @@ func NewLogger(config Config) (*Logger, error) {
 	})
 
 	auditLoggerBase := slog.New(auditLoggerHandler)
-	auditLogger := audit.CreateAuditLogger(*auditLoggerBase)
+	auditOptions := []audit.Option{audit.WithDiagnosticLogger(sLogger)}
+	if loggerOpts.auditProcessor != nil {
+		auditOptions = append(auditOptions, audit.WithProcessor(loggerOpts.auditProcessor))
+	}
+	auditLogger := audit.CreateAuditLogger(*auditLoggerBase, auditOptions...)
 
 	logger.Logger = sLogger
 	logger.Audit = auditLogger

--- a/service/pkg/server/options.go
+++ b/service/pkg/server/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/casbin/casbin/v2/persist"
 	"github.com/opentdf/platform/sdk"
 	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/logger/audit"
 	"github.com/opentdf/platform/service/pkg/authz"
 	"github.com/opentdf/platform/service/pkg/config"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
@@ -49,11 +50,23 @@ type StartConfig struct {
 
 	authzRoleProvider          authz.RoleProvider
 	authzRoleProviderFactories map[string]authz.RoleProviderFactory
+	auditProcessor             audit.Processor
+	auditProcessorSet          bool
 
 	// CORS additive configuration - appended to YAML/env config values
 	additionalCORSHeaders        []string
 	additionalCORSMethods        []string
 	additionalCORSExposedHeaders []string
+}
+
+// WithAuditProcessor configures an instance-scoped processor for finalized
+// audit events. The processor must be safe for concurrent use.
+func WithAuditProcessor(processor audit.Processor) StartOptions {
+	return func(c StartConfig) StartConfig {
+		c.auditProcessor = processor
+		c.auditProcessorSet = true
+		return c
+	}
 }
 
 // Deprecated: Use WithConfigKey

--- a/service/pkg/server/options_test.go
+++ b/service/pkg/server/options_test.go
@@ -8,11 +8,29 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/logger/audit"
 	"github.com/opentdf/platform/service/pkg/authz"
 	"github.com/opentdf/platform/service/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWithAuditProcessor(t *testing.T) {
+	processor := audit.ProcessorFunc(func(context.Context, audit.FinalizedEvent) (audit.ProcessResult, error) {
+		return audit.ProcessResult{Drop: true}, nil
+	})
+
+	cfg := WithAuditProcessor(processor)(StartConfig{})
+	require.NotNil(t, cfg.auditProcessor)
+	require.True(t, cfg.auditProcessorSet)
+}
+
+func TestWithAuditProcessorRejectsNil(t *testing.T) {
+	require.ErrorIs(t, Start(WithAuditProcessor(nil)), ErrAuditProcessorRequired)
+
+	var processor audit.ProcessorFunc
+	require.ErrorIs(t, Start(WithAuditProcessor(processor)), ErrAuditProcessorRequired)
+}
 
 // noopInterceptor returns a connect.UnaryInterceptorFunc that passes through.
 func noopInterceptor() connect.Interceptor {

--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -290,7 +290,10 @@ func buildNamespaceLogger(baseLogger *logging.Logger, cfg *config.Config, ns, le
 	newLoggerConfig := cfg.Logger
 	newLoggerConfig.Level = level
 
-	namespaceLogger, loggerErr := logging.NewLogger(newLoggerConfig)
+	namespaceLogger, loggerErr := logging.NewLogger(
+		newLoggerConfig,
+		logging.WithAuditProcessor(baseLogger.Audit.Processor()),
+	)
 	if loggerErr != nil {
 		return nil, fmt.Errorf("invalid namespace logger config for %s: %w", ns, loggerErr)
 	}

--- a/service/pkg/server/services_test.go
+++ b/service/pkg/server/services_test.go
@@ -8,11 +8,18 @@ import (
 
 	"github.com/opentdf/platform/service/internal/server"
 	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/logger/audit"
 	"github.com/opentdf/platform/service/pkg/config"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 )
+
+type dropAuditProcessor struct{}
+
+func (*dropAuditProcessor) Process(context.Context, audit.FinalizedEvent) (audit.ProcessResult, error) {
+	return audit.ProcessResult{Drop: true}, nil
+}
 
 type spyTestService struct {
 	wasCalled  bool
@@ -230,6 +237,20 @@ func (suite *ServiceTestSuite) TestBuildNamespaceLoggerRejectsInvalidOverrideLev
 	suite.Require().Error(err)
 	suite.Nil(namespaceLogger)
 	suite.ErrorContains(err, "invalid namespace logger config for policy")
+}
+
+func (suite *ServiceTestSuite) TestBuildNamespaceLoggerRetainsAuditProcessor() {
+	processor := &dropAuditProcessor{}
+	baseLogger, err := logger.NewLogger(
+		logger.Config{Output: "stdout", Level: "info", Type: "json"},
+		logger.WithAuditProcessor(processor),
+	)
+	suite.Require().NoError(err)
+	cfg := &config.Config{Logger: logger.Config{Output: "stdout", Level: "info", Type: "json"}}
+
+	namespaceLogger, err := buildNamespaceLogger(baseLogger, cfg, "policy", "debug")
+	suite.Require().NoError(err)
+	suite.Same(processor, namespaceLogger.Audit.Processor())
 }
 
 func (suite *ServiceTestSuite) TestStartServicesWithVariousCases() {

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"reflect"
 	"slices"
 	"syscall"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/opentdf/platform/service/internal/auth/authz"
 	"github.com/opentdf/platform/service/internal/server"
 	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/logger/audit"
 	"github.com/opentdf/platform/service/pkg/cache"
 	"github.com/opentdf/platform/service/pkg/config"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
@@ -41,12 +43,16 @@ const dpopKeySize = 2048
 var (
 	ErrExternalInterceptorFactoryNameRequired = errors.New("external connect interceptor factory name is required")
 	ErrExternalInterceptorFactoryFuncRequired = errors.New("external connect interceptor factory func is required")
+	ErrAuditProcessorRequired                 = errors.New("audit processor is required")
 )
 
 func Start(f ...StartOptions) error {
 	startConfig := StartConfig{}
 	for _, fn := range f {
 		startConfig = fn(startConfig)
+	}
+	if startConfig.auditProcessorSet && isNilAuditProcessor(startConfig.auditProcessor) {
+		return ErrAuditProcessorRequired
 	}
 
 	ctx := context.Background()
@@ -114,7 +120,11 @@ func Start(f ...StartOptions) error {
 	}
 
 	slog.Debug("configuring logger")
-	logger, err := logger.NewLogger(cfg.Logger)
+	loggerOptions := make([]logger.Option, 0, 1)
+	if startConfig.auditProcessor != nil {
+		loggerOptions = append(loggerOptions, logger.WithAuditProcessor(startConfig.auditProcessor))
+	}
+	logger, err := logger.NewLogger(cfg.Logger, loggerOptions...)
 	if err != nil {
 		return fmt.Errorf("could not start logger: %w", err)
 	}
@@ -358,6 +368,20 @@ func Start(f ...StartOptions) error {
 	}
 
 	return nil
+}
+
+func isNilAuditProcessor(processor audit.Processor) bool {
+	if processor == nil {
+		return true
+	}
+	value := reflect.ValueOf(processor)
+	//nolint:exhaustive // only nil-capable reflection kinds require handling
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 func validateExternalInterceptorFactory(factory InterceptorFactory) error {


### PR DESCRIPTION
### Proposed Changes

- process finalized typed events after cancellation handling and JWT enrichment
- support explicit zero (`Drop`), one, or ordered many slog emissions for downstream partitioning
- fall back to the unchanged default OpenTDF audit record on processor error, panic, invalid empty output, or filtered levels
- keep authoritative pre-enrichment event fields separate from the enriched output map for ownership decisions
- inject one concurrency-safe processor through `server.WithAuditProcessor` and retain it across scoped and namespace-rebuilt loggers
- document the public recorder/processor contract and ownership boundary

This is PR 2 of 2 for PEP-5181 and is based on PR #3816.

### Design and compatibility

- the default processor preserves `level:"AUDIT"`, `msg:<verb>`, and `audit:{...}`
- processors run outside transaction locks and receive isolated snapshots
- conversion failures produce an operational diagnostic and exactly one default fallback event
- JWT claims may enrich actor/request context but must not establish resource ownership
- lowercase audit level serialization remains a downstream handler concern; processors can emit the required `message` attribute without importing downstream models upstream

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation

### Testing Instructions

- `cd service && go test -race ./logger/audit ./pkg/config ./pkg/server ./internal/server`
- `cd service && golangci-lint run --new-from-rev=origin/main ./logger/audit/... ./logger/... ./pkg/server/...`
- `cd sdk && go test -run TestREADMECodeBlocks`
- `git diff --check origin/main...HEAD`

Repository-wide `make lint` is blocked locally by an invalid Buf API token. Repository-wide `make test` reaches environment-dependent Keycloak/Docker suites that are unavailable locally; the focused race suites above pass.
