### PR TITLE
feat(sdk): add TDF decrypt convenience helpers

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -33,6 +33,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -90,7 +91,7 @@ func main() {
 	}
 	defer f.Close()
 
-	if err := s.DecryptTo(f, ciphertext.Bytes()); err != nil {
+	if err := s.DecryptTo(context.Background(), f, ciphertext.Bytes()); err != nil {
 		log.Fatalf("Failed to decrypt TDF: %v", err)
 	}
 
@@ -100,12 +101,14 @@ func main() {
 
 `DecryptTo` is one of three decrypt convenience helpers, each a thin wrapper
 over `LoadTDF` + `Reader.WriteTo` for the common decrypt-to-plaintext case —
-pick whichever shape fits:
+pick whichever shape fits. Each takes a `ctx context.Context` that governs
+its KAS rewrap request.
 
 **`DecryptBytes`** — decrypt ciphertext bytes to plaintext bytes:
 
+Before:
+
 ```go
-// Before
 reader, err := s.LoadTDF(bytes.NewReader(ciphertext))
 if err != nil {
     return err
@@ -113,34 +116,45 @@ if err != nil {
 var buf bytes.Buffer
 _, err = reader.WriteTo(&buf)
 plaintext := buf.Bytes()
+```
 
-// After
-plaintext, err := s.DecryptBytes(ciphertext)
+After:
+
+```go
+plaintext, err := s.DecryptBytes(ctx, ciphertext)
 ```
 
 **`DecryptTo`** — decrypt ciphertext bytes to any `io.Writer`:
 
+Before:
+
 ```go
-// Before
 reader, err := s.LoadTDF(bytes.NewReader(ciphertext))
 if err != nil {
     return err
 }
 _, err = reader.WriteTo(os.Stdout)
+```
 
-// After
-err := s.DecryptTo(os.Stdout, ciphertext)
+After:
+
+```go
+err := s.DecryptTo(ctx, os.Stdout, ciphertext)
 ```
 
 **`DecryptFile`** — decrypt a TDF file to an output file:
 
-```go
-// Before
+Before (elided — open input, `LoadTDF`, create output, `WriteTo`, close both, handle errors at each step):
+
+```text
 in, err := os.Open("secret.tdf")
 // ... LoadTDF, os.Create("secret.txt"), WriteTo, close both, handle errors at each step
+```
 
-// After
-err := s.DecryptFile("secret.tdf", "secret.txt")
+After:
+
+```go
+err := s.DecryptFile(ctx, "secret.tdf", "secret.txt")
 ```
 
 Call `LoadTDF` directly instead when streaming very large payloads, or when

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -34,7 +34,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"strings"
@@ -80,30 +79,36 @@ func main() {
 
 	fmt.Printf("Ciphertext is %d bytes long\n", ciphertext.Len())
 
-	// Decrypt the TDF
-	// LoadTDF contacts the Key Access Service (KAS) to verify that this client
-	// has been granted access to the data attributes, then decrypts the TDF.
+	// Decrypt the TDF and write the plaintext to a file.
+	// DecryptTo contacts the Key Access Service (KAS) to verify that this
+	// client has been granted access to the data attributes, then decrypts
+	// the TDF and writes the plaintext directly to the given writer.
 	// Note: The client must have entitlements configured on the platform first.
-	r, err := s.LoadTDF(bytes.NewReader(ciphertext.Bytes()))
-	if err != nil {
-		log.Fatalf("Failed to load TDF: %v", err)
-	}
-
-	// Write the decrypted plaintext to a file
 	f, err := os.Create("output.txt")
 	if err != nil {
 		log.Fatalf("Failed to create output file: %v", err)
 	}
 	defer f.Close()
 
-	_, err = io.Copy(f, r)
-	if err != nil {
-		log.Fatalf("Failed to write decrypted content: %v", err)
+	if err := s.DecryptTo(f, ciphertext.Bytes()); err != nil {
+		log.Fatalf("Failed to decrypt TDF: %v", err)
 	}
 
 	fmt.Println("Successfully created and decrypted TDF")
 }
 ```
+
+`DecryptTo` is one of three decrypt convenience helpers, each a thin wrapper
+over `LoadTDF` + `Reader.WriteTo` for the common decrypt-to-plaintext case —
+pick whichever shape fits:
+
+- `DecryptBytes(ciphertext []byte) ([]byte, error)` — ciphertext in memory, plaintext back as `[]byte`.
+- `DecryptTo(out io.Writer, ciphertext []byte) error` — ciphertext in memory, plaintext to any `io.Writer`.
+- `DecryptFile(inputPath, outputPath string) error` — TDF file on disk, plaintext to another file on disk; streams directly, never buffers the whole payload in memory.
+
+Call `LoadTDF` directly instead when streaming very large payloads, or when
+you need to read manifest data (attributes, assertions) between load and
+write.
 
 ### Configuration Values
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -102,9 +102,46 @@ func main() {
 over `LoadTDF` + `Reader.WriteTo` for the common decrypt-to-plaintext case —
 pick whichever shape fits:
 
-- `DecryptBytes(ciphertext []byte) ([]byte, error)` — ciphertext in memory, plaintext back as `[]byte`.
-- `DecryptTo(out io.Writer, ciphertext []byte) error` — ciphertext in memory, plaintext to any `io.Writer`.
-- `DecryptFile(inputPath, outputPath string) error` — TDF file on disk, plaintext to another file on disk; streams directly, never buffers the whole payload in memory.
+**`DecryptBytes`** — decrypt ciphertext bytes to plaintext bytes:
+
+```go
+// Before
+reader, err := s.LoadTDF(bytes.NewReader(ciphertext))
+if err != nil {
+    return err
+}
+var buf bytes.Buffer
+_, err = reader.WriteTo(&buf)
+plaintext := buf.Bytes()
+
+// After
+plaintext, err := s.DecryptBytes(ciphertext)
+```
+
+**`DecryptTo`** — decrypt ciphertext bytes to any `io.Writer`:
+
+```go
+// Before
+reader, err := s.LoadTDF(bytes.NewReader(ciphertext))
+if err != nil {
+    return err
+}
+_, err = reader.WriteTo(os.Stdout)
+
+// After
+err := s.DecryptTo(os.Stdout, ciphertext)
+```
+
+**`DecryptFile`** — decrypt a TDF file to an output file:
+
+```go
+// Before
+in, err := os.Open("secret.tdf")
+// ... LoadTDF, os.Create("secret.txt"), WriteTo, close both, handle errors at each step
+
+// After
+err := s.DecryptFile("secret.tdf", "secret.txt")
+```
 
 Call `LoadTDF` directly instead when streaming very large payloads, or when
 you need to read manifest data (attributes, assertions) between load and

--- a/sdk/decrypt.go
+++ b/sdk/decrypt.go
@@ -1,0 +1,189 @@
+package sdk
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// DecryptBytes decrypts a TDF payload held in memory and returns the
+// plaintext. A thin wrapper over [SDK.LoadTDF] + [Reader.WriteTo] for the
+// common case where the ciphertext already fits comfortably in memory:
+//
+//	plaintext, err := sdk.DecryptBytes(ciphertext)
+//
+// For streaming, very large payloads, or reading manifest data (attributes,
+// assertions) between load and write, call [SDK.LoadTDF] directly.
+func (s SDK) DecryptBytes(ciphertext []byte, opts ...TDFReaderOption) ([]byte, error) {
+	reader, err := s.LoadTDF(bytes.NewReader(ciphertext), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrTDFNotDecryptable, err)
+	}
+	var buf bytes.Buffer
+	if _, err = reader.WriteTo(&buf); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrTDFDecryptFailed, err)
+	}
+	return buf.Bytes(), nil
+}
+
+// DecryptTo decrypts a TDF payload held in memory and writes the plaintext
+// to out. A thin wrapper over [SDK.LoadTDF] + [Reader.WriteTo] for callers
+// who already have a destination writer (a file, os.Stdout, an HTTP
+// response, etc.) and don't need the plaintext held in memory:
+//
+//	err := sdk.DecryptTo(os.Stdout, ciphertext)
+func (s SDK) DecryptTo(out io.Writer, ciphertext []byte, opts ...TDFReaderOption) error {
+	reader, err := s.LoadTDF(bytes.NewReader(ciphertext), opts...)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrTDFNotDecryptable, err)
+	}
+	if _, err = reader.WriteTo(out); err != nil {
+		return fmt.Errorf("%w: %w", ErrTDFDecryptFailed, err)
+	}
+	return nil
+}
+
+// DecryptFile decrypts the TDF at inputPath and writes the plaintext to
+// outputPath. A thin wrapper over [SDK.LoadTDF] + [Reader.WriteTo] for the
+// common file-to-file case; streams directly from disk rather than
+// buffering the ciphertext or plaintext in memory:
+//
+//	err := sdk.DecryptFile("secret.tdf", "secret.txt")
+//
+// Plaintext is written to a temp file in outputPath's directory (created
+// with mode 0600, since it holds decrypted content) and only renamed onto
+// outputPath once decryption fully succeeds. A pre-existing file at
+// outputPath is therefore never touched, truncated, or deleted if
+// decryption fails partway — the rename is the only step that can change
+// it, and that only happens on success. On any failure the temp file is
+// removed; if that removal itself also fails, both errors are returned via
+// [errors.Join] so callers can detect the leftover temp file with
+// [errors.Is]/[errors.As] instead of it failing silently.
+//
+// If outputPath already exists as a file, it's moved aside to a reserved
+// backup name before the rename rather than removed outright: unlike
+// POSIX, Windows' rename fails rather than replaces when the destination
+// exists, so an existing file has to be out of the way first. If the
+// rename then fails for any other reason, the backup is restored, so a
+// pre-existing outputPath is never left destroyed by a failed finalize —
+// only a successful finalize discards it. An existing outputPath that's a
+// directory is rejected up front (before LoadTDF runs) rather than moved
+// aside or removed.
+//
+// inputPath and outputPath must not refer to the same file: the final
+// rename would replace the input while it may still be open, which some
+// platforms (notably Windows) reject or handle inconsistently. DecryptFile
+// checks with [os.SameFile] and returns an error up front rather than
+// relying on platform-specific rename-over-an-open-file semantics.
+func (s SDK) DecryptFile(inputPath, outputPath string, opts ...TDFReaderOption) error {
+	in, err := os.Open(inputPath)
+	if err != nil {
+		return fmt.Errorf("failed to open input TDF %s: %w", inputPath, err)
+	}
+	defer in.Close()
+
+	outInfo, outStatErr := os.Stat(outputPath)
+	if outStatErr == nil {
+		if inInfo, inStatErr := in.Stat(); inStatErr == nil && os.SameFile(inInfo, outInfo) {
+			return fmt.Errorf("inputPath and outputPath must not be the same file: %s", outputPath)
+		}
+		if outInfo.IsDir() {
+			return fmt.Errorf("outputPath %s is a directory, not a file", outputPath)
+		}
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(outputPath), ".decrypt-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %w", outputPath, err)
+	}
+	tmpPath := tmp.Name()
+
+	reader, err := s.LoadTDF(in, opts...)
+	if err != nil {
+		loadErr := fmt.Errorf("%w: %w", ErrTDFNotDecryptable, err)
+		if closeErr := tmp.Close(); closeErr != nil {
+			loadErr = errors.Join(loadErr, closeErr)
+		}
+		return joinTempFileCleanup(loadErr, tmpPath)
+	}
+
+	_, writeErr := reader.WriteTo(tmp)
+	closeErr := tmp.Close()
+	switch {
+	case writeErr != nil:
+		decryptErr := fmt.Errorf("%w: %w", ErrTDFDecryptFailed, writeErr)
+		if closeErr != nil {
+			decryptErr = errors.Join(decryptErr, closeErr)
+		}
+		return joinTempFileCleanup(decryptErr, tmpPath)
+	case closeErr != nil:
+		return joinTempFileCleanup(closeErr, tmpPath)
+	}
+
+	return finalizeOutput(tmpPath, outputPath)
+}
+
+// finalizeOutput renames tmpPath onto outputPath, now that decryption has
+// fully succeeded.
+//
+// os.Rename fails on Windows when outputPath already exists (unlike POSIX,
+// which replaces it atomically), so an existing outputPath is moved aside
+// to a reserved backup name first rather than removed outright: if the
+// rename then fails for some other reason (a transient permission/lock
+// issue, antivirus scanning, etc.), the backup is moved back into place so
+// a pre-existing file is never left destroyed by a failed finalize. The
+// backup is discarded once the rename succeeds. outputPath is rejected
+// outright if it's an existing directory, rather than being moved aside or
+// removed like a file would be.
+func finalizeOutput(tmpPath, outputPath string) error {
+	fi, statErr := os.Stat(outputPath)
+	switch {
+	case statErr != nil:
+		// Nothing at outputPath to preserve; rename directly.
+		if renameErr := os.Rename(tmpPath, outputPath); renameErr != nil {
+			return joinTempFileCleanup(fmt.Errorf("failed to finalize output file %s: %w", outputPath, renameErr), tmpPath)
+		}
+		return nil
+	case fi.IsDir():
+		return joinTempFileCleanup(fmt.Errorf("outputPath %s is a directory, not a file", outputPath), tmpPath)
+	}
+
+	backup, err := os.CreateTemp(filepath.Dir(outputPath), ".decrypt-bak-*.tmp")
+	if err != nil {
+		return joinTempFileCleanup(fmt.Errorf("failed to prepare to replace existing output file %s: %w", outputPath, err), tmpPath)
+	}
+	backupPath := backup.Name()
+	_ = backup.Close()
+	// os.CreateTemp leaves backupPath occupied; free it before renaming
+	// outputPath onto it, since os.Rename fails on Windows when the
+	// destination already exists.
+	if removeErr := os.Remove(backupPath); removeErr != nil {
+		return joinTempFileCleanup(fmt.Errorf("failed to prepare to replace existing output file %s: %w", outputPath, removeErr), tmpPath)
+	}
+
+	if renameErr := os.Rename(outputPath, backupPath); renameErr != nil {
+		return joinTempFileCleanup(fmt.Errorf("failed to prepare to replace existing output file %s: %w", outputPath, renameErr), tmpPath)
+	}
+
+	if renameErr := os.Rename(tmpPath, outputPath); renameErr != nil {
+		finalizeErr := fmt.Errorf("failed to finalize output file %s: %w", outputPath, renameErr)
+		if restoreErr := os.Rename(backupPath, outputPath); restoreErr != nil {
+			return errors.Join(finalizeErr, fmt.Errorf("failed to restore original output file %s: %w", outputPath, restoreErr))
+		}
+		return joinTempFileCleanup(finalizeErr, tmpPath)
+	}
+	_ = os.Remove(backupPath)
+	return nil
+}
+
+// joinTempFileCleanup removes tmpPath and, if that removal itself fails,
+// joins the removal error with err rather than discarding it.
+func joinTempFileCleanup(err error, tmpPath string) error {
+	if removeErr := os.Remove(tmpPath); removeErr != nil {
+		return errors.Join(err, removeErr)
+	}
+	return err
+}

