### PR TITLE
feat(cli): expose required policy flag metadata

### DIFF
--- a/otdfctl/cmd/policy/policy.go
+++ b/otdfctl/cmd/policy/policy.go
@@ -125,4 +125,21 @@ func InitCommands() {
 	initKASKeysCommands()
 	initKASGrantsCommands()
 	initBaseKeysCommands()
+
+	// Enforce `required: true` from the man docs across all policy commands now
+	// that every command's flags are registered. Marking required at the cobra
+	// layer both validates invocations and lets generated tooling (e.g. MCP)
+	// advertise which inputs are mandatory.
+	markPolicyRequiredFlags()
+}
+
+// markPolicyRequiredFlags applies MarkRequiredFlags to every policy command doc.
+// The doc registry caches the same *Doc used to build each command, so this
+// reads the flags registered by the init*Commands functions above.
+func markPolicyRequiredFlags() {
+	for path, doc := range man.Docs.En {
+		if path == "policy" || strings.HasPrefix(path, "policy/") {
+			doc.MarkRequiredFlags()
+		}
+	}
 }

--- a/otdfctl/cmd/policy/policy.go
+++ b/otdfctl/cmd/policy/policy.go
@@ -125,21 +125,4 @@ func InitCommands() {
 	initKASKeysCommands()
 	initKASGrantsCommands()
 	initBaseKeysCommands()
-
-	// Enforce `required: true` from the man docs across all policy commands now
-	// that every command's flags are registered. Marking required at the cobra
-	// layer both validates invocations and lets generated tooling (e.g. MCP)
-	// advertise which inputs are mandatory.
-	markPolicyRequiredFlags()
-}
-
-// markPolicyRequiredFlags applies MarkRequiredFlags to every policy command doc.
-// The doc registry caches the same *Doc used to build each command, so this
-// reads the flags registered by the init*Commands functions above.
-func markPolicyRequiredFlags() {
-	for path, doc := range man.Docs.En {
-		if path == "policy" || strings.HasPrefix(path, "policy/") {
-			doc.MarkRequiredFlags()
-		}
-	}
 }

--- a/otdfctl/docs/man/policy/attributes/create.md
+++ b/otdfctl/docs/man/policy/attributes/create.md
@@ -22,7 +22,6 @@ command:
     - name: value
       shorthand: v
       description: Value of the attribute (i.e. 'value1')
-      required: true
     - name: namespace
       shorthand: s
       description: Namespace ID of the attribute

--- a/otdfctl/docs/man/policy/attributes/get.md
+++ b/otdfctl/docs/man/policy/attributes/get.md
@@ -8,6 +8,7 @@ command:
     - name: id
       shorthand: i
       description: ID of the attribute
+      required: true
 ---
 
 Retrieve an attribute along with its metadata, rule, and values.

--- a/otdfctl/docs/man/policy/attributes/values/create.md
+++ b/otdfctl/docs/man/policy/attributes/values/create.md
@@ -10,9 +10,11 @@ command:
     - name: attribute-id
       shorthand: a
       description: The ID of the attribute to create a value for
+      required: true
     - name: value
       shorthand: v
       description: The value to create
+      required: true
     - name: label
       description: "Optional metadata 'labels' in the format: key=value"
       shorthand: l

--- a/otdfctl/docs/man/policy/attributes/values/deactivate.md
+++ b/otdfctl/docs/man/policy/attributes/values/deactivate.md
@@ -6,6 +6,7 @@ command:
     - name: id
       shorthand: i
       description: The ID of the attribute value to deactivate
+      required: true
     - name: force
       description: Force deactivation without interactive confirmation (dangerous)
 ---

--- a/otdfctl/docs/man/policy/attributes/values/get.md
+++ b/otdfctl/docs/man/policy/attributes/values/get.md
@@ -8,6 +8,7 @@ command:
     - name: id
       shorthand: i
       description: The ID of the attribute value to get
+      required: true
 ---
 
 Retrieve an attribute value along with its metadata.

--- a/otdfctl/docs/man/policy/attributes/values/list.md
+++ b/otdfctl/docs/man/policy/attributes/values/list.md
@@ -9,6 +9,7 @@ command:
     - name: attribute-id
       shorthand: a
       description: The ID of the attribute to list values for
