### PR TITLE
chore(docs): clarify OpenTDF OIDC relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ service follows a modular binary architecture, while the sub-services are gRPC s
 
 **Policy** is the set of rules that govern access to the platform.
 
-**OIDC** is the OpenID Connect protocol used solely for authentication within the OpenTDF platform.
+**OIDC** is the OpenID Connect protocol OpenTDF uses for authentication plus trusted identity claims that feed authorization and policy decisions. See [OpenTDF and OpenID Connect (OIDC)](./docs/OIDC.md).
 
 - **IdP** - Identity Provider. This is the service that authenticates the user.
 - **Keycloak** is the turn-key OIDC provider used within the platform for proof-of-value, but should be replaced with a

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 ## Documentation
 
 - [Configuration](./docs/Configuring.md)
-- [Multi-Strategy Entity Resolution Service](./ERS_TESTING.md)
+- [OpenID Connect (OIDC)](./docs/OIDC.md)
+- [Multi-Strategy Entity Resolution Service](./service/entityresolution/multi-strategy/README.md)
 - [Development](#for-contributors)
 - [Policy Config Schema](./service/policy/db/schema_erd.md)
 - [Policy Config Testing Diagram](./service/integration/testing_diagram.png)
@@ -101,7 +102,7 @@ go test ./service/entityresolution/integration -run TestMultiStrategy -v
 #### Configuration Options
 
 - **`opentdf-ers-test.yaml`** - Complete OpenTDF platform with multi-strategy ERS
-- **`ERS_TESTING.md`** - Comprehensive documentation and examples
+- [**`service/entityresolution/multi-strategy/README.md`**](./service/entityresolution/multi-strategy/README.md) - Comprehensive documentation and examples
 
 The multi-strategy ERS (preview) provides enterprise-grade identity resolution with failover, multiple provider support, and flexible mapping strategies.
 
@@ -234,7 +235,7 @@ service follows a modular binary architecture, while the sub-services are gRPC s
 
 **Policy** is the set of rules that govern access to the platform.
 
-**OIDC** is the OpenID Connect protocol used solely for authentication within the OpenTDF platform.
+**OIDC** is the OpenID Connect protocol OpenTDF uses for authentication plus trusted identity claims that feed authorization and policy decisions. See [OpenTDF and OpenID Connect (OIDC)](./docs/OIDC.md).
 
 - **IdP** - Identity Provider. This is the service that authenticates the user.
 - **Keycloak** is the turn-key OIDC provider used within the platform for proof-of-value, but should be replaced with a

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 ## Documentation
 
 - [Configuration](./docs/Configuring.md)
-- [Multi-Strategy Entity Resolution Service](./ERS_TESTING.md)
+- [OpenID Connect (OIDC)](./docs/OIDC.md)
+- [Multi-Strategy Entity Resolution Service](./service/entityresolution/multi-strategy/README.md)
 - [Development](#for-contributors)
 - [Policy Config Schema](./service/policy/db/schema_erd.md)
 - [Policy Config Testing Diagram](./service/integration/testing_diagram.png)
@@ -101,7 +102,7 @@ go test ./service/entityresolution/integration -run TestMultiStrategy -v
 #### Configuration Options
 
 - **`opentdf-ers-test.yaml`** - Complete OpenTDF platform with multi-strategy ERS
-- **`ERS_TESTING.md`** - Comprehensive documentation and examples
+- [**`service/entityresolution/multi-strategy/README.md`**](./service/entityresolution/multi-strategy/README.md) - Comprehensive documentation and examples
 
 The multi-strategy ERS (preview) provides enterprise-grade identity resolution with failover, multiple provider support, and flexible mapping strategies.
 

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -120,6 +120,9 @@ The server configuration is used to define how the application runs its server.
 
 Root level key `server`
 
+> [!NOTE]
+> `server.auth` configures OpenTDF as an OIDC token consumer, not as the identity provider itself. See [OpenTDF and OpenID Connect (OIDC)](./OIDC.md) for the deployment boundary and end-to-end flow.
+
 | Field                   | Description                                                                                                   | Default | Environment Variable                 |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------ |
 | `auth.audience`         | The audience for the IDP.                                                                                     |         | OPENTDF_SERVER_AUTH_AUDIENCE         |
@@ -140,6 +143,8 @@ Root level key `server`
 | `tls.enabled`           | Enable tls.                                                                                                   | `false` | OPENTDF_SERVER_TLS_ENABLED           |
 | `tls.cert`              | The path to the tls certificate.                                                                              |         | OPENTDF_SERVER_TLS_CERT              |
 | `tls.key`               | The path to the tls key.                                                                                      |         | OPENTDF_SERVER_TLS_KEY               |
+
+OpenTDF expects the configured `auth.issuer` and the discovery document's `issuer` value to agree. If they differ, the discovery document's issuer value is used for token validation.
 
 Example:
 
@@ -637,7 +642,7 @@ server:
       username_claim: "email"
 
       ## Dot notation is used to access the groups claim
-      group_claim: "realm_access.roles"
+      groups_claim: "realm_access.roles"
 
       # Dot notation is used to access the claim the represents the idP client ID 
       client_id_claim: # azp

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -116,21 +116,24 @@ The server configuration is used to define how the application runs its server.
 
 Root level key `server`
 
-| Field                   | Description                                                                                                   | Default | Environment Variable                 |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------ |
-| `auth.audience`         | The audience for the IDP.                                                                                     |         | OPENTDF_SERVER_AUTH_AUDIENCE         |
-| `auth.issuer`           | The issuer for the IDP.                                                                                       |         | OPENTDF_SERVER_AUTH_ISSUER           |
-| `auth.policy`           | The Casbin policy for enforcing authorization on endpoints. Described [below](#casbin-endpoint-authorization) |         |                                      |
-| `auth.cache_refresh`    | Interval in which the IDP jwks should be refreshed                                                            | `15m`   | OPENTDF_SERVER_AUTH_CACHE_REFRESH    |
-| `auth.dpopskew`         | The amount of time drift allowed between when the client generated a dpop proof and the server time.          | `1h`    | OPENTDF_SERVER_AUTH                  |
-| `auth.skew`             | The amount of time drift allowed between a tokens `exp` claim and the server time.                            | `1m`    | OPENTDF_SERVER_AUTH_SKEW             |
-| `auth.public_client_id` | [DEPRECATED] The oidc client id. This is leveraged by otdfctl.                                                |         | OPENTDF_SERVER_AUTH_PUBLIC_CLIENT_ID |
-| `auth.dpop.enforce`     | If true, DPoP bindings on Access Tokens are enforced.                                                         | `false` | OPENTDF_SERVER_AUTH_DPOP_ENFORCE     |
-| `auth.enforceDPoP`      | [DEPRECATED] Use `auth.dpop.enforce`. Still honored: DPoP is enforced when either field is true.              | `false` | OPENTDF_SERVER_AUTH_ENFORCEDPOP      |
-| `cryptoProvider`        | A list of public/private keypairs and their use. Described [below](#crypto-provider)                          | empty   |                                      |
-| `enable_pprof`          | Enable golang performance profiling                                                                           | `false` | OPENTDF_SERVER_ENABLE_PPROF          |
-| `grpc.reflection`       | The configuration for the grpc server.                                                                        | `true`  | OPENTDF_SERVER_GRPC_REFLECTION       |
-| `public_hostname`       | The public facing hostname for the server.                                                                    |         | OPENTDF_SERVER_PUBLIC_HOSTNAME       |
+> [!NOTE]
+> `server.auth` configures OpenTDF as an OIDC token consumer, not as the identity provider itself. See [OpenTDF and OpenID Connect (OIDC)](./OIDC.md) for the deployment boundary and end-to-end flow.
+
+| Field                            | Description                                                                                                   | Default | Environment Variable                          |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------------------- |
+| `auth.audience`                  | The audience for the IDP.                                                                                     |         | OPENTDF_SERVER_AUTH_AUDIENCE                  |
+| `auth.issuer`                    | The issuer for the IDP.                                                                                       |         | OPENTDF_SERVER_AUTH_ISSUER                    |
+| `auth.policy`                    | The Casbin policy for enforcing authorization on endpoints. Described [below](#casbin-endpoint-authorization) |         |                                               |
+| `auth.cache_refresh_interval`    | Interval in which the IDP JWKS should be refreshed                                                            | `15m`   | OPENTDF_SERVER_AUTH_CACHE_REFRESH_INTERVAL    |
+| `auth.dpopskew`                  | The amount of time drift allowed between when the client generated a dpop proof and the server time.          | `1h`    | OPENTDF_SERVER_AUTH_DPOPSKEW                  |
+| `auth.skew`                      | The amount of time drift allowed between a tokens `exp` claim and the server time.                            | `1m`    | OPENTDF_SERVER_AUTH_SKEW                      |
+| `auth.public_client_id`          | [DEPRECATED] The oidc client id. This is leveraged by otdfctl.                                                |         | OPENTDF_SERVER_AUTH_PUBLIC_CLIENT_ID          |
+| `auth.dpop.enforce`              | If true, DPoP bindings on Access Tokens are enforced.                                                         | `false` | OPENTDF_SERVER_AUTH_DPOP_ENFORCE              |
+| `auth.enforceDPoP`               | [DEPRECATED] Use `auth.dpop.enforce`. Still honored: DPoP is enforced when either field is true.              | `false` | OPENTDF_SERVER_AUTH_ENFORCEDPOP               |
+| `cryptoProvider`                 | A list of public/private keypairs and their use. Described [below](#crypto-provider)                          | empty   |                                               |
+| `enable_pprof`                   | Enable golang performance profiling                                                                           | `false` | OPENTDF_SERVER_ENABLE_PPROF                   |
+| `grpc.reflection`                | The configuration for the grpc server.                                                                        | `true`  | OPENTDF_SERVER_GRPC_REFLECTION                |
+| `public_hostname`                | The public facing hostname for the server.                                                                    |         | OPENTDF_SERVER_PUBLIC_HOSTNAME                |
 | `host`                  | The host address for the server.                                                                              | `""`    | OPENTDF_SERVER_HOST                  |
 | `port`                  | The port number for the server.                                                                               | `9000`  | OPENTDF_SERVER_PORT                  |
 | `tls.enabled`           | Enable tls.                                                                                                   | `false` | OPENTDF_SERVER_TLS_ENABLED           |

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -119,26 +119,28 @@ Root level key `server`
 > [!NOTE]
 > `server.auth` configures OpenTDF as an OIDC token consumer, not as the identity provider itself. See [OpenTDF and OpenID Connect (OIDC)](./OIDC.md) for the deployment boundary and end-to-end flow.
 
-| Field                            | Description                                                                                                   | Default | Environment Variable                          |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------------------- |
-| `auth.audience`                  | The audience for the IDP.                                                                                     |         | OPENTDF_SERVER_AUTH_AUDIENCE                  |
-| `auth.issuer`                    | The issuer for the IDP.                                                                                       |         | OPENTDF_SERVER_AUTH_ISSUER                    |
-| `auth.policy`                    | The Casbin policy for enforcing authorization on endpoints. Described [below](#casbin-endpoint-authorization) |         |                                               |
-| `auth.cache_refresh_interval`    | Interval in which the IDP JWKS should be refreshed                                                            | `15m`   | OPENTDF_SERVER_AUTH_CACHE_REFRESH_INTERVAL    |
-| `auth.dpopskew`                  | The amount of time drift allowed between when the client generated a dpop proof and the server time.          | `1h`    | OPENTDF_SERVER_AUTH_DPOPSKEW                  |
-| `auth.skew`                      | The amount of time drift allowed between a tokens `exp` claim and the server time.                            | `1m`    | OPENTDF_SERVER_AUTH_SKEW                      |
-| `auth.public_client_id`          | [DEPRECATED] The oidc client id. This is leveraged by otdfctl.                                                |         | OPENTDF_SERVER_AUTH_PUBLIC_CLIENT_ID          |
-| `auth.dpop.enforce`              | If true, DPoP bindings on Access Tokens are enforced.                                                         | `false` | OPENTDF_SERVER_AUTH_DPOP_ENFORCE              |
-| `auth.enforceDPoP`               | [DEPRECATED] Use `auth.dpop.enforce`. Still honored: DPoP is enforced when either field is true.              | `false` | OPENTDF_SERVER_AUTH_ENFORCEDPOP               |
-| `cryptoProvider`                 | A list of public/private keypairs and their use. Described [below](#crypto-provider)                          | empty   |                                               |
-| `enable_pprof`                   | Enable golang performance profiling                                                                           | `false` | OPENTDF_SERVER_ENABLE_PPROF                   |
-| `grpc.reflection`                | The configuration for the grpc server.                                                                        | `true`  | OPENTDF_SERVER_GRPC_REFLECTION                |
-| `public_hostname`                | The public facing hostname for the server.                                                                    |         | OPENTDF_SERVER_PUBLIC_HOSTNAME                |
-| `host`                  | The host address for the server.                                                                              | `""`    | OPENTDF_SERVER_HOST                  |
-| `port`                  | The port number for the server.                                                                               | `9000`  | OPENTDF_SERVER_PORT                  |
-| `tls.enabled`           | Enable tls.                                                                                                   | `false` | OPENTDF_SERVER_TLS_ENABLED           |
-| `tls.cert`              | The path to the tls certificate.                                                                              |         | OPENTDF_SERVER_TLS_CERT              |
-| `tls.key`               | The path to the tls key.                                                                                      |         | OPENTDF_SERVER_TLS_KEY               |
+| Field                         | Description                                                                                                          | Default | Environment Variable                       |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
+| `auth.audience`               | Expected `aud` claim for access tokens accepted from the external OIDC issuer.                                      |         | OPENTDF_SERVER_AUTH_AUDIENCE               |
+| `auth.issuer`                 | Base URL of the external OIDC issuer used for discovery and token validation.                                       |         | OPENTDF_SERVER_AUTH_ISSUER                 |
+| `auth.policy`                 | The Casbin policy for enforcing authorization on endpoints. Described [below](#casbin-endpoint-authorization)       |         |                                            |
+| `auth.cache_refresh_interval` | Minimum refresh interval for the external OIDC issuer's JWKS cache.                                                 | `15m`   | OPENTDF_SERVER_AUTH_CACHE_REFRESH_INTERVAL |
+| `auth.dpopskew`               | The amount of time drift allowed between when the client generated a DPoP proof and the server time.               | `1h`    | OPENTDF_SERVER_AUTH_DPOPSKEW               |
+| `auth.skew`                   | The amount of time drift allowed between a token's `exp` claim and the server time.                                 | `1m`    | OPENTDF_SERVER_AUTH_SKEW                   |
+| `auth.public_client_id`       | [DEPRECATED] The OIDC client ID leveraged by otdfctl.                                                               |         | OPENTDF_SERVER_AUTH_PUBLIC_CLIENT_ID       |
+| `auth.dpop.enforce`           | If true, DPoP bindings on access tokens are enforced.                                                               | `false` | OPENTDF_SERVER_AUTH_DPOP_ENFORCE           |
+| `auth.enforceDPoP`            | [DEPRECATED] Use `auth.dpop.enforce`. Still honored: DPoP is enforced when either field is true.                   | `false` | OPENTDF_SERVER_AUTH_ENFORCEDPOP            |
+| `cryptoProvider`              | A list of public/private keypairs and their use. Described [below](#crypto-provider)                                | empty   |                                            |
+| `enable_pprof`                | Enable golang performance profiling.                                                                                | `false` | OPENTDF_SERVER_ENABLE_PPROF                |
+| `grpc.reflection`             | The configuration for the gRPC server.                                                                              | `true`  | OPENTDF_SERVER_GRPC_REFLECTION             |
+| `public_hostname`             | The public-facing hostname for the server.                                                                          |         | OPENTDF_SERVER_PUBLIC_HOSTNAME             |
+| `host`                        | The host address for the server.                                                                                    | `""`    | OPENTDF_SERVER_HOST                        |
+| `port`                        | The port number for the server.                                                                                     | `9000`  | OPENTDF_SERVER_PORT                        |
+| `tls.enabled`                 | Enable TLS.                                                                                                         | `false` | OPENTDF_SERVER_TLS_ENABLED                 |
+| `tls.cert`                    | The path to the TLS certificate.                                                                                    |         | OPENTDF_SERVER_TLS_CERT                    |
+| `tls.key`                     | The path to the TLS key.                                                                                            |         | OPENTDF_SERVER_TLS_KEY                     |
+
+OpenTDF expects the configured `auth.issuer` and the discovery document's `issuer` value to agree. If they differ, the discovery document's issuer value is used for token validation.
 
 Example:
 
@@ -606,7 +608,7 @@ server:
       ## Dot notation is used to access the groups claim
       group_claim: "realm_access.roles"
 
-      # Dot notation is used to access the claim the represents the idP client ID 
+      # Dot notation is used to access the claim that represents the IdP client ID
       client_id_claim: # azp
       
       ## Deprecated: Use standard casbin policy groupings (g, <user/group>, <role>)

--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -51,6 +51,10 @@ https://github.com/opentdf/platform/blob/main/service/go.mod#L3
    ```shell
    go run ./service provision keycloak
    ```
+
+   > [!NOTE]
+   > In this local quickstart, Keycloak is the external OIDC provider. OpenTDF uses the resulting access tokens and claims for authentication and authorization, but OpenTDF is not itself an IdP. See [OpenTDF and OpenID Connect (OIDC)](./OIDC.md).
+
 4. **Add Sample Attributes and Metadata**
    ```shell
    go run ./service provision fixtures

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -1,0 +1,113 @@
+# OpenTDF and OpenID Connect (OIDC)
+
+OpenTDF uses OpenID Connect (OIDC) as an external source of authentication and identity claims. It is **not** an identity provider (IdP).
+
+In the current implementation, OpenTDF expects an external OIDC issuer to:
+
+- authenticate users or clients
+- issue signed access tokens
+- publish discovery metadata at `/.well-known/openid-configuration`
+- publish signing keys through the discovered `jwks_uri`
+
+OpenTDF then validates those tokens and uses selected claims as trusted input for endpoint authorization and policy decisions.
+
+For concrete setup details, see [Configuration](./Configuring.md#server-configuration), [Running the Platform Locally](./Consuming.md#running-the-platform-locally), the [Go SDK README](../sdk/README.md), and [`otdfctl auth`](../otdfctl/docs/man/auth/_index.md).
+
+## Deployment boundary
+
+| Responsibility | External OIDC provider | OpenTDF |
+| --- | --- | --- |
+| Authenticate end users or OAuth clients | Yes | No |
+| Host `/.well-known/openid-configuration` | Yes | No |
+| Publish JWKS signing keys | Yes | No |
+| Issue signed access tokens with claims | Yes | No |
+| Validate access tokens on OpenTDF API requests | No | Yes |
+| Use validated claims for authorization and policy evaluation | No | Yes |
+| Publish `/.well-known/opentdf-configuration` for OpenTDF clients | No | Yes |
+
+In this repository's local quickstart, Keycloak fills the external IdP role. In other deployments, OpenTDF's OIDC authentication relies on the configured issuer, audience, and the issuer's discovery/JWKS endpoints.
+
+## Two different well-known endpoints
+
+OpenTDF deployments commonly involve two different discovery documents:
+
+| Endpoint | Hosted by | Purpose |
+| --- | --- | --- |
+| `<issuer>/.well-known/openid-configuration` | external OIDC provider | OIDC discovery for issuer metadata such as `issuer`, `token_endpoint`, and `jwks_uri` |
+| `<platform>/.well-known/opentdf-configuration` | OpenTDF | OpenTDF-specific metadata that SDKs can read, including the platform issuer reference and discovered IdP metadata |
+
+That distinction is important: OpenTDF may publish metadata *about* the configured IdP, but authentication still happens at the external IdP.
+
+## Relevant OIDC concepts in OpenTDF
+
+- **Issuer**
+  - Configured as `server.auth.issuer`.
+  - OpenTDF uses this URL to discover OIDC metadata at `/.well-known/openid-configuration`.
+  - During discovery, OpenTDF uses the issuer value returned by the discovery document for token validation.
+
+- **Audience**
+  - Configured as `server.auth.audience`.
+  - OpenTDF validates the incoming token's `aud` claim against this value.
+
+- **JWKS / signing keys**
+  - OpenTDF reads `jwks_uri` from the discovery document.
+  - It caches the remote key set and refreshes it using `server.auth.cache_refresh_interval`.
+  - Incoming access-token signatures are validated against that cached JWKS.
+
+- **Claims**
+  - After token validation, OpenTDF uses configured claims from the access token to build request identity context.
+  - The current auth policy configuration supports:
+    - `server.auth.policy.username_claim` (default `preferred_username`)
+    - `server.auth.policy.groups_claim` (default `realm_access.roles`)
+    - `server.auth.policy.client_id_claim` (default `azp`)
+
+- **DPoP**
+  - When enabled, OpenTDF also validates DPoP proof material associated with the access token.
+  - This is additional request binding on top of normal OIDC token validation, not a replacement for issuer/audience/signature checks.
+
+## End-to-end conceptual flow
+
+1. A client authenticates with the external OIDC provider.
+2. The provider issues an access token for the audience OpenTDF expects.
+3. OpenTDF uses the configured issuer to discover OIDC metadata and load the provider's JWKS.
+4. The client calls an OpenTDF API with the access token (and optionally DPoP proof headers when that deployment uses DPoP).
+5. OpenTDF validates the token signature, issuer, audience, and time-based constraints before trusting its claims.
+6. OpenTDF extracts configured identity claims and uses them for endpoint authorization and downstream policy or decisioning context.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant IdP as External OIDC provider
+    participant OpenTDF
+    participant Policy as OpenTDF authz/policy
+
+    Note over OpenTDF,IdP: OpenTDF discovers issuer metadata and JWKS from the external IdP
+    Client->>IdP: Authenticate and request access token
+    IdP-->>Client: Signed access token with claims
+    Client->>OpenTDF: API request with token\n(+ DPoP proof when configured)
+    OpenTDF->>OpenTDF: Validate signature, issuer, audience,\nexpiry/skew, optional DPoP
+    OpenTDF->>Policy: Extract configured claims\n(username / groups / client ID)
+    Policy-->>OpenTDF: Authorization + policy context
+    OpenTDF-->>Client: API response
+```
+
+## Where OpenTDF currently uses that identity context
+
+Today, the implementation uses validated token context in a few distinct places:
+
+- **Request authentication middleware** validates the incoming access token against the configured issuer, audience, and JWKS.
+- **Endpoint authorization** builds subjects from configured claims and evaluates them through the configured authorization policy.
+- **Authorization service request context** propagates the resolved client ID into downstream policy request context.
+- **Entity Resolution Service (ERS)** can be configured separately:
+  - `keycloak` mode integrates with Keycloak using ERS-specific service credentials.
+  - `claims` mode resolves entity information from claims already present in JWT input.
+
+## See also
+
+- [Configuration](./Configuring.md#server-configuration)
+- [Entity Resolution configuration](./Configuring.md#entity-resolution)
+- [Casbin endpoint authorization](./Configuring.md#casbin-endpoint-authorization)
+- [Running the Platform Locally](./Consuming.md#running-the-platform-locally)
+- [Go SDK README](../sdk/README.md)
+- [`otdfctl auth login`](../otdfctl/docs/man/auth/login.md)
+- [`otdfctl auth client-credentials`](../otdfctl/docs/man/auth/client-credentials.md)

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -1,0 +1,113 @@
+# OpenTDF and OpenID Connect (OIDC)
+
+OpenTDF uses OpenID Connect (OIDC) as an external source of authentication and identity claims. It is **not** an identity provider (IdP).
+
+In the current implementation, OpenTDF expects an external OIDC issuer to:
+
+- authenticate users or clients
+- issue signed access tokens
+- publish discovery metadata at `/.well-known/openid-configuration`
+- publish signing keys through the discovered `jwks_uri`
+
+OpenTDF then validates those tokens and uses selected claims as trusted input for endpoint authorization and policy decisions.
+
+For concrete setup details, see [Configuration](./Configuring.md#server-configuration), [Running the Platform Locally](./Consuming.md#running-the-platform-locally), the [Go SDK README](../sdk/README.md), and [`otdfctl auth`](../otdfctl/docs/man/auth/_index.md).
+
+## Deployment boundary
+
+| Responsibility | External OIDC provider | OpenTDF |
+| --- | --- | --- |
+| Authenticate end users or OAuth clients | Yes | No |
+| Host `/.well-known/openid-configuration` | Yes | No |
+| Publish JWKS signing keys | Yes | No |
+| Issue signed access tokens with claims | Yes | No |
+| Validate access tokens on OpenTDF API requests | No | Yes |
+| Use validated claims for authorization and policy evaluation | No | Yes |
+| Publish `/.well-known/opentdf-configuration` for OpenTDF clients | No | Yes |
+
+In this repository's local quickstart, Keycloak fills the external IdP role. In other deployments, OpenTDF's OIDC authentication relies on the configured external issuer, expected audience, and that issuer's discovery/JWKS endpoints.
+
+## Two different well-known endpoints
+
+OpenTDF deployments commonly involve two different discovery documents:
+
+| Endpoint | Hosted by | Purpose |
+| --- | --- | --- |
+| `<issuer>/.well-known/openid-configuration` | external OIDC provider | OIDC discovery for issuer metadata such as `issuer`, `token_endpoint`, and `jwks_uri` |
+| `<platform>/.well-known/opentdf-configuration` | OpenTDF | OpenTDF-specific metadata that SDKs can read, including the platform issuer reference and discovered IdP metadata |
+
+That distinction is important: OpenTDF may publish metadata *about* the configured IdP, but authentication still happens at the external IdP.
+
+## Relevant OIDC concepts in OpenTDF
+
+- **Issuer**
+  - Configured as `server.auth.issuer`.
+  - OpenTDF uses this URL to discover OIDC metadata at `/.well-known/openid-configuration`.
+  - OpenTDF expects the configured issuer and the discovery document's `issuer` value to agree; if they differ, the discovery document's issuer value is used for token validation.
+
+- **Audience**
+  - Configured as `server.auth.audience`.
+  - OpenTDF validates the incoming token's `aud` claim against this expected audience value.
+
+- **JWKS / signing keys**
+  - OpenTDF reads `jwks_uri` from the discovery document.
+  - It caches the remote key set and uses `server.auth.cache_refresh_interval` as the minimum refresh interval for that JWKS cache.
+  - Incoming access-token signatures are validated against that cached JWKS.
+
+- **Claims**
+  - After token validation, OpenTDF uses configured claims from the access token to build request identity context.
+  - The current auth policy configuration supports:
+    - `server.auth.policy.username_claim` (default `preferred_username`)
+    - `server.auth.policy.groups_claim` (default `realm_access.roles`)
+    - `server.auth.policy.client_id_claim` (default `azp`)
+
+- **DPoP**
+  - When enabled, OpenTDF also validates DPoP proof material associated with the access token.
+  - This is additional request binding on top of normal OIDC token validation, not a replacement for issuer/audience/signature checks.
+
+## End-to-end conceptual flow
+
+1. An end user or a machine-to-machine OAuth client authenticates with the external OIDC provider.
+2. The provider issues an access token for the audience OpenTDF expects.
+3. OpenTDF uses the configured issuer to discover OIDC metadata and load the provider's JWKS.
+4. The client calls an OpenTDF API with the access token (and optionally DPoP proof headers when that deployment uses DPoP).
+5. OpenTDF validates the token signature, issuer, audience, and time-based constraints before trusting its claims.
+6. OpenTDF extracts configured identity claims and uses them for endpoint authorization and downstream policy or decisioning context.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant IdP as External OIDC provider
+    participant OpenTDF
+    participant Policy as OpenTDF authz/policy
+
+    Note over OpenTDF,IdP: OpenTDF discovers issuer metadata and JWKS from the external IdP
+    Client->>IdP: Authenticate user or client<br/>and request access token
+    IdP-->>Client: Signed access token with claims
+    Client->>OpenTDF: API request with token<br/>(+ DPoP proof when configured)
+    OpenTDF->>OpenTDF: Validate signature, issuer, audience,<br/>expiry/skew, optional DPoP
+    OpenTDF->>Policy: Extract configured claims<br/>(username / groups / client ID)
+    Policy-->>OpenTDF: Authorization + policy context
+    OpenTDF-->>Client: API response
+```
+
+## Where OpenTDF currently uses that identity context
+
+Today, the implementation uses validated token context in a few distinct places:
+
+- **Request authentication middleware** validates the incoming access token against the configured issuer, audience, and JWKS.
+- **Endpoint authorization** builds subjects from configured claims and evaluates them through the configured authorization policy.
+- **Authorization service request context** propagates the resolved client ID into downstream policy request context.
+- **Entity Resolution Service (ERS)** can be configured separately:
+  - `keycloak` mode integrates with Keycloak using ERS-specific service credentials.
+  - `claims` mode resolves entity information from claims already present in JWT input.
+
+## See also
+
+- [Configuration](./Configuring.md#server-configuration)
+- [Entity Resolution configuration](./Configuring.md#entity-resolution)
+- [Casbin endpoint authorization](./Configuring.md#casbin-endpoint-authorization)
+- [Running the Platform Locally](./Consuming.md#running-the-platform-locally)
+- [Go SDK README](../sdk/README.md)
+- [`otdfctl auth login`](../otdfctl/docs/man/auth/login.md)
+- [`otdfctl auth client-credentials`](../otdfctl/docs/man/auth/client-credentials.md)

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -36,7 +36,7 @@ OpenTDF deployments commonly involve two different discovery documents:
 | `<issuer>/.well-known/openid-configuration` | external OIDC provider | OIDC discovery for issuer metadata such as `issuer`, `token_endpoint`, and `jwks_uri` |
 | `<platform>/.well-known/opentdf-configuration` | OpenTDF | OpenTDF-specific metadata, including the resolved issuer and selected discovered IdP metadata, that clients use to bootstrap authentication |
 
-OpenTDF discovers the configured provider at startup and republishes selected metadata under `idp`, together with `platform_issuer`, in its own well-known configuration. `otdfctl` reads `idp.issuer`, `idp.authorization_endpoint`, and `idp.token_endpoint`, so it needs only the OpenTDF platform endpoint for IdP endpoint discovery instead of separate IdP endpoint configuration. The caller must still supply its client ID and any required credentials, and authentication still happens at the external IdP.
+OpenTDF discovers the configured provider at startup and republishes selected metadata under `idp`, together with `platform_issuer`, in its own well-known configuration. OpenTDF Policy Enforcement Points (PEPs) should use the SDK to read this platform configuration and bootstrap IdP endpoint discovery from only the OpenTDF platform endpoint, rather than requiring separate IdP endpoint configuration. A PEP must still supply its client ID and any required credentials, and authentication still happens at the external IdP.
 
 ## Relevant OIDC concepts in OpenTDF
 

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -34,9 +34,9 @@ OpenTDF deployments commonly involve two different discovery documents:
 | Endpoint | Hosted by | Purpose |
 | --- | --- | --- |
 | `<issuer>/.well-known/openid-configuration` | external OIDC provider | OIDC discovery for issuer metadata such as `issuer`, `token_endpoint`, and `jwks_uri` |
-| `<platform>/.well-known/opentdf-configuration` | OpenTDF | OpenTDF-specific metadata that SDKs can read, including the platform issuer reference and discovered IdP metadata |
+| `<platform>/.well-known/opentdf-configuration` | OpenTDF | OpenTDF-specific metadata, including the resolved issuer and selected discovered IdP metadata, that clients use to bootstrap authentication |
 
-That distinction is important: OpenTDF may publish metadata *about* the configured IdP, but authentication still happens at the external IdP.
+OpenTDF discovers the configured provider at startup and republishes selected metadata under `idp`, together with `platform_issuer`, in its own well-known configuration. `otdfctl` reads `idp.issuer`, `idp.authorization_endpoint`, and `idp.token_endpoint`, so it needs only the OpenTDF platform endpoint for IdP endpoint discovery instead of separate IdP endpoint configuration. The caller must still supply its client ID and any required credentials, and authentication still happens at the external IdP.
 
 ## Relevant OIDC concepts in OpenTDF
 

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -25,7 +25,7 @@ For concrete setup details, see [Configuration](./Configuring.md#server-configur
 | Use validated claims for authorization and policy evaluation | No | Yes |
 | Publish `/.well-known/opentdf-configuration` for OpenTDF clients | No | Yes |
 
-In this repository's local quickstart, Keycloak fills the external IdP role. In other deployments, OpenTDF's OIDC authentication relies on the configured issuer, audience, and the issuer's discovery/JWKS endpoints.
+In this repository's local quickstart, Keycloak fills the external IdP role. In other deployments, OpenTDF's OIDC authentication relies on the configured external issuer, expected audience, and that issuer's discovery/JWKS endpoints.
 
 ## Two different well-known endpoints
 
@@ -43,15 +43,15 @@ That distinction is important: OpenTDF may publish metadata *about* the configur
 - **Issuer**
   - Configured as `server.auth.issuer`.
   - OpenTDF uses this URL to discover OIDC metadata at `/.well-known/openid-configuration`.
-  - During discovery, OpenTDF uses the issuer value returned by the discovery document for token validation.
+  - OpenTDF expects the configured issuer and the discovery document's `issuer` value to agree; if they differ, the discovery document's issuer value is used for token validation.
 
 - **Audience**
   - Configured as `server.auth.audience`.
-  - OpenTDF validates the incoming token's `aud` claim against this value.
+  - OpenTDF validates the incoming token's `aud` claim against this expected audience value.
 
 - **JWKS / signing keys**
   - OpenTDF reads `jwks_uri` from the discovery document.
-  - It caches the remote key set and refreshes it using `server.auth.cache_refresh_interval`.
+  - It caches the remote key set and uses `server.auth.cache_refresh_interval` as the minimum refresh interval for that JWKS cache.
   - Incoming access-token signatures are validated against that cached JWKS.
 
 - **Claims**
@@ -67,7 +67,7 @@ That distinction is important: OpenTDF may publish metadata *about* the configur
 
 ## End-to-end conceptual flow
 
-1. A client authenticates with the external OIDC provider.
+1. An end user or a machine-to-machine OAuth client authenticates with the external OIDC provider.
 2. The provider issues an access token for the audience OpenTDF expects.
 3. OpenTDF uses the configured issuer to discover OIDC metadata and load the provider's JWKS.
 4. The client calls an OpenTDF API with the access token (and optionally DPoP proof headers when that deployment uses DPoP).
@@ -82,11 +82,11 @@ sequenceDiagram
     participant Policy as OpenTDF authz/policy
 
     Note over OpenTDF,IdP: OpenTDF discovers issuer metadata and JWKS from the external IdP
-    Client->>IdP: Authenticate and request access token
+    Client->>IdP: Authenticate user or client<br/>and request access token
     IdP-->>Client: Signed access token with claims
-    Client->>OpenTDF: API request with token\n(+ DPoP proof when configured)
-    OpenTDF->>OpenTDF: Validate signature, issuer, audience,\nexpiry/skew, optional DPoP
-    OpenTDF->>Policy: Extract configured claims\n(username / groups / client ID)
+    Client->>OpenTDF: API request with token<br/>(+ DPoP proof when configured)
+    OpenTDF->>OpenTDF: Validate signature, issuer, audience,<br/>expiry/skew, optional DPoP
+    OpenTDF->>Policy: Extract configured claims<br/>(username / groups / client ID)
     Policy-->>OpenTDF: Authorization + policy context
     OpenTDF-->>Client: API response
 ```


### PR DESCRIPTION
## Summary
- add a dedicated OIDC relationship document explaining the IdP/OpenTDF boundary
- link the new doc from the repo docs entry points and local quickstart
- correct the documented auth cache refresh and DPoP skew config keys to match current implementation

Closes #3824
Jira: https://virtru.atlassian.net/browse/DSPX-4261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for deploying and configuring external OIDC authentication, including discovery, issuer validation, audiences, JWKS, claims, DPoP, and authentication flows.
  * Clarified that OpenTDF consumes tokens and claims from an external identity provider rather than acting as one.
  * Documented identity-context usage and Entity Resolution Service integration modes.
  * Updated OIDC and Entity Resolution Service references, including corrected links and claim naming examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->