--- a/sdk/decrypt.go
+++ b/sdk/decrypt.go
@@ -171,11 +171,13 @@ func finalizeOutput(tmpPath, outputPath string) error {
 	if renameErr := os.Rename(tmpPath, outputPath); renameErr != nil {
 		finalizeErr := fmt.Errorf("failed to finalize output file %s: %w", outputPath, renameErr)
 		if restoreErr := os.Rename(backupPath, outputPath); restoreErr != nil {
-			return errors.Join(finalizeErr, fmt.Errorf("failed to restore original output file %s: %w", outputPath, restoreErr))
+			return joinTempFileCleanup(errors.Join(finalizeErr, fmt.Errorf("failed to restore original output file %s from backup %s: %w", outputPath, backupPath, restoreErr)), tmpPath)
 		}
 		return joinTempFileCleanup(finalizeErr, tmpPath)
 	}
-	_ = os.Remove(backupPath)
+	if removeErr := os.Remove(backupPath); removeErr != nil {
+		return fmt.Errorf("output file %s finalized, but failed to remove backup %s: %w", outputPath, backupPath, removeErr)
+	}
 	return nil
 }
 

--- a/sdk/decrypt.go
+++ b/sdk/decrypt.go
@@ -9,20 +9,44 @@ import (
 	"path/filepath"
 )
 