+      required: true
     - name: state
       shorthand: s
       description: Filter by state

--- a/otdfctl/docs/man/policy/attributes/values/update.md
+++ b/otdfctl/docs/man/policy/attributes/values/update.md
@@ -9,6 +9,7 @@ command:
     - name: id
       shorthand: i
       description: The ID of the attribute value to update
+      required: true
     - name: label
       description: "Optional metadata 'labels' in the format: key=value"
       shorthand: l

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
@@ -10,15 +10,18 @@ command:
     - name: attribute
       description: URI or ID of the Attribute Definition to scope the mapping to
       shorthand: a
+      required: true
     - name: selector
       description: Selector for a field on the flattened Entity Representation (e.g. '.patientAssignments[]')
       shorthand: s
+      required: true
     - name: operator
       description: How the requested resource value segment is compared against each entity selector value
       shorthand: o
       enum:
         - IN
         - IN_CONTAINS
+      required: true
     - name: action
       description: Each 'id' or 'name' of an Action to be entitled (i.e. 'create', 'read', 'update', 'delete'). At least one is required.
     - name: subject-condition-set

--- a/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
+++ b/otdfctl/docs/man/policy/dynamic-value-mappings/create.md
@@ -24,6 +24,7 @@ command:
       required: true
     - name: action
       description: Each 'id' or 'name' of an Action to be entitled (i.e. 'create', 'read', 'update', 'delete'). At least one is required.
+      required: true
     - name: subject-condition-set
       description: "Static pre-gate Subject Condition Set: either a known preexisting Subject Condition Set ID, or a JSON array of Subject Sets to create a new one"
     - name: namespace

--- a/otdfctl/docs/man/policy/kas-grants/assign.md
+++ b/otdfctl/docs/man/policy/kas-grants/assign.md
@@ -18,15 +18,12 @@ command:
     - name: attribute-id
       shorthand: a
       description: The ID of the Attribute Definition being assigned a KAS Grant
-      required: true
     - name: value-id
       shorthand: v
       description: The ID of the Value being assigned a KAS Grant
-      required: true
     - name: kas-id
       shorthand: k
       description: The ID of the Key Access Server being assigned to the grant
-      required: true
     - name: label
       description: "Optional metadata 'labels' in the format: key=value"
       shorthand: l

--- a/otdfctl/docs/man/policy/kas-grants/unassign.md
+++ b/otdfctl/docs/man/policy/kas-grants/unassign.md
@@ -14,11 +14,9 @@ command:
     - name: attribute-id
       shorthand: a
       description: The ID of the Attribute Definition being unassigned the KAS grant
-      required: true
     - name: value-id
       shorthand: v
       description: The ID of the Value being unassigned the KAS Grant
-      required: true
     - name: kas-id
       shorthand: k
       description: The Key Access Server (KAS) ID being unassigned a grant

--- a/otdfctl/docs/man/policy/kas-registry/key/get.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/get.md
@@ -11,7 +11,6 @@ command:
       required: true
     - name: kas
       description: Specify the Key Access Server (KAS) where the key (identified by `--key`) is registered. The KAS can be identified by its ID, URI, or Name.
-      required: true
     
 ---
 

--- a/otdfctl/docs/man/policy/kas-registry/key/list-mappings.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/list-mappings.md
@@ -8,11 +8,9 @@ command:
     - name: limit
       shorthand: l
       description: Maximum number of key mappings to return
-      required: true
     - name: offset
       shorthand: o
       description: Offset (page) quantity from start of the list
-      required: true
     - name: id
       shorthand: i
       description: The system ID of the key for which to list mappings.

--- a/otdfctl/docs/man/policy/kas-registry/key/list.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/list.md
@@ -8,11 +8,9 @@ command:
     - name: limit
       shorthand: l
       description: Maximum number of keys to return
-      required: true
     - name: offset
       shorthand: o
       description: Number of keys to skip before starting to return results
-      required: true
     - name: algorithm
       shorthand: a
       description: Key Algorithm to filter for

--- a/otdfctl/docs/man/policy/kas-registry/key/rotate.md
+++ b/otdfctl/docs/man/policy/kas-registry/key/rotate.md
@@ -12,7 +12,6 @@ command:
       required: true
     - name: kas
       description: Specify the Key Access Server (KAS) where the key is registered. The KAS can be identified by its ID, URI, or Name.
