### PR TITLE
feat(authz): wrap streaming/bidi handlers in Connect authN/authz interceptors

### DIFF
--- a/adr/decisions/2026-01-02-authz-fine-grain-resource-support.md
+++ b/adr/decisions/2026-01-02-authz-fine-grain-resource-support.md
@@ -3,7 +3,7 @@
 **Status:** Proposed (active implementation)
 **Authors:** Platform Team
 **Created:** 2024-12-30
-**Last Updated:** 2026-03-05
+**Last Updated:** 2026-08-12
 **Record Date:** 2026-01-02 (ADR filename/index date)
 
 ## Problem Statement
@@ -327,6 +327,8 @@ The authorization interceptor orchestrates the authorization flow as a ConnectRP
 ```
 
 This flow describes **v2 mode**. In **v1 mode**, authorization uses the legacy path+action model and does not invoke resource resolvers.
+
+For **streaming and bidi RPCs**, the interceptor authenticates and authorizes once at stream establishment, before the handler runs. No request message is available at that point, so step 2 (resolver invocation) is skipped and enforcement uses wildcard dimensions (`*`). Streaming authorization is therefore procedure-level only, and dimension-scoped v2 policy fails closed for streams — a stream is authorized only by a wildcard-dimension rule. This mirrors the raw-HTTP `MuxHandler` path.
 
 **Key behaviors:**
 - No resolver registered = empty dimensions serialized as `*` (matches wildcard policies)

--- a/service/internal/auth/README.md
+++ b/service/internal/auth/README.md
@@ -77,6 +77,20 @@ The table lists production resolver coverage in this workspace. The v2 authorize
 | `/policy.kasregistry.KeyAccessServerRegistryService/ListKeys` | `kas_uri` |
 | All other RPCs | none (`*`) |
 
+### Streaming and Bidi RPCs
+
+The Connect authN and authz interceptors cover unary, streaming, and bidi RPCs. A
+streaming RPC is authenticated and authorized once, at stream establishment, before the
+handler runs.
+
+Because no request message is available at establishment, resource-dimension resolvers
+cannot run for streams. Streaming authorization is therefore **procedure-level only**: the
+enforcement request always uses wildcard dimensions (`*`). As a result, a dimension-scoped
+v2 policy row (one that requires a concrete dimension such as `kas_uri=...`) never matches
+a stream, so dimension-scoped policy **fails closed** for streaming RPCs. To authorize a
+stream, grant it with a wildcard-dimension rule. This mirrors the raw-HTTP `MuxHandler`
+path, which is likewise procedure-level.
+
 ### KAS URI Policy Encoding
 
 When writing `kas_uri` dimension values in v2 Casbin policy, encode only the characters that conflict with dimension parsing:

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -633,178 +633,137 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 	})
 }
 
-// ConnectAuthNInterceptor authenticates Connect requests and enriches the
-// request context with configured token claims needed by later middleware.
-func (a Authentication) ConnectAuthNInterceptor() connect.UnaryInterceptorFunc {
-	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
-		return connect.UnaryFunc(func(
-			ctx context.Context,
-			req connect.AnyRequest,
-		) (connect.AnyResponse, error) {
-			publicRoute := slices.ContainsFunc(a.publicRoutes, a.isPublicRoute(req.Spec().Procedure)) //nolint:contextcheck // There is no way to pass a context here
-			ctx = ctxAuth.ContextWithPublicRoute(ctx, publicRoute)
-			if publicRoute {
-				return next(ctx, req)
-			}
-
-			log := a.logger
-
-			procedure := req.Spec().Procedure
-			host := req.Header().Get("Host")
-			// Build the acceptable htu values with the same normalization the SDK
-			// applies when signing its proof (lowercased host, default ports
-			// stripped) so the exact-string htu comparison in matchHTU succeeds.
-			// Both schemes are offered because the interceptor cannot observe the
-			// wire scheme here.
-			ri := receiverInfo{
-				u: []string{
-					originFromHost(host, false) + procedure,
-					originFromHost(host, true) + procedure,
-				},
-				m: []string{req.HTTPMethod()},
-			}
-			log.DebugContext(
-				ctx, "dpop receiverInfo set (connect interceptor)",
-				slog.Any("expected_htm", ri.m),
-				slog.Any("expected_htu", ri.u),
-				slog.String("procedure", procedure),
-				slog.String("connect_http_method", req.HTTPMethod()),
-			)
-
-			header := req.Header()["Authorization"]
-			if len(header) < 1 {
-				return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("missing authorization header"))
-			}
-
-			token, ctxWithJWK, err := a.checkToken(
-				ctx,
-				header,
-				ri,
-				req.Header()["Dpop"],
-			)
-			if err != nil {
-				// Check if this is a nonce error requiring a challenge
-				var nonceErr *DPoPNonceError
-				if errors.As(err, &nonceErr) {
-					nonce := a.dpopNonceManager.getCurrentNonce()
-					connectErr := connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
-					connectErr.Meta().Set("DPoP-Nonce", nonce)
-					connectErr.Meta().Set("WWW-Authenticate", `DPoP error="use_dpop_nonce"`)
-					return nil, connectErr
-				}
-				// Other DPoP proof failures get an invalid_dpop_proof challenge (RFC 9449 §7.1).
-				var proofErr *DPoPProofError
-				if errors.As(err, &proofErr) {
-					connectErr := connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
-					if a.dpopNonceManager.requireNonce {
-						connectErr.Meta().Set("DPoP-Nonce", a.dpopNonceManager.getCurrentNonce())
-					}
-					connectErr.Meta().Set("WWW-Authenticate", `DPoP error="invalid_dpop_proof"`)
-					return nil, connectErr
-				}
-				return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
-			}
-
-			// Always send fresh nonce in successful responses when nonces are enabled.
-			// Wrap next so the DPoP-Nonce header is set on the response, not the outgoing client context.
-			if a.dpopNonceManager.requireNonce {
-				originalNext := next
-				next = func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-					res, err := originalNext(ctx, req)
-					if err != nil {
-						var connectErr *connect.Error
-						if errors.As(err, &connectErr) {
-							connectErr.Meta().Set("DPoP-Nonce", a.dpopNonceManager.getCurrentNonce())
-						}
-						return nil, err
-					}
-					res.Header().Set("DPoP-Nonce", a.dpopNonceManager.getCurrentNonce())
-					return res, nil
-				}
-			}
-
-			clientID, err := a.subjectExtractor.ClientIDFromToken(ctxWithJWK, token)
-			if err != nil {
-				log.WarnContext(
-					ctxWithJWK,
-					"could not determine client ID from token",
-					slog.Any("err", err),
-				)
-			} else {
-				log = log.
-					With("client_id", clientID).
-					With("configured_client_id_claim_name", a.oidcConfiguration.Policy.ClientIDClaim)
-				ctxWithJWK = ctxAuth.EnrichIncomingContextMetadataWithAuthn(ctxWithJWK, log, clientID)
-				ctxWithJWK = authz.ContextWithClientID(ctxWithJWK, clientID)
-			}
-
-			roleReq, err := roleRequestForConnectProcedure(a.oidcConfiguration.Issuer, req.Spec().Procedure)
-			if err != nil {
-				return nil, connect.NewError(connect.CodeInvalidArgument, err)
-			}
-			ctxWithJWK, err = a.subjectExtractor.ContextWithClaims(ctxWithJWK, token, roleReq)
-			if err != nil {
-				log.WarnContext(ctxWithJWK, "role provider error", slog.Any("error", err))
-				return nil, connect.NewError(connect.CodeInternal, errors.New("role provider error"))
-			}
-			return next(ctxWithJWK, req)
-		})
-	}
-	return connect.UnaryInterceptorFunc(interceptor)
+// connectInterceptor adapts unary and streaming-handler wrap functions into a
+// connect.Interceptor so the same authN/authz applies to unary and
+// streaming/bidi RPCs. Streaming client calls pass through unchanged because
+// these are server-side interceptors.
+type connectInterceptor struct {
+	unary  func(connect.UnaryFunc) connect.UnaryFunc
+	stream func(connect.StreamingHandlerFunc) connect.StreamingHandlerFunc
 }
 
-// ConnectAuthZInterceptor authorizes Connect requests using token and
-// configured claims already stored in the request context.
-func (a Authentication) ConnectAuthZInterceptor() connect.UnaryInterceptorFunc {
-	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
-		return connect.UnaryFunc(func(
-			ctx context.Context,
-			req connect.AnyRequest,
-		) (connect.AnyResponse, error) {
-			if publicRoute, ok := ctxAuth.PublicRouteFromContext(ctx); ok && publicRoute {
+func (i connectInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return i.unary(next)
+}
+
+func (i connectInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+func (i connectInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return i.stream(next)
+}
+
+// ConnectAuthNInterceptor authenticates Connect requests and enriches the
+// request context with configured token claims needed by later middleware. It
+// covers unary, streaming, and bidi RPCs; streaming RPCs are authenticated once
+// at stream establishment.
+func (a Authentication) ConnectAuthNInterceptor() connect.Interceptor {
+	return connectInterceptor{
+		unary: func(next connect.UnaryFunc) connect.UnaryFunc {
+			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+				ctx, cerr := a.authenticateConnect(ctx, req.Spec().Procedure, req.HTTPMethod(), req.Header())
+				if cerr != nil {
+					return nil, cerr
+				}
+
+				// Always send a fresh nonce in successful responses when nonces are enabled.
+				// Wrap next so the DPoP-Nonce header is set on the response, not the outgoing client context.
+				if publicRoute, _ := ctxAuth.PublicRouteFromContext(ctx); !publicRoute && a.dpopNonceManager.requireNonce {
+					originalNext := next
+					next = func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+						res, err := originalNext(ctx, req)
+						if err != nil {
+							var connectErr *connect.Error
+							if errors.As(err, &connectErr) {
+								connectErr.Meta().Set("DPoP-Nonce", a.dpopNonceManager.getCurrentNonce())
+							}
+							return nil, err
+						}
+						res.Header().Set("DPoP-Nonce", a.dpopNonceManager.getCurrentNonce())
+						return res, nil
+					}
+				}
 				return next(ctx, req)
 			}
-
-			token := ctxAuth.GetAccessTokenFromContext(ctx, a.logger)
-			if token == nil {
-				return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("missing access token in context"))
+		},
+		stream: func(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+			return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+				// Streaming RPCs are always POST and expose no HTTPMethod on the conn.
+				ctx, cerr := a.authenticateConnect(ctx, conn.Spec().Procedure, http.MethodPost, conn.RequestHeader())
+				if cerr != nil {
+					return cerr
+				}
+				if publicRoute, _ := ctxAuth.PublicRouteFromContext(ctx); !publicRoute && a.dpopNonceManager.requireNonce {
+					conn.ResponseHeader().Set("DPoP-Nonce", a.dpopNonceManager.getCurrentNonce())
+				}
+				return next(ctx, conn)
 			}
-
-			roleReq, err := roleRequestForConnectProcedure(a.oidcConfiguration.Issuer, req.Spec().Procedure)
-			if err != nil {
-				return nil, connect.NewError(connect.CodeInvalidArgument, err)
-			}
-
-			log := a.logger
-			result := a.authorize(ctx, log, token, req, roleReq.Action)
-			if result.err != nil {
-				return nil, connect.NewError(result.errCode, result.err)
-			}
-
-			decision := result.decision
-			if !decision.Allowed {
-				log.WarnContext(
-					ctx, "permission denied",
-					permissionDeniedDecisionLogAttrs(token, decision, nil)...,
-				)
-				return nil, connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
-			}
-
-			log.DebugContext(
-				ctx, "authorization granted",
-				slog.String("mode", string(decision.Mode)),
-				slog.String("reason", decision.Reason),
-			)
-
-			handlerCtx := ctx
-			if result.resourceContext != nil {
-				handlerCtx = internalauthz.ContextWithResolverContext(handlerCtx, result.resourceContext)
-			}
-
-			return next(handlerCtx, req)
-		})
+		},
 	}
-	return connect.UnaryInterceptorFunc(interceptor)
+}
+
+// ConnectAuthZInterceptor authorizes Connect requests using the token and
+// configured claims already stored in the request context. It covers unary,
+// streaming, and bidi RPCs; streaming RPCs are authorized once at stream
+// establishment.
+//
+// Streaming RPCs have no request message available at establishment, so
+// resource-dimension resolvers cannot run and authorization is procedure-level
+// only. Dimension-scoped v2 policy therefore fails closed for streams unless the
+// policy explicitly allows wildcard dimensions, mirroring the raw-HTTP MuxHandler.
+func (a Authentication) ConnectAuthZInterceptor() connect.Interceptor {
+	return connectInterceptor{
+		unary: func(next connect.UnaryFunc) connect.UnaryFunc {
+			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+				if publicRoute, ok := ctxAuth.PublicRouteFromContext(ctx); ok && publicRoute {
+					return next(ctx, req)
+				}
+
+				token := ctxAuth.GetAccessTokenFromContext(ctx, a.logger)
+				if token == nil {
+					return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("missing access token in context"))
+				}
+
+				roleReq, err := roleRequestForConnectProcedure(a.oidcConfiguration.Issuer, req.Spec().Procedure)
+				if err != nil {
+					return nil, connect.NewError(connect.CodeInvalidArgument, err)
+				}
+
+				log := a.logger
+				handlerCtx, cerr := a.finalizeAuthzDecision(ctx, log, token, a.authorize(ctx, log, token, req, roleReq.Action))
+				if cerr != nil {
+					return nil, cerr
+				}
+				return next(handlerCtx, req)
+			}
+		},
+		stream: func(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+			return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+				if publicRoute, ok := ctxAuth.PublicRouteFromContext(ctx); ok && publicRoute {
+					return next(ctx, conn)
+				}
+
+				token := ctxAuth.GetAccessTokenFromContext(ctx, a.logger)
+				if token == nil {
+					return connect.NewError(connect.CodeUnauthenticated, errors.New("missing access token in context"))
+				}
+
+				procedure := conn.Spec().Procedure
+				roleReq, err := roleRequestForConnectProcedure(a.oidcConfiguration.Issuer, procedure)
+				if err != nil {
+					return connect.NewError(connect.CodeInvalidArgument, err)
+				}
+
+				log := a.logger
+				handlerCtx, cerr := a.finalizeAuthzDecision(ctx, log, token, a.authorizeProcedure(ctx, log, token, procedure, roleReq.Action))
+				if cerr != nil {
+					return cerr
+				}
+				return next(handlerCtx, conn)
+			}
+		},
+	}
 }
 
 func permissionDeniedDecisionLogAttrs(token jwt.Token, decision *internalauthz.Decision, err error) []any {
@@ -973,6 +932,135 @@ type authzResult struct {
 	errCode         connect.Code
 }
 
+// authenticateConnect performs JWT/DPoP authentication for a Connect request
+// given its procedure and headers, returning a context enriched with the
+// configured token claims needed by later middleware. httpMethod is
+// http.MethodPost for streaming RPCs, which have no other method. On failure it
+// returns a *connect.Error carrying any DPoP nonce/proof challenge metadata.
+//
+// Public routes short-circuit: the returned context records the public-route
+// flag (retrievable via ctxAuth.PublicRouteFromContext) and no token is required.
+func (a Authentication) authenticateConnect(ctx context.Context, procedure, httpMethod string, header http.Header) (context.Context, *connect.Error) {
+	publicRoute := slices.ContainsFunc(a.publicRoutes, a.isPublicRoute(procedure))
+	ctx = ctxAuth.ContextWithPublicRoute(ctx, publicRoute)
+	if publicRoute {
+		return ctx, nil
+	}
+
+	log := a.logger
+
+	host := header.Get("Host")
+	// Build the acceptable htu values with the same normalization the SDK
+	// applies when signing its proof (lowercased host, default ports
+	// stripped) so the exact-string htu comparison in matchHTU succeeds.
+	// Both schemes are offered because the interceptor cannot observe the
+	// wire scheme here.
+	ri := receiverInfo{
+		u: []string{
+			originFromHost(host, false) + procedure,
+			originFromHost(host, true) + procedure,
+		},
+		m: []string{httpMethod},
+	}
+	log.DebugContext(
+		ctx, "dpop receiverInfo set (connect interceptor)",
+		slog.Any("expected_htm", ri.m),
+		slog.Any("expected_htu", ri.u),
+		slog.String("procedure", procedure),
+		slog.String("connect_http_method", httpMethod),
+	)
+
+	authHeader := header["Authorization"]
+	if len(authHeader) < 1 {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("missing authorization header"))
+	}
+
+	token, ctxWithJWK, err := a.checkToken(
+		ctx,
+		authHeader,
+		ri,
+		header["Dpop"],
+	)
+	if err != nil {
+		// Check if this is a nonce error requiring a challenge
+		var nonceErr *DPoPNonceError
+		if errors.As(err, &nonceErr) {
+			nonce := a.dpopNonceManager.getCurrentNonce()
+			connectErr := connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
+			connectErr.Meta().Set("DPoP-Nonce", nonce)
+			connectErr.Meta().Set("WWW-Authenticate", `DPoP error="use_dpop_nonce"`)
+			return nil, connectErr
+		}
+		// Other DPoP proof failures get an invalid_dpop_proof challenge (RFC 9449 §7.1).
+		var proofErr *DPoPProofError
+		if errors.As(err, &proofErr) {
+			connectErr := connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
+			if a.dpopNonceManager.requireNonce {
+				connectErr.Meta().Set("DPoP-Nonce", a.dpopNonceManager.getCurrentNonce())
+			}
+			connectErr.Meta().Set("WWW-Authenticate", `DPoP error="invalid_dpop_proof"`)
+			return nil, connectErr
+		}
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
+	}
+
+	clientID, err := a.subjectExtractor.ClientIDFromToken(ctxWithJWK, token)
+	if err != nil {
+		log.WarnContext(
+			ctxWithJWK,
+			"could not determine client ID from token",
+			slog.Any("err", err),
+		)
+	} else {
+		log = log.
+			With("client_id", clientID).
+			With("configured_client_id_claim_name", a.oidcConfiguration.Policy.ClientIDClaim)
+		ctxWithJWK = ctxAuth.EnrichIncomingContextMetadataWithAuthn(ctxWithJWK, log, clientID)
+		ctxWithJWK = authz.ContextWithClientID(ctxWithJWK, clientID)
+	}
+
+	roleReq, err := roleRequestForConnectProcedure(a.oidcConfiguration.Issuer, procedure)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	ctxWithJWK, err = a.subjectExtractor.ContextWithClaims(ctxWithJWK, token, roleReq)
+	if err != nil {
+		log.WarnContext(ctxWithJWK, "role provider error", slog.Any("error", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.New("role provider error"))
+	}
+	return ctxWithJWK, nil
+}
+
+// finalizeAuthzDecision inspects an authorization result and returns the context
+// to pass to the handler, or a *connect.Error when the check failed or access is
+// denied. On success it attaches any resolved resource context so the handler can
+// reuse it.
+func (a Authentication) finalizeAuthzDecision(ctx context.Context, log *logger.Logger, token jwt.Token, result authzResult) (context.Context, *connect.Error) {
+	if result.err != nil {
+		return nil, connect.NewError(result.errCode, result.err)
+	}
+
+	decision := result.decision
+	if !decision.Allowed {
+		log.WarnContext(
+			ctx, "permission denied",
+			permissionDeniedDecisionLogAttrs(token, decision, nil)...,
+		)
+		return nil, connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+	}
+
+	log.DebugContext(
+		ctx, "authorization granted",
+		slog.String("mode", string(decision.Mode)),
+		slog.String("reason", decision.Reason),
+	)
+
+	if result.resourceContext != nil {
+		ctx = internalauthz.ContextWithResolverContext(ctx, result.resourceContext)
+	}
+	return ctx, nil
+}
+
 // resolveResourceContext attempts to resolve authorization dimensions using a registered resolver.
 // Returns errNoResourceContext if no resolver is registered or if resolvers are not supported.
 func (a *Authentication) resolveResourceContext(
@@ -1003,7 +1091,7 @@ func (a *Authentication) resolveResourceContext(
 	return &resolvedCtx, nil
 }
 
-// authorize performs the full authorization check for a request.
+// authorize performs the full authorization check for a unary request.
 // It builds the authorization request, resolves resource context if applicable,
 // and returns the authorization decision.
 func (a *Authentication) authorize(
@@ -1042,13 +1130,48 @@ func (a *Authentication) authorize(
 		authzReq.ResourceContext = resourceCtx
 	}
 
-	// Perform authorization check
+	result := a.decide(ctx, log, authzReq)
+	if result.err == nil {
+		result.resourceContext = resourceCtx // Pass resolved data to handler for cache reuse
+	}
+	return result
+}
+
+// authorizeProcedure performs procedure-level authorization without resolving
+// resource dimensions. It is used where no request message is available (e.g.
+// streaming RPCs at stream establishment), so dimension-scoped v2 policy fails
+// closed unless the policy explicitly allows wildcard dimensions.
+func (a *Authentication) authorizeProcedure(
+	ctx context.Context,
+	log *logger.Logger,
+	token jwt.Token,
+	procedure, action string,
+) authzResult {
+	// Defensive check: authorizer must be initialized
+	if a.authorizer == nil {
+		log.ErrorContext(ctx, "authorizer not initialized")
+		return authzResult{
+			err:     errors.New("authorization system not configured"),
+			errCode: connect.CodeInternal,
+		}
+	}
+
+	return a.decide(ctx, log, &internalauthz.Request{
+		Token:  token,
+		RPC:    procedure,
+		Action: action,
+	})
+}
+
+// decide runs the authorizer for the given request and normalizes its output
+// (transport errors and nil decisions) into an authzResult.
+func (a *Authentication) decide(ctx context.Context, log *logger.Logger, authzReq *internalauthz.Request) authzResult {
 	decision, authzErr := a.authorizer.Authorize(ctx, authzReq)
 	if authzErr != nil {
 		log.ErrorContext(
 			ctx, "authorization error",
 			slog.Any("error", authzErr),
-			slog.String("procedure", req.Spec().Procedure),
+			slog.String("procedure", authzReq.RPC),
 		)
 		return authzResult{
 			err:     errors.New("authorization system error"),
@@ -1059,7 +1182,7 @@ func (a *Authentication) authorize(
 		log.ErrorContext(
 			ctx, "authorization error",
 			slog.String("error", "authorizer returned nil decision"),
-			slog.String("procedure", req.Spec().Procedure),
+			slog.String("procedure", authzReq.RPC),
 		)
 		return authzResult{
 			err:     errors.New("authorization system error"),
@@ -1067,10 +1190,7 @@ func (a *Authentication) authorize(
 		}
 	}
 
-	return authzResult{
-		decision:        decision,
-		resourceContext: resourceCtx, // Pass resolved data to handler for cache reuse
-	}
+	return authzResult{decision: decision}
 }
 
 // getAction returns the action based on the rpc name

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -637,6 +637,9 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 // connect.Interceptor so the same authN/authz applies to unary and
 // streaming/bidi RPCs. Streaming client calls pass through unchanged because
 // these are server-side interceptors.
+//
+// See the Connect protocol for the stream/handler distinction:
+// https://connectrpc.com/docs/protocol/
 type connectInterceptor struct {
 	unary  func(connect.UnaryFunc) connect.UnaryFunc
 	stream func(connect.StreamingHandlerFunc) connect.StreamingHandlerFunc

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -727,7 +727,7 @@ func (s *AuthSuite) Test_ConnectAuthNInterceptor_RoleProviderErrorReturnsInterna
 		procedure: "/kas.AccessService/Rewrap",
 	}
 	req.Header().Set("Authorization", "Bearer "+string(signedTok))
-	_, err = interceptor(next)(s.T().Context(), req)
+	_, err = interceptor.WrapUnary(next)(s.T().Context(), req)
 	s.Require().Error(err)
 	s.Equal(connect.CodeInternal, connect.CodeOf(err))
 	s.False(called)
@@ -756,6 +756,127 @@ func (r *authnTestRequest) HTTPMethod() string {
 		return http.MethodPost
 	}
 	return r.httpMethod
+}
+
+// fakeStreamingHandlerConn is a minimal connect.StreamingHandlerConn used to
+// drive the streaming auth interceptors without a live stream.
+type fakeStreamingHandlerConn struct {
+	spec        connect.Spec
+	reqHeader   http.Header
+	respHeader  http.Header
+	respTrailer http.Header
+}
+
+func newFakeStreamingHandlerConn(procedure string) *fakeStreamingHandlerConn {
+	return &fakeStreamingHandlerConn{
+		spec:        connect.Spec{Procedure: procedure, StreamType: connect.StreamTypeBidi},
+		reqHeader:   http.Header{},
+		respHeader:  http.Header{},
+		respTrailer: http.Header{},
+	}
+}
+
+func (c *fakeStreamingHandlerConn) Spec() connect.Spec           { return c.spec }
+func (c *fakeStreamingHandlerConn) Peer() connect.Peer           { return connect.Peer{} }
+func (c *fakeStreamingHandlerConn) Receive(any) error            { return nil }
+func (c *fakeStreamingHandlerConn) RequestHeader() http.Header   { return c.reqHeader }
+func (c *fakeStreamingHandlerConn) Send(any) error               { return nil }
+func (c *fakeStreamingHandlerConn) ResponseHeader() http.Header  { return c.respHeader }
+func (c *fakeStreamingHandlerConn) ResponseTrailer() http.Header { return c.respTrailer }
+
+func (s *AuthSuite) Test_ConnectAuthNInterceptor_Streaming_MissingAuthHeaderExpectError() {
+	interceptor := s.auth.ConnectAuthNInterceptor()
+	called := false
+	next := func(context.Context, connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+	conn := newFakeStreamingHandlerConn("/kas.AccessService/Rewrap")
+
+	err := interceptor.WrapStreamingHandler(next)(s.T().Context(), conn)
+
+	s.Require().Error(err)
+	s.Equal(connect.CodeUnauthenticated, connect.CodeOf(err))
+	s.False(called, "handler must not run when stream authentication fails")
+}
+
+func (s *AuthSuite) Test_ConnectAuthNInterceptor_Streaming_ValidTokenEnrichesContext() {
+	tok := jwt.New()
+	s.Require().NoError(tok.Set(jwt.ExpirationKey, time.Now().Add(time.Hour)))
+	s.Require().NoError(tok.Set("iss", s.server.URL))
+	s.Require().NoError(tok.Set("aud", "test"))
+	s.Require().NoError(tok.Set("azp", "client-stream"))
+	s.Require().NoError(tok.Set("realm_access", map[string][]string{"roles": {"opentdf-standard"}}))
+
+	// Stub checkToken to bypass DPoP validation and enrich the context the way the
+	// real implementation does, so the handler can read the authenticated token.
+	s.auth._testCheckTokenFunc = func(ctx context.Context, _ []string, _ receiverInfo, _ []string) (jwt.Token, context.Context, error) {
+		return tok, ctxAuth.ContextWithAuthNInfo(ctx, nil, tok, "raw-token"), nil
+	}
+	s.T().Cleanup(func() { s.auth._testCheckTokenFunc = nil })
+
+	interceptor := s.auth.ConnectAuthNInterceptor()
+	var handlerToken jwt.Token
+	next := func(ctx context.Context, _ connect.StreamingHandlerConn) error {
+		handlerToken = ctxAuth.GetAccessTokenFromContext(ctx, s.auth.logger)
+		return nil
+	}
+	conn := newFakeStreamingHandlerConn("/kas.AccessService/Rewrap")
+	conn.RequestHeader().Set("Authorization", "DPoP token")
+
+	err := interceptor.WrapStreamingHandler(next)(s.T().Context(), conn)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(handlerToken, "authenticated token should reach the handler context")
+	s.Equal("client-stream", handlerToken.PrivateClaims()["azp"])
+}
+
+func (s *AuthSuite) Test_ConnectAuthNInterceptor_Streaming_SetsNonceHeaderWhenRequired() {
+	auth := s.newAuthDPoP(true)
+
+	tok := jwt.New()
+	s.Require().NoError(tok.Set(jwt.ExpirationKey, time.Now().Add(time.Hour)))
+	s.Require().NoError(tok.Set("iss", s.server.URL))
+	s.Require().NoError(tok.Set("aud", "test"))
+
+	// Bypass DPoP proof validation; on success the interceptor still issues a
+	// fresh nonce on the stream response for the client's next request.
+	auth._testCheckTokenFunc = func(ctx context.Context, _ []string, _ receiverInfo, _ []string) (jwt.Token, context.Context, error) {
+		return tok, ctxAuth.ContextWithAuthNInfo(ctx, nil, tok, "raw-token"), nil
+	}
+
+	interceptor := auth.ConnectAuthNInterceptor()
+	called := false
+	next := func(context.Context, connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+	conn := newFakeStreamingHandlerConn(dpopChallengeRoute)
+	conn.RequestHeader().Set("Authorization", "DPoP token")
+	conn.RequestHeader().Set("DPoP", "proof")
+
+	err := interceptor.WrapStreamingHandler(next)(s.T().Context(), conn)
+
+	s.Require().NoError(err)
+	s.True(called, "handler should run once the stream is authenticated")
+	s.NotEmpty(conn.ResponseHeader().Get("DPoP-Nonce"), "a fresh nonce should be set on the stream response when RequireNonce is enabled")
+}
+
+func (s *AuthSuite) Test_ConnectAuthNInterceptor_Streaming_PublicRouteBypassesAuth() {
+	interceptor := s.auth.ConnectAuthNInterceptor()
+	var publicRoute, publicRouteSet bool
+	next := func(ctx context.Context, _ connect.StreamingHandlerConn) error {
+		publicRoute, publicRouteSet = ctxAuth.PublicRouteFromContext(ctx)
+		return nil
+	}
+	// No Authorization header set: a public route must still succeed.
+	conn := newFakeStreamingHandlerConn("/public")
+
+	err := interceptor.WrapStreamingHandler(next)(s.T().Context(), conn)
+
+	s.Require().NoError(err, "public routes should bypass stream authentication")
+	s.True(publicRouteSet)
+	s.True(publicRoute)
 }
 
 func (s *AuthSuite) Test_ConnectAuthNInterceptor_SetsPublicRouteContextForChainedMiddleware() {
@@ -833,7 +954,7 @@ func (s *AuthSuite) Test_ConnectAuthNInterceptor_When_Authorization_Header_Missi
 	// Create a request
 	req := connect.NewRequest[string](nil)
 
-	_, err := interceptor(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+	_, err := interceptor.WrapUnary(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		return next(ctx, req)
 	})(context.Background(), req)
 
@@ -854,7 +975,7 @@ func (s *AuthSuite) Test_ConnectAuthNInterceptor_RequiresHeaderWithExistingConte
 	req := connect.NewRequest[string](nil)
 	ctx := ctxAuth.ContextWithAuthNInfo(s.T().Context(), nil, jwt.New(), "raw-token")
 
-	_, err := interceptor(next)(ctx, req)
+	_, err := interceptor.WrapUnary(next)(ctx, req)
 
 	s.Require().Error(err)
 
@@ -1222,7 +1343,7 @@ func (s *AuthSuite) Test_ConnectAuthNInterceptor_PropagatesHTTPMethod() {
 			}
 			req.Header().Set("Authorization", "DPoP "+string(signedTok))
 
-			_, err := interceptor(next)(s.T().Context(), req)
+			_, err := interceptor.WrapUnary(next)(s.T().Context(), req)
 			s.Require().NoError(err)
 			s.True(called)
 			s.Equal([]string{method}, capturedMethods)
@@ -1259,7 +1380,7 @@ func (s *AuthSuite) Test_ConnectAuthNInterceptor_NormalizesHostForHTU() {
 	req.Header().Set("Authorization", "DPoP test")
 	req.Header().Set("Host", "EXAMPLE.com:443")
 
-	_, err := interceptor(next)(s.T().Context(), req)
+	_, err := interceptor.WrapUnary(next)(s.T().Context(), req)
 	s.Require().NoError(err)
 	s.True(called)
 	// Host lowercased; :443 stripped for https (default) but kept for http (non-default).
@@ -1596,7 +1717,7 @@ func (s *AuthSuite) connectAuthError(auth *Authentication, retErr error) *connec
 	}
 	req.Header().Set("Authorization", "DPoP token")
 	req.Header().Set("DPoP", "proof")
-	_, err := interceptor(next)(s.T().Context(), req)
+	_, err := interceptor.WrapUnary(next)(s.T().Context(), req)
 	s.Require().Error(err)
 	var connectErr *connect.Error
 	s.Require().ErrorAs(err, &connectErr)

--- a/service/internal/auth/interceptor_authz_test.go
+++ b/service/internal/auth/interceptor_authz_test.go
@@ -692,6 +692,57 @@ func (s *InterceptorAuthzSuite) TestStreaming_DimensionScopedPolicyFailsClosed()
 	s.False(resolverCalled, "resolvers must never run for streams; authorization is procedure-level only")
 }
 
+// Streaming authorization is mode-agnostic: the stream path authorizes at the
+// procedure level regardless of authorizer version. These tests exercise the
+// legacy v1 (path+action) authorizer to complement the v2 coverage above.
+
+func (s *InterceptorAuthzSuite) TestStreaming_V1_AllowedRoleInvokesNext() {
+	policyCfg := internalauthz.PolicyConfig{}
+	s.Require().NoError(defaults.Set(&policyCfg))
+
+	authn := &Authentication{
+		logger:     s.logger,
+		authorizer: s.createV1Authorizer(policyCfg),
+	}
+	ctx := ctxAuth.ContextWithAuthNInfo(s.T().Context(), nil, s.newTokenWithRoles("opentdf-admin"), "raw-token")
+
+	called := false
+	next := func(context.Context, connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+	conn := newFakeStreamingHandlerConn("/policy.attributes.AttributesService/GetAttribute")
+
+	err := authn.ConnectAuthZInterceptor().WrapStreamingHandler(next)(ctx, conn)
+
+	s.Require().NoError(err)
+	s.True(called, "handler should run when the v1 policy allows the RPC")
+}
+
+func (s *InterceptorAuthzSuite) TestStreaming_V1_DeniedReturnsPermissionDenied() {
+	policyCfg := internalauthz.PolicyConfig{}
+	s.Require().NoError(defaults.Set(&policyCfg))
+
+	authn := &Authentication{
+		logger:     s.logger,
+		authorizer: s.createV1Authorizer(policyCfg),
+	}
+	ctx := ctxAuth.ContextWithAuthNInfo(s.T().Context(), nil, s.newTokenWithRoles("unknown-role"), "raw-token")
+
+	called := false
+	next := func(context.Context, connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+	conn := newFakeStreamingHandlerConn("/policy.attributes.AttributesService/GetAttribute")
+
+	err := authn.ConnectAuthZInterceptor().WrapStreamingHandler(next)(ctx, conn)
+
+	s.Require().Error(err)
+	s.Equal(connect.CodePermissionDenied, connect.CodeOf(err))
+	s.False(called, "handler must not run when the v1 policy denies the stream")
+}
+
 func (s *InterceptorAuthzSuite) TestV2_EmptyToken() {
 	csvPolicy := "p, role:admin, *, *, allow"
 	authorizer := s.createV2Authorizer(csvPolicy)

--- a/service/internal/auth/interceptor_authz_test.go
+++ b/service/internal/auth/interceptor_authz_test.go
@@ -559,11 +559,137 @@ func (s *InterceptorAuthzSuite) TestAuthorizeV2_UnregisteredResolverProcedureUse
 		return connect.NewResponse(&attributes.GetAttributeResponse{}), nil
 	}
 
-	resp, err := authn.ConnectAuthZInterceptor()(next)(ctx, req)
+	resp, err := authn.ConnectAuthZInterceptor().WrapUnary(next)(ctx, req)
 
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 	s.True(nextCalled, "next handler should be called when wildcard-dimension policy allows the RPC")
+}
+
+// Streaming authorization tests. Streaming RPCs have no request message at stream
+// establishment, so authorization is procedure-level only (no resolver runs).
+
+func (s *InterceptorAuthzSuite) TestStreaming_AllowedRoleInvokesNext() {
+	const requestedRPC = "/policy.attributes.AttributesService/GetAttribute"
+	csvPolicy := "p, role:attribute-reader, " + requestedRPC + ", *, allow"
+	authn := &Authentication{
+		logger:     s.logger,
+		authorizer: s.createV2Authorizer(csvPolicy),
+	}
+	ctx := ctxAuth.ContextWithAuthNInfo(s.T().Context(), nil, s.newTokenWithRoles("attribute-reader"), "raw-token")
+
+	called := false
+	next := func(context.Context, connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+	conn := newFakeStreamingHandlerConn(requestedRPC)
+
+	err := authn.ConnectAuthZInterceptor().WrapStreamingHandler(next)(ctx, conn)
+
+	s.Require().NoError(err)
+	s.True(called, "handler should run when the wildcard-dimension policy allows the RPC")
+}
+
+func (s *InterceptorAuthzSuite) TestStreaming_DeniedReturnsPermissionDenied() {
+	const requestedRPC = "/policy.attributes.AttributesService/GetAttribute"
+	csvPolicy := "p, role:attribute-reader, " + requestedRPC + ", *, allow"
+	authn := &Authentication{
+		logger:     s.logger,
+		authorizer: s.createV2Authorizer(csvPolicy),
+	}
+	ctx := ctxAuth.ContextWithAuthNInfo(s.T().Context(), nil, s.newTokenWithRoles("unrelated-role"), "raw-token")
+
+	called := false
+	next := func(context.Context, connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+	conn := newFakeStreamingHandlerConn(requestedRPC)
+
+	err := authn.ConnectAuthZInterceptor().WrapStreamingHandler(next)(ctx, conn)
+
+	s.Require().Error(err)
+	s.Equal(connect.CodePermissionDenied, connect.CodeOf(err))
+	s.False(called, "handler must not run when authorization denies the stream")
+}
+
+func (s *InterceptorAuthzSuite) TestStreaming_MissingTokenReturnsUnauthenticated() {
+	authn := &Authentication{
+		logger:     s.logger,
+		authorizer: s.createV2Authorizer("p, role:x, *, *, allow"),
+	}
+
+	called := false
+	next := func(context.Context, connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+	conn := newFakeStreamingHandlerConn("/policy.attributes.AttributesService/GetAttribute")
+
+	err := authn.ConnectAuthZInterceptor().WrapStreamingHandler(next)(s.T().Context(), conn)
+
+	s.Require().Error(err)
+	s.Equal(connect.CodeUnauthenticated, connect.CodeOf(err))
+	s.False(called, "handler must not run without an authenticated token")
+}
+
+func (s *InterceptorAuthzSuite) TestStreaming_PublicRouteBypassesAuthz() {
+	authn := &Authentication{logger: s.logger}
+
+	called := false
+	next := func(context.Context, connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+	conn := newFakeStreamingHandlerConn("/kas.AccessService/PublicKey")
+	ctx := ctxAuth.ContextWithPublicRoute(s.T().Context(), true)
+
+	err := authn.ConnectAuthZInterceptor().WrapStreamingHandler(next)(ctx, conn)
+
+	s.Require().NoError(err, "public routes should bypass stream authorization")
+	s.True(called)
+}
+
+func (s *InterceptorAuthzSuite) TestStreaming_DimensionScopedPolicyFailsClosed() {
+	const requestedRPC = "/policy.attributes.AttributesService/GetAttribute"
+	// The policy only permits the RPC within namespace=hr. A stream cannot supply
+	// resource dimensions at establishment, so this must fail closed.
+	csvPolicy := "p, role:hr-admin, " + requestedRPC + ", namespace=hr, allow"
+
+	// Register a resolver for the RPC so we can prove the documented mechanism:
+	// streams authorize at procedure level and never invoke resolvers, even when
+	// one is registered and the authorizer supports resource authorization.
+	registry := internalauthz.NewResolverRegistry()
+	resolverCalled := false
+	s.Require().NoError(registry.ScopedForService(&attributes.AttributesService_ServiceDesc).Register(
+		"GetAttribute",
+		func(context.Context, connect.AnyRequest) (internalauthz.ResolverContext, error) {
+			resolverCalled = true
+			return internalauthz.NewResolverContext(), nil
+		},
+	))
+
+	authn := &Authentication{
+		logger:                s.logger,
+		authorizer:            s.createV2Authorizer(csvPolicy),
+		authzResolverRegistry: registry,
+	}
+	ctx := ctxAuth.ContextWithAuthNInfo(s.T().Context(), nil, s.newTokenWithRoles("hr-admin"), "raw-token")
+
+	called := false
+	next := func(context.Context, connect.StreamingHandlerConn) error {
+		called = true
+		return nil
+	}
+	conn := newFakeStreamingHandlerConn(requestedRPC)
+
+	err := authn.ConnectAuthZInterceptor().WrapStreamingHandler(next)(ctx, conn)
+
+	s.Require().Error(err)
+	s.Equal(connect.CodePermissionDenied, connect.CodeOf(err))
+	s.False(called, "dimension-scoped policy must fail closed for streams")
+	s.False(resolverCalled, "resolvers must never run for streams; authorization is procedure-level only")
 }
 
 func (s *InterceptorAuthzSuite) TestV2_EmptyToken() {
@@ -704,7 +830,7 @@ func (s *InterceptorAuthzSuite) TestAuthorizeV2_DenyPathReturnsPermissionDenied(
 		return connect.NewResponse(&kasregistry.GetKeyResponse{}), nil
 	}
 
-	_, err := authn.ConnectAuthZInterceptor()(next)(ctx, req)
+	_, err := authn.ConnectAuthZInterceptor().WrapUnary(next)(ctx, req)
 
 	s.Require().Error(err)
 	s.Equal(connect.CodePermissionDenied, connect.CodeOf(err))
@@ -728,7 +854,7 @@ func (s *InterceptorAuthzSuite) TestAuthorize_NoToken_ReturnsCodeUnauthenticated
 		return connect.NewResponse(&attributes.GetAttributeResponse{}), nil
 	}
 
-	_, err := authn.ConnectAuthZInterceptor()(next)(s.T().Context(), req)
+	_, err := authn.ConnectAuthZInterceptor().WrapUnary(next)(s.T().Context(), req)
 
 	s.Require().Error(err)
 	s.Equal(connect.CodeUnauthenticated, connect.CodeOf(err))


### PR DESCRIPTION
Closes #3866.

The Connect authN/authz interceptors were `connect.UnaryInterceptorFunc`, so their streaming wrap methods were no-ops — any streaming/bidi RPC would bypass JWT/DPoP authN and casbin authz. Both now return a full `connect.Interceptor` that also covers streaming/bidi at stream establishment, failing closed by default.

Streaming authz is procedure-level only (no request message exists at establishment, so resource resolvers can't run), mirroring the raw-HTTP `MuxHandler` path.

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authentication and authorization support for streaming and bidirectional RPCs.
  - Streams now authenticate at establishment and enforce procedure-level authorization by default.
  - Added optional fine-grained authorization based on each received message’s resource dimensions.
  - Authorization decisions are reused for matching dimensions and rechecked when dimensions change.
  - Unauthorized messages terminate the stream with a permission error.

- **Documentation**
  - Documented streaming authorization behavior, configuration, caching, and enforcement caveats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->