+// maxDecryptBytesSize caps the plaintext size DecryptBytes will buffer into
+// memory. Payloads larger than this should use DecryptTo, DecryptFile (both
+// stream to their destination instead of buffering), or LoadTDF directly.
+// A var, not a const, so tests can override it rather than constructing a
+// multi-gigabyte fixture.
+var maxDecryptBytesSize int64 = 1 << 30 // 1 GiB
+
 // DecryptBytes decrypts a TDF payload held in memory and returns the
 // plaintext. A thin wrapper over [SDK.LoadTDF] + [Reader.WriteTo] for the
 // common case where the ciphertext already fits comfortably in memory:
 //
 //	plaintext, err := sdk.DecryptBytes(ciphertext)
 //
-// For streaming, very large payloads, or reading manifest data (attributes,
-// assertions) between load and write, call [SDK.LoadTDF] directly.
+// Rejects payloads over 1 GiB up front, before buffering anything, since
+// DecryptBytes holds the full plaintext in memory. For streaming, very
+// large payloads, or reading manifest data (attributes, assertions)
+// between load and write, call [SDK.LoadTDF] directly, or use [SDK.DecryptTo]
+// / [SDK.DecryptFile], which stream to their destination instead of
+// buffering.
 func (s SDK) DecryptBytes(ciphertext []byte, opts ...TDFReaderOption) ([]byte, error) {
 	reader, err := s.LoadTDF(bytes.NewReader(ciphertext), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrTDFNotDecryptable, err)
 	}
+
+	size, err := reader.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrTDFNotDecryptable, err)
+	}
+	if size > maxDecryptBytesSize {
+		return nil, fmt.Errorf("%w: plaintext is %d bytes, exceeds the %d byte limit for DecryptBytes; use DecryptTo, DecryptFile, or LoadTDF directly for large payloads", ErrTDFNotDecryptable, size, maxDecryptBytesSize)
+	}
+	if _, err = reader.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrTDFNotDecryptable, err)
+	}
+
 	var buf bytes.Buffer
+	buf.Grow(int(size))
 	if _, err = reader.WriteTo(&buf); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrTDFDecryptFailed, err)
 	}