-      required: true
     
     # Flags for the new key creation (from create.md)
     - name: key-id

--- a/otdfctl/docs/man/policy/key-management/provider/list.md
+++ b/otdfctl/docs/man/policy/key-management/provider/list.md
@@ -8,11 +8,9 @@ command:
     - name: limit
       shorthand: l
       description: Maximum number of results to return
-      required: true
     - name: offset
       shorthand: o
       description: Offset for pagination
-      required: true
 ---
 
 Lists all provider configs with pagination support.

--- a/otdfctl/docs/man/policy/namespaces/get.md
+++ b/otdfctl/docs/man/policy/namespaces/get.md
@@ -8,6 +8,7 @@ command:
     - name: id
       shorthand: i
       description: ID of the attribute namespace
+      required: true
 ---
 
 For more information, see the `namespaces` subcommand.

--- a/otdfctl/docs/man/policy/registered-resources/values/list.md
+++ b/otdfctl/docs/man/policy/registered-resources/values/list.md
@@ -8,6 +8,7 @@ command:
     - name: resource
       shorthand: r
       description: Identifier of the associated registered resource (ID or name)
+      required: true
     - name: namespace
       shorthand: s
       description: "Namespace ID or FQN (required when --resource is a name)"

--- a/otdfctl/docs/man/policy/registered-resources/values/update.md
+++ b/otdfctl/docs/man/policy/registered-resources/values/update.md
@@ -8,6 +8,7 @@ command:
     - name: id
       shorthand: i
       description: ID of the registered resource value to update
+      required: true
     - name: value
       shorthand: v
       description: Optional updated value of the registered resource value (must be unique within the Registered Resource)

--- a/otdfctl/docs/man/policy/resource-mapping-groups/create.md
+++ b/otdfctl/docs/man/policy/resource-mapping-groups/create.md
@@ -10,9 +10,11 @@ command:
     - name: namespace-id
       description: The ID of the namespace of the group
       default: ''
+      required: true
     - name: name
       description: The name of the group
       default: ''
+      required: true
     - name: label
       description: "Optional metadata 'labels' in the format: key=value"
       shorthand: l

--- a/otdfctl/docs/man/policy/resource-mapping-groups/delete.md
+++ b/otdfctl/docs/man/policy/resource-mapping-groups/delete.md
@@ -6,6 +6,7 @@ command:
     - name: id
       description: The ID of the resource mapping group to delete
       default: ''
+      required: true
     - name: force
       description: Force deletion without interactive confirmation (dangerous)
 ---

--- a/otdfctl/docs/man/policy/resource-mapping-groups/get.md
+++ b/otdfctl/docs/man/policy/resource-mapping-groups/get.md
@@ -8,6 +8,7 @@ command:
     - name: id
       description: The ID of the resource mapping group to get.
       default: ''
+      required: true
 ---
 
 For more information about resource mapping groups, see the `resource-mapping-groups` subcommand.

--- a/otdfctl/docs/man/policy/resource-mapping-groups/update.md
+++ b/otdfctl/docs/man/policy/resource-mapping-groups/update.md
@@ -8,6 +8,7 @@ command:
     - name: id
       description: The ID of the resource mapping group to update.
       default: ''
+      required: true
     - name: namespace-id
       description: The ID of the namespace of the group
       default: ''

--- a/otdfctl/docs/man/policy/resource-mappings/create.md
+++ b/otdfctl/docs/man/policy/resource-mappings/create.md
@@ -14,6 +14,7 @@ command:
     - name: terms
       description: The synonym terms to match for the resource mapping.
       default: ''
+      required: true
     - name: group-id
       description: The ID of the resource mapping group to assign this mapping to
       default: ''

--- a/otdfctl/docs/man/policy/resource-mappings/create.md
+++ b/otdfctl/docs/man/policy/resource-mappings/create.md
@@ -10,6 +10,7 @@ command:
     - name: attribute-value-id
       description: The ID of the attribute value to map to the resource.
       default: ''
+      required: true
     - name: terms
       description: The synonym terms to match for the resource mapping.
       default: ''

