### PR TITLE
fix(cli): move noisy refresh log to debug

### DIFF
--- a/otdfctl/pkg/auth/refresh.go
+++ b/otdfctl/pkg/auth/refresh.go
@@ -119,7 +119,7 @@ func refreshAccessToken(ctx context.Context, profile *profiles.OtdfctlProfileSto
 		return fmt.Errorf("failed to save refreshed credentials: %w", err)
 	}
 
-	slog.Info("access token refreshed and saved")
+	slog.Debug("access token refreshed and saved")
 	return nil
 }
 


### PR DESCRIPTION
### Proposed Changes

* Logs on every refresh can get noisy, move to debug

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