--- a/sdk/decrypt.go
+++ b/sdk/decrypt.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -20,7 +21,10 @@ var maxDecryptBytesSize int64 = 1 << 30 // 1 GiB
 // plaintext. A thin wrapper over [SDK.LoadTDF] + [Reader.WriteTo] for the
 // common case where the ciphertext already fits comfortably in memory:
 //
-//	plaintext, err := sdk.DecryptBytes(ciphertext)
+//	plaintext, err := sdk.DecryptBytes(ctx, ciphertext)
+//
+// ctx governs the KAS rewrap request (the only network call this method
+// makes) and is honored for cancellation/timeout.
 //
 // Rejects payloads over 1 GiB up front, before buffering anything, since
 // DecryptBytes holds the full plaintext in memory. For streaming, very
@@ -28,10 +32,13 @@ var maxDecryptBytesSize int64 = 1 << 30 // 1 GiB
 // between load and write, call [SDK.LoadTDF] directly, or use [SDK.DecryptTo]
 // / [SDK.DecryptFile], which stream to their destination instead of
 // buffering.
-func (s SDK) DecryptBytes(ciphertext []byte, opts ...TDFReaderOption) ([]byte, error) {
-	reader, err := s.LoadTDF(bytes.NewReader(ciphertext), opts...)
+func (s SDK) DecryptBytes(ctx context.Context, ciphertext []byte, opts ...TDFReaderOption) ([]byte, error) {
+	reader, err := s.LoadTDF(bytes.NewReader(ciphertext), opts...) //nolint:contextcheck // LoadTDF doesn't accept a context; ctx is applied via reader.Init below
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrTDFNotDecryptable, err)
+	}
+	if err = reader.Init(ctx); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrTDFDecryptFailed, err)
 	}
 
 	size, err := reader.Seek(0, io.SeekEnd)