--- a/otdfctl/docs/man/policy/resource-mappings/delete.md
+++ b/otdfctl/docs/man/policy/resource-mappings/delete.md
@@ -6,6 +6,7 @@ command:
     - name: id
       description: The ID of the resource mapping to delete
       default: ''
+      required: true
     - name: force
       description: Force deletion without interactive confirmation (dangerous)
 ---

--- a/otdfctl/docs/man/policy/resource-mappings/get.md
+++ b/otdfctl/docs/man/policy/resource-mappings/get.md
@@ -8,6 +8,7 @@ command:
     - name: id
       description: The ID of the resource mapping to get.
       default: ''
+      required: true
 ---
 
 For more information about resource mappings, see the `resource-mappings` subcommand.

--- a/otdfctl/docs/man/policy/resource-mappings/update.md
+++ b/otdfctl/docs/man/policy/resource-mappings/update.md
@@ -8,6 +8,7 @@ command:
     - name: id
       description: The ID of the resource mapping to update.
       default: ''
+      required: true
     - name: attribute-value-id
       description: The ID of the attribute value to map to the resource.
       default: ''

--- a/otdfctl/docs/man/policy/subject-condition-sets/create.md
+++ b/otdfctl/docs/man/policy/subject-condition-sets/create.md
@@ -11,7 +11,6 @@ command:
     - name: subject-sets
       description: A JSON array of subject sets, containing a list of condition groups, each with one or more conditions
       shorthand: s
-      required: true
       default: ''
     - name: subject-sets-file-json
       description: A JSON file with path from the current working directory containing an array of subject sets

--- a/otdfctl/docs/man/policy/subject-mappings/create.md
+++ b/otdfctl/docs/man/policy/subject-mappings/create.md
@@ -13,6 +13,7 @@ command:
       required: true
     - name: action
       description: Each 'id' or 'name' of an Action to be entitled (i.e. 'create', 'read', 'update', 'delete')
+      required: true
     - name: subject-condition-set-id
       description: Known preexisting Subject Condition Set Id
     - name: subject-condition-set-new

--- a/otdfctl/pkg/man/docflags.go
+++ b/otdfctl/pkg/man/docflags.go
@@ -19,6 +19,7 @@ type DocFlag struct {
 	Default     string   `yaml:"default"`
 	Enum        []string `yaml:"enum"`
 	Sensitive   bool     `yaml:"sensitive"`
+	Required    bool     `yaml:"required"`
 }
 
 func (d *Doc) GetDocFlag(name string) DocFlag {
@@ -55,6 +56,26 @@ func (d *Doc) MarkSensitiveFlags() {
 			if err := d.Flags().SetAnnotation(df.Name, SensitiveAnnotationKey, []string{"true"}); err != nil {
 				panic(fmt.Sprintf("failed to mark flag %q as sensitive for command %q: %v", df.Name, d.Use, err))
 			}
+		}
+	}
+}
+
+// MarkRequiredFlags marks every flag the doc metadata declares `required: true`
+// as required on the command, so cobra enforces it and tools generated from the
+// command tree (e.g. MCP) can advertise the flag as required. Flags declared
+// required in the doc but not registered on this command are skipped (they may
+// be registered on a subcommand or via a shared injector). Call after all flags
+// have been registered.
+func (d *Doc) MarkRequiredFlags() {
+	for _, df := range d.DocFlags {
+		if !df.Required {
+			continue
+		}
+		if d.Flags().Lookup(df.Name) == nil {
+			continue
+		}
+		if err := d.MarkFlagRequired(df.Name); err != nil {
+			panic(fmt.Sprintf("failed to mark flag %q as required for command %q: %v", df.Name, d.Use, err))
 		}
 	}
 }

--- a/otdfctl/pkg/man/docflags.go
+++ b/otdfctl/pkg/man/docflags.go
@@ -59,23 +59,3 @@ func (d *Doc) MarkSensitiveFlags() {
 		}
 	}
 }
