### PR TITLE
fix(sdk,policy): skip grant table entry when mapped key has empty PEM/KID

### DIFF
--- a/sdk/granter.go
+++ b/sdk/granter.go
@@ -333,16 +333,17 @@ func (r *granter) addAllGrants(fqn AttributeValueFQN, ag grantableObject, attr *
 			continue
 		}
 		kasURI := k.GetKasUri()
-		r.typ = mappedFound
-		result = r.typ
 		err := r.addMappedKey(fqn, k)
 		if err != nil {
-			r.logger.Debug("failed to add mapped key",
+			r.logger.Warn("failed to add mapped key, skipping KAS grant",
 				slog.Any("fqn", fqn),
 				slog.String("kas", kasURI),
 				slog.Any("error", err),
 			)
+			continue
 		}
+		r.typ = mappedFound
+		result = r.typ
 		if _, present := r.grantTable[fqn.key]; !present {
 			r.grantTable[fqn.key] = &keyAccessGrant{attr, []string{kasURI}}
 		} else {

--- a/service/policy/db/grant_mappings.go
+++ b/service/policy/db/grant_mappings.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/service/logger"
@@ -59,8 +58,12 @@ func mapKasKeysToGrants(keys []*policy.SimpleKasKey, existingGrants []*policy.Ke
 		}
 
 		kasKeyInfo := key.GetPublicKey()
-		if kasKeyInfo == nil {
-			return nil, fmt.Errorf("kas key info is nil for a key with kas uri %s", key.GetKasUri())
+		if kasKeyInfo == nil || kasKeyInfo.GetPem() == "" || kasKeyInfo.GetKid() == "" {
+			l.Warn("skipping key with missing public key material",
+				"kas_uri", key.GetKasUri(),
+				"kas_id", key.GetKasId(),
+			)
+			continue
 		}
 
 		newKasPublicKey := &policy.KasPublicKey{

--- a/service/policy/db/grant_mappings_test.go
+++ b/service/policy/db/grant_mappings_test.go
@@ -140,8 +140,7 @@ func TestMapKasKeysToGrants(t *testing.T) {
 			},
 			existingGrants: []*policy.KeyAccessServer{},
 			expectedGrants: []*policy.KeyAccessServer{},
-			wantErr:        true,
-			errContains:    "kas key info is nil for a key with kas uri http://kas1.example.com",
+			wantErr:        false,
 		},
 		{
 			name: "existing grant with nil PublicKey",


### PR DESCRIPTION
## Summary
- **SDK fix (granter.go):** When `addMappedKey()` rejects a `SimpleKasKey` due to missing PEM or KID, skip adding the KAS URI to the grant table instead of adding it unconditionally. This prevents `prepareManifest()` from falling back to dialing unreachable partner KAS URIs.
- **Platform fix (grant_mappings.go):** Validate that PEM and KID are non-empty before including keys in `SimpleKasKey` responses. Skip keys with missing material instead of aborting all grant mapping.
- Log level upgraded from Debug to Warn for missing key material — this is a configuration issue operators need to see.

## Context
When encrypting with RSA 4096 partner KAS keys, the clib SDK falls back to fetching the public key from the partner KAS URI (e.g. `https://partner.example.com`), which is a logical identifier not a reachable endpoint. This causes DNS failures and dropped email attachments in the Exchange MTA.

Root cause: `addAllGrants()` unconditionally added the KAS URI to the grant table even after `addMappedKey()` rejected the key. Later, `prepareManifest()` saw the URI with no cached key and tried to dial it.

Fixes: PEP-5140, PEP-4333

## Test plan
- [x] `go test ./sdk/... -run "TestReasoner|TestConfiguration|TestAttribute"` — PASS
- [x] `go test ./service/policy/db/... -run TestMapKasKeysToGrants` — PASS (updated test expectation for nil public key: skip instead of error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or incomplete public-key data is now skipped instead of preventing other valid grants from being processed.
  * Clear warnings are logged when a KAS grant cannot be added, improving visibility into skipped grants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->