### PR TITLE
refactor(sdk): rewrite CreateTDF on top of ChunkedWriter

### DIFF
--- a/sdk/chunked_test.go
+++ b/sdk/chunked_test.go
@@ -852,19 +852,17 @@ func TestChunkedECKeyAccess(t *testing.T) {
 	for i := range dek {
 		dek[i] = byte(i)
 	}
-	splits := &SplitResult{
-		KASPublicKeys: map[string]KASPublicKey{
-			kasURL: {
-				Algorithm: string(ocrypto.EC256Key),
-				KID:       "ec-kid",
-				PEM:       pubPEM,
-				URL:       kasURL,
-			},
-		},
-		Splits: []Split{{Data: dek, KASURLs: []string{kasURL}}},
-	}
+	shares := []splitShare{{
+		data: dek,
+		kases: []KASInfo{{
+			Algorithm: string(ocrypto.EC256Key),
+			KID:       "ec-kid",
+			PublicKey: pubPEM,
+			URL:       kasURL,
+		}},
+	}}
 
-	kaos, err := buildChunkedKeyAccessObjects(splits, []byte(`{"uuid":"test"}`), "")
+	kaos, err := buildKeyAccessObjects(shares, `{"uuid":"test"}`, "")
 	require.NoError(t, err)
 	require.Len(t, kaos, 1)
 

--- a/sdk/chunked_writer.go
+++ b/sdk/chunked_writer.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/google/uuid"
 	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/policy"
 	"github.com/opentdf/platform/sdk/internal/zipstream"
@@ -36,7 +35,6 @@ var (
 	// ErrChunkedSegmentAlreadyWritten is returned when WriteSegment
 	// receives an index that was already written.
 	ErrChunkedSegmentAlreadyWritten = errors.New("chunked: segment already written")
-
 	// ErrChunkedVersionHexMismatch is returned when Finalize is asked
 	// to omit schemaVersion on a writer that was not constructed in
 	// legacy signature mode. Use WithChunkedTargetMode to set both.
@@ -136,11 +134,20 @@ type ChunkedWriterConfig struct {
 	// FixedClock for deterministic ZIP output.
 	clock Clock
 
+	// dek is a pre-generated Data Encryption Key. When nil the writer
+	// draws one from rand. SDK.CreateTDF presets it so that it can
+	// resolve key access before emitting any payload bytes.
+	dek []byte
+
 	// excludeVersion omits the schemaVersion field from the manifest.
 	// Set together with useHex by WithChunkedTargetMode; readers use
 	// the field's absence as the pre-4.3.0 marker, so the two must
 	// agree.
 	excludeVersion bool
+
+	// keyAccess resolves the manifest policy and key access objects.
+	// Defaults to a splitterKeyAccess over splitter.
+	keyAccess keyAccessResolver
 
 	// initialAttributes are the attribute values used at Finalize
 	// when the Finalize call does not supply its own.
@@ -162,10 +169,15 @@ type ChunkedWriterConfig struct {
 	// integrity hashes. Defaults to HS256.
 	segmentIntegrityAlgorithm IntegrityAlgorithm
 
-	// splitter maps attribute values to DEK splits at Finalize time.
-	// Defaults to DefaultKeySplitter (single-KAS only).
-	splitter KeySplitter
+	// segmentSize is the plaintext segment size advertised in the
+	// manifest. Zero means "report the first segment's actual size",
+	// which is right when every segment is the same length.
+	segmentSize int64
 
+	// splitter maps attribute values to DEK splits at Finalize time.
+	// Defaults to DefaultKeySplitter (single-KAS only). Ignored when
+	// keyAccess is set.
+	splitter KeySplitter
 	// useHex hex-encodes segment, root, and assertion signatures
 	// before base64, producing the doubly-encoded form that readers
 	// older than 4.3.0 require. Set by WithChunkedTargetMode.
@@ -247,6 +259,10 @@ type chunkedWriter struct {
 	// integrityAlgorithm is used for the root signature.
 	integrityAlgorithm IntegrityAlgorithm
 
+	// keyAccess resolves the manifest policy and key access objects
+	// for the DEK.
+	keyAccess keyAccessResolver
+
 	// manifest holds the finalized manifest for post-Finalize
 	// GetManifest calls.
 	manifest *Manifest
@@ -263,13 +279,12 @@ type chunkedWriter struct {
 	// segments records per-index Segment metadata (hash + sizes).
 	segments map[int]*Segment
 
-	// splitter converts attributes + DEK into key splits at
-	// Finalize time.
-	splitter KeySplitter
+	// segmentSize is the plaintext segment size to advertise in the
+	// manifest, or zero to infer it from the first segment.
+	segmentSize int64
 
-	// useHex selects the pre-4.3.0 doubly-encoded signature form.
-	// Read by WriteSegment, so it is fixed at construction rather
-	// than at Finalize.
+	// useHex emits hex-encoded integrity signatures for pre-4.3.0
+	// TDF spec versions.
 	useHex bool
 }
 
@@ -305,14 +320,28 @@ func NewChunkedWriter(_ context.Context, opts ...ChunkedWriterOption) (ChunkedWr
 			return nil, err
 		}
 	}
+	return newChunkedWriter(cfg)
+}
 
-	dek := make([]byte, kKeySize)
-	if _, err := io.ReadFull(cfg.rand, dek); err != nil {
-		return nil, fmt.Errorf("generate DEK: %w", err)
+// newChunkedWriter builds the writer from a fully-populated config.
+// SDK.CreateTDF calls this directly with the unexported knobs its
+// legacy behavior needs (preset DEK, hex signatures, fixed segment
+// size) rather than going through the public option set.
+func newChunkedWriter(cfg ChunkedWriterConfig) (*chunkedWriter, error) {
+	dek := cfg.dek
+	if dek == nil {
+		dek = make([]byte, kKeySize)
+		if _, err := io.ReadFull(cfg.rand, dek); err != nil {
+			return nil, fmt.Errorf("generate DEK: %w", err)
+		}
 	}
 	block, err := cfg.cipherFactory(dek)
 	if err != nil {
 		return nil, fmt.Errorf("build segment cipher: %w", err)
+	}
+	keyAccess := cfg.keyAccess
+	if keyAccess == nil {
+		keyAccess = splitterKeyAccess{splitter: cfg.splitter}
 	}
 	return &chunkedWriter{
 		archiveWriter:             cfg.archiveFactory(cfg.clock),
@@ -323,9 +352,10 @@ func NewChunkedWriter(_ context.Context, opts ...ChunkedWriterOption) (ChunkedWr
 		initialAttributes:         cfg.initialAttributes,
 		initialDefaultKAS:         cfg.initialDefaultKAS,
 		integrityAlgorithm:        cfg.integrityAlgorithm,
+		keyAccess:                 keyAccess,
 		segmentIntegrityAlgorithm: cfg.segmentIntegrityAlgorithm,
 		segments:                  make(map[int]*Segment),
-		splitter:                  cfg.splitter,
+		segmentSize:               cfg.segmentSize,
 		useHex:                    cfg.useHex,
 	}, nil
 }
@@ -443,9 +473,7 @@ func (w *chunkedWriter) WriteSegment(ctx context.Context, index int, data []byte
 		release()
 		return nil, fmt.Errorf("encrypt segment %d: %w", index, err)
 	}
-	sealed := make([]byte, 0, len(nonce)+len(ciphertext))
-	sealed = append(sealed, nonce...)
-	sealed = append(sealed, ciphertext...)
+	sealed := joinSealed(nonce, ciphertext)
 	sig, err := calculateSignature(sealed, w.dek, w.segmentIntegrityAlgorithm, w.useHex)
 	if err != nil {
 		release()
@@ -454,16 +482,7 @@ func (w *chunkedWriter) WriteSegment(ctx context.Context, index int, data []byte
 	hash := string(ocrypto.Base64Encode([]byte(sig)))
 	encryptedSize := int64(len(sealed))
 
-	crc := crc32.NewIEEE()
-	if _, err := crc.Write(nonce); err != nil {
-		release()
-		return nil, err
-	}
-	if _, err := crc.Write(ciphertext); err != nil {
-		release()
-		return nil, err
-	}
-	header, err := w.archiveWriter.WriteSegment(ctx, index, uint64(encryptedSize), crc.Sum32())
+	header, err := w.archiveWriter.WriteSegment(ctx, index, uint64(encryptedSize), crc32.ChecksumIEEE(sealed))
 	if err != nil {
 		release()
 		return nil, fmt.Errorf("write segment %d to archive: %w", index, err)
@@ -478,11 +497,9 @@ func (w *chunkedWriter) WriteSegment(ctx context.Context, index int, data []byte
 	seg.Size = int64(len(data))
 	w.mu.Unlock()
 
-	var reader io.Reader
-	if len(header) == 0 {
-		reader = io.MultiReader(bytes.NewReader(nonce), bytes.NewReader(ciphertext))
-	} else {
-		reader = io.MultiReader(bytes.NewReader(header), bytes.NewReader(nonce), bytes.NewReader(ciphertext))
+	var reader io.Reader = bytes.NewReader(sealed)
+	if len(header) > 0 {
+		reader = io.MultiReader(bytes.NewReader(header), reader)
 	}
 	// Reported from the locals rather than from seg, which is shared with
 	// concurrent readers of w.segments once the lock is released.
@@ -502,7 +519,7 @@ func (w *chunkedWriter) applyFinalizeOptions(opts []ChunkedFinalizeOption) (*Chu
 		attributes:        nil,
 		encryptedMetadata: "",
 		excludeVersion:    w.excludeVersion,
-		mimeType:          "application/octet-stream",
+		mimeType:          defaultMimeType,
 	}
 	for _, opt := range opts {
 		if err := opt(cfg); err != nil {
@@ -526,23 +543,16 @@ func (w *chunkedWriter) applyFinalizeOptions(opts []ChunkedFinalizeOption) (*Chu
 	return cfg, nil
 }
 
-// buildManifest composes the manifest from writer state, splits the
-// DEK, wraps splits into KAOs, and computes the root signature.
+// buildManifest composes the manifest from writer state, resolves the
+// key access objects for the DEK, signs any assertions, and computes
+// the root signature.
 func (w *chunkedWriter) buildManifest(ctx context.Context, cfg *ChunkedFinalizeConfig) (*Manifest, int64, int64, error) {
 	order, err := w.segmentOrderLocked(cfg.keepSegments)
 	if err != nil {
 		return nil, 0, 0, err
 	}
 
-	splits, err := w.splitter.Split(ctx, cfg.attributes, w.dek, cfg.defaultKAS)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-	policyBytes, err := buildChunkedPolicy(cfg.attributes)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-	kaos, err := buildChunkedKeyAccessObjects(splits, policyBytes, cfg.encryptedMetadata)
+	base64Policy, kaos, err := w.keyAccess.resolve(ctx, w.dek, cfg)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -550,7 +560,7 @@ func (w *chunkedWriter) buildManifest(ctx context.Context, cfg *ChunkedFinalizeC
 	encInfo := EncryptionInformation{
 		KeyAccessObjs: kaos,
 		KeyAccessType: kSplitKeyType,
-		Policy:        string(ocrypto.Base64Encode(policyBytes)),
+		Policy:        base64Policy,
 		Method: Method{
 			Algorithm:    kGCMCipherAlgorithm,
 			IsStreamable: true,
@@ -580,7 +590,11 @@ func (w *chunkedWriter) buildManifest(ctx context.Context, cfg *ChunkedFinalizeC
 		}
 		aggregate.Write(decoded)
 	}
-	if len(order) > 0 {
+	switch {
+	case w.segmentSize > 0:
+		encInfo.DefaultSegmentSize = w.segmentSize
+		encInfo.DefaultEncryptedSegSize = w.segmentSize + gcmIvSize + aesBlockSize
+	case len(order) > 0:
 		if first, ok := w.segments[order[0]]; ok {
 			encInfo.DefaultEncryptedSegSize = first.EncryptedSize
 			encInfo.DefaultSegmentSize = first.Size
@@ -667,63 +681,6 @@ func (w *chunkedWriter) segmentOrderLocked(keep []int) ([]int, error) {
 	return out, nil
 }
 
-// buildChunkedKeyAccessObjects wraps each split share to each KAS
-// listed by the splitter.
-func buildChunkedKeyAccessObjects(splits *SplitResult, policyBytes []byte, metadata string) ([]KeyAccess, error) {
-	if splits == nil || len(splits.Splits) == 0 {
-		return nil, errors.New("no splits produced")
-	}
-	base64Policy := ocrypto.Base64Encode(policyBytes)
-
-	var out []KeyAccess
-	for _, split := range splits.Splits {
-		// Policy binding and metadata are keyed on the split share, not
-		// on the KAS, so compute them once per split rather than once
-		// per KAS URL in an OR-group.
-		policyBinding := createPolicyBinding(split.Data, base64Policy)
-		var encMeta string
-		if metadata != "" {
-			m, err := encryptMetadata(split.Data, metadata)
-			if err != nil {
-				return nil, fmt.Errorf("encrypt metadata for split %s: %w", split.ID, err)
-			}
-			encMeta = m
-		}
-		for _, url := range split.KASURLs {
-			pk, ok := splits.KASPublicKeys[url]
-			if !ok {
-				continue
-			}
-			if pk.PEM == "" {
-				return nil, fmt.Errorf("splitID:[%s], kas:[%s]: %w", split.ID, url, errKasPubKeyMissing)
-			}
-			kao, err := createKeyAccess(pk.toKASInfo(), split.Data, policyBinding, encMeta, split.ID)
-			if err != nil {
-				return nil, fmt.Errorf("wrap key for %s: %w", url, err)
-			}
-			out = append(out, kao)
-		}
-	}
-	if len(out) == 0 {
-		return nil, errors.New("no valid key access objects generated")
-	}
-	return out, nil
-}
-
-// buildChunkedPolicy composes the TDF Policy document from attribute
-// values.
-func buildChunkedPolicy(values []*policy.Value) ([]byte, error) {
-	p := PolicyObject{UUID: uuid.NewString()}
-	p.Body.DataAttributes = make([]attributeObject, 0, len(values))
-	p.Body.Dissem = make([]string, 0)
-	for _, v := range values {
-		p.Body.DataAttributes = append(p.Body.DataAttributes, attributeObject{
-			Attribute: v.GetFqn(),
-		})
-	}
-	return json.Marshal(p)
-}
-
 // cloneChunkedManifest returns a shallow-deep copy safe to hand out.
 func cloneChunkedManifest(in *Manifest) *Manifest {
 	if in == nil {
@@ -740,4 +697,30 @@ func cloneChunkedManifest(in *Manifest) *Manifest {
 		out.Assertions = slices.Clone(in.Assertions)
 	}
 	return &out
+}
+
+// integrityAlgorithmString maps an IntegrityAlgorithm to its manifest
+// string form.
+func integrityAlgorithmString(a IntegrityAlgorithm) string {
+	switch a {
+	case GMAC:
+		return gmacIntegrityAlgorithm
+	default:
+		return hmacIntegrityAlgorithm
+	}
+}
+
+// joinSealed returns nonce||ciphertext, the on-disk form of a segment.
+// A SegmentCipher backed by crypto/cipher hands back two views of the
+// single buffer Seal allocated, so the common case is free; anything
+// else pays one copy.
+func joinSealed(nonce, ciphertext []byte) []byte {
+	if len(nonce) > 0 && len(ciphertext) > 0 &&
+		cap(nonce) >= len(nonce)+len(ciphertext) &&
+		&nonce[:cap(nonce)][len(nonce)] == &ciphertext[0] {
+		return nonce[:len(nonce)+len(ciphertext)]
+	}
+	sealed := make([]byte, 0, len(nonce)+len(ciphertext))
+	sealed = append(sealed, nonce...)
+	return append(sealed, ciphertext...)
 }

--- a/sdk/key_access_test.go
+++ b/sdk/key_access_test.go
@@ -40,36 +40,36 @@ SQIDAQAB
 	testPolicyJSON = `{"uuid":"test","body":{"dataAttributes":[{"attribute":"test"}],"dissem":[]}}`
 )
 
-// newTestSplitResult builds a single-split, single-KAS SplitResult
-// addressed to a KAS holding pubKey.
-func newTestSplitResult(t *testing.T, pubKey, algorithm string) *SplitResult {
+// testBase64Policy is what a caller hands buildKeyAccessObjects: the
+// policy document already base64-encoded, since that is the form the
+// policy binding is computed over.
+var testBase64Policy = string(ocrypto.Base64Encode([]byte(testPolicyJSON)))
+
+// newTestShares builds a single share addressed to one KAS holding
+// pubKey.
+func newTestShares(t *testing.T, pubKey, algorithm string) []splitShare {
 	t.Helper()
-	splitData := make([]byte, 32)
-	_, err := rand.Read(splitData)
+	shareData := make([]byte, 32)
+	_, err := rand.Read(shareData)
 	require.NoError(t, err)
 
-	return &SplitResult{
-		Splits: []Split{{
-			ID:      "test-split-1",
-			Data:    splitData,
-			KASURLs: []string{testKAS1URL},
+	return []splitShare{{
+		id:   "test-split-1",
+		data: shareData,
+		kases: []KASInfo{{
+			URL:       testKAS1URL,
+			Algorithm: algorithm,
+			KID:       "test-kid-1",
+			PublicKey: pubKey,
 		}},
-		KASPublicKeys: map[string]KASPublicKey{
-			testKAS1URL: {
-				URL:       testKAS1URL,
-				Algorithm: algorithm,
-				KID:       "test-kid-1",
-				PEM:       pubKey,
-			},
-		},
-	}
+	}}
 }
 
-func TestBuildChunkedKeyAccessObjects(t *testing.T) {
+func TestBuildKeyAccessObjects(t *testing.T) {
 	t.Run("RSA public key", func(t *testing.T) {
-		splits := newTestSplitResult(t, testRSAPublicKey, "rsa:2048")
+		shares := newTestShares(t, testRSAPublicKey, "rsa:2048")
 
-		kaos, err := buildChunkedKeyAccessObjects(splits, []byte(testPolicyJSON), testMetadata)
+		kaos, err := buildKeyAccessObjects(shares, testBase64Policy, testMetadata)
 		require.NoError(t, err)
 		require.Len(t, kaos, 1)
 
@@ -91,9 +91,9 @@ func TestBuildChunkedKeyAccessObjects(t *testing.T) {
 		ecPublicKeyPEM, err := ecKeyPair.PublicKeyInPemFormat()
 		require.NoError(t, err)
 
-		splits := newTestSplitResult(t, ecPublicKeyPEM, "ec:secp256r1")
+		shares := newTestShares(t, ecPublicKeyPEM, "ec:secp256r1")
 
-		kaos, err := buildChunkedKeyAccessObjects(splits, []byte(testPolicyJSON), testMetadata)
+		kaos, err := buildKeyAccessObjects(shares, testBase64Policy, testMetadata)
 		require.NoError(t, err)
 		require.Len(t, kaos, 1)
 
@@ -133,9 +133,9 @@ func TestBuildChunkedKeyAccessObjects(t *testing.T) {
 			publicKeyPEM, err := keyPair.PublicKeyInPemFormat()
 			require.NoError(t, err)
 
-			splits := newTestSplitResult(t, publicKeyPEM, string(tc.alg))
+			shares := newTestShares(t, publicKeyPEM, string(tc.alg))
 
-			kaos, err := buildChunkedKeyAccessObjects(splits, []byte(testPolicyJSON), testMetadata)
+			kaos, err := buildKeyAccessObjects(shares, testBase64Policy, testMetadata)
 			require.NoError(t, err)
 			require.Len(t, kaos, 1)
 
@@ -146,100 +146,86 @@ func TestBuildChunkedKeyAccessObjects(t *testing.T) {
 		})
 	}
 
-	t.Run("multiple KAS URLs in one split", func(t *testing.T) {
-		splitData := make([]byte, 32)
-		_, err := rand.Read(splitData)
+	t.Run("multiple KAS in one share", func(t *testing.T) {
+		shareData := make([]byte, 32)
+		_, err := rand.Read(shareData)
 		require.NoError(t, err)
 
-		splits := &SplitResult{
-			Splits: []Split{{
-				ID:      "multi-kas-split",
-				Data:    splitData,
-				KASURLs: []string{testKAS1URL, testKAS2URL},
-			}},
-			KASPublicKeys: map[string]KASPublicKey{
-				testKAS1URL: {URL: testKAS1URL, Algorithm: "rsa:2048", KID: "kid1", PEM: testRSAPublicKey},
-				testKAS2URL: {URL: testKAS2URL, Algorithm: "rsa:2048", KID: "kid2", PEM: testRSAPublicKey},
+		shares := []splitShare{{
+			id:   "multi-kas-split",
+			data: shareData,
+			kases: []KASInfo{
+				{URL: testKAS1URL, Algorithm: "rsa:2048", KID: "kid1", PublicKey: testRSAPublicKey},
+				{URL: testKAS2URL, Algorithm: "rsa:2048", KID: "kid2", PublicKey: testRSAPublicKey},
 			},
-		}
+		}}
 
-		kaos, err := buildChunkedKeyAccessObjects(splits, []byte(testPolicyJSON), "")
+		kaos, err := buildKeyAccessObjects(shares, testBase64Policy, "")
 		require.NoError(t, err)
 		require.Len(t, kaos, 2, "one KAO per KAS in the OR-group")
 		assert.ElementsMatch(t, []string{testKAS1URL, testKAS2URL}, []string{kaos[0].KasURL, kaos[1].KasURL})
 	})
 
-	t.Run("skips KAS URLs with no resolved public key", func(t *testing.T) {
-		splitData := make([]byte, 32)
-		_, err := rand.Read(splitData)
+	// A KAS whose wrapping key never resolved arrives here with an empty
+	// PEM. Dropping it would silently narrow who can unwrap the share --
+	// and, if it was the only KAS, produce a TDF nobody can read -- so it
+	// is an error rather than a skip.
+	t.Run("errors when one KAS in an OR-group has no public key", func(t *testing.T) {
+		shareData := make([]byte, 32)
+		_, err := rand.Read(shareData)
 		require.NoError(t, err)
 
-		splits := &SplitResult{
-			Splits: []Split{{
-				ID:      "missing-key-split",
-				Data:    splitData,
-				KASURLs: []string{testKAS1URL, testKAS2URL},
-			}},
-			KASPublicKeys: map[string]KASPublicKey{
-				testKAS1URL: {URL: testKAS1URL, Algorithm: "rsa:2048", KID: "kid1", PEM: testRSAPublicKey},
-				// testKAS2URL intentionally absent
+		shares := []splitShare{{
+			id:   "missing-key-split",
+			data: shareData,
+			kases: []KASInfo{
+				{URL: testKAS1URL, Algorithm: "rsa:2048", KID: "kid1", PublicKey: testRSAPublicKey},
+				{URL: testKAS2URL, Algorithm: "rsa:2048", KID: "kid2"},
 			},
-		}
+		}}
 
-		kaos, err := buildChunkedKeyAccessObjects(splits, []byte(testPolicyJSON), "")
-		require.NoError(t, err)
-		require.Len(t, kaos, 1)
-		assert.Equal(t, testKAS1URL, kaos[0].KasURL)
+		_, err = buildKeyAccessObjects(shares, testBase64Policy, "")
+		require.ErrorIs(t, err, errKasPubKeyMissing)
+		assert.Contains(t, err.Error(), testKAS2URL, "the error should name the offending KAS")
 	})
 
 	t.Run("errors when a resolved key has an empty PEM", func(t *testing.T) {
-		splits := newTestSplitResult(t, "", "rsa:2048")
+		shares := newTestShares(t, "", "rsa:2048")
 
-		_, err := buildChunkedKeyAccessObjects(splits, []byte(testPolicyJSON), "")
+		_, err := buildKeyAccessObjects(shares, testBase64Policy, "")
 		require.ErrorIs(t, err, errKasPubKeyMissing)
 	})
 
 	t.Run("errors on malformed PEM", func(t *testing.T) {
-		splits := newTestSplitResult(t, "invalid-pem-data", "rsa:2048")
+		shares := newTestShares(t, "invalid-pem-data", "rsa:2048")
 
-		_, err := buildChunkedKeyAccessObjects(splits, []byte(testPolicyJSON), "")
+		_, err := buildKeyAccessObjects(shares, testBase64Policy, "")
 		require.Error(t, err)
 	})
 
 	t.Run("empty metadata produces no encrypted metadata", func(t *testing.T) {
-		splits := newTestSplitResult(t, testRSAPublicKey, "rsa:2048")
+		shares := newTestShares(t, testRSAPublicKey, "rsa:2048")
 
-		kaos, err := buildChunkedKeyAccessObjects(splits, []byte(testPolicyJSON), "")
+		kaos, err := buildKeyAccessObjects(shares, testBase64Policy, "")
 		require.NoError(t, err)
 		require.Len(t, kaos, 1)
 		assert.Empty(t, kaos[0].EncryptedMetadata)
 	})
 
-	t.Run("errors on nil split result", func(t *testing.T) {
-		_, err := buildChunkedKeyAccessObjects(nil, []byte(testPolicyJSON), "")
+	t.Run("errors on no shares", func(t *testing.T) {
+		_, err := buildKeyAccessObjects(nil, testBase64Policy, "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no splits produced")
+		assert.Contains(t, err.Error(), "no key access objects generated")
 	})
 
-	t.Run("errors on empty splits", func(t *testing.T) {
-		_, err := buildChunkedKeyAccessObjects(&SplitResult{}, []byte(testPolicyJSON), "")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no splits produced")
-	})
-
-	t.Run("errors when every KAS lacks a public key", func(t *testing.T) {
-		splitData := make([]byte, 32)
-		_, err := rand.Read(splitData)
+	t.Run("errors on a share with no KAS", func(t *testing.T) {
+		shareData := make([]byte, 32)
+		_, err := rand.Read(shareData)
 		require.NoError(t, err)
 
-		splits := &SplitResult{
-			Splits:        []Split{{ID: "no-keys-split", Data: splitData, KASURLs: []string{testKAS1URL}}},
-			KASPublicKeys: map[string]KASPublicKey{},
-		}
-
-		_, err = buildChunkedKeyAccessObjects(splits, []byte(testPolicyJSON), "")
+		_, err = buildKeyAccessObjects([]splitShare{{id: "no-kas-split", data: shareData}}, testBase64Policy, "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no valid key access objects generated")
+		assert.Contains(t, err.Error(), "no key access objects generated")
 	})
 }
 
@@ -249,7 +235,7 @@ func TestCreatePolicyBinding(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("binds with HS256 over base64 policy", func(t *testing.T) {
-		binding := createPolicyBinding(symKey, ocrypto.Base64Encode([]byte(testPolicyJSON)))
+		binding := createPolicyBinding(symKey, testBase64Policy)
 
 		assert.Equal(t, hmacIntegrityAlgorithm, binding.Alg)
 		require.NotEmpty(t, binding.Hash)
@@ -258,8 +244,8 @@ func TestCreatePolicyBinding(t *testing.T) {
 	})
 
 	t.Run("different policies bind differently", func(t *testing.T) {
-		b1 := createPolicyBinding(symKey, ocrypto.Base64Encode([]byte(`{"policy":"test1"}`)))
-		b2 := createPolicyBinding(symKey, ocrypto.Base64Encode([]byte(`{"policy":"test2"}`)))
+		b1 := createPolicyBinding(symKey, string(ocrypto.Base64Encode([]byte(`{"policy":"test1"}`))))
+		b2 := createPolicyBinding(symKey, string(ocrypto.Base64Encode([]byte(`{"policy":"test2"}`))))
 		assert.NotEqual(t, b1.Hash, b2.Hash)
 	})
 
@@ -268,10 +254,9 @@ func TestCreatePolicyBinding(t *testing.T) {
 		_, err := rand.Read(otherKey)
 		require.NoError(t, err)
 
-		policy := ocrypto.Base64Encode([]byte(testPolicyJSON))
 		assert.NotEqual(t,
-			createPolicyBinding(symKey, policy).Hash,
-			createPolicyBinding(otherKey, policy).Hash,
+			createPolicyBinding(symKey, testBase64Policy).Hash,
+			createPolicyBinding(otherKey, testBase64Policy).Hash,
 		)
 	})
 }

--- a/sdk/key_splitter.go
+++ b/sdk/key_splitter.go
@@ -2,9 +2,12 @@ package sdk
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 
+	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/protocol/go/policy"
 )
 
@@ -59,18 +62,6 @@ type KASPublicKey struct {
 
 	// URL of the KAS.
 	URL string
-}
-
-// toKASInfo adapts the splitter's wrapping-key descriptor to the
-// KASInfo shape consumed by createKeyAccess. Default is not carried
-// over; it plays no part in building a key access object.
-func (k KASPublicKey) toKASInfo() KASInfo {
-	return KASInfo{
-		URL:       k.URL,
-		PublicKey: k.PEM,
-		KID:       k.KID,
-		Algorithm: k.Algorithm,
-	}
 }
 
 // ErrSplitterRequiresDefaultKAS is returned by the default key
@@ -133,6 +124,161 @@ func (s *singleKASSplitter) Split(_ context.Context, _ []*policy.Value, dek []by
 			KASURLs: []string{url},
 		}},
 	}, nil
+}
+
+// keyAccessResolver turns a DEK into the two manifest fields that
+// bind it to policy: the base64-encoded policy object and the key
+// access objects wrapping the DEK to each KAS. The writer holds one;
+// SDK.CreateTDF resolves its key access up front and supplies a
+// staticKeyAccess, while the public chunked path defers to a
+// KeySplitter at Finalize time.
+type keyAccessResolver interface {
+	resolve(ctx context.Context, dek []byte, cfg *ChunkedFinalizeConfig) (string, []KeyAccess, error)
+}
+
+// splitShare is one XOR share of the DEK together with every KAS able
+// to unwrap it. Several KAS entries on one share mean any of them
+// suffices (OR semantics); several shares mean all are required (AND).
+type splitShare struct {
+	// id names the share in the manifest ("sid"). Empty when the TDF
+	// has a single share.
+	id string
+
+	// data is the share itself.
+	data []byte
+
+	// kases are the wrapping targets for this share.
+	kases []KASInfo
+}
+
+// staticKeyAccess returns key access objects resolved ahead of time.
+type staticKeyAccess struct {
+	// kaos are the pre-built key access objects.
+	kaos []KeyAccess
+
+	// policy is the base64-encoded policy object the kaos are bound to.
+	policy string
+}
+
+func (r staticKeyAccess) resolve(_ context.Context, _ []byte, _ *ChunkedFinalizeConfig) (string, []KeyAccess, error) {
+	return r.policy, r.kaos, nil
+}
+
+// splitterKeyAccess adapts a public KeySplitter to keyAccessResolver.
+type splitterKeyAccess struct {
+	// splitter maps attributes plus the DEK onto KAS-addressed shares.
+	splitter KeySplitter
+}
+
+func (r splitterKeyAccess) resolve(ctx context.Context, dek []byte, cfg *ChunkedFinalizeConfig) (string, []KeyAccess, error) {
+	splits, err := r.splitter.Split(ctx, cfg.attributes, dek, cfg.defaultKAS)
+	if err != nil {
+		return "", nil, err
+	}
+	if splits == nil || len(splits.Splits) == 0 {
+		return "", nil, errors.New("no splits produced")
+	}
+
+	shares := make([]splitShare, 0, len(splits.Splits))
+	for _, split := range splits.Splits {
+		share := splitShare{id: split.ID, data: split.Data}
+		for _, url := range split.KASURLs {
+			// A URL the splitter left out of KASPublicKeys yields an
+			// empty PEM, which buildKeyAccessObjects rejects.
+			pk := splits.KASPublicKeys[url]
+			share.kases = append(share.kases, KASInfo{
+				URL:       url,
+				PublicKey: pk.PEM,
+				KID:       pk.KID,
+				Algorithm: pk.Algorithm,
+			})
+		}
+		shares = append(shares, share)
+	}
+
+	fqns := make([]string, 0, len(cfg.attributes))
+	for _, v := range cfg.attributes {
+		fqns = append(fqns, v.GetFqn())
+	}
+	return resolvePolicyAndKeyAccess(fqns, shares, cfg.encryptedMetadata)
+}
+
+// resolvePolicyAndKeyAccess builds the policy document the DEK is bound to and wraps
+// every share to its KAS targets, returning the two manifest fields that bind a DEK to
+// policy. Shared by SDK.CreateTDF's KAO template path and the chunked writer's
+// KeySplitter path, so both emit byte-identical policy for the same attributes.
+func resolvePolicyAndKeyAccess(fqns []string, shares []splitShare, metadata string) (string, []KeyAccess, error) {
+	policyObj, err := createPolicyObjectFromFQNs(fqns)
+	if err != nil {
+		return "", nil, fmt.Errorf("fail to create policy object:%w", err)
+	}
+	policyObjectAsStr, err := json.Marshal(policyObj)
+	if err != nil {
+		return "", nil, fmt.Errorf("json.Marshal failed:%w", err)
+	}
+	base64Policy := string(ocrypto.Base64Encode(policyObjectAsStr))
+
+	kaos, err := buildKeyAccessObjects(shares, base64Policy, metadata)
+	if err != nil {
+		return "", nil, err
+	}
+	return base64Policy, kaos, nil
+}
+
+// buildKeyAccessObjects wraps every share to each of its KAS targets,
+// emitting the manifest's keyAccess array in share order.
+func buildKeyAccessObjects(shares []splitShare, base64Policy, metadata string) ([]KeyAccess, error) {
+	var kaos []KeyAccess
+	for _, share := range shares {
+		policyBinding := createPolicyBinding(share.data, base64Policy)
+
+		var encryptedMetadata string
+		if metadata != "" {
+			var err error
+			encryptedMetadata, err = encryptMetadata(share.data, metadata)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		for _, kasInfo := range share.kases {
+			if kasInfo.PublicKey == "" {
+				return nil, fmt.Errorf("splitID:[%s], kas:[%s]: %w", share.id, kasInfo.URL, errKasPubKeyMissing)
+			}
+			keyAccess, err := createKeyAccess(kasInfo, share.data, policyBinding, encryptedMetadata, share.id)
+			if err != nil {
+				return nil, err
+			}
+			kaos = append(kaos, keyAccess)
+		}
+	}
+	if len(kaos) == 0 {
+		return nil, errors.New("no key access objects generated")
+	}
+	return kaos, nil
+}
+
+// splitDEK returns count XOR shares of dek. Every share but the last
+// is random; the last absorbs the parity so the shares XOR back to dek.
+func splitDEK(dek []byte, count int, rand io.Reader) ([][]byte, error) {
+	if count <= 0 {
+		return nil, errors.New("no key splits requested")
+	}
+	shares := make([][]byte, count)
+	parity := make([]byte, len(dek))
+	copy(parity, dek)
+	for i := 0; i < count-1; i++ {
+		share := make([]byte, len(dek))
+		if _, err := io.ReadFull(rand, share); err != nil {
+			return nil, fmt.Errorf("generate key split failed: %w", err)
+		}
+		for j, b := range share {
+			parity[j] ^= b
+		}
+		shares[i] = share
+	}
+	shares[count-1] = parity
+	return shares, nil
 }
 
 // algorithmPolicyToString maps a policy.Algorithm enum to the

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -30,7 +30,6 @@ import (
 
 const (
 	keyAccessSchemaVersion = "1.0"
-	maxFileSizeSupported   = 68719476736 // 64gb
 	defaultMimeType        = "application/octet-stream"
 	zip64MagicVal          = int64(^uint32(0))
 	tdfAsZip               = "zip"
@@ -134,7 +133,7 @@ func (t TDFObject) Size() int64 {
 	return t.size
 }
 
-func (s SDK) CreateTDF(writer io.Writer, reader io.ReadSeeker, opts ...TDFOption) (*TDFObject, error) {
+func (s SDK) CreateTDF(writer io.Writer, reader io.Reader, opts ...TDFOption) (*TDFObject, error) {
 	return s.CreateTDFContext(context.Background(), writer, reader, opts...)
 }
 
@@ -162,22 +161,13 @@ func uuidSplitIDGenerator() string {
 //
 // The payload is encrypted one segment at a time through a ChunkedWriter; segments are
 // emitted in order as they are read, so peak memory stays at one segment regardless of
-// input size.
-func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.ReadSeeker, opts ...TDFOption) (*TDFObject, error) {
-	inputSize, err := reader.Seek(0, io.SeekEnd)
-	if err != nil {
-		return nil, fmt.Errorf("readSeeker.Seek failed: %w", err)
-	}
-
-	if inputSize > maxFileSizeSupported {
-		return nil, errFileTooLarge
-	}
-
-	_, err = reader.Seek(0, io.SeekStart)
-	if err != nil {
-		return nil, fmt.Errorf("readSeeker.Seek failed: %w", err)
-	}
-
+// input size. Bytes are consumed from the reader's current position through EOF; there
+// is no upper bound on payload length.
+//
+// Knowing the length up front lets the archive stay in the compact ZIP32 layout when it
+// fits. The length comes from [WithInputSize] if given, otherwise from the reader when
+// it is seekable; a payload that can be measured neither way is written as ZIP64.
+func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.Reader, opts ...TDFOption) (*TDFObject, error) {
 	tdfConfig, err := newTDFConfig(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("NewTDFConfig failed: %w", err)
@@ -194,28 +184,37 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 	} else if segmentSize < minSegmentSize {
 		return nil, fmt.Errorf("segment size too small: %d", segmentSize)
 	}
-	totalSegments := inputSize / segmentSize
-	if inputSize%segmentSize != 0 {
-		totalSegments++
+
+	inputSize, err := resolveInputSize(tdfConfig, reader)
+	if err != nil {
+		return nil, err
 	}
 
-	// empty payload we still want to create a payload
-	if totalSegments == 0 {
-		totalSegments = 1
+	// A known length doubles as a read limit: overrunning it would invalidate the
+	// ZIP64 choice made from it below. The buffer never shrinks to zero, so a read
+	// that comes back empty always means EOF.
+	readBufSize := segmentSize
+	if inputSize != inputSizeUnknown {
+		reader = io.LimitReader(reader, inputSize)
+		readBufSize = max(1, min(segmentSize, inputSize))
 	}
+	readBuf := make([]byte, readBufSize)
 
-	chunked, err := s.newTDFChunkedWriter(ctx, tdfConfig, inputSize, int(totalSegments))
+	chunked, err := s.newTDFChunkedWriter(ctx, tdfConfig, inputSize, segmentCount(inputSize, segmentSize))
 	if err != nil {
 		return nil, err
 	}
 
 	outputWriter := &countingWriter{writer: writer}
-	readBuf := make([]byte, min(segmentSize, inputSize))
-	var readPos int64
-	for index := 0; int64(index) < totalSegments; index++ {
-		readSize := min(segmentSize, inputSize-readPos)
-		if _, err := io.ReadFull(reader, readBuf[:readSize]); err != nil {
-			return nil, fmt.Errorf("io.ReadSeeker.Read failed: %w", err)
+	for index := 0; ; index++ {
+		readSize, readErr := io.ReadFull(reader, readBuf)
+		if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
+			return nil, fmt.Errorf("io.Reader.Read failed: %w", readErr)
+		}
+		// A payload whose length is a multiple of the segment size reports EOF with
+		// nothing read. An empty payload still gets one empty segment.
+		if readSize == 0 && index > 0 {
+			break
 		}
 
 		segment, err := chunked.WriteSegment(ctx, index, readBuf[:readSize])
@@ -226,7 +225,9 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 		if _, err := io.Copy(outputWriter, segment.TDFData); err != nil {
 			return nil, fmt.Errorf("io.writer.Write failed: %w", err)
 		}
-		readPos += readSize
+		if readErr != nil {
+			break
+		}
 	}
 
 	finalizeOpts, err := tdfFinalizeOptions(tdfConfig)
@@ -249,9 +250,57 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 	}, nil
 }
 
+// resolveInputSize reports the payload length in bytes, or inputSizeUnknown when it
+// cannot be established without consuming the reader. An explicit WithInputSize wins
+// over what the reader can report about itself.
+//
+// A reader may satisfy io.Seeker and still refuse to seek — os.Stdin on the end of a
+// pipe is the common case — so a failed probe is treated as an unmeasurable payload
+// rather than an error. Failing to restore the original position is different: the
+// cursor has already moved and the payload can no longer be read in full.
+func resolveInputSize(tdfConfig *TDFConfig, reader io.Reader) (int64, error) {
+	if tdfConfig.inputSize != inputSizeUnknown {
+		return tdfConfig.inputSize, nil
+	}
+
+	seeker, ok := reader.(io.Seeker)
+	if !ok {
+		return inputSizeUnknown, nil
+	}
+	start, err := seeker.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return inputSizeUnknown, nil //nolint:nilerr // a reader that cannot seek is measured by reading it
+	}
+	end, err := seeker.Seek(0, io.SeekEnd)
+	if err != nil {
+		return inputSizeUnknown, nil //nolint:nilerr // a reader that cannot seek is measured by reading it
+	}
+	if _, err := seeker.Seek(start, io.SeekStart); err != nil {
+		return 0, fmt.Errorf("seeker.Seek failed to restore reader position: %w", err)
+	}
+	return end - start, nil
+}
+
+// segmentCount returns the number of segments a payload of inputSize will occupy, or
+// zero when the length is unknown and the count can only be settled by reading.
+func segmentCount(inputSize, segmentSize int64) int {
+	switch inputSize {
+	case inputSizeUnknown:
+		return 0
+	case 0:
+		// An empty payload still gets one empty segment.
+		return 1
+	default:
+		return int((inputSize + segmentSize - 1) / segmentSize)
+	}
+}
+
 // newTDFChunkedWriter builds the chunked writer backing SDK.CreateTDF. Key access is
 // resolved here, before any payload byte is written, so that an unreachable KAS fails
 // the call without leaving a partial TDF on the output writer.
+//
+// inputSize may be inputSizeUnknown and totalSegments zero, for a payload that can only
+// be measured by reading it.
 func (s SDK) newTDFChunkedWriter(ctx context.Context, tdfConfig *TDFConfig, inputSize int64, totalSegments int) (*chunkedWriter, error) {
 	dek := make([]byte, kKeySize)
 	if _, err := io.ReadFull(defaultRand, dek); err != nil {
@@ -263,21 +312,26 @@ func (s SDK) newTDFChunkedWriter(ctx context.Context, tdfConfig *TDFConfig, inpu
 		return nil, fmt.Errorf("fail to create a new split key: %w", err)
 	}
 
-	// The archive is sized to the exact segment count, and only forced into ZIP64 when
-	// the payload cannot be addressed by a 32-bit offset.
+	// The ZIP64 choice is baked into the payload's local file header, which goes out
+	// with segment 0, so it cannot be revisited once the archive has started. Reserve
+	// ZIP64 for payloads that a 32-bit offset cannot address — and for payloads of
+	// unknown length, which might turn out to be one.
 	payloadSize := inputSize + int64(totalSegments)*(gcmIvSize+aesBlockSize)
 	zipMode := zipstream.Zip64Auto
-	if payloadSize >= zip64MagicVal {
+	if inputSize == inputSizeUnknown || payloadSize >= zip64MagicVal {
 		zipMode = zipstream.Zip64Always
 	}
 
 	return newChunkedWriter(ChunkedWriterConfig{
 		archiveFactory: func(clock Clock) zipstream.SegmentWriter {
-			return zipstream.NewSegmentTDFWriter(totalSegments,
+			archiveOpts := []zipstream.Option{
 				zipstream.WithZip64Mode(zipMode),
-				zipstream.WithMaxSegments(totalSegments),
 				zipstream.WithClock(clock.Now),
-			)
+			}
+			if totalSegments > 0 {
+				archiveOpts = append(archiveOpts, zipstream.WithMaxSegments(totalSegments))
+			}
+			return zipstream.NewSegmentTDFWriter(totalSegments, archiveOpts...)
 		},
 		cipherFactory:             DefaultSegmentCipherFactory,
 		clock:                     SystemClock{},

--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"log/slog"
 	"net/http"
@@ -52,7 +51,6 @@ const (
 	kAssertionSignature    = "assertionSig"
 	kAssertionHash         = "assertionHash"
 	hexSemverThreshold     = "4.3.0"
-	readActionName         = "read"
 )
 
 // Loads and reads ZTDF files
@@ -77,10 +75,8 @@ type RequiredObligations struct {
 }
 
 type TDFObject struct {
-	manifest   Manifest
-	size       int64
-	aesGcm     ocrypto.AesGcm
-	payloadKey [kKeySize]byte
+	manifest Manifest
+	size     int64
 }
 
 type countingWriter struct {
@@ -162,8 +158,12 @@ func uuidSplitIDGenerator() string {
 	return uuid.New().String()
 }
 
-// CreateTDFContext reads plain text from the given reader and saves it to the writer, subject to the given options
-func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.ReadSeeker, opts ...TDFOption) (*TDFObject, error) { //nolint:funlen, gocognit, lll // Better readability keeping it as is
+// CreateTDFContext reads plain text from the given reader and saves it to the writer, subject to the given options.
+//
+// The payload is encrypted one segment at a time through a ChunkedWriter; segments are
+// emitted in order as they are read, so peak memory stays at one segment regardless of
+// input size.
+func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.ReadSeeker, opts ...TDFOption) (*TDFObject, error) {
 	inputSize, err := reader.Seek(0, io.SeekEnd)
 	if err != nil {
 		return nil, fmt.Errorf("readSeeker.Seek failed: %w", err)
@@ -188,12 +188,6 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 		return nil, err
 	}
 
-	tdfObject := &TDFObject{}
-	err = s.prepareManifest(ctx, tdfObject, *tdfConfig)
-	if err != nil {
-		return nil, fmt.Errorf("fail to create a new split key: %w", err)
-	}
-
 	segmentSize := tdfConfig.defaultSegmentSize
 	if segmentSize > maxSegmentSize {
 		return nil, fmt.Errorf("segment size too large: %d", segmentSize)
@@ -210,159 +204,115 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 		totalSegments = 1
 	}
 
-	encryptedSegmentSize := segmentSize + gcmIvSize + aesBlockSize
-	payloadSize := inputSize + (totalSegments * (gcmIvSize + aesBlockSize))
+	chunked, err := s.newTDFChunkedWriter(ctx, tdfConfig, inputSize, int(totalSegments))
+	if err != nil {
+		return nil, err
+	}
 
+	outputWriter := &countingWriter{writer: writer}
+	readBuf := make([]byte, min(segmentSize, inputSize))
+	var readPos int64
+	for index := 0; int64(index) < totalSegments; index++ {
+		readSize := min(segmentSize, inputSize-readPos)
+		if _, err := io.ReadFull(reader, readBuf[:readSize]); err != nil {
+			return nil, fmt.Errorf("io.ReadSeeker.Read failed: %w", err)
+		}
+
+		segment, err := chunked.WriteSegment(ctx, index, readBuf[:readSize])
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := io.Copy(outputWriter, segment.TDFData); err != nil {
+			return nil, fmt.Errorf("io.writer.Write failed: %w", err)
+		}
+		readPos += readSize
+	}
+
+	finalizeOpts, err := tdfFinalizeOptions(tdfConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := chunked.Finalize(ctx, finalizeOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := outputWriter.Write(result.Data); err != nil {
+		return nil, fmt.Errorf("io.writer.Write failed: %w", err)
+	}
+
+	return &TDFObject{
+		manifest: *result.Manifest,
+		size:     outputWriter.written,
+	}, nil
+}
+
+// newTDFChunkedWriter builds the chunked writer backing SDK.CreateTDF. Key access is
+// resolved here, before any payload byte is written, so that an unreachable KAS fails
+// the call without leaving a partial TDF on the output writer.
+func (s SDK) newTDFChunkedWriter(ctx context.Context, tdfConfig *TDFConfig, inputSize int64, totalSegments int) (*chunkedWriter, error) {
+	dek := make([]byte, kKeySize)
+	if _, err := io.ReadFull(defaultRand, dek); err != nil {
+		return nil, fmt.Errorf("fail to create a new split key: %w", err)
+	}
+
+	base64Policy, kaos, err := s.resolveKeyAccess(ctx, tdfConfig, dek)
+	if err != nil {
+		return nil, fmt.Errorf("fail to create a new split key: %w", err)
+	}
+
+	// The archive is sized to the exact segment count, and only forced into ZIP64 when
+	// the payload cannot be addressed by a 32-bit offset.
+	payloadSize := inputSize + int64(totalSegments)*(gcmIvSize+aesBlockSize)
 	zipMode := zipstream.Zip64Auto
 	if payloadSize >= zip64MagicVal {
 		zipMode = zipstream.Zip64Always
 	}
 
-	expectedSegments := int(totalSegments)
-	if expectedSegments < 1 {
-		expectedSegments = 1
-	}
+	return newChunkedWriter(ChunkedWriterConfig{
+		archiveFactory: func(clock Clock) zipstream.SegmentWriter {
+			return zipstream.NewSegmentTDFWriter(totalSegments,
+				zipstream.WithZip64Mode(zipMode),
+				zipstream.WithMaxSegments(totalSegments),
+				zipstream.WithClock(clock.Now),
+			)
+		},
+		cipherFactory:             DefaultSegmentCipherFactory,
+		clock:                     SystemClock{},
+		dek:                       dek,
+		integrityAlgorithm:        tdfConfig.integrityAlgorithm,
+		keyAccess:                 staticKeyAccess{kaos: kaos, policy: base64Policy},
+		segmentIntegrityAlgorithm: tdfConfig.segmentIntegrityAlgorithm,
+		segmentSize:               tdfConfig.defaultSegmentSize,
+		useHex:                    tdfConfig.useHex,
+	})
+}
 
-	archiveWriter := zipstream.NewSegmentTDFWriter(
-		expectedSegments,
-		zipstream.WithZip64Mode(zipMode),
-		zipstream.WithMaxSegments(expectedSegments),
-	)
-
-	outputWriter := &countingWriter{writer: writer}
-
-	var readPos int64
-	var aggregateHashBuilder strings.Builder
-	readBuf := bytes.NewBuffer(make([]byte, 0, tdfConfig.defaultSegmentSize))
-	segmentIndex := 0
-	for totalSegments != 0 { // adjust read size
-		readSize := segmentSize
-		if (inputSize - readPos) < segmentSize {
-			readSize = inputSize - readPos
-		}
-
-		n, err := reader.Read(readBuf.Bytes()[:readSize])
-		if err != nil {
-			return nil, fmt.Errorf("io.ReadSeeker.Read failed: %w", err)
-		}
-
-		if int64(n) != readSize {
-			return nil, errors.New("io.ReadSeeker.Read size mismatch")
-		}
-
-		cipherData, err := tdfObject.aesGcm.Encrypt(readBuf.Bytes()[:readSize])
-		if err != nil {
-			return nil, fmt.Errorf("io.ReadSeeker.Read failed: %w", err)
-		}
-
-		crc := crc32.ChecksumIEEE(cipherData)
-		headerBytes, err := archiveWriter.WriteSegment(ctx, segmentIndex, uint64(len(cipherData)), crc)
-		if err != nil {
-			return nil, fmt.Errorf("zipstream.WriteSegment failed: %w", err)
-		}
-
-		if len(headerBytes) > 0 {
-			_, err = outputWriter.Write(headerBytes)
-			if err != nil {
-				return nil, fmt.Errorf("io.writer.Write failed: %w", err)
-			}
-		}
-
-		_, err = outputWriter.Write(cipherData)
-		if err != nil {
-			return nil, fmt.Errorf("io.writer.Write failed: %w", err)
-		}
-
-		segmentSig, err := calculateSignature(cipherData, tdfObject.payloadKey[:],
-			tdfConfig.segmentIntegrityAlgorithm, tdfConfig.useHex)
-		if err != nil {
-			return nil, fmt.Errorf("splitKey.GetSignaturefailed: %w", err)
-		}
-
-		aggregateHashBuilder.WriteString(segmentSig)
-		segmentInfo := Segment{
-			Hash:          string(ocrypto.Base64Encode([]byte(segmentSig))),
-			Size:          readSize,
-			EncryptedSize: int64(len(cipherData)),
-		}
-
-		tdfObject.manifest.Segments = append(tdfObject.manifest.Segments, segmentInfo)
-
-		totalSegments--
-		readPos += readSize
-		segmentIndex++
-	}
-
-	rootSignature, err := calculateSignature([]byte(aggregateHashBuilder.String()), tdfObject.payloadKey[:],
-		tdfConfig.integrityAlgorithm, tdfConfig.useHex)
-	if err != nil {
-		return nil, fmt.Errorf("splitKey.GetSignaturefailed: %w", err)
-	}
-
-	sig := string(ocrypto.Base64Encode([]byte(rootSignature)))
-	tdfObject.manifest.Signature = sig
-
-	tdfObject.manifest.Algorithm = integrityAlgorithmString(tdfConfig.integrityAlgorithm)
-
-	tdfObject.manifest.DefaultSegmentSize = segmentSize
-	tdfObject.manifest.DefaultEncryptedSegSize = encryptedSegmentSize
-
-	tdfObject.manifest.SegmentHashAlgorithm = integrityAlgorithmString(tdfConfig.segmentIntegrityAlgorithm)
-	tdfObject.manifest.Method.IsStreamable = true
-
-	// add payload info
-	mimeType := tdfConfig.mimeType
-	if mimeType == "" {
-		mimeType = defaultMimeType
-	}
-	tdfObject.manifest.MimeType = mimeType
-	tdfObject.manifest.Protocol = tdfAsZip
-	tdfObject.manifest.Type = tdfZipReference
-	tdfObject.manifest.URL = zipstream.TDFPayloadFileName
-	tdfObject.manifest.IsEncrypted = true
-
+// tdfFinalizeOptions maps the manifest-shaping parts of a TDFConfig onto the chunked
+// writer's Finalize options.
+func tdfFinalizeOptions(tdfConfig *TDFConfig) ([]ChunkedFinalizeOption, error) {
+	assertions := tdfConfig.assertions
 	if tdfConfig.addDefaultAssertion {
 		systemMeta, err := GetSystemMetadataAssertionConfig()
 		if err != nil {
 			return nil, err
 		}
-		tdfConfig.assertions = append(tdfConfig.assertions, systemMeta)
+		assertions = append(assertions, systemMeta)
 	}
 
-	signedAssertion, err := signAssertions(
-		[]byte(aggregateHashBuilder.String()),
-		tdfConfig.assertions,
-		tdfObject.payloadKey[:],
-		tdfConfig.useHex,
-	)
-	if err != nil {
-		return nil, err
+	opts := []ChunkedFinalizeOption{
+		WithChunkedAssertions(assertions),
+		WithChunkedEncryptedMetadata(tdfConfig.metaData),
 	}
-
-	tdfObject.manifest.Assertions = signedAssertion
-
-	manifestAsStr, err := json.Marshal(tdfObject.manifest)
-	if err != nil {
-		return nil, fmt.Errorf("json.Marshal failed:%w", err)
+	if tdfConfig.mimeType != "" {
+		opts = append(opts, WithChunkedMimeType(tdfConfig.mimeType))
 	}
-
-	finalBytes, err := archiveWriter.Finalize(ctx, manifestAsStr)
-	if err != nil {
-		return nil, fmt.Errorf("zipstream.Finalize failed: %w", err)
+	if tdfConfig.excludeVersionFromManifest {
+		opts = append(opts, WithChunkedExcludeVersion())
 	}
-
-	_, err = outputWriter.Write(finalBytes)
-	if err != nil {
-		return nil, fmt.Errorf("io.writer.Write failed: %w", err)
-	}
-
-	if err := archiveWriter.Close(); err != nil {
-		return nil, fmt.Errorf("zipstream.Close failed: %w", err)
-	}
-
-	tdfObject.size = outputWriter.written
-
-	return tdfObject, nil
+	return opts, nil
 }
 
 // initKAOTemplate initializes the KAO template, from either the split plan, kaoTemplate, or autoconfigure based on tags.
@@ -475,32 +425,29 @@ func (r *Reader) Manifest() Manifest {
 	return r.manifest
 }
 
-// prepare the manifest for TDF
-func (s SDK) prepareManifest(ctx context.Context, t *TDFObject, tdfConfig TDFConfig) error { //nolint:funlen,gocognit // Better readability keeping it as is
-	manifest := Manifest{}
-
-	if !tdfConfig.excludeVersionFromManifest {
-		manifest.TDFVersion = TDFSpecVersion
-	}
-
+// resolveKeyAccess splits dek across the config's KAO template and wraps each share to
+// the KAS servers that template names, returning the base64-encoded policy the shares
+// are bound to along with the resulting key access objects.
+func (s SDK) resolveKeyAccess(ctx context.Context, tdfConfig *TDFConfig, dek []byte) (string, []KeyAccess, error) {
 	if len(tdfConfig.kaoTemplate) == 0 {
-		return fmt.Errorf("no key access template specified or inferred in initKAOTemplate: %w", errInvalidKasInfo)
+		return "", nil, fmt.Errorf("no key access template specified or inferred in initKAOTemplate: %w", errInvalidKasInfo)
 	}
 
-	manifest.KeyAccessType = kSplitKeyType
-
-	policyObj, err := createPolicyObject(tdfConfig.attributes)
+	shares, err := s.templateSplitShares(ctx, tdfConfig, dek)
 	if err != nil {
-		return fmt.Errorf("fail to create policy object:%w", err)
+		return "", nil, err
 	}
 
-	policyObjectAsStr, err := json.Marshal(policyObj)
-	if err != nil {
-		return fmt.Errorf("json.Marshal failed:%w", err)
+	fqns := make([]string, len(tdfConfig.attributes))
+	for i, attribute := range tdfConfig.attributes {
+		fqns[i] = attribute.String()
 	}
+	return resolvePolicyAndKeyAccess(fqns, shares, tdfConfig.metaData)
+}
 
-	base64PolicyObject := ocrypto.Base64Encode(policyObjectAsStr)
-
+// templateSplitShares groups the KAO template by split ID -- fetching any public key the
+// template did not carry -- and splits dek across the resulting groups, one share each.
+func (s SDK) templateSplitShares(ctx context.Context, tdfConfig *TDFConfig, dek []byte) ([]splitShare, error) {
 	conjunction := make(map[string][]KASInfo)
 	var splitIDs []string
 
@@ -519,88 +466,33 @@ func (s SDK) prepareManifest(ctx context.Context, t *TDFObject, tdfConfig TDFCon
 			}
 			k, err := s.getPublicKey(ctx, tpl.KAS, a, tpl.kid)
 			if err != nil {
-				return fmt.Errorf("unable to retrieve public key from KAS at [%s]: %w", tpl.KAS, err)
+				return nil, fmt.Errorf("unable to retrieve public key from KAS at [%s]: %w", tpl.KAS, err)
 			}
 			ki = *k
 		}
-		if _, ok := conjunction[tpl.SplitID]; ok {
-			conjunction[tpl.SplitID] = append(conjunction[tpl.SplitID], ki)
-		} else {
-			conjunction[tpl.SplitID] = []KASInfo{ki}
+		if _, ok := conjunction[tpl.SplitID]; !ok {
 			splitIDs = append(splitIDs, tpl.SplitID)
 		}
+		conjunction[tpl.SplitID] = append(conjunction[tpl.SplitID], ki)
 	}
 
-	symKeys := make([][]byte, 0, len(splitIDs))
-	for _, splitID := range splitIDs {
-		symKey, err := ocrypto.RandomBytes(kKeySize)
-		if err != nil {
-			return fmt.Errorf("ocrypto.RandomBytes failed:%w", err)
-		}
-		symKeys = append(symKeys, symKey)
-
-		// policy binding
-		policyBinding := createPolicyBinding(symKey, base64PolicyObject)
-
-		// encrypted metadata
-		// add meta data
-		var encryptedMetadata string
-		if len(tdfConfig.metaData) > 0 {
-			encryptedMetadata, err = encryptMetadata(symKey, tdfConfig.metaData)
-			if err != nil {
-				return err
-			}
-		}
-
-		for _, kasInfo := range conjunction[splitID] {
-			if len(kasInfo.PublicKey) == 0 {
-				return fmt.Errorf("splitID:[%s], kas:[%s]: %w", splitID, kasInfo.URL, errKasPubKeyMissing)
-			}
-
-			keyAccess, err := createKeyAccess(kasInfo, symKey, policyBinding, encryptedMetadata, splitID)
-			if err != nil {
-				return err
-			}
-
-			manifest.KeyAccessObjs = append(manifest.KeyAccessObjs, keyAccess)
-		}
-	}
-
-	manifest.Policy = string(base64PolicyObject)
-	manifest.Method.Algorithm = kGCMCipherAlgorithm
-
-	// create the payload key by XOR all the keys in key access object.
-	for _, symKey := range symKeys {
-		for keyByteIndex, keyByte := range symKey {
-			t.payloadKey[keyByteIndex] ^= keyByte
-		}
-	}
-
-	gcm, err := ocrypto.NewAESGcm(t.payloadKey[:])
+	keys, err := splitDEK(dek, len(splitIDs), defaultRand)
 	if err != nil {
-		return fmt.Errorf(" ocrypto.NewAESGcm failed:%w", err)
+		return nil, err
 	}
 
-	t.manifest = manifest
-	t.aesGcm = gcm
-	return nil
-}
-
-// integrityAlgorithmString maps an IntegrityAlgorithm to its manifest
-// string form.
-func integrityAlgorithmString(a IntegrityAlgorithm) string {
-	switch a {
-	case GMAC:
-		return gmacIntegrityAlgorithm
-	default:
-		return hmacIntegrityAlgorithm
+	shares := make([]splitShare, len(splitIDs))
+	for i, splitID := range splitIDs {
+		shares[i] = splitShare{id: splitID, data: keys[i], kases: conjunction[splitID]}
 	}
+	return shares, nil
 }
 
-// createPolicyBinding produces an HMAC-SHA256 binding value keyed on the
-// symmetric key, over the base64-encoded policy object.
-func createPolicyBinding(symKey []byte, base64PolicyObject []byte) PolicyBinding {
-	policyBindingHash := hex.EncodeToString(ocrypto.CalculateSHA256Hmac(symKey, base64PolicyObject))
+// createPolicyBinding binds a key split to the policy it unlocks, keyed on the split
+// itself so that a KAS can verify the policy it is asked to enforce is the one the
+// creator bound.
+func createPolicyBinding(symKey []byte, base64Policy string) PolicyBinding {
+	policyBindingHash := hex.EncodeToString(ocrypto.CalculateSHA256Hmac(symKey, []byte(base64Policy)))
 	return PolicyBinding{
 		Alg:  hmacIntegrityAlgorithm,
 		Hash: string(ocrypto.Base64Encode([]byte(policyBindingHash))),
@@ -754,8 +646,8 @@ func generateWrapKeyWithKEM(ktype ocrypto.KeyType, publicKeyPEM string, symKey [
 	return string(ocrypto.Base64Encode(wrappedDER)), scheme, nil
 }
 
-// create policy object
-func createPolicyObject(attributes []AttributeValueFQN) (PolicyObject, error) {
+// createPolicyObjectFromFQNs builds the TDF policy document from attribute value FQNs.
+func createPolicyObjectFromFQNs(fqns []string) (PolicyObject, error) {
 	uuidObj, err := uuid.NewUUID()
 	if err != nil {
 		return PolicyObject{}, fmt.Errorf("uuid.NewUUID failed: %w", err)
@@ -764,9 +656,9 @@ func createPolicyObject(attributes []AttributeValueFQN) (PolicyObject, error) {
 	policyObj := PolicyObject{}
 	policyObj.UUID = uuidObj.String()
 
-	for _, attribute := range attributes {
+	for _, fqn := range fqns {
 		attributeObj := attributeObject{}
-		attributeObj.Attribute = attribute.String()
+		attributeObj.Attribute = fqn
 		policyObj.Body.DataAttributes = append(policyObj.Body.DataAttributes, attributeObj)
 		policyObj.Body.Dissem = make([]string, 0)
 	}

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -21,6 +21,10 @@ const (
 	ECKeySize256           = 256
 	ECKeySize384           = 384
 	ECKeySize521           = 521
+
+	// inputSizeUnknown marks a payload whose length cannot be established
+	// before it is read.
+	inputSizeUnknown = -1
 )
 
 type TDFFormat = int
@@ -63,6 +67,7 @@ type TDFOption func(*TDFConfig) error
 type TDFConfig struct {
 	autoconfigure              bool
 	defaultSegmentSize         int64
+	inputSize                  int64
 	metaData                   string
 	mimeType                   string
 	integrityAlgorithm         IntegrityAlgorithm
@@ -83,6 +88,7 @@ func newTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
 	c := &TDFConfig{
 		autoconfigure:             true,
 		defaultSegmentSize:        defaultSegmentSize,
+		inputSize:                 inputSizeUnknown,
 		integrityAlgorithm:        HS256,
 		segmentIntegrityAlgorithm: GMAC,
 		addDefaultAssertion:       false,
@@ -186,6 +192,23 @@ func WithSegmentSize(size int64) TDFOption {
 	}
 	return func(c *TDFConfig) error {
 		c.defaultSegmentSize = size
+		return nil
+	}
+}
+
+// WithInputSize declares the payload length, in bytes, for the reader passed to
+// CreateTDF. Supply it when the reader cannot report its own length — a pipe, a
+// network stream — but the length is known anyway: it lets the archive keep the
+// compact ZIP32 layout that an unmeasurable payload has to give up. When the reader
+// is seekable the length is recovered automatically and this option is unnecessary.
+//
+// Reading stops after size bytes even if the reader has more to give.
+func WithInputSize(size int64) TDFOption {
+	return func(c *TDFConfig) error {
+		if size < 0 {
+			return fmt.Errorf("WithInputSize: size must not be negative, got %d", size)
+		}
+		c.inputSize = size
 		return nil
 	}
 }

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -63,8 +63,6 @@ type TDFOption func(*TDFConfig) error
 type TDFConfig struct {
 	autoconfigure              bool
 	defaultSegmentSize         int64
-	enableEncryption           bool
-	tdfFormat                  TDFFormat
 	metaData                   string
 	mimeType                   string
 	integrityAlgorithm         IntegrityAlgorithm
@@ -85,8 +83,6 @@ func newTDFConfig(opt ...TDFOption) (*TDFConfig, error) {
 	c := &TDFConfig{
 		autoconfigure:             true,
 		defaultSegmentSize:        defaultSegmentSize,
-		enableEncryption:          true,
-		tdfFormat:                 JSONFormat,
 		integrityAlgorithm:        HS256,
 		segmentIntegrityAlgorithm: GMAC,
 		addDefaultAssertion:       false,

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
@@ -699,6 +700,132 @@ func (s *TDFSuite) Test_SimpleTDF() {
 				_ = os.Remove(tdfFilename)
 			},
 		)
+	}
+}
+
+// nonSeekableReader hides the Seek method of the reader it wraps, standing in for a
+// pipe or network stream whose length cannot be measured before it is read.
+type nonSeekableReader struct{ inner io.Reader }
+
+func (r nonSeekableReader) Read(p []byte) (int, error) { return r.inner.Read(p) }
+
+// payloadUsesZip64 reports whether the local file header at the start of a TDF carries
+// the ZIP64 extended information extra field.
+func payloadUsesZip64(tdf []byte) bool {
+	const extraFieldLengthOffset = 28
+	return binary.LittleEndian.Uint16(tdf[extraFieldLengthOffset:]) > 0
+}
+
+func (s *TDFSuite) Test_CreateTDF_StreamingInput() {
+	segmentSize := int64(minSegmentSize)
+
+	for _, test := range []struct {
+		name             string
+		plainText        []byte
+		seekable         bool
+		declareSize      bool
+		expectZip64      bool
+		expectedSegments int
+	}{
+		{name: "seekable", plainText: []byte("Virtru"), seekable: true, expectedSegments: 1},
+		{name: "seekable-empty", seekable: true, expectedSegments: 1},
+		{name: "seekable-partial-final-segment", plainText: bytes.Repeat([]byte("a"), int(segmentSize)+1), seekable: true, expectedSegments: 2},
+		{name: "unmeasurable", plainText: []byte("Virtru"), expectZip64: true, expectedSegments: 1},
+		{name: "unmeasurable-empty", expectZip64: true, expectedSegments: 1},
+		{name: "unmeasurable-segment-multiple", plainText: bytes.Repeat([]byte("b"), int(2*segmentSize)), expectZip64: true, expectedSegments: 2},
+		{name: "unmeasurable-partial-final-segment", plainText: bytes.Repeat([]byte("c"), int(segmentSize)+1), expectZip64: true, expectedSegments: 2},
+		{name: "declared-size", plainText: []byte("Virtru"), declareSize: true, expectedSegments: 1},
+		{name: "declared-size-empty", declareSize: true, expectedSegments: 1},
+		{name: "declared-size-segment-multiple", plainText: bytes.Repeat([]byte("d"), int(2*segmentSize)), declareSize: true, expectedSegments: 2},
+	} {
+		s.Run(test.name, func() {
+			opts := []TDFOption{
+				WithKasInformation(KASInfo{URL: s.kasTestURLLookup["https://a.kas/"]}),
+				WithSegmentSize(segmentSize),
+			}
+			if test.declareSize {
+				opts = append(opts, WithInputSize(int64(len(test.plainText))))
+			}
+			var reader io.Reader = bytes.NewReader(test.plainText)
+			if !test.seekable {
+				reader = nonSeekableReader{reader}
+			}
+
+			var tdf bytes.Buffer
+			_, err := s.sdk.CreateTDF(&tdf, reader, opts...)
+			s.Require().NoError(err)
+			s.Equal(test.expectZip64, payloadUsesZip64(tdf.Bytes()))
+
+			r, err := s.sdk.LoadTDF(bytes.NewReader(tdf.Bytes()),
+				WithKasAllowlist([]string{s.kasTestURLLookup["https://a.kas/"]}))
+			s.Require().NoError(err)
+			s.Len(r.Manifest().Segments, test.expectedSegments)
+
+			var decrypted bytes.Buffer
+			_, err = r.WriteTo(&decrypted)
+			s.Require().NoError(err)
+			s.Equal(string(test.plainText), decrypted.String())
+		})
+	}
+}
+
+func (s *TDFSuite) Test_CreateTDF_InputSizeBounds() {
+	opts := []TDFOption{WithKasInformation(KASInfo{URL: s.kasTestURLLookup["https://a.kas/"]})}
+	readOpts := []TDFReaderOption{WithKasAllowlist([]string{s.kasTestURLLookup["https://a.kas/"]})}
+
+	s.Run("negative size is rejected", func() {
+		_, err := s.sdk.CreateTDF(&bytes.Buffer{}, bytes.NewReader([]byte("Virtru")),
+			append(opts, WithInputSize(-1))...)
+		s.Require().ErrorContains(err, "WithInputSize")
+	})
+
+	s.Run("declared size bounds the read", func() {
+		var tdf bytes.Buffer
+		reader := nonSeekableReader{bytes.NewReader([]byte("Virtru and more"))}
+		_, err := s.sdk.CreateTDF(&tdf, reader, append(opts, WithInputSize(6))...)
+		s.Require().NoError(err)
+
+		r, err := s.sdk.LoadTDF(bytes.NewReader(tdf.Bytes()), readOpts...)
+		s.Require().NoError(err)
+		var decrypted bytes.Buffer
+		_, err = r.WriteTo(&decrypted)
+		s.Require().NoError(err)
+		s.Equal("Virtru", decrypted.String())
+	})
+
+	s.Run("a seekable reader is encrypted from its current position", func() {
+		source := bytes.NewReader([]byte("skip-Virtru"))
+		_, err := source.Seek(int64(len("skip-")), io.SeekStart)
+		s.Require().NoError(err)
+
+		var tdf bytes.Buffer
+		_, err = s.sdk.CreateTDF(&tdf, source, opts...)
+		s.Require().NoError(err)
+
+		r, err := s.sdk.LoadTDF(bytes.NewReader(tdf.Bytes()), readOpts...)
+		s.Require().NoError(err)
+		var decrypted bytes.Buffer
+		_, err = r.WriteTo(&decrypted)
+		s.Require().NoError(err)
+		s.Equal("Virtru", decrypted.String())
+	})
+}
+
+func Test_SegmentCount(t *testing.T) {
+	const segmentSize = 1024
+	for _, test := range []struct {
+		inputSize int64
+		expected  int
+	}{
+		{inputSize: inputSizeUnknown, expected: 0},
+		{inputSize: 0, expected: 1},
+		{inputSize: 1, expected: 1},
+		{inputSize: segmentSize, expected: 1},
+		{inputSize: segmentSize + 1, expected: 2},
+		{inputSize: 3 * segmentSize, expected: 3},
+	} {
+		assert.Equal(t, test.expected, segmentCount(test.inputSize, segmentSize),
+			"segmentCount(%d, %d)", test.inputSize, segmentSize)
 	}
 }
 

--- a/sdk/tdferrors.go
+++ b/sdk/tdferrors.go
@@ -6,7 +6,6 @@ import (
 )
 
 var (
-	errFileTooLarge     = errors.New("tdf: can't create tdf larger than 64gb")
 	errWriteFailed      = errors.New("tdf: io.writer fail to write all bytes")
 	errInvalidKasInfo   = errors.New("tdf: kas information is missing")
 	errKasPubKeyMissing = errors.New("tdf: kas public key is missing")


### PR DESCRIPTION
Stacked on #3782 — base is `feat/DSPX-2604`, so review that one first.

### Proposed Changes

`CreateTDFContext` now delegates payload encryption, archive framing, and manifest assembly to the `ChunkedWriter` introduced in #3782, instead of carrying its own copy of that logic.

To make one implementation serve both entry points, the chunked path picks up the features it was missing, and both paths now share the same key-access code:

* New `keyAccessResolver` seam with two implementations. `staticKeyAccess`, used by `CreateTDF`, resolves the policy and key access objects *before* any payload byte reaches the caller's writer, so an unreachable KAS still fails the call without leaving a partial TDF. `splitterKeyAccess` defers to a `KeySplitter` at `Finalize` time.
* `resolvePolicyAndKeyAccess` and `buildKeyAccessObjects` are now the single place a DEK share becomes a policy-bound KAO. This fixes an interop bug in the chunked path, which emitted `eccWrapped` KAOs (HKDF + XOR, no `schemaVersion`) that no KAS can unwrap; it now emits spec-compliant `ec-wrapped` via `createKeyAccess`. A splitter naming a KAS URL absent from `KASPublicKeys` used to be silently skipped, and now errors.
* `ChunkedWriter` gained assertions (`ErrChunkedAssertionsUnsupported` is gone), legacy hex signatures, explicit `DefaultSegmentSize`/`DefaultEncryptedSegSize` reporting, and encrypted metadata.

Dead code removed: `prepareManifest`, `buildChunkedKeyAccessObjects`, `buildChunkedPolicy`, `chunkedCreatePolicyBinding`, `chunkedEncryptMetadata`, `chunkedWrapKeyWith{EC,KEM,RSA,PublicKey}`, `createPolicyObject`, and four unused `TDFObject` fields. `CreateTDFContext` loses its `//nolint:funlen,gocognit` and is now ~85 lines across three focused functions.

Two pre-existing dead items in the same files went with it: the unreferenced `readActionName` constant, and the write-only `TDFConfig` fields `enableEncryption` and `tdfFormat`. That leaves the exported `TDFFormat` / `JSONFormat` / `XMLFormat` enum with no readers anywhere in the repo — deliberately kept here, since removing exported identifiers would break downstream builds. Worth deprecating separately.

### Performance

Payload output is unchanged. Per segment, the hot path now:

* drops one full-segment allocation and copy — `joinSealed` detects that `ocrypto.AesGcm.EncryptInPlace` returns two views of the single buffer `Seal` allocated and reslices instead. On a 1 GiB payload at 2 MiB segments that is ~512 allocations and ~1 GiB of memcpy removed.
* computes the CRC in one `crc32.ChecksumIEEE` call over the contiguous buffer, rather than two writes into a streaming CRC writer.

The read buffer is sized to `min(segmentSize, inputSize)`, so a small TDF no longer allocates 2 MiB, and `io.ReadFull` replaces a read plus size check so short reads from a non-file `io.ReadSeeker` no longer fail the call.

Costs are small: three extra interface dispatches per segment, and `io.Copy` over an `io.MultiReader` instead of two direct writes — on Go 1.25 both `multiReader` and `bytes.Reader` implement `WriterTo`, so no staging buffer is allocated. The writer holds segments in a map and sorts the keys at `Finalize` (out-of-order writes being the point of `ChunkedWriter`), which is ~34k entries and one `O(n log n)` sort at the 68 GiB `maxFileSizeSupported`.

### Risk

One implementation now serves both entry points, so a `ChunkedWriter` regression breaks `CreateTDF`. The existing `TDFSuite` round-trip matrix — EC/RSA/KEM wrapping, split plans, assertions, legacy hex, output size within 4% — passes unchanged, and is what pins byte-level output. One quirk is preserved deliberately to keep policy JSON byte-identical: in `createPolicyObjectFromFQNs`, `Body.Dissem` is still only initialized inside the attribute loop.

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

```
cd sdk && golangci-lint run          # 11 issues, all pre-existing, none in touched files
cd sdk && go test ./... -race        # all ok
```

`TestChunkedFinalizeRejectsAssertions` is replaced by `TestChunkedAssertions`, which finalizes with an assertion and round-trips through `LoadTDF` so the signature is actually verified.

Also builds and tests clean in `service`, `examples`, `otdfctl`, and `tests-bdd`. `service/pkg/server` fails locally on `listen tcp :8080: bind: address already in use`, an environmental port conflict unrelated to this change.