-
-// MarkRequiredFlags marks every flag the doc metadata declares `required: true`
-// as required on the command, so cobra enforces it and tools generated from the
-// command tree (e.g. MCP) can advertise the flag as required. Flags declared
-// required in the doc but not registered on this command are skipped (they may
-// be registered on a subcommand or via a shared injector). Call after all flags
-// have been registered.
-func (d *Doc) MarkRequiredFlags() {
-	for _, df := range d.DocFlags {
-		if !df.Required {
-			continue
-		}
-		if d.Flags().Lookup(df.Name) == nil {
-			continue
-		}
-		if err := d.MarkFlagRequired(df.Name); err != nil {
-			panic(fmt.Sprintf("failed to mark flag %q as required for command %q: %v", df.Name, d.Use, err))
-		}
-	}
-}

--- a/otdfctl/pkg/man/docflags_test.go
+++ b/otdfctl/pkg/man/docflags_test.go
@@ -109,3 +109,72 @@ func TestAddStringFlagPanicsOnUnknown(t *testing.T) {
 		doc.AddStringFlag(&cobra.Command{Use: "test"}, "missing")
 	})
 }
+
+func TestDocFlagRequiredParsing(t *testing.T) {
+	doc, err := ProcessDoc(`---
+title: Test Command
+command:
+  name: test
+  flags:
+    - name: id
+      required: true
+      description: A required flag
+    - name: label
+      description: An optional flag
+---
+
+Body.
+`)
+	require.NoError(t, err)
+	require.Len(t, doc.DocFlags, 2)
+
+	assert.True(t, doc.GetDocFlag("id").Required)
+	assert.False(t, doc.GetDocFlag("label").Required)
+}
+
+func TestMarkRequiredFlags(t *testing.T) {
+	doc, err := ProcessDoc(`---
+title: Test Command
+command:
+  name: test
+  flags:
+    - name: id
+      required: true
+      description: Required
+    - name: label
+      description: Optional
+---
+
+Body.
+`)
+	require.NoError(t, err)
+
+	doc.Flags().String("id", "", "Required")
+	doc.Flags().String("label", "", "Optional")
+
+	doc.MarkRequiredFlags()
+
+	idFlag := doc.Flags().Lookup("id")
+	require.NotNil(t, idFlag)
+	assert.Equal(t, []string{"true"}, idFlag.Annotations[cobra.BashCompOneRequiredFlag])
+
+	labelFlag := doc.Flags().Lookup("label")
+	require.NotNil(t, labelFlag)
+	assert.Nil(t, labelFlag.Annotations[cobra.BashCompOneRequiredFlag])
+}
+
+// A flag declared required in the doc but not registered on the command is
+// skipped rather than panicking, so a central sweep can run over commands whose
+// flags are registered elsewhere (subcommands, shared injectors).
+func TestMarkRequiredFlagsSkipsUnregistered(t *testing.T) {
+	doc := &Doc{
+		Command: cobra.Command{Use: "test"},
+		DocFlags: []DocFlag{
+			{Name: "missing-flag", Required: true},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		doc.MarkRequiredFlags()
+	})
+}

--- a/otdfctl/pkg/man/docflags_test.go
+++ b/otdfctl/pkg/man/docflags_test.go
@@ -77,6 +77,75 @@ func TestMarkSensitiveFlagsPanicsOnUnregistered(t *testing.T) {
 	})
 }
 