@@ -47,7 +54,7 @@ func (s SDK) DecryptBytes(ciphertext []byte, opts ...TDFReaderOption) ([]byte, e
 
 	var buf bytes.Buffer
 	buf.Grow(int(size))
-	if _, err = reader.WriteTo(&buf); err != nil {
+	if _, err = reader.WriteTo(&buf); err != nil { //nolint:contextcheck // WriteTo doesn't accept a context; the key unwrap already ran under ctx via reader.Init above
 		return nil, fmt.Errorf("%w: %w", ErrTDFDecryptFailed, err)
 	}
 	return buf.Bytes(), nil
@@ -58,13 +65,19 @@ func (s SDK) DecryptBytes(ciphertext []byte, opts ...TDFReaderOption) ([]byte, e
 // who already have a destination writer (a file, os.Stdout, an HTTP
 // response, etc.) and don't need the plaintext held in memory:
 //
-//	err := sdk.DecryptTo(os.Stdout, ciphertext)
-func (s SDK) DecryptTo(out io.Writer, ciphertext []byte, opts ...TDFReaderOption) error {
-	reader, err := s.LoadTDF(bytes.NewReader(ciphertext), opts...)
+//	err := sdk.DecryptTo(ctx, os.Stdout, ciphertext)
+//
+// ctx governs the KAS rewrap request (the only network call this method
+// makes) and is honored for cancellation/timeout.
+func (s SDK) DecryptTo(ctx context.Context, out io.Writer, ciphertext []byte, opts ...TDFReaderOption) error {
+	reader, err := s.LoadTDF(bytes.NewReader(ciphertext), opts...) //nolint:contextcheck // LoadTDF doesn't accept a context; ctx is applied via reader.Init below
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrTDFNotDecryptable, err)
 	}
-	if _, err = reader.WriteTo(out); err != nil {
+	if err = reader.Init(ctx); err != nil {
+		return fmt.Errorf("%w: %w", ErrTDFDecryptFailed, err)
+	}
+	if _, err = reader.WriteTo(out); err != nil { //nolint:contextcheck // WriteTo doesn't accept a context; the key unwrap already ran under ctx via reader.Init above
 		return fmt.Errorf("%w: %w", ErrTDFDecryptFailed, err)
 	}
 	return nil
@@ -75,7 +88,10 @@ func (s SDK) DecryptTo(out io.Writer, ciphertext []byte, opts ...TDFReaderOption
 // common file-to-file case; streams directly from disk rather than
 // buffering the ciphertext or plaintext in memory:
 //
-//	err := sdk.DecryptFile("secret.tdf", "secret.txt")
+//	err := sdk.DecryptFile(ctx, "secret.tdf", "secret.txt")
+//
+// ctx governs the KAS rewrap request (the only network call this method
+// makes) and is honored for cancellation/timeout.
 //
 // Plaintext is written to a temp file in outputPath's directory (created
 // with mode 0600, since it holds decrypted content) and only renamed onto
@@ -102,7 +118,7 @@ func (s SDK) DecryptTo(out io.Writer, ciphertext []byte, opts ...TDFReaderOption
 // platforms (notably Windows) reject or handle inconsistently. DecryptFile
 // checks with [os.SameFile] and returns an error up front rather than
 // relying on platform-specific rename-over-an-open-file semantics.
-func (s SDK) DecryptFile(inputPath, outputPath string, opts ...TDFReaderOption) error {
+func (s SDK) DecryptFile(ctx context.Context, inputPath, outputPath string, opts ...TDFReaderOption) error {
 	in, err := os.Open(inputPath)
 	if err != nil {
 		return fmt.Errorf("failed to open input TDF %s: %w", inputPath, err)
@@ -110,13 +126,20 @@ func (s SDK) DecryptFile(inputPath, outputPath string, opts ...TDFReaderOption) 
 	defer in.Close()
 
 	outInfo, outStatErr := os.Stat(outputPath)
-	if outStatErr == nil {
-		if inInfo, inStatErr := in.Stat(); inStatErr == nil && os.SameFile(inInfo, outInfo) {
+	switch {
+	case outStatErr == nil:
+		inInfo, inStatErr := in.Stat()
+		if inStatErr != nil {
+			return fmt.Errorf("failed to inspect input TDF %s: %w", inputPath, inStatErr)
+		}
+		if os.SameFile(inInfo, outInfo) {
 			return fmt.Errorf("inputPath and outputPath must not be the same file: %s", outputPath)
 		}
 		if outInfo.IsDir() {
 			return fmt.Errorf("outputPath %s is a directory, not a file", outputPath)
 		}
+	case !errors.Is(outStatErr, os.ErrNotExist):
+		return fmt.Errorf("failed to inspect output file %s: %w", outputPath, outStatErr)
 	}
 
 	tmp, err := os.CreateTemp(filepath.Dir(outputPath), ".decrypt-*.tmp")
@@ -125,7 +148,7 @@ func (s SDK) DecryptFile(inputPath, outputPath string, opts ...TDFReaderOption) 
 	}
 	tmpPath := tmp.Name()
 
-	reader, err := s.LoadTDF(in, opts...)
+	reader, err := s.LoadTDF(in, opts...) //nolint:contextcheck // LoadTDF doesn't accept a context; ctx is applied via reader.Init below
 	if err != nil {
 		loadErr := fmt.Errorf("%w: %w", ErrTDFNotDecryptable, err)
 		if closeErr := tmp.Close(); closeErr != nil {
@@ -134,7 +157,15 @@ func (s SDK) DecryptFile(inputPath, outputPath string, opts ...TDFReaderOption) 
 		return joinTempFileCleanup(loadErr, tmpPath)
 	}
 
-	_, writeErr := reader.WriteTo(tmp)
+	if err = reader.Init(ctx); err != nil {
+		initErr := fmt.Errorf("%w: %w", ErrTDFDecryptFailed, err)
+		if closeErr := tmp.Close(); closeErr != nil {
+			initErr = errors.Join(initErr, closeErr)
+		}
+		return joinTempFileCleanup(initErr, tmpPath)
+	}
+
+	_, writeErr := reader.WriteTo(tmp) //nolint:contextcheck // WriteTo doesn't accept a context; the key unwrap already ran under ctx via reader.Init above
 	closeErr := tmp.Close()
 	switch {
 	case writeErr != nil:
@@ -165,12 +196,14 @@ func (s SDK) DecryptFile(inputPath, outputPath string, opts ...TDFReaderOption) 
 func finalizeOutput(tmpPath, outputPath string) error {
 	fi, statErr := os.Stat(outputPath)
 	switch {
-	case statErr != nil:
+	case errors.Is(statErr, os.ErrNotExist):
 		// Nothing at outputPath to preserve; rename directly.
 		if renameErr := os.Rename(tmpPath, outputPath); renameErr != nil {
 			return joinTempFileCleanup(fmt.Errorf("failed to finalize output file %s: %w", outputPath, renameErr), tmpPath)
 		}
 		return nil
+	case statErr != nil:
+		return joinTempFileCleanup(fmt.Errorf("failed to inspect output file %s: %w", outputPath, statErr), tmpPath)
 	case fi.IsDir():
 		return joinTempFileCleanup(fmt.Errorf("outputPath %s is a directory, not a file", outputPath), tmpPath)
 	}

--- a/sdk/decrypt_test.go
+++ b/sdk/decrypt_test.go
@@ -1,0 +1,230 @@
+package sdk
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecryptBytes_InvalidCiphertext(t *testing.T) {
+	sdk := newSDK()
+
+	plaintext, err := sdk.DecryptBytes([]byte("not a valid tdf"))
+
+	require.ErrorIs(t, err, ErrTDFNotDecryptable)
+	require.Nil(t, plaintext)
+}
+
+func TestDecryptTo_InvalidCiphertext(t *testing.T) {
+	sdk := newSDK()
+	var dest bytes.Buffer
+
+	err := sdk.DecryptTo(&dest, []byte("not a valid tdf"))
+
+	require.ErrorIs(t, err, ErrTDFNotDecryptable)
+	require.Empty(t, dest.Bytes())
+}
+
+func TestDecryptBytes_OptionErrorSurfaces(t *testing.T) {
+	sdk := newSDK()
+	failErr := errors.New("boom")
+	failingOption := TDFReaderOption(func(*TDFReaderConfig) error {
+		return failErr
+	})
+
+	plaintext, err := sdk.DecryptBytes([]byte("not a valid tdf"), failingOption)
+
+	require.ErrorIs(t, err, failErr)
+	require.ErrorIs(t, err, ErrTDFNotDecryptable)
+	require.Nil(t, plaintext)
+}
+
+func TestDecryptTo_OptionErrorSurfaces(t *testing.T) {
+	sdk := newSDK()
+	failErr := errors.New("boom")
+	failingOption := TDFReaderOption(func(*TDFReaderConfig) error {
+		return failErr
+	})
+	var dest bytes.Buffer
+
+	err := sdk.DecryptTo(&dest, []byte("not a valid tdf"), failingOption)
+
+	require.ErrorIs(t, err, failErr)
+	require.ErrorIs(t, err, ErrTDFNotDecryptable)
+	require.Empty(t, dest.Bytes())
+}
+
+func TestDecryptFile_MissingInput(t *testing.T) {
+	sdk := newSDK()
+	inputPath := filepath.Join(t.TempDir(), "does-not-exist.tdf")
+	outputPath := filepath.Join(t.TempDir(), "out.txt")
+
+	err := sdk.DecryptFile(inputPath, outputPath)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, inputPath)
+	_, statErr := os.Stat(outputPath)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestDecryptFile_UnwritableOutput(t *testing.T) {
+	sdk := newSDK()
+	inputPath := filepath.Join(t.TempDir(), "in.tdf")
+	require.NoError(t, os.WriteFile(inputPath, []byte("not a valid tdf"), 0o600))
+	outputPath := filepath.Join(t.TempDir(), "missing-dir", "out.txt")
+
+	err := sdk.DecryptFile(inputPath, outputPath)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, outputPath)
+}
+
+func TestDecryptFile_RemovesOutputOnLoadFailure(t *testing.T) {
+	sdk := newSDK()
+	inputPath := filepath.Join(t.TempDir(), "in.tdf")
+	require.NoError(t, os.WriteFile(inputPath, []byte("not a valid tdf"), 0o600))
+	outputPath := filepath.Join(t.TempDir(), "out.txt")
+
+	err := sdk.DecryptFile(inputPath, outputPath)
+
+	require.ErrorIs(t, err, ErrTDFNotDecryptable)
+	_, statErr := os.Stat(outputPath)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestDecryptFile_PreservesExistingOutputOnLoadFailure(t *testing.T) {
+	sdk := newSDK()
+	inputPath := filepath.Join(t.TempDir(), "in.tdf")
+	require.NoError(t, os.WriteFile(inputPath, []byte("not a valid tdf"), 0o600))
+	outputPath := filepath.Join(t.TempDir(), "out.txt")
+	original := []byte("pre-existing content that must survive a failed decrypt")
+	require.NoError(t, os.WriteFile(outputPath, original, 0o600))
+
+	err := sdk.DecryptFile(inputPath, outputPath)
+
+	require.ErrorIs(t, err, ErrTDFNotDecryptable)
+	got, readErr := os.ReadFile(outputPath)
+	require.NoError(t, readErr)
+	require.Equal(t, original, got)
+}
+
+func TestDecryptFile_RejectsSamePath(t *testing.T) {
+	sdk := newSDK()
+	path := filepath.Join(t.TempDir(), "same.tdf")
+	original := []byte("must not be touched")
+	require.NoError(t, os.WriteFile(path, original, 0o600))
+
+	err := sdk.DecryptFile(path, path)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, path)
+	got, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	require.Equal(t, original, got)
+}
+
+func TestDecryptFile_RejectsSameFileViaDifferentPath(t *testing.T) {
+	sdk := newSDK()
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "in.tdf")
+	linkedPath := filepath.Join(dir, "link.tdf")
+	original := []byte("must not be touched")
+	require.NoError(t, os.WriteFile(inputPath, original, 0o600))
+	require.NoError(t, os.Link(inputPath, linkedPath))
+
+	err := sdk.DecryptFile(inputPath, linkedPath)
+
+	require.Error(t, err)
+	got, readErr := os.ReadFile(inputPath)
+	require.NoError(t, readErr)
+	require.Equal(t, original, got)
+}
+
+func TestDecryptFile_RejectsDirectoryOutputPath(t *testing.T) {
+	sdk := newSDK()
+	inputPath := filepath.Join(t.TempDir(), "in.tdf")
+	require.NoError(t, os.WriteFile(inputPath, []byte("not a valid tdf"), 0o600))
+	outputPath := filepath.Join(t.TempDir(), "a-directory")
+	require.NoError(t, os.Mkdir(outputPath, 0o700))
+
+	err := sdk.DecryptFile(inputPath, outputPath)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, outputPath)
+	info, statErr := os.Stat(outputPath)
+	require.NoError(t, statErr)
+	require.True(t, info.IsDir())
+}
+
+func TestDecryptFile_OptionErrorSurfaces(t *testing.T) {
+	sdk := newSDK()
+	inputPath := filepath.Join(t.TempDir(), "in.tdf")
+	require.NoError(t, os.WriteFile(inputPath, []byte("not a valid tdf"), 0o600))
+	outputPath := filepath.Join(t.TempDir(), "out.txt")
+	failErr := errors.New("boom")
+	failingOption := TDFReaderOption(func(*TDFReaderConfig) error {
+		return failErr
+	})
+
+	err := sdk.DecryptFile(inputPath, outputPath, failingOption)
+
+	require.ErrorIs(t, err, failErr)
+	require.ErrorIs(t, err, ErrTDFNotDecryptable)
+	_, statErr := os.Stat(outputPath)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+// White-box coverage for finalizeOutput's rename mechanics, independent of
+// LoadTDF/decryption.
+func TestFinalizeOutput_NoExistingOutput(t *testing.T) {
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "out.txt")
+	tmp, err := os.CreateTemp(dir, ".decrypt-*.tmp")
+	require.NoError(t, err)
+	tmpPath := tmp.Name()
+	_, err = tmp.WriteString("plaintext")
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	require.NoError(t, finalizeOutput(tmpPath, outputPath))
+
+	got, readErr := os.ReadFile(outputPath)
+	require.NoError(t, readErr)
+	require.Equal(t, "plaintext", string(got))
+	_, statErr := os.Stat(tmpPath)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+// Covers the previously-untested replace-existing-output path. Note this
+// can't reproduce the Windows-specific bug it guards against (finalizeOutput
+// renaming onto a backupPath that os.CreateTemp had already created): POSIX
+// os.Rename silently replaces an existing destination, so a missing
+// os.Remove(backupPath) would be invisible on Linux/macOS CI. This asserts
+// the platform-independent outcome — correct content, no leftover
+// temp/backup files.
+func TestFinalizeOutput_ReplacesExistingOutput(t *testing.T) {
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "out.txt")
+	require.NoError(t, os.WriteFile(outputPath, []byte("stale content"), 0o600))
+	tmp, err := os.CreateTemp(dir, ".decrypt-*.tmp")
+	require.NoError(t, err)
+	tmpPath := tmp.Name()
+	_, err = tmp.WriteString("fresh plaintext")
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	require.NoError(t, finalizeOutput(tmpPath, outputPath))
+
+	got, readErr := os.ReadFile(outputPath)
+	require.NoError(t, readErr)
+	require.Equal(t, "fresh plaintext", string(got))
+
+	entries, readDirErr := os.ReadDir(dir)
+	require.NoError(t, readDirErr)
+	require.Len(t, entries, 1, "no leftover temp or backup files should remain: %v", entries)
+	require.Equal(t, "out.txt", entries[0].Name())
+}

--- a/sdk/decrypt_test.go
+++ b/sdk/decrypt_test.go
@@ -13,7 +13,7 @@ import (
 func TestDecryptBytes_InvalidCiphertext(t *testing.T) {
 	sdk := newSDK()
 
-	plaintext, err := sdk.DecryptBytes([]byte("not a valid tdf"))
+	plaintext, err := sdk.DecryptBytes(t.Context(), []byte("not a valid tdf"))
 
 	require.ErrorIs(t, err, ErrTDFNotDecryptable)
 	require.Nil(t, plaintext)
@@ -23,7 +23,7 @@ func TestDecryptTo_InvalidCiphertext(t *testing.T) {
 	sdk := newSDK()
 	var dest bytes.Buffer
 
-	err := sdk.DecryptTo(&dest, []byte("not a valid tdf"))
+	err := sdk.DecryptTo(t.Context(), &dest, []byte("not a valid tdf"))
 
 	require.ErrorIs(t, err, ErrTDFNotDecryptable)
 	require.Empty(t, dest.Bytes())
@@ -52,7 +52,7 @@ func TestDecryptBytes_RejectsPayloadOverSizeLimit(t *testing.T) {
 	maxDecryptBytesSize = int64(len(plaintext)) - 1
 	defer func() { maxDecryptBytesSize = original }()
 
-	got, err := sdk.DecryptBytes(ciphertext.Bytes())
+	got, err := sdk.DecryptBytes(t.Context(), ciphertext.Bytes())
 
 	require.ErrorIs(t, err, ErrTDFNotDecryptable)
 	require.Nil(t, got)
@@ -65,7 +65,7 @@ func TestDecryptBytes_OptionErrorSurfaces(t *testing.T) {
 		return failErr
 	})
 
-	plaintext, err := sdk.DecryptBytes([]byte("not a valid tdf"), failingOption)
+	plaintext, err := sdk.DecryptBytes(t.Context(), []byte("not a valid tdf"), failingOption)
 
 	require.ErrorIs(t, err, failErr)
 	require.ErrorIs(t, err, ErrTDFNotDecryptable)
@@ -80,7 +80,7 @@ func TestDecryptTo_OptionErrorSurfaces(t *testing.T) {
 	})
 	var dest bytes.Buffer
 
-	err := sdk.DecryptTo(&dest, []byte("not a valid tdf"), failingOption)
+	err := sdk.DecryptTo(t.Context(), &dest, []byte("not a valid tdf"), failingOption)
 
 	require.ErrorIs(t, err, failErr)
 	require.ErrorIs(t, err, ErrTDFNotDecryptable)
@@ -92,7 +92,7 @@ func TestDecryptFile_MissingInput(t *testing.T) {
 	inputPath := filepath.Join(t.TempDir(), "does-not-exist.tdf")
 	outputPath := filepath.Join(t.TempDir(), "out.txt")
 
-	err := sdk.DecryptFile(inputPath, outputPath)
+	err := sdk.DecryptFile(t.Context(), inputPath, outputPath)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, inputPath)
@@ -106,7 +106,7 @@ func TestDecryptFile_UnwritableOutput(t *testing.T) {
 	require.NoError(t, os.WriteFile(inputPath, []byte("not a valid tdf"), 0o600))
 	outputPath := filepath.Join(t.TempDir(), "missing-dir", "out.txt")
 
-	err := sdk.DecryptFile(inputPath, outputPath)
+	err := sdk.DecryptFile(t.Context(), inputPath, outputPath)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, outputPath)
@@ -118,7 +118,7 @@ func TestDecryptFile_RemovesOutputOnLoadFailure(t *testing.T) {
 	require.NoError(t, os.WriteFile(inputPath, []byte("not a valid tdf"), 0o600))
 	outputPath := filepath.Join(t.TempDir(), "out.txt")
 
-	err := sdk.DecryptFile(inputPath, outputPath)
+	err := sdk.DecryptFile(t.Context(), inputPath, outputPath)
 
 	require.ErrorIs(t, err, ErrTDFNotDecryptable)
 	_, statErr := os.Stat(outputPath)
@@ -133,7 +133,7 @@ func TestDecryptFile_PreservesExistingOutputOnLoadFailure(t *testing.T) {
 	original := []byte("pre-existing content that must survive a failed decrypt")
 	require.NoError(t, os.WriteFile(outputPath, original, 0o600))
 
-	err := sdk.DecryptFile(inputPath, outputPath)
+	err := sdk.DecryptFile(t.Context(), inputPath, outputPath)
 
 	require.ErrorIs(t, err, ErrTDFNotDecryptable)
 	got, readErr := os.ReadFile(outputPath)
@@ -147,7 +147,7 @@ func TestDecryptFile_RejectsSamePath(t *testing.T) {
 	original := []byte("must not be touched")
 	require.NoError(t, os.WriteFile(path, original, 0o600))
 
-	err := sdk.DecryptFile(path, path)
+	err := sdk.DecryptFile(t.Context(), path, path)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, path)
@@ -165,7 +165,7 @@ func TestDecryptFile_RejectsSameFileViaDifferentPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(inputPath, original, 0o600))
 	require.NoError(t, os.Link(inputPath, linkedPath))
 
-	err := sdk.DecryptFile(inputPath, linkedPath)
+	err := sdk.DecryptFile(t.Context(), inputPath, linkedPath)
 
 	require.Error(t, err)
 	got, readErr := os.ReadFile(inputPath)
@@ -180,7 +180,7 @@ func TestDecryptFile_RejectsDirectoryOutputPath(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "a-directory")
 	require.NoError(t, os.Mkdir(outputPath, 0o700))
 
-	err := sdk.DecryptFile(inputPath, outputPath)
+	err := sdk.DecryptFile(t.Context(), inputPath, outputPath)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, outputPath)
@@ -199,7 +199,7 @@ func TestDecryptFile_OptionErrorSurfaces(t *testing.T) {
 		return failErr
 	})
 
-	err := sdk.DecryptFile(inputPath, outputPath, failingOption)
+	err := sdk.DecryptFile(t.Context(), inputPath, outputPath, failingOption)
 
 	require.ErrorIs(t, err, failErr)
 	require.ErrorIs(t, err, ErrTDFNotDecryptable)

--- a/sdk/decrypt_test.go
+++ b/sdk/decrypt_test.go
@@ -29,6 +29,35 @@ func TestDecryptTo_InvalidCiphertext(t *testing.T) {
 	require.Empty(t, dest.Bytes())
 }
 
+// DecryptBytes checks the plaintext size (via Seek, from the manifest's
+// segment sizes) before buffering anything, so this never needs a working
+// KAS to reach the size check.
+func TestDecryptBytes_RejectsPayloadOverSizeLimit(t *testing.T) {
+	sdk := newSDK()
+	sdk.wellknownConfiguration = newMockWellKnownService(createWellKnown(nil), nil)
+	plaintext := []byte("this plaintext is bigger than our lowered test limit")
+
+	var ciphertext bytes.Buffer
+	_, err := sdk.CreateTDF(&ciphertext, bytes.NewReader(plaintext), func(tdfConfig *TDFConfig) error {
+		tdfConfig.kasInfoList = []KASInfo{{
+			URL:       "example.com",
+			PublicKey: mockRSAPublicKey1,
+			Default:   true,
+		}}
+		return nil
+	})
+	require.NoError(t, err)
+
+	original := maxDecryptBytesSize
+	maxDecryptBytesSize = int64(len(plaintext)) - 1
+	defer func() { maxDecryptBytesSize = original }()
+
+	got, err := sdk.DecryptBytes(ciphertext.Bytes())
+
+	require.ErrorIs(t, err, ErrTDFNotDecryptable)
+	require.Nil(t, got)
+}
+
 func TestDecryptBytes_OptionErrorSurfaces(t *testing.T) {
 	sdk := newSDK()
 	failErr := errors.New("boom")

--- a/sdk/decrypterrors.go
+++ b/sdk/decrypterrors.go
@@ -1,0 +1,21 @@
+package sdk
+
+import "errors"
+
+var (
+	// ErrTDFNotDecryptable marks DecryptBytes/DecryptTo/DecryptFile as having
+	// failed before decryption began — the input itself isn't decryptable
+	// (corrupt/invalid TDF bytes, a rejected TDFReaderOption, a schema
+	// validation failure). Retrying with the same input won't help. Test for
+	// it with errors.Is(err, ErrTDFNotDecryptable); the underlying LoadTDF
+	// error remains reachable through the same chain.
+	ErrTDFNotDecryptable = errors.New("tdf: input is not decryptable")
+
+	// ErrTDFDecryptFailed marks DecryptBytes/DecryptTo/DecryptFile as having
+	// failed during decryption itself — most commonly a KAS rewrap failure
+	// (the caller isn't entitled), but also writer errors or payload
+	// integrity errors. Test for it with errors.Is(err, ErrTDFDecryptFailed);
+	// the underlying Reader.WriteTo error remains reachable through the same
+	// chain.
+	ErrTDFDecryptFailed = errors.New("tdf: decrypt failed")
+)


### PR DESCRIPTION
## Summary

Adds `DecryptBytes`, `DecryptTo`, and `DecryptFile` on `SDK` — thin convenience wrappers over `LoadTDF` + `Reader.WriteTo` for the common decrypt-to-plaintext case.

- All three take `ctx context.Context` as their first parameter, governing the KAS rewrap request (the only network call each makes). `LoadTDF`/`Reader.WriteTo` don't accept a context, so `ctx` is threaded in via `reader.Init(ctx)` right after `LoadTDF` succeeds — `Init` does the rewrap under `ctx`, and the subsequent `WriteTo` call skips its own key unwrap since the payload key is already set.
- New sentinel errors `ErrTDFNotDecryptable` / `ErrTDFDecryptFailed` let callers branch on which stage failed via `errors.Is`.
- `DecryptFile` writes to a temp file (mode `0600`, since it holds decrypted content) in `outputPath`'s directory and only renames onto `outputPath` once decryption fully succeeds.
- A pre-existing `outputPath` is moved aside to a reserved backup and restored if the final rename fails, so it's never left destroyed by a failed decrypt — only a successful finalize discards it.
- `inputPath`/`outputPath` referring to the same file (including via a hard link) is rejected up front via `os.SameFile`, since the final rename would otherwise replace the input while it may still be open.
- `DecryptBytes` rejects plaintext over 1 GiB up front, before buffering anything — it holds the full plaintext in memory, unlike `DecryptTo`/`DecryptFile`, which stream to their destination.
- Only `os.ErrNotExist` is treated as "outputPath doesn't exist" (in both the up-front checks and `finalizeOutput`) — any other stat error (permission, transient I/O) is a hard failure rather than silently bypassing the same-file/directory checks or the backup-before-replace safety path.

## Before / after

**`DecryptBytes`** — decrypt ciphertext bytes to plaintext bytes:

```go
// Before
reader, err := sdk.LoadTDF(bytes.NewReader(ciphertext))
if err != nil {
    return err
}
var buf bytes.Buffer
_, err = reader.WriteTo(&buf)
plaintext := buf.Bytes()

// After
plaintext, err := sdk.DecryptBytes(ctx, ciphertext)
```

**`DecryptTo`** — decrypt ciphertext bytes to any `io.Writer`:

```go
// Before
reader, err := sdk.LoadTDF(bytes.NewReader(ciphertext))
if err != nil {
    return err
}
_, err = reader.WriteTo(os.Stdout)

// After
err := sdk.DecryptTo(ctx, os.Stdout, ciphertext)
```

**`DecryptFile`** — decrypt a TDF file to an output file:

```go
// Before
in, err := os.Open("secret.tdf")
// ... LoadTDF, os.Create("secret.txt"), WriteTo, close both, handle errors at each step

// After
err := sdk.DecryptFile(ctx, "secret.tdf", "secret.txt")
```

## Errors

```go
plaintext, err := sdk.DecryptBytes(ctx, ciphertext)
switch {
case errors.Is(err, sdk.ErrTDFNotDecryptable):
    // Pre-decrypt: the input itself isn't decryptable. Retrying won't help.
case errors.Is(err, sdk.ErrTDFDecryptFailed):
    // Decrypt-time: most commonly a KAS rewrap failure (not entitled).
}
```

Every failure from all three helpers wraps one of these two sentinels — there's no third case. The underlying error (e.g. a KAS rewrap error, a payload integrity error, or the exact error a custom `TDFReaderOption` returned) stays reachable via `errors.As` through the same chain — nothing is swallowed or coerced away.

## Test plan

- [x] `go test -race -count=1 ./sdk/...` — all packages pass, including 15 new tests in `decrypt_test.go` covering invalid ciphertext, missing input, unwritable output, output preserved/removed on load failure, same-path/hard-link rejection, directory-output rejection, `TDFReaderOption` error passthrough, the DecryptBytes size-limit rejection, and `finalizeOutput`'s replace-existing-output path, each asserting `errors.Is` against the new sentinels where applicable — all offline, no live platform required.
- [x] `golangci-lint run ./sdk/...` — 0 new issues (11 pre-existing issues elsewhere in the package are unrelated to this change).
- [x] `go vet ./sdk/...` clean.