+func TestDocFlagRequiredParsing(t *testing.T) {
+	doc, err := ProcessDoc(`---
+title: Test Command
+command:
+  name: test
+  flags:
+    - name: id
+      required: true
+      description: A required flag
+    - name: label
+      description: An optional flag
+---
+
+Body.
+`)
+	require.NoError(t, err)
+	require.Len(t, doc.DocFlags, 2)
+
+	assert.True(t, doc.GetDocFlag("id").Required)
+	assert.False(t, doc.GetDocFlag("label").Required)
+}
+
+func TestMarkRequiredFlags(t *testing.T) {
+	doc, err := ProcessDoc(`---
+title: Test Command
+command:
+  name: test
+  flags:
+    - name: id
+      required: true
+      description: Required
+    - name: label
+      description: Optional
+---
+
+Body.
+`)
+	require.NoError(t, err)
+
+	doc.Flags().String("id", "", "Required")
+	doc.Flags().String("label", "", "Optional")
+
+	doc.MarkRequiredFlags()
+
+	idFlag := doc.Flags().Lookup("id")
+	require.NotNil(t, idFlag)
+	assert.Equal(t, []string{"true"}, idFlag.Annotations[cobra.BashCompOneRequiredFlag])
+
+	labelFlag := doc.Flags().Lookup("label")
+	require.NotNil(t, labelFlag)
+	assert.Nil(t, labelFlag.Annotations[cobra.BashCompOneRequiredFlag])
+}
+
+// A flag declared required in the doc but not registered on the command is
+// skipped rather than panicking, so a central sweep can run over commands whose
+// flags are registered elsewhere (subcommands, shared injectors).
+func TestMarkRequiredFlagsSkipsUnregistered(t *testing.T) {
+	doc := &Doc{
+		Command: cobra.Command{Use: "test"},
+		DocFlags: []DocFlag{
+			{Name: "missing-flag", Required: true},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		doc.MarkRequiredFlags()
+	})
+}
+
 func TestAddStringFlag(t *testing.T) {
 	doc, err := ProcessDoc(`---
 title: Test Command

--- a/otdfctl/pkg/man/docflags_test.go
+++ b/otdfctl/pkg/man/docflags_test.go
@@ -130,51 +130,9 @@ Body.
 
 	assert.True(t, doc.GetDocFlag("id").Required)
 	assert.False(t, doc.GetDocFlag("label").Required)
-}
-
-func TestMarkRequiredFlags(t *testing.T) {
-	doc, err := ProcessDoc(`---
-title: Test Command
-command:
-  name: test
-  flags:
-    - name: id
-      required: true
-      description: Required
-    - name: label
-      description: Optional
----
-
-Body.
-`)
-	require.NoError(t, err)
 
 	doc.Flags().String("id", "", "Required")
-	doc.Flags().String("label", "", "Optional")
-
-	doc.MarkRequiredFlags()
-
 	idFlag := doc.Flags().Lookup("id")
 	require.NotNil(t, idFlag)
-	assert.Equal(t, []string{"true"}, idFlag.Annotations[cobra.BashCompOneRequiredFlag])
-
-	labelFlag := doc.Flags().Lookup("label")
-	require.NotNil(t, labelFlag)
-	assert.Nil(t, labelFlag.Annotations[cobra.BashCompOneRequiredFlag])
-}
-
-// A flag declared required in the doc but not registered on the command is
-// skipped rather than panicking, so a central sweep can run over commands whose
-// flags are registered elsewhere (subcommands, shared injectors).
-func TestMarkRequiredFlagsSkipsUnregistered(t *testing.T) {
-	doc := &Doc{
-		Command: cobra.Command{Use: "test"},
-		DocFlags: []DocFlag{
-			{Name: "missing-flag", Required: true},
-		},
-	}
-
-	assert.NotPanics(t, func() {
-		doc.MarkRequiredFlags()
-	})
+	assert.Nil(t, idFlag.Annotations[cobra.BashCompOneRequiredFlag])
 }


### PR DESCRIPTION
## Summary

- Parse `required: true` from command man-doc frontmatter into `man.DocFlag.Required`.
- Reconcile policy flag metadata with the requirements enforced by each command handler.
- Keep requiredness as schema metadata. The command tree does not receive Cobra required annotations, so existing handler validation, error text, and `--json` error formatting remain unchanged.

The metadata is available to generated tooling after consumers update to an `otdfctl` release containing this change.

## Metadata Changes

- Add `required: true` where handlers unconditionally require a flag, including namespace IDs, resource mapping fields, attribute value IDs, and dynamic value mapping inputs.
- Remove `required: true` from deprecated no-op flags, one-of input groups, and pagination flags with defaults.

## Testing

- `go test ./... -race` from `otdfctl`
- `go test -run TestREADMECodeBlocks` from `sdk`
- Tests cover required metadata parsing without adding Cobra required annotations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated policy CLI guidance to clearly identify required inputs for creating, retrieving, updating, and deleting attributes, values, namespaces, mappings, resource groups, and registered resources.
  * Clarified required inputs for dynamic value mappings, subject mappings, and resource mapping operations.
  * Documented optional inputs for pagination, subject condition sets, KAS registry commands, and deprecated KAS grant commands.
  * Added support for indicating whether command-line options are required in generated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->