### PR TITLE
docs(spec): BaseTDF 5.0 scale and detached storage goals

### DIFF
--- a/spec/basetdf/v5/README.md
+++ b/spec/basetdf/v5/README.md
@@ -1,0 +1,75 @@
+# BaseTDF Specification Suite — Version 5.0.0
+
+The BaseTDF suite defines the Trusted Data Format (TDF) for data-centric security.
+Version 5 separates the logical TDF manifest from physical packaging and adds
+integrity layouts suitable for very large, streamed, distributed, detached, and
+randomly accessed payloads.
+
+BaseTDF 5.0 is a breaking wire-format release. Version 4 objects remain readable by
+a 5.0 implementation, but a 4.x reader is expected to reject a 5.0 manifest.
+
+## Document Overview
+
+| Layer | Document | Title | File |
+|---|---|---|---|
+| Foundation | BaseTDF-SEC | Security Model and Zero Trust Architecture | [basetdf-sec.md](basetdf-sec.md) |
+| Foundation | BaseTDF-ALG | Algorithm Registry | [basetdf-alg.md](basetdf-alg.md) |
+| Policy | BaseTDF-POL | Policy and Attribute-Based Access Control | [basetdf-pol.md](basetdf-pol.md) |
+| Policy | BaseTDF-KAS | Key Access Service Protocol | [basetdf-kas.md](basetdf-kas.md) |
+| Operations | BaseTDF-KAO | Key Access Object | [basetdf-kao.md](basetdf-kao.md) |
+| Operations | BaseTDF-INT | Integrity Verification and Scalable Layouts | [basetdf-int.md](basetdf-int.md) |
+| Operations | BaseTDF-ASN | Assertions and Manifest Signatures | [basetdf-asn.md](basetdf-asn.md) |
+| Storage | BaseTDF-LOC | Resource Locators and Fetch Policy | [basetdf-loc.md](basetdf-loc.md) |
+| Storage | BaseTDF-PKG | Packaging Profiles | [basetdf-pkg.md](basetdf-pkg.md) |
+| Assembly | BaseTDF-CORE | Manifest and End-to-End Processing | [basetdf-core.md](basetdf-core.md) |
+| Examples | BaseTDF-EX | Examples and Test Vectors | [basetdf-ex.md](basetdf-ex.md) |
+
+## Architecture
+
+SEC defines security invariants and ALG defines identifiers. POL, KAS, and KAO
+retain the 4.4 policy and key-access model. INT defines segmentation, explicit and
+Merkle layouts, proofs, and key derivation. ASN defines assertions and public-key
+manifest signatures. LOC constrains external retrieval. PKG defines attached,
+detached, and sharded serializations. CORE binds the suite together.
+
+```text
+SEC ──► ALG ──► KAO, INT, ASN
+ │              ▲
+ ├──► POL ──────┤
+ ├──► KAS ◄─────┘
+ └──► LOC
+
+KAO, INT, ASN, LOC ──► PKG
+SEC, ALG, POL, KAO, KAS, INT, ASN, LOC, PKG ──► CORE ──► EX
+```
+
+## Recommended Reading Order
+
+1. [SEC](basetdf-sec.md) and [ALG](basetdf-alg.md)
+2. [POL](basetdf-pol.md), [KAO](basetdf-kao.md), and [KAS](basetdf-kas.md)
+3. [INT](basetdf-int.md) and [ASN](basetdf-asn.md)
+4. [LOC](basetdf-loc.md) and [PKG](basetdf-pkg.md)
+5. [CORE](basetdf-core.md) and [EX](basetdf-ex.md)
+
+## Version 5 Scope
+
+Version 5 adds packaging profiles, scalable Merkle layouts, partition-scoped keys,
+deterministic segment IVs, manifest signatures, safe locators, multi-manifest
+semantics, and append consistency proofs. BaseTDF-KAO, BaseTDF-POL, and BaseTDF-KAS
+are frozen at their 4.4 semantics. Policy-language, KAS-protocol, and new
+post-quantum work are outside the 5.0 charter.
+
+## Conventions
+
+BCP 14 requirement terms are normative only when written in all capitals. Unless
+specified otherwise, cryptographic integers are unsigned 64-bit big-endian values,
+`||` means concatenation, and JSON binary values use standard padded base64.
+
+## JSON Schemas
+
+The suite prose is authoritative. Implementations SHOULD also validate against the
+version 5 schema when published under [`spec/schema/BaseTDF/`](../../schema/BaseTDF/).
+
+## License
+
+This specification is licensed under the repository's license terms.

--- a/spec/basetdf/v5/README.md
+++ b/spec/basetdf/v5/README.md
@@ -3,7 +3,10 @@
 The BaseTDF suite defines the Trusted Data Format (TDF) for data-centric security.
 Version 5 separates the logical TDF manifest from physical packaging and adds
 integrity layouts suitable for very large, streamed, distributed, detached, and
-randomly accessed payloads.
+randomly accessed payloads. Scalable layouts support logical plaintexts of at least
+50 TiB while partition-key derivation preserves the suite's object-wide AES-GCM
+confidentiality target and sharded packaging avoids individual storage-object
+limits.
 
 BaseTDF 5.0 is a breaking wire-format release. Version 4 objects remain readable by
 a 5.0 implementation, but a 4.x reader is expected to reject a 5.0 manifest.

--- a/spec/basetdf/v5/basetdf-alg.md
+++ b/spec/basetdf/v5/basetdf-alg.md
@@ -1,0 +1,712 @@
+# BaseTDF-ALG: Algorithm Registry
+
+| Field | Value |
+|-------|-------|
+| **Title** | Algorithm Registry |
+| **Document** | BaseTDF-ALG |
+| **Version** | 5.0.0 |
+| **Status** | Standards Track |
+| **Date** | 2026-08 |
+| **Depends on** | BaseTDF-SEC |
+| **Referenced by** | BaseTDF-KAO, BaseTDF-INT, BaseTDF-ASN, BaseTDF-CORE, BaseTDF-PKG |
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This document is the central registry of cryptographic algorithm identifiers for
+the BaseTDF specification suite. Every cryptographic operation referenced by other
+BaseTDF documents -- content encryption, key protection, integrity verification,
+key derivation, and assertion signing -- is defined here by a unique string identifier, its
+parameters, and its implementation requirements.
+
+By factoring algorithm definitions into a single registry, the suite achieves a
+clean extensibility point: new algorithms (including post-quantum constructions)
+can be introduced by adding entries to this document without modifying the
+structural specifications (BaseTDF-KAO, BaseTDF-INT, BaseTDF-ASN, BaseTDF-CORE).
+
+### 1.2 Scope
+
+This document defines:
+
+- The format and semantics of algorithm identifiers
+- Registry tables for all algorithm categories
+- Detailed parameters, key sizes, and encoding requirements for each algorithm
+- Key protection categories and their operational procedures
+- Security strength classifications
+- Backward compatibility mappings from earlier TDF versions
+
+This document does **not** define how algorithms are selected, negotiated, or
+composed into a TDF manifest. Those concerns belong to the documents that
+reference this registry (see BaseTDF-KAO for key access objects, BaseTDF-INT for
+integrity, BaseTDF-ASN for assertions).
+
+### 1.3 Adding New Algorithms
+
+To add a new algorithm to the BaseTDF suite:
+
+1. Add an entry to the appropriate registry table in [Section 3](#3-algorithm-registry-tables).
+2. Add a detailed parameter section in [Section 5](#5-key-protection-algorithm-details) or [Section 6](#6-assertion-signing-algorithm-details).
+3. Add a row to the security strength table in [Section 7](#7-security-strength-classification).
+4. If the algorithm introduces a new key protection category, add it to [Section 4](#4-key-protection-categories).
+5. Update referencing documents (BaseTDF-KAO, BaseTDF-INT, BaseTDF-ASN) to
+   describe how the new algorithm is used in their respective contexts.
+
+No changes to BaseTDF-CORE or the manifest schema are required unless the new
+algorithm introduces a structural change to the manifest.
+
+### 1.4 Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in [BCP 14][rfc2119] [RFC 8174][rfc8174]
+when, and only when, they appear in ALL CAPITALS, as shown here.
+
+---
+
+## 2. Algorithm Identifier Format
+
+Algorithm identifiers are **case-sensitive strings**. They appear in `alg` fields
+throughout the BaseTDF suite, including:
+
+- The `alg` field of Key Access Objects (BaseTDF-KAO)
+- The `algorithm` field of integrity configuration (BaseTDF-INT)
+- The `alg` field of assertion signatures (BaseTDF-ASN)
+- The `alg` field of partition key derivation (BaseTDF-CORE)
+
+Each identifier maps to **exactly one** cryptographic operation with a fixed set
+of parameters. Implementations MUST NOT interpret an identifier as referring to a
+different operation or parameter set than what is defined in this registry.
+
+Identifiers follow these conventions:
+
+- Classical symmetric algorithms use JWA-style short names (e.g., `A256GCM`, `HS256`).
+- Classical asymmetric algorithms use descriptive names (e.g., `RSA-OAEP-256`, `ECDH-HKDF`).
+- Post-quantum algorithms use their NIST standardized names with security level (e.g., `ML-KEM-768`).
+
+Implementations MUST reject any `alg` value that is not recognized. Unknown
+algorithm identifiers MUST NOT be silently ignored.
+
+---
+
+## 3. Algorithm Registry Tables
+
+### 3.1 Content Encryption Algorithms
+
+These algorithms protect TDF payload data. They are symmetric authenticated
+encryption algorithms that provide both confidentiality and integrity of the
+plaintext.
+
+| Identifier | Description | Key Size | IV Size | Tag Size | Status |
+|:-----------|:------------|:---------|:--------|:---------|:-------|
+| `A256GCM` | AES-256-GCM | 256 bits | 96 bits | 128 bits | REQUIRED |
+
+**A256GCM**: AES-256 in Galois/Counter Mode as specified in [NIST SP 800-38D][sp800-38d].
+The 96-bit initialization vector (IV, also called nonce) MUST be unique for every
+encryption operation performed under the same key. Reuse of an IV under the same
+key catastrophically compromises both confidentiality and authenticity. The 128-bit
+authentication tag MUST be appended to each ciphertext segment and verified before
+any plaintext is released.
+
+### 3.2 Key Protection Algorithms
+
+These algorithms protect DEK shares within Key Access Objects (see BaseTDF-KAO).
+Each algorithm belongs to one of the key protection categories defined in
+[Section 4](#4-key-protection-categories).
+
+| Identifier | Description | Category | Status |
+|:-----------|:------------|:---------|:-------|
+| `RSA-OAEP` | RSA-OAEP with SHA-1 | Key Wrapping | LEGACY |
+| `RSA-OAEP-256` | RSA-OAEP with SHA-256 | Key Wrapping | RECOMMENDED |
+| `ECDH-HKDF` | ECDH + HKDF-SHA256 | Key Agreement | RECOMMENDED |
+| `ML-KEM-768` | ML-KEM-768 encapsulation | Key Encapsulation | RECOMMENDED |
+| `ML-KEM-1024` | ML-KEM-1024 encapsulation | Key Encapsulation | OPTIONAL |
+
+**Scope note on hybrid PQ/T algorithms**: This registry deliberately defines no
+hybrid post-quantum/traditional (PQ/T) key protection algorithms. BaseTDF
+targets the algorithm set supported by existing FIPS 203-compliant hardware
+security modules, which do not currently — and may never — support composite
+PQ/T KEM constructions. Should hardware support materialize, hybrid algorithms
+can be added to this registry per the process in [Section 1.3](#13-adding-new-algorithms)
+without structural changes to the manifest.
+
+### 3.3 Integrity MAC Algorithms
+
+These algorithms produce message authentication codes for payload integrity
+verification (see BaseTDF-INT).
+
+| Identifier | Description | Output Size | Status |
+|:-----------|:------------|:------------|:-------|
+| `HS256` | HMAC-SHA256 | 256 bits | REQUIRED |
+| `GMAC` | AES-256-GMAC | 128 bits | OPTIONAL |
+| `MERKLE-HS256` | Domain-separated HMAC-SHA256 Merkle root | 256 bits | REQUIRED |
+
+**HS256**: HMAC with SHA-256 as specified in [RFC 2104][rfc2104]. Used both for
+per-segment integrity tags and for the root integrity signature over the segment
+hash table.
+
+**GMAC**: The GMAC mode of AES-256-GCM (i.e., GCM applied to an empty plaintext),
+producing a 128-bit authentication tag. When used, the IV requirements of AES-GCM
+apply (see Section 3.1).
+
+**MERKLE-HS256**: The leaf, internal-node, and root HMAC-SHA256 construction in
+BaseTDF-INT Section 6. It is valid only for `rootSignature.alg`, not for
+`segmentHashAlg`. It is REQUIRED for both scalable layouts.
+
+### 3.4 Assertion Signing Algorithms
+
+These algorithms sign or MAC assertion payloads (see BaseTDF-ASN). They establish
+the authenticity of verifiable statements bound to a TDF.
+
+| Identifier | Description | Status |
+|:-----------|:------------|:-------|
+| `HS256` | HMAC-SHA256 | REQUIRED |
+| `RS256` | RSASSA-PKCS1-v1_5 with SHA-256 | OPTIONAL |
+| `ES256` | ECDSA P-256 with SHA-256 | RECOMMENDED |
+| `ES384` | ECDSA P-384 with SHA-384 | OPTIONAL |
+| `ML-DSA-44` | ML-DSA-44 (FIPS 204) | RECOMMENDED |
+| `ML-DSA-65` | ML-DSA-65 (FIPS 204) | OPTIONAL |
+
+For `scope: "manifest"`, BaseTDF-ASN prohibits HS256, recommends ES256, and
+permits RS256. Other assertion scopes retain the statuses above.
+
+### 3.5 Key Derivation Algorithms
+
+| Identifier | Description | Output Size | Status |
+|:-----------|:------------|:------------|:-------|
+| `HKDF-SHA256` | RFC 5869 HKDF-Expand with HMAC-SHA256 | 256 bits | REQUIRED |
+
+For BaseTDF partition keys, the DEK is used directly as the HKDF pseudorandom key;
+implementations MUST NOT perform HKDF-Extract. The exact `info` value and partition
+number encoding are defined by BaseTDF-CORE.
+
+---
+
+## 4. Key Protection Categories
+
+Key protection algorithms in Section 3.2 fall into three categories. Each category
+defines a distinct operational pattern for how a DEK share is protected and
+recovered. These categories replace the legacy `type` field values (`"wrapped"`,
+`"ec-wrapped"`) from BaseTDF v4.3.0 (see [Section 9](#9-backward-compatibility)).
+
+### 4.1 Key Wrapping (Direct Encryption)
+
+**Used by**: `RSA-OAEP`, `RSA-OAEP-256`
+
+In key wrapping, the DEK share is directly encrypted under the KAS public key.
+No ephemeral key generation or key agreement is involved.
+
+**Encryption operation**:
+
+```
+protectedKey = RSA-OAEP(kas_public_key, DEK_share)
+```
+
+**Decryption operation**:
+
+```
+DEK_share = RSA-OAEP-Decrypt(kas_private_key, protectedKey)
+```
+
+**Requirements**:
+
+- Minimum RSA key size: 2048 bits (LEGACY deployments).
+- RECOMMENDED RSA key size: 4096 bits for new deployments.
+- The `ephemeralKey` field in the KAO is not used and SHOULD be omitted.
+
+### 4.2 Key Agreement
+
+**Used by**: `ECDH-HKDF`
+
+In key agreement, an ephemeral key pair is generated by the encrypting party. The
+ephemeral private key and the KAS public key are used to derive a shared secret
+via Elliptic Curve Diffie-Hellman. A key derivation function produces a symmetric
+key that protects the DEK share.
+
+**Encryption operation**:
+
+```
+1. ephemeral_ec = generate_ec_keypair(curve)
+2. shared_secret = ECDH(ephemeral_ec.sk, kas_ec_pk)
+3. derived_key = HKDF-SHA256(
+     salt = SHA256("TDF"),
+     ikm  = shared_secret,
+     info = "",          // empty by default
+     len  = 32
+   )
+4. protectedKey = AES-256-GCM(derived_key, DEK_share)
+5. ephemeralKey = ephemeral_ec.pk   // sent in KAO
+```
+
+**Decryption operation**:
+
+```
+1. shared_secret = ECDH(kas_ec_sk, ephemeralKey)
+2. derived_key = HKDF-SHA256(salt=SHA256("TDF"), shared_secret, info="", 32)
+3. DEK_share = AES-256-GCM-Decrypt(derived_key, protectedKey)
+```
+
+**Requirements**:
+
+- Supported curves: P-256 (secp256r1) is REQUIRED; P-384 (secp384r1) and
+  P-521 (secp521r1) are OPTIONAL.
+- Salt: MUST be `SHA256("TDF")` -- the SHA-256 hash of the three ASCII bytes
+  `0x54 0x44 0x46`. This is a fixed 32-byte value. See BaseTDF-KAO Section 4.2.
+- Info: empty by default. Implementations MAY provide a custom info value.
+- Wrapping algorithm: AES-256-GCM, in both v4.3.0 and v4.4.0.
+
+### 4.3 Key Encapsulation
+
+**Used by**: `ML-KEM-768`, `ML-KEM-1024`
+
+In key encapsulation, the encrypting party uses the KAS public encapsulation key
+to produce a ciphertext and a shared secret in a single operation (KEM). The
+32-byte shared secret is used **directly** as the AES-256-GCM key that protects
+the DEK share. No key derivation function is applied; see
+[Section 4.3.1](#431-rationale-for-omitting-a-kdf).
+
+The KEM ciphertext and the encrypted DEK share travel together inside a single
+ASN.1 DER envelope carried in the KAO `protectedKey` field. The `ephemeralKey`
+field is NOT used by this category.
+
+**Encryption operation**:
+
+```
+1. (ct, ss)     = ML-KEM.Encapsulate(kas_mlkem_pk)
+2. encryptedDEK = AES-256-GCM(key = ss, DEK_share)
+3. protectedKey = DER(MLKEMWrappedKey {
+                    mlkemCiphertext = ct,
+                    encryptedDEK    = encryptedDEK
+                  })
+```
+
+**Decryption operation**:
+
+```
+1. (ct, encryptedDEK) = DER-Parse(MLKEMWrappedKey, protectedKey)
+2. ss                 = ML-KEM.Decapsulate(kas_mlkem_sk, ct)
+3. DEK_share          = AES-256-GCM-Decrypt(key = ss, encryptedDEK)
+```
+
+**Envelope**:
+
+```asn1
+MLKEMWrappedKey ::= SEQUENCE {
+    mlkemCiphertext  [0] IMPLICIT OCTET STRING,
+    encryptedDEK     [1] IMPLICIT OCTET STRING
+}
+```
+
+The DER encoding of this SEQUENCE is base64-encoded when stored in the KAO
+`protectedKey` field.
+
+`encryptedDEK` uses the following layout, with no additional authenticated data
+(AAD):
+
+| Offset | Length | Content |
+|:-------|:-------|:--------|
+| 0 | 12 bytes | AES-GCM nonce (random, unique per wrap) |
+| 12 | *n* bytes | AES-256-GCM ciphertext of the DEK share |
+| 12 + *n* | 16 bytes | AES-GCM authentication tag |
+
+**Parameters by algorithm**:
+
+| Algorithm | Public Key Size | Ciphertext Size | Shared Secret Size | NIST Security Level |
+|:----------|:----------------|:----------------|:-------------------|:--------------------|
+| `ML-KEM-768` | 1184 bytes | 1088 bytes | 32 bytes | Level 3 |
+| `ML-KEM-1024` | 1568 bytes | 1568 bytes | 32 bytes | Level 5 |
+
+**Requirements**:
+
+- Implementations MUST use the ML-KEM shared secret directly as the AES-256-GCM
+  key. Implementations MUST NOT apply HKDF or any other KDF to the shared
+  secret.
+- The AES-GCM nonce MUST be freshly generated from a CSPRNG for every wrap
+  operation.
+- `mlkemCiphertext` MUST be exactly the ciphertext size for the algorithm named
+  by `alg` (1088 bytes for `ML-KEM-768`, 1568 bytes for `ML-KEM-1024`).
+  Implementations MUST reject an envelope whose ciphertext length does not
+  match, and MUST reject an envelope with trailing bytes after the SEQUENCE.
+- The `ephemeralKey` field MUST NOT be used and SHOULD be omitted.
+- ML-KEM operations MUST conform to [NIST FIPS 203][fips203].
+
+#### 4.3.1 Rationale for Omitting a KDF
+
+Applying a KDF to the ML-KEM shared secret would exclude HSM-backed KAS
+deployments. On FIPS 203-compliant hardware in strict-FIPS mode, the
+decapsulation mechanism can only materialize its 32-byte shared secret as a
+sensitive, non-extractable AES key object. Such an HSM will neither run an HMAC
+over the shared secret (blocking HKDF on-HSM) nor release it (blocking HKDF
+off-HSM), so any KDF in the unwrap chain makes the algorithm unimplementable on
+that hardware.
+
+Omitting the KDF costs nothing cryptographically:
+
+1. **Uniformity.** [FIPS 203][fips203] Sections 6.3 and 7.3 specify the Decaps
+   output *K* as a 32-byte value produced through the standard's internal SHA-3
+   family functions. It is already uniformly distributed, so a KDF would only
+   re-mix uniformly random bits into different uniformly random bits.
+2. **Per-wrap independence.** Encapsulation samples fresh randomness on every
+   call, so *K* is independent across wraps by construction. The key-isolation
+   property a KDF conventionally supplies is already present in the input.
+3. **Authenticated unwrap.** AES-256-GCM authenticates the wrapped DEK. FIPS 203
+   implicit rejection returns a pseudorandom *K* for a wrong-key ciphertext
+   rather than an error, and that *K* is uncorrelated with the encryptor's, so
+   the GCM tag check fails as expected.
+4. **Domain separation.** The `alg` identifier and the `MLKEMWrappedKey`
+   envelope themselves provide domain separation, so no `info` string is
+   required to prevent cross-protocol collisions.
+
+---
+
+## 5. Key Protection Algorithm Details
+
+### 5.1 RSA-OAEP
+
+| Parameter | Value |
+|:----------|:------|
+| Identifier | `RSA-OAEP` |
+| Standard | [PKCS#1 v2.1][rfc8017], Section 7.1 |
+| Hash function | SHA-1 |
+| Mask generation function | MGF1 with SHA-1 |
+| Key format | PKCS#8 or PKCS#1 PEM |
+| Minimum key size | 2048 bits |
+| Status | LEGACY |
+
+**Status rationale**: SHA-1 is used within OAEP as a random oracle in the
+encryption padding scheme, not for collision resistance. The known collision
+weaknesses in SHA-1 do not translate to a practical attack on RSA-OAEP.
+Nevertheless, new deployments SHOULD use `RSA-OAEP-256` to align with current
+best practice. Implementations MUST support `RSA-OAEP` for decrypting existing
+TDFs but MUST NOT use it when creating new TDFs in security-sensitive contexts.
+
+### 5.2 RSA-OAEP-256
+
+| Parameter | Value |
+|:----------|:------|
+| Identifier | `RSA-OAEP-256` |
+| Standard | [PKCS#1 v2.1][rfc8017], Section 7.1 |
+| Hash function | SHA-256 |
+| Mask generation function | MGF1 with SHA-256 |
+| Key format | PKCS#8 or PKCS#1 PEM |
+| Minimum key size | 2048 bits |
+| RECOMMENDED key size | 4096 bits |
+| Status | RECOMMENDED |
+
+### 5.3 ECDH-HKDF
+
+| Parameter | Value |
+|:----------|:------|
+| Identifier | `ECDH-HKDF` |
+| Key agreement | ECDH per [RFC 6090][rfc6090] |
+| KDF | HKDF-SHA256 per [RFC 5869][rfc5869] |
+| HKDF salt | `SHA256("TDF")` (fixed 32 bytes) |
+| HKDF info | Empty by default |
+| Wrapping algorithm | AES-256-GCM |
+| REQUIRED curve | P-256 (secp256r1) |
+| OPTIONAL curves | P-384 (secp384r1), P-521 (secp521r1) |
+| Ephemeral key format | Uncompressed EC point (`0x04 \|\| x \|\| y`) or PEM |
+| Status | RECOMMENDED |
+
+**Implementation note**: AES-256-GCM is the wrapping algorithm for `ECDH-HKDF`
+in both v4.3.0 and v4.4.0; the wire format for this algorithm is unchanged
+between the two versions. Only the KAO field names differ (see BaseTDF-KAO
+Section 7).
+
+### 5.4 ML-KEM-768
+
+| Parameter | Value |
+|:----------|:------|
+| Identifier | `ML-KEM-768` |
+| Standard | [NIST FIPS 203][fips203] |
+| Public key size | 1184 bytes |
+| Ciphertext size | 1088 bytes |
+| Shared secret size | 32 bytes |
+| NIST security level | Level 3 (equivalent to AES-192 security) |
+| KDF | None -- shared secret used directly (see Section 4.3.1) |
+| Wrapping algorithm | AES-256-GCM |
+| Envelope | `MLKEMWrappedKey` DER (see Section 4.3) |
+| Algorithm OID | `2.16.840.1.101.3.4.4.2` |
+| Status | RECOMMENDED |
+
+**Key encoding**: See [Section 5.6](#56-ml-kem-key-encoding).
+
+### 5.5 ML-KEM-1024
+
+| Parameter | Value |
+|:----------|:------|
+| Identifier | `ML-KEM-1024` |
+| Standard | [NIST FIPS 203][fips203] |
+| Public key size | 1568 bytes |
+| Ciphertext size | 1568 bytes |
+| Shared secret size | 32 bytes |
+| NIST security level | Level 5 (equivalent to AES-256 security) |
+| KDF | None -- shared secret used directly (see Section 4.3.1) |
+| Wrapping algorithm | AES-256-GCM |
+| Envelope | `MLKEMWrappedKey` DER (see Section 4.3) |
+| Algorithm OID | `2.16.840.1.101.3.4.4.3` |
+| Status | OPTIONAL |
+
+**Key encoding**: See [Section 5.6](#56-ml-kem-key-encoding).
+
+### 5.6 ML-KEM Key Encoding
+
+ML-KEM keys are encoded differently depending on whether they are being
+distributed by the KAS or embedded in a TDF.
+
+**KAS public keys (distribution)**: ML-KEM encapsulation keys published by a KAS
+MUST be encoded as [RFC 5280][rfc5280] `SubjectPublicKeyInfo` in DER, wrapped in
+a `PUBLIC KEY` PEM block. The `AlgorithmIdentifier` carries the algorithm OID
+from Sections 5.4 / 5.5 and MUST have absent parameters. The raw FIPS 203
+encapsulation key bytes are the contents of the `subjectPublicKey` BIT STRING,
+which MUST be byte-aligned.
+
+```
+SubjectPublicKeyInfo ::= SEQUENCE {
+    algorithm         AlgorithmIdentifier,   -- OID only, no parameters
+    subjectPublicKey  BIT STRING             -- raw FIPS 203 encapsulation key
+}
+```
+
+**KAS private keys (storage)**: ML-KEM decapsulation keys MUST be encoded as
+[RFC 5958][rfc5958] `OneAsymmetricKey` (version 1) in DER, wrapped in a
+`PRIVATE KEY` PEM block. The inner `privateKey` OCTET STRING contains the
+KEM-PrivateKey CHOICE encoded as `[0] IMPLICIT OCTET STRING` holding the 64-byte
+FIPS 203 seed (`d || z`).
+
+**KEM ciphertexts (in the manifest)**: The ML-KEM ciphertext is carried as raw
+FIPS 203 bytes in the `mlkemCiphertext` field of the `MLKEMWrappedKey` envelope
+(Section 4.3). It is not separately base64-encoded and is never PEM-wrapped; the
+envelope as a whole is base64-encoded into the KAO `protectedKey` field.
+
+---
+
+## 6. Assertion Signing Algorithm Details
+
+### 6.1 HS256
+
+| Parameter | Value |
+|:----------|:------|
+| Identifier | `HS256` |
+| Standard | HMAC with SHA-256 per [RFC 2104][rfc2104] |
+| Key size | Minimum 256 bits |
+| Output size | 256 bits (32 bytes) |
+| Status | REQUIRED |
+
+**Dual role**: `HS256` serves two purposes in the BaseTDF suite:
+
+1. **Policy binding MAC** (BaseTDF-KAO): the HMAC over the policy object that
+   binds the policy to the encrypted key material.
+2. **Assertion signing** (BaseTDF-ASN): HMAC-based authentication of assertion
+   payloads.
+
+In both roles, the key MUST be at least 256 bits and MUST be generated using a
+cryptographically secure random number generator.
+
+### 6.2 RS256
+
+| Parameter | Value |
+|:----------|:------|
+| Identifier | `RS256` |
+| Standard | RSASSA-PKCS1-v1_5 with SHA-256 per [RFC 8017][rfc8017] |
+| Minimum key size | 2048 bits |
+| Status | OPTIONAL |
+
+### 6.3 ES256
+
+| Parameter | Value |
+|:----------|:------|
+| Identifier | `ES256` |
+| Standard | ECDSA with P-256 and SHA-256 per [FIPS 186-4][fips186-4] |
+| Curve | P-256 (secp256r1) |
+| Hash | SHA-256 |
+| Status | RECOMMENDED |
+
+ES256 is the recommended publisher-signature algorithm for manifest-scope
+assertions. Publisher-key authentication and rotation are deployment concerns
+defined by BaseTDF-ASN and local trust policy.
+
+### 6.4 ES384
+
+| Parameter | Value |
+|:----------|:------|
+| Identifier | `ES384` |
+| Standard | ECDSA with P-384 and SHA-384 per [FIPS 186-4][fips186-4] |
+| Curve | P-384 (secp384r1) |
+| Hash | SHA-384 |
+| Status | OPTIONAL |
+
+### 6.5 ML-DSA-44
+
+| Parameter | Value |
+|:----------|:------|
+| Identifier | `ML-DSA-44` |
+| Standard | [NIST FIPS 204][fips204] |
+| Public key size | 1312 bytes |
+| Signature size | 2420 bytes |
+| NIST security level | Level 2 (approximately equivalent to AES-128 / SHA-256 collision resistance) |
+| Key format | Raw bytes, base64-encoded in assertion fields |
+| Status | RECOMMENDED |
+
+**Recommended use**: `ML-DSA-44` is the RECOMMENDED post-quantum signing algorithm
+for assertion signing. Its Level 2 security is appropriate for assertions where
+the primary threat is signature forgery, and its relatively compact signatures
+(compared to higher ML-DSA parameter sets) make it suitable for inclusion in TDF
+manifests.
+
+### 6.6 ML-DSA-65
+
+| Parameter | Value |
+|:----------|:------|
+| Identifier | `ML-DSA-65` |
+| Standard | [NIST FIPS 204][fips204] |
+| Public key size | 1952 bytes |
+| Signature size | 3309 bytes |
+| NIST security level | Level 3 (approximately equivalent to AES-192 security) |
+| Key format | Raw bytes, base64-encoded in assertion fields |
+| Status | OPTIONAL |
+
+---
+
+## 7. Security Strength Classification
+
+The following table summarizes the security strength of each algorithm against
+classical and quantum adversaries. For the security model and minimum strength
+requirements, see BaseTDF-SEC.
+
+| Algorithm | Classical Security | Post-Quantum Security | Notes |
+|:----------|:-------------------|:----------------------|:------|
+| `A256GCM` | 256 bits | 128 bits (Grover's bound) | Content encryption |
+| `RSA-OAEP` (2048-bit) | ~112 bits | 0 (Shor's algorithm) | LEGACY only |
+| `RSA-OAEP-256` (4096-bit) | ~150 bits | 0 (Shor's algorithm) | Transition period |
+| `ECDH-HKDF` (P-256) | 128 bits | 0 (Shor's algorithm) | Transition period |
+| `ML-KEM-768` | N/A | 192 bits (NIST Level 3) | Post-quantum |
+| `ML-KEM-1024` | N/A | 256 bits (NIST Level 5) | Post-quantum |
+| `HS256` | 256 bits | 128 bits (Grover's bound) | MAC / policy binding |
+| `MERKLE-HS256` | 256 bits | 128 bits (Grover's bound) | Scalable integrity root |
+| `GMAC` | 128 bits | 64 bits (Grover's bound) | Integrity MAC |
+| `HKDF-SHA256` | 256 bits | 128 bits (Grover's bound) | Partition key derivation |
+| `RS256` (2048-bit) | ~112 bits | 0 (Shor's algorithm) | Assertion signing |
+| `ES256` | 128 bits | 0 (Shor's algorithm) | Assertion signing |
+| `ES384` | 192 bits | 0 (Shor's algorithm) | Assertion signing |
+| `ML-DSA-44` | N/A | ~128 bits (NIST Level 2) | Assertion signing |
+| `ML-DSA-65` | N/A | ~192 bits (NIST Level 3) | Assertion signing |
+
+**Post-quantum security = 0** means the algorithm is completely broken by a
+cryptographically relevant quantum computer (CRQC) running Shor's algorithm.
+**Grover's bound** means the symmetric key space is effectively halved by
+Grover's algorithm (e.g., 256-bit key provides 128-bit post-quantum security).
+
+Because this registry defines no hybrid PQ/T algorithms (see Section 3.2), a
+deployment requiring post-quantum confidentiality MUST select a pure ML-KEM
+algorithm; the classical algorithms offer no protection against a CRQC.
+
+---
+
+## 8. Status Definitions
+
+| Status | RFC 2119 Keyword | Meaning |
+|:-------|:-----------------|:--------|
+| REQUIRED | MUST | All conformant implementations MUST support this algorithm. Interoperability depends on it. |
+| RECOMMENDED | SHOULD | Implementations SHOULD support this algorithm. It is the preferred choice for new deployments unless specific constraints dictate otherwise. |
+| OPTIONAL | MAY | Implementations MAY support this algorithm. It is defined for use cases with specific requirements (e.g., higher security levels). |
+| LEGACY | MUST (read) / MUST NOT (write) | Implementations MUST support this algorithm when reading existing TDFs for backward compatibility. Implementations MUST NOT use this algorithm when creating new TDFs in security-sensitive contexts. |
+
+---
+
+## 9. Backward Compatibility
+
+### 9.1 Mapping from v4.3.0 Type Strings
+
+BaseTDF v4.3.0 used a `type` field in Key Access Objects to indicate the key
+protection mechanism. Version 4.4.0 replaces this with the explicit `alg` field.
+The following mapping defines the equivalence:
+
+| v4.3.0 `type` Value | v4.4.0 `alg` Value | Notes |
+|:---------------------|:---------------------|:------|
+| `"wrapped"` | `"RSA-OAEP"` | SHA-1 variant, for historical compatibility |
+| `"ec-wrapped"` | `"ECDH-HKDF"` | Wire format identical in both versions |
+| `"mlkem-wrapped"` | `"ML-KEM-768"` or `"ML-KEM-1024"` | **Ambiguous** -- see below |
+
+The `"mlkem-wrapped"` type value does not distinguish ML-KEM-768 from
+ML-KEM-1024. A reader that encounters `"mlkem-wrapped"` without an `alg` field
+resolves the algorithm through the KAO's `kid`, which the KAS must look up
+against its key registry regardless in order to select a private key; that
+lookup yields the parameter set. A reader without access to the key registry MAY
+instead infer it from the length of `mlkemCiphertext` in the decoded envelope
+(1088 bytes implies ML-KEM-768, 1568 bytes implies ML-KEM-1024).
+
+### 9.2 Reading Legacy KAOs
+
+When reading a Key Access Object that contains a `type` field but no `alg` field,
+implementations MUST apply the mapping in Section 9.1 to determine the algorithm.
+The `type` field alone is sufficient to unambiguously identify the algorithm for
+every value except `"mlkem-wrapped"`, which requires the additional resolution
+step described in Section 9.1.
+
+### 9.3 Writing New KAOs
+
+When creating new Key Access Objects, implementations MUST include the `alg`
+field. The `type` field MAY be included for backward compatibility with older
+readers, but the `alg` field is the authoritative identifier.
+
+If both `type` and `alg` are present and they conflict (e.g., `type: "wrapped"`
+with `alg: "ECDH-HKDF"`), the `alg` field takes precedence. Implementations
+SHOULD NOT produce conflicting values.
+
+---
+
+## 10. Normative References
+
+- <a id="sp800-38d"></a>**[NIST SP 800-38D]** — Dworkin, M., "Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC", NIST Special Publication 800-38D, November 2007.
+  https://csrc.nist.gov/publications/detail/sp/800-38d/final
+
+- <a id="fips203"></a>**[NIST FIPS 203]** — "Module-Lattice-Based Key-Encapsulation Mechanism Standard", Federal Information Processing Standards Publication 203, August 2024.
+  https://csrc.nist.gov/publications/detail/fips/203/final
+
+- <a id="fips204"></a>**[NIST FIPS 204]** — "Module-Lattice-Based Digital Signature Standard", Federal Information Processing Standards Publication 204, August 2024.
+  https://csrc.nist.gov/publications/detail/fips/204/final
+
+- <a id="fips186-4"></a>**[NIST FIPS 186-4]** — "Digital Signature Standard (DSS)", Federal Information Processing Standards Publication 186-4, July 2013.
+  https://csrc.nist.gov/publications/detail/fips/186-4/final
+
+- <a id="rfc5869"></a>**[RFC 5869]** — Krawczyk, H. and P. Eronen, "HMAC-based Extract-and-Expand Key Derivation Function (HKDF)", RFC 5869, May 2010.
+  https://www.rfc-editor.org/rfc/rfc5869
+
+- <a id="rfc8017"></a>**[RFC 8017]** — Moriarty, K., Ed., Kaliski, B., Jonsson, J., and A. Rusch, "PKCS #1: RSA Cryptography Specifications Version 2.2", RFC 8017, November 2016.
+  https://www.rfc-editor.org/rfc/rfc8017
+
+- <a id="rfc6090"></a>**[RFC 6090]** — McGrew, D., Igoe, K., and M. Salter, "Fundamental Elliptic Curve Cryptography Algorithms", RFC 6090, February 2011.
+  https://www.rfc-editor.org/rfc/rfc6090
+
+- <a id="rfc2104"></a>**[RFC 2104]** — Krawczyk, H., Bellare, M., and R. Canetti, "HMAC: Keyed-Hashing for Message Authentication", RFC 2104, February 1997.
+  https://www.rfc-editor.org/rfc/rfc2104
+
+- <a id="rfc5280"></a>**[RFC 5280]** — Cooper, D., Santesson, S., Farrell, S., Boeyen, S., Housley, R., and W. Polk, "Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile", RFC 5280, May 2008.
+  https://www.rfc-editor.org/rfc/rfc5280
+
+- <a id="rfc5958"></a>**[RFC 5958]** — Turner, S., "Asymmetric Key Packages", RFC 5958, August 2010.
+  https://www.rfc-editor.org/rfc/rfc5958
+
+- <a id="rfc2119"></a>**[BCP 14 / RFC 2119]** — Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997.
+  https://www.rfc-editor.org/rfc/rfc2119
+
+- <a id="rfc8174"></a>**[RFC 8174]** — Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, May 2017.
+  https://www.rfc-editor.org/rfc/rfc8174
+
+---
+
+[sp800-38d]: https://csrc.nist.gov/publications/detail/sp/800-38d/final
+[fips203]: https://csrc.nist.gov/publications/detail/fips/203/final
+[fips204]: https://csrc.nist.gov/publications/detail/fips/204/final
+[fips186-4]: https://csrc.nist.gov/publications/detail/fips/186-4/final
+[rfc5869]: https://www.rfc-editor.org/rfc/rfc5869
+[rfc8017]: https://www.rfc-editor.org/rfc/rfc8017
+[rfc6090]: https://www.rfc-editor.org/rfc/rfc6090
+[rfc2104]: https://www.rfc-editor.org/rfc/rfc2104
+[rfc5280]: https://www.rfc-editor.org/rfc/rfc5280
+[rfc5958]: https://www.rfc-editor.org/rfc/rfc5958
+[rfc2119]: https://www.rfc-editor.org/rfc/rfc2119
+[rfc8174]: https://www.rfc-editor.org/rfc/rfc8174

--- a/spec/basetdf/v5/basetdf-alg.md
+++ b/spec/basetdf/v5/basetdf-alg.md
@@ -108,7 +108,8 @@ The 96-bit initialization vector (IV, also called nonce) MUST be unique for ever
 encryption operation performed under the same key. Reuse of an IV under the same
 key catastrophically compromises both confidentiality and authenticity. The 128-bit
 authentication tag MUST be appended to each ciphertext segment and verified before
-any plaintext is released.
+any plaintext is released. The plaintext volume protected under one A256GCM key and
+the plaintext size of one invocation are both bounded (see BaseTDF-SEC Section 6.7).
 
 ### 3.2 Key Protection Algorithms
 

--- a/spec/basetdf/v5/basetdf-asn.md
+++ b/spec/basetdf/v5/basetdf-asn.md
@@ -1,0 +1,1022 @@
+# BaseTDF-ASN: Assertions
+
+| Field | Value |
+|-------|-------|
+| **Title** | Assertions |
+| **Document** | BaseTDF-ASN |
+| **Version** | 5.0.0 |
+| **Status** | Standards Track |
+| **Date** | 2026-08 |
+| **Depends on** | BaseTDF-ALG, BaseTDF-SEC, BaseTDF-INT |
+| **Referenced by** | BaseTDF-CORE, BaseTDF-PKG, BaseTDF-LOC |
+
+---
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Assertion Object Schema](#2-assertion-object-schema)
+3. [Statement Object](#3-statement-object)
+4. [Assertion Types](#4-assertion-types)
+5. [Binding Mechanism](#5-binding-mechanism)
+6. [Assertion Hash Computation](#6-assertion-hash-computation)
+7. [Signing Assertions](#7-signing-assertions)
+8. [Verifying Assertions](#8-verifying-assertions)
+9. [PQC Considerations](#9-pqc-considerations)
+10. [Security Considerations](#10-security-considerations)
+11. [Manifest Signature](#11-manifest-signature)
+12. [Normative References](#12-normative-references)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Assertions are optional verifiable statements that can be bound to a Trusted
+Data Format (TDF) object. They provide a mechanism for attaching metadata,
+handling instructions, and other claims to protected data in a way that is
+cryptographically linked to the TDF itself.
+
+Assertions serve two primary functions:
+
+1. **Handling instructions**: Conveying data handling requirements such as
+   classification markings, distribution restrictions, retention policies, and
+   processing obligations.
+2. **General metadata**: Attaching provenance, audit, or application-specific
+   metadata to the TDF.
+
+### 1.2 Scope
+
+This document defines:
+
+- The structure and fields of an assertion object within the TDF manifest.
+- The statement formats and assertion types.
+- The cryptographic binding mechanism that prevents assertions from being
+  tampered with or replayed across different TDFs.
+- The procedures for creating and verifying signed assertions.
+- Post-quantum considerations for assertion signatures.
+
+This document does **not** define:
+
+- The assertion signing algorithms themselves (see BaseTDF-ALG Section 3.4 and
+  Section 6).
+- The manifest container format in which assertions reside (see BaseTDF-CORE).
+- The security model and trust assumptions (see BaseTDF-SEC).
+
+### 1.3 Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in [BCP 14][rfc2119]
+[RFC 8174][rfc8174] when, and only when, they appear in ALL CAPITALS, as shown
+here.
+
+### 1.4 Relationship to Other Documents
+
+- **BaseTDF-ALG**: Defines the assertion signing algorithms (`HS256`, `RS256`,
+  `ES256`, `ES384`, `ML-DSA-44`, `ML-DSA-65`) and their parameters.
+- **BaseTDF-SEC**: Establishes the security model and cryptographic
+  requirements that assertions MUST satisfy.
+- **BaseTDF-INT**: Defines the integrity verification scheme whose aggregate
+  hash is incorporated into the assertion binding payload.
+- **BaseTDF-CORE**: Defines the manifest structure that carries assertions.
+
+---
+
+## 2. Assertion Object Schema
+
+An assertion is a JSON object within the `assertions` array of the TDF
+manifest. The following is a complete example:
+
+```json
+{
+  "id": "424ff3a3-50ca-4f01-a2ae-ef851cd3cac0",
+  "type": "handling",
+  "scope": "tdo",
+  "appliesToState": "encrypted",
+  "statement": {
+    "format": "json+stanag5636",
+    "schema": "urn:nato:stanag:5636:A:1:elements:json",
+    "value": "{\"ocl\":{\"pol\":\"62c76c68-...\",\"cls\":\"SECRET\"}}"
+  },
+  "binding": {
+    "method": "jws",
+    "signature": "eyJhbGciOiJIUzI1NiIs..."
+  }
+}
+```
+
+### 2.1 Field Definitions
+
+| Field | Type | Required | Description |
+|:------|:-----|:---------|:------------|
+| `id` | string | REQUIRED | Unique identifier for this assertion within the TDF instance. Implementations SHOULD use UUIDs or other globally unique identifiers. |
+| `type` | string | REQUIRED | The category of the assertion. See [Section 4](#4-assertion-types). |
+| `scope` | string | REQUIRED | What the assertion applies to. MUST be `"tdo"`, `"payload"`, or `"manifest"`. See [Section 2.2](#22-scope-values). |
+| `appliesToState` | string | REQUIRED | Whether the statement applies to data in the `"encrypted"` or `"unencrypted"` state. See [Section 2.3](#23-appliestostate-values). |
+| `statement` | object | REQUIRED | The assertion content. See [Section 3](#3-statement-object). |
+| `binding` | object | OPTIONAL | Cryptographic binding that prevents modification and cross-TDF replay. See [Section 5](#5-binding-mechanism). |
+
+**Uniqueness**: The `id` field MUST be unique within the `assertions` array of
+a single TDF manifest. Implementations MUST reject manifests containing
+duplicate assertion IDs.
+
+### 2.2 Scope Values
+
+| Value | Name | Description |
+|:------|:-----|:------------|
+| `"tdo"` | Trusted Data Object | The assertion applies to the entire TDF object, including the manifest, key access objects, and payload. |
+| `"payload"` | Payload | The assertion applies only to the encrypted payload data. |
+| `"manifest"` | Manifest | The assertion authenticates the complete manifest for pre-fetch validation under Section 11. |
+
+Implementations MUST reject assertions with unrecognized `scope` values.
+
+### 2.3 appliesToState Values
+
+| Value | Description |
+|:------|:------------|
+| `"encrypted"` | The statement applies to the data in its encrypted state. Consuming applications SHOULD evaluate such assertions before attempting decryption. |
+| `"unencrypted"` | The statement applies to the data in its decrypted (plaintext) state. Consuming applications SHOULD evaluate such assertions after successful decryption. |
+
+Implementations MUST reject assertions with unrecognized `appliesToState`
+values.
+
+---
+
+## 3. Statement Object
+
+The `statement` field carries the actual content of the assertion. It is a JSON
+object with the following fields:
+
+| Field | Type | Required | Description |
+|:------|:-----|:---------|:------------|
+| `format` | string | REQUIRED | Describes the encoding format of the `value` field. See [Section 3.1](#31-statement-formats). |
+| `schema` | string | REQUIRED | Identifies the schema or vocabulary that the `value` conforms to. This is typically a URI or well-known identifier. |
+| `value` | string | REQUIRED | The assertion payload, encoded according to `format`. |
+
+### 3.1 Statement Formats
+
+The `format` field indicates how the `value` field is encoded. The following
+formats are defined:
+
+| Format Identifier | Description | Value Encoding |
+|:------------------|:------------|:---------------|
+| `"json-structured"` | A JSON object serialized as a string. | The `value` field contains a JSON object. When serialized in the manifest, the value MAY appear either as an inline JSON object or as a JSON-encoded string. Implementations MUST accept both representations. |
+| `"json"` | A JSON string value. | The `value` field contains a JSON-encoded string. |
+| `"base64binary"` | Base64-encoded binary data. | The `value` field contains base64-encoded ([RFC 4648][rfc4648] Section 4) binary data. |
+| `"string"` | Plain text. | The `value` field contains a plain text string with no additional encoding. |
+
+Additional format identifiers MAY be defined by applications. Format
+identifiers SHOULD follow a naming convention that avoids collision with future
+standardized formats (e.g., use a reverse-domain prefix for
+application-specific formats).
+
+### 3.2 Statement Value Deserialization
+
+When the `format` is `"json-structured"`, the `value` field in the serialized
+manifest MAY be either:
+
+- A JSON object (inline), or
+- A JSON string containing the serialized JSON object.
+
+Implementations MUST handle both representations. When deserializing a
+`json-structured` value that appears as an inline JSON object, the
+implementation MUST re-serialize it to a JSON string for internal
+representation. This ensures consistent hashing behavior (see [Section 6](#6-assertion-hash-computation)).
+
+**Example -- inline JSON object**:
+
+```json
+{
+  "statement": {
+    "format": "json-structured",
+    "schema": "urn:example:handling",
+    "value": {
+      "classification": "SECRET",
+      "releasableTo": ["usa"]
+    }
+  }
+}
+```
+
+**Example -- JSON-encoded string**:
+
+```json
+{
+  "statement": {
+    "format": "json-structured",
+    "schema": "urn:example:handling",
+    "value": "{\"classification\":\"SECRET\",\"releasableTo\":[\"usa\"]}"
+  }
+}
+```
+
+Both representations MUST produce the same assertion hash after
+canonicalization (see [Section 6](#6-assertion-hash-computation)).
+
+---
+
+## 4. Assertion Types
+
+### 4.1 Handling Assertions (type: "handling")
+
+Handling assertions carry instructions that govern how the protected data
+SHOULD be processed, distributed, retained, or destroyed by consuming
+applications. Examples include:
+
+- **Classification markings**: Security classification levels and caveats
+  (e.g., STANAG 5636 markings).
+- **Distribution restrictions**: Limits on who may receive or forward the data.
+- **Retention policies**: How long the data must or may be retained.
+- **Processing obligations**: Actions that MUST be performed before, during, or
+  after data access.
+
+Consuming applications SHOULD evaluate handling assertions and apply the
+specified instructions. An application that does not understand a handling
+assertion's schema SHOULD treat the data with the highest applicable
+restriction or refuse to process it.
+
+### 4.2 Other Assertions (type: "other")
+
+Other assertions provide general-purpose metadata that is not directly related
+to data handling. Examples include:
+
+- **System metadata**: Information about the TDF creation environment (SDK
+  version, operating system, creation timestamp).
+- **Provenance**: Origin and lineage information for the protected data.
+- **Audit markers**: Tracking identifiers for compliance and audit trails.
+- **Application-specific metadata**: Custom metadata defined by the consuming
+  application.
+
+Other assertions are informational. Consuming applications MAY ignore other
+assertions that they do not understand.
+
+### 4.3 System Metadata Assertion
+
+A well-known assertion with `id` value `"system-metadata"` and schema
+`"system-metadata-v1"` is defined for recording TDF creation context. This
+assertion has type `"other"`, scope `"payload"`, and `appliesToState`
+`"unencrypted"`.
+
+The statement value is a JSON object with the following fields:
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `tdf_spec_version` | string | The TDF specification version (e.g., `"5.0.0"`). |
+| `creation_date` | string | The creation timestamp in [RFC 3339][rfc3339] format. |
+| `operating_system` | string | The OS identifier (e.g., `"linux"`, `"darwin"`, `"windows"`). |
+| `sdk_version` | string | The SDK implementation version (e.g., `"Go-0.5.0"`). |
+| `go_version` | string | The Go runtime version (if applicable). |
+| `architecture` | string | The CPU architecture (e.g., `"amd64"`, `"arm64"`). |
+
+**Example**:
+
+```json
+{
+  "id": "system-metadata",
+  "type": "other",
+  "scope": "payload",
+  "appliesToState": "unencrypted",
+  "statement": {
+    "format": "json",
+    "schema": "system-metadata-v1",
+    "value": "{\"tdf_spec_version\":\"5.0.0\",\"creation_date\":\"2026-08-15T10:30:00Z\",\"operating_system\":\"linux\",\"sdk_version\":\"Go-0.5.0\",\"go_version\":\"go1.23.0\",\"architecture\":\"amd64\"}"
+  },
+  "binding": {
+    "method": "jws",
+    "signature": "eyJhbGciOiJIUzI1NiIs..."
+  }
+}
+```
+
+### 4.4 Extensibility
+
+The `type` field is extensible. Applications MAY define additional assertion
+types beyond `"handling"` and `"other"`. Custom types SHOULD use a namespaced
+identifier (e.g., `"x-myapp-audit"`) to avoid collisions with future
+standardized types.
+
+Implementations that encounter an unrecognized assertion type MUST NOT reject
+the TDF. The unrecognized assertion SHOULD be preserved if the TDF is
+re-serialized.
+
+---
+
+## 5. Binding Mechanism
+
+The binding mechanism cryptographically links an assertion to a specific TDF
+instance. This prevents two categories of attack:
+
+1. **Assertion tampering**: Modifying the content of an assertion after TDF
+   creation.
+2. **Cross-TDF replay**: Copying an assertion from one TDF and inserting it
+   into another TDF's manifest.
+
+### 5.1 Binding Object
+
+The `binding` field is a JSON object with the following fields:
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `method` | string | The binding method. MUST be `"jws"` when present. |
+| `signature` | string | A JWS Compact Serialization ([RFC 7515][rfc7515]) containing the signed binding payload. |
+
+**Example**:
+
+```json
+{
+  "binding": {
+    "method": "jws",
+    "signature": "eyJhbGciOiJIUzI1NiJ9.eyJhc3NlcnRpb25IYXNoIjoiNGE0NDdhMTNjNWEzMjczMGQyMGJkZjdmZWVjYjlmZmUxNjY0OWJjNzMxOTE0YjU3NGQ4MDAzNWEzOTI3Zjg2MCIsImFzc2VydGlvblNpZyI6ImJHRnlaMlZmWW1GelpUWTBYM1poYkhWbCJ9.XYZ_signature_bytes"
+  }
+}
+```
+
+### 5.2 JWS Binding (method: "jws")
+
+When the binding method is `"jws"`, the `signature` field contains a JWS
+Compact Serialization as defined in [RFC 7515][rfc7515], Section 3.1.
+
+The JWS encodes a JWT ([RFC 7519][rfc7519]) whose payload contains two claims
+that together bind the assertion to the specific TDF:
+
+| JWT Claim | Key | Type | Description |
+|:----------|:----|:-----|:------------|
+| Assertion Hash | `assertionHash` | string | The SHA-256 hash of the canonicalized assertion object (excluding the `binding` field), encoded as a lowercase hexadecimal string. See [Section 6](#6-assertion-hash-computation). |
+| Assertion Signature | `assertionSig` | string | Base64 of the BaseTDF-INT payload-binding value concatenated with the assertion hash. See [Section 7.2](#72-binding-payload-construction). |
+
+The `assertionHash` claim binds the JWS to the specific assertion content. If
+the assertion is modified, the hash will not match.
+
+The `assertionSig` claim binds the assertion to the specific TDF instance by
+incorporating the BaseTDF-INT payload-binding value. This value is
+unique to each TDF and prevents the assertion from being replayed to a
+different TDF.
+
+This JWT claim format applies to `tdo` and `payload`. A `manifest` assertion uses
+the direct canonical-manifest JWS payload defined in Section 11.
+
+### 5.3 Signing Algorithms
+
+The JWS `alg` header parameter indicates which signing algorithm was used.
+Assertion signing algorithms are defined in BaseTDF-ALG Section 3.4 and
+Section 6. The following table summarizes their status:
+
+| Algorithm | Description | Status |
+|:----------|:------------|:-------|
+| `HS256` | HMAC-SHA256 | REQUIRED |
+| `RS256` | RSASSA-PKCS1-v1_5 with SHA-256 | OPTIONAL |
+| `ES256` | ECDSA P-256 with SHA-256 | RECOMMENDED |
+| `ES384` | ECDSA P-384 with SHA-384 | OPTIONAL |
+| `ML-DSA-44` | ML-DSA-44 (FIPS 204), NIST Level 2 | RECOMMENDED |
+| `ML-DSA-65` | ML-DSA-65 (FIPS 204), NIST Level 3 | OPTIONAL |
+
+All conformant implementations MUST support `HS256` for signing and verification
+of `tdo` and `payload` assertions. Manifest-scope support is governed by Section 11.
+
+### 5.4 Key Sources for Signing
+
+#### 5.4.1 HS256 (Symmetric / DEK-Based)
+
+When using `HS256`, the HMAC key is typically the TDF's Data Encryption Key
+(DEK), which is the payload encryption key. This creates an **implicit
+binding**: only entities that possess the DEK (i.e., entities authorized to
+decrypt the TDF) can create or verify HS256-bound assertions.
+
+If no explicit signing key is provided for an assertion, implementations MUST
+default to `HS256` with the DEK as the signing key.
+
+This default MUST NOT be applied to `scope: "manifest"`; HS256 is prohibited for
+that scope because it cannot be verified before DEK recovery.
+
+#### 5.4.2 RS256 / ES256 / ES384 (Asymmetric / Classical)
+
+When using asymmetric algorithms, the signing key is an asymmetric key pair
+that is independent of the DEK. The private key signs the assertion, and the
+public key verifies it.
+
+The public key MAY be conveyed in the JWS protected header using one of the
+following mechanisms:
+
+- The `jwk` header parameter ([RFC 7515][rfc7515], Section 4.1.3), containing
+  the public key as a JWK ([RFC 7517][rfc7517]).
+- The `x5c` header parameter ([RFC 7515][rfc7515], Section 4.1.6), containing
+  an X.509 certificate chain with the signing certificate first.
+
+When the public key is included in the JWS header, verifiers MAY use it as a
+candidate verification key. Verifiers SHOULD still validate the key against a
+trust store or expected key identifier before accepting the signature.
+
+#### 5.4.3 ML-DSA-44 / ML-DSA-65 (Asymmetric / Post-Quantum)
+
+ML-DSA signing keys are used in the same manner as classical asymmetric keys.
+The private key signs and the public key verifies. ML-DSA keys are encoded as
+raw bytes (per [FIPS 204][fips204]) and base64-encoded when embedded in JWS
+header fields.
+
+See [Section 9](#9-pqc-considerations) for additional post-quantum guidance.
+
+#### 5.4.4 Hardware-Backed Keys
+
+The signing key interface MUST support hardware-backed keys. Implementations
+MUST accept any object that implements a standard cryptographic signer interface
+(e.g., Go's `crypto.Signer`) as the key material. This enables assertion
+signing via Hardware Security Modules (HSMs), Trusted Platform Modules (TPMs),
+and cloud Key Management Services (KMS).
+
+### 5.5 Binding is RECOMMENDED
+
+The `binding` field is OPTIONAL in the assertion schema but is RECOMMENDED for
+all assertions that influence security decisions, handling behavior, or access
+control.
+
+Assertions without a binding MUST NOT be used for security-critical decisions
+(see [Section 10.1](#101-unbound-assertions)).
+
+---
+
+## 6. Assertion Hash Computation
+
+The assertion hash uniquely identifies the content of an assertion. It is used
+as the `assertionHash` claim in the JWS binding payload and is the primary
+mechanism for detecting assertion tampering.
+
+### 6.1 Procedure
+
+To compute the hash of an assertion:
+
+1. **Exclude the binding**: Create a copy of the assertion object with the
+   `binding` field removed entirely (not set to null or empty -- removed from
+   the JSON structure).
+
+2. **Serialize to JSON**: Marshal the assertion object (without binding) to
+   JSON.
+
+3. **Canonicalize**: Apply JSON Canonicalization Scheme (JCS) as defined in
+   [RFC 8785][rfc8785] to the serialized JSON. JCS produces a deterministic
+   byte-level representation that is independent of field ordering, whitespace,
+   and Unicode normalization differences.
+
+4. **Hash**: Compute SHA-256 over the canonicalized bytes.
+
+5. **Hex-encode**: Encode the 32-byte SHA-256 digest as a lowercase
+   hexadecimal string (64 characters).
+
+### 6.2 Pseudocode
+
+```
+function computeAssertionHash(assertion):
+    // Step 1: Remove binding
+    assertionCopy = deepCopy(assertion)
+    delete assertionCopy.binding
+
+    // Step 2: Serialize to JSON
+    jsonBytes = JSON.serialize(assertionCopy)
+
+    // Step 3: Canonicalize with JCS (RFC 8785)
+    canonicalBytes = JCS(jsonBytes)
+
+    // Step 4-5: Hash and hex-encode
+    return hexEncode(SHA-256(canonicalBytes))
+```
+
+### 6.3 Example
+
+Given the following assertion (without binding):
+
+```json
+{
+  "id": "424ff3a3-50ca-4f01-a2ae-ef851cd3cac0",
+  "type": "handling",
+  "scope": "tdo",
+  "appliesToState": "encrypted",
+  "statement": {
+    "format": "json+stanag5636",
+    "schema": "urn:nato:stanag:5636:A:1:elements:json",
+    "value": "{\"ocl\":{\"pol\":\"62c76c68-d73d-4628-8ccc-4c1e18118c22\",\"cls\":\"SECRET\",\"catl\":[{\"type\":\"P\",\"name\":\"Releasable To\",\"vals\":[\"usa\"]}],\"dcr\":\"2024-10-21T20:47:36Z\"},\"context\":{\"@base\":\"urn:nato:stanag:5636:A:1:elements:json\"}}"
+  }
+}
+```
+
+The assertion hash is:
+
+```
+4a447a13c5a32730d20bdf7feecb9ffe16649bc731914b574d80035a3927f860
+```
+
+---
+
+## 7. Signing Assertions
+
+This section defines the procedure for creating a signed assertion during TDF
+creation.
+
+### 7.1 Prerequisites
+
+Before signing an assertion, the following MUST be available:
+
+- The fully constructed assertion object (all required fields populated).
+- The payload-binding value from BaseTDF-INT: the concatenation of segment hashes
+  for `explicit`, or the 32-byte Merkle `H_root` for `uniform`/`indexed`.
+- A signing key (either the DEK for HS256 or an asymmetric key pair for other
+  algorithms).
+
+### 7.2 Binding Payload Construction
+
+The binding payload incorporates both the assertion content and the TDF's
+integrity context, creating a two-way binding:
+
+1. **Compute the assertion hash**: Follow the procedure in
+   [Section 6](#6-assertion-hash-computation) to obtain `assertionHash` as a
+   hexadecimal string.
+
+2. **Decode the assertion hash**: Decode the hexadecimal `assertionHash`
+   string to raw bytes.
+
+3. **Concatenate with payload binding**: Concatenate the applicable integrity
+   payload-binding value from BaseTDF-INT with
+   the decoded assertion hash bytes:
+
+   ```
+   bindingInput = payloadBinding || assertionHashBytes
+   ```
+
+4. **Base64-encode**: Encode the concatenated bytes using base64
+   ([RFC 4648][rfc4648], Section 4):
+
+   ```
+   assertionSig = base64encode(bindingInput)
+   ```
+
+The two claim values for the JWT are:
+
+- `assertionHash`: The hexadecimal assertion hash string (from step 1).
+- `assertionSig`: The base64-encoded binding input (from step 4).
+
+### 7.3 JWS Construction
+
+1. **Create the JWT**: Construct a JWT with the following claims:
+
+   ```json
+   {
+     "assertionHash": "<hex-encoded SHA-256 of canonicalized assertion>",
+     "assertionSig": "<base64-encoded payloadBinding || assertionHashBytes>"
+   }
+   ```
+
+2. **Select the signing algorithm**: Use the algorithm specified in the
+   assertion's signing key configuration. If no explicit key is configured,
+   default to `HS256` with the DEK as the key.
+
+3. **Sign the JWT**: Sign the JWT using the JWS Compact Serialization format
+   ([RFC 7515][rfc7515]) with the selected algorithm and key.
+
+4. **Populate the binding**: Set the assertion's `binding` field:
+
+   ```json
+   {
+     "method": "jws",
+     "signature": "<JWS Compact Serialization>"
+   }
+   ```
+
+### 7.4 Complete Signing Procedure (Pseudocode)
+
+```
+function signAssertion(assertion, payloadBinding, signingKey):
+    // 1. Compute assertion hash
+    assertionHash = computeAssertionHash(assertion)  // hex string
+
+    // 2. Decode hex to bytes
+    assertionHashBytes = hexDecode(assertionHash)
+
+    // 3. Build binding input
+    bindingInput = payloadBinding + assertionHashBytes
+
+    // 4. Base64-encode
+    assertionSig = base64encode(bindingInput)
+
+    // 5. Create JWT
+    jwt = newJWT()
+    jwt.setClaim("assertionHash", assertionHash)
+    jwt.setClaim("assertionSig", assertionSig)
+
+    // 6. Sign
+    if signingKey is empty:
+        signingKey = { alg: "HS256", key: DEK }
+    jwsCompact = jwt.sign(signingKey.alg, signingKey.key)
+
+    // 7. Set binding
+    assertion.binding = {
+        method: "jws",
+        signature: jwsCompact
+    }
+```
+
+### 7.5 Legacy Compatibility
+
+TDFs created prior to version 4.3.0 (identified by an absent or empty
+`schemaVersion` field in the manifest) use the hexadecimal-encoded assertion
+hash bytes directly in the concatenation (step 3 of Section 7.2) instead of
+the decoded raw bytes. Implementations creating new TDFs MUST use decoded raw
+bytes. Implementations reading existing TDFs MUST detect the legacy format
+(by checking for an absent `schemaVersion` field) and apply the legacy
+concatenation method during verification.
+
+---
+
+## 8. Verifying Assertions
+
+This section defines the procedure for verifying an assertion when reading a
+TDF.
+
+### 8.1 Verification Procedure
+
+For each assertion in the manifest's `assertions` array:
+
+1. **Validate required fields**: Verify that `id`, `type`, `scope`,
+   `appliesToState`, and `statement` are present and contain recognized values.
+   If any required field is missing or unrecognized, the assertion MUST be
+   rejected.
+
+2. **Check for binding**: If the `binding` field is absent or empty, the
+   assertion is unbound. Skip to step 8.
+
+3. **Determine the verification key**:
+   - If the application has registered a verification key for this assertion's
+     `id`, use that key.
+   - Otherwise, if a default verification key is configured, use it.
+   - Otherwise, use the DEK with `HS256` as the default.
+
+4. **Parse the JWS**: Parse the `binding.signature` field as a JWS Compact
+   Serialization.
+
+5. **Resolve the signing key**: The verification key is resolved in the
+   following priority order:
+   a. The explicitly configured key for this assertion ID.
+   b. The configured default verification key.
+   c. A public key embedded in the JWS protected header (`jwk` or `x5c`
+      parameter), if present and trusted.
+   d. The DEK (for `HS256` verification).
+
+   If multiple candidate keys are available, the implementation SHOULD attempt
+   verification with each until one succeeds or all fail.
+
+6. **Verify the JWS signature**: Verify the JWS using the resolved key and
+   algorithm. If verification fails, the assertion MUST be rejected with an
+   error.
+
+7. **Validate the claims**:
+   a. Extract the `assertionHash` and `assertionSig` claims from the verified
+      JWT.
+   b. Recompute the assertion hash using the procedure in
+      [Section 6](#6-assertion-hash-computation).
+   c. Compare the recomputed hash with the `assertionHash` claim. If they do
+      not match, the assertion MUST be rejected (the assertion content has been
+      modified).
+   d. Recompute the expected `assertionSig` value using the aggregate
+      integrity hash from the TDF and the assertion hash bytes (following the
+      procedure in [Section 7.2](#72-binding-payload-construction)).
+   e. Compare the recomputed `assertionSig` with the claim value. If they do
+      not match, the assertion MUST be rejected (the assertion has been
+      replayed from a different TDF).
+
+8. **Unbound assertions**: If the assertion has no binding, it MUST be treated
+   as informational only. The consuming application MUST NOT use unbound
+   assertions for security decisions, access control, or handling instructions
+   that affect data confidentiality or integrity.
+
+### 8.2 Verification Pseudocode
+
+```
+function verifyAssertion(assertion, payloadBinding, verificationKeys, dek):
+    // Step 1: Validate fields
+    validateRequiredFields(assertion)
+
+    // Step 2: Check binding
+    if assertion.binding is empty:
+        return UNBOUND  // informational only
+
+    // Step 3-5: Resolve key
+    key = resolveVerificationKey(assertion.id, verificationKeys, dek)
+
+    // Step 6: Verify JWS
+    jwt = JWS.verify(assertion.binding.signature, key)
+    if jwt is invalid:
+        return ERROR("signature verification failed")
+
+    // Step 7a: Extract claims
+    claimedHash = jwt.getClaim("assertionHash")
+    claimedSig  = jwt.getClaim("assertionSig")
+
+    // Step 7b-c: Verify assertion hash
+    computedHash = computeAssertionHash(assertion)
+    if computedHash != claimedHash:
+        return ERROR("assertion hash mismatch")
+
+    // Step 7d-e: Verify TDF binding
+    assertionHashBytes = hexDecode(computedHash)
+    expectedSig = base64encode(payloadBinding + assertionHashBytes)
+    if expectedSig != claimedSig:
+        return ERROR("assertion signature mismatch - cross-TDF replay")
+
+    return VERIFIED
+```
+
+### 8.3 Error Handling
+
+Implementations MUST distinguish between the following error conditions:
+
+| Error | Cause | Action |
+|:------|:------|:-------|
+| Signature verification failed | The JWS signature does not verify with any available key. | Reject the assertion. The signing key may be wrong or the JWS has been tampered with. |
+| Assertion hash mismatch | The `assertionHash` claim does not match the recomputed hash. | Reject the assertion. The assertion content has been modified after signing. |
+| Assertion signature mismatch | The `assertionSig` claim does not match the expected value. | Reject the assertion. The assertion has likely been replayed from a different TDF. |
+| Missing required claims | The `assertionHash` or `assertionSig` claim is absent from the JWT. | Reject the assertion. The JWS payload is malformed. |
+
+When an assertion fails verification, implementations SHOULD include the
+assertion `id` in the error message to assist debugging but MUST NOT include
+any key material.
+
+---
+
+## 9. PQC Considerations
+
+### 9.1 Recommended Algorithm
+
+`ML-DSA-44` is RECOMMENDED for new deployments concerned with quantum threats
+to assertion integrity. ML-DSA-44 provides NIST Level 2 security
+(approximately equivalent to 128-bit classical security against quantum
+adversaries), which is appropriate for assertions where the primary concern is
+signature forgery.
+
+### 9.2 Signature Size Impact
+
+ML-DSA signatures are significantly larger than classical signatures:
+
+| Algorithm | Signature Size | Public Key Size |
+|:----------|:---------------|:----------------|
+| `HS256` | 32 bytes (HMAC tag) | N/A (symmetric) |
+| `RS256` (2048-bit) | 256 bytes | 256 bytes |
+| `ES256` | 64 bytes | 33 bytes (compressed) |
+| `ES384` | 96 bytes | 49 bytes (compressed) |
+| `ML-DSA-44` | 2420 bytes | 1312 bytes |
+| `ML-DSA-65` | 3309 bytes | 1952 bytes |
+
+The JWS Compact Serialization base64-encodes the signature, increasing its
+on-wire size by approximately 33%. For TDFs with many assertions signed with
+ML-DSA, the manifest size increase may be significant. Implementations SHOULD
+account for this when designing systems that process large numbers of
+assertions.
+
+### 9.3 Migration Guidance
+
+For assertion signatures, the recommended migration path is:
+
+```
+Phase 1 (Current)       Phase 2 (PQC)          Phase 3 (PQC-Only)
+-----------------       ---------------        ------------------
+HS256 / RS256 / ES256   ML-DSA-44 / ML-DSA-65  ML-DSA-44 / ML-DSA-65
+                        (alongside classical)   (classical deprecated)
+```
+
+During Phase 2, implementations SHOULD support both classical and post-quantum
+algorithms for verification. The algorithm used for a specific assertion is
+indicated by the JWS `alg` header parameter, so there is no ambiguity during
+verification.
+
+### 9.4 HS256 Quantum Resistance
+
+`HS256` (HMAC-SHA256) is not affected by Shor's algorithm and provides 128-bit
+post-quantum security (via Grover's bound). For assertions that use HS256 with
+the DEK, no migration to post-quantum algorithms is necessary for the assertion
+signing itself. However, the DEK's availability depends on the key protection
+algorithm, which may be quantum-vulnerable (see BaseTDF-SEC Section 8).
+
+---
+
+## 10. Security Considerations
+
+### 10.1 Unbound Assertions
+
+Assertions without a `binding` field are NOT authenticated. They carry no
+cryptographic guarantee of origin or integrity. Implementations:
+
+- MUST NOT use unbound assertions for security decisions.
+- MUST NOT use unbound assertions for access control.
+- MUST NOT use unbound assertions to determine handling behavior that affects
+  data confidentiality or integrity.
+- SHOULD treat unbound assertions as untrusted metadata that may have been
+  inserted or modified by any party with access to the TDF manifest.
+
+### 10.2 Cross-TDF Replay Prevention
+
+The inclusion of the BaseTDF-INT payload-binding value in the
+`assertionSig` claim binds each assertion to a specific TDF instance. Because
+the binding value depends on the encrypted payload content, an assertion
+signed for one TDF will fail verification when inserted into a different TDF.
+
+This binding is effective because:
+
+- The binding value is the explicit aggregate hash or scalable Merkle root and is
+  unique to each encryption operation.
+- The `assertionSig` combines the binding value with the assertion hash,
+  creating a value that is specific to both the assertion content and the TDF
+  instance.
+
+### 10.3 Symmetric vs. Asymmetric Binding
+
+| Property | HS256 (Symmetric) | RS256 / ES256 / ML-DSA (Asymmetric) |
+|:---------|:-------------------|:-------------------------------------|
+| **Authentication** | Yes -- any holder of the DEK can verify. | Yes -- anyone with the public key can verify. |
+| **Non-repudiation** | No -- any holder of the DEK can also forge assertions. | Yes -- only the private key holder can sign. |
+| **Key management** | Implicit (DEK), no additional key distribution needed. | Requires distribution of public keys or certificates. |
+| **Use case** | Self-asserted metadata bound to TDF encryption. | Third-party attestations, regulatory markings, multi-party workflows. |
+
+When non-repudiation is required (e.g., a third party attests to the
+classification of the data), asymmetric algorithms (RS256, ES256, ES384,
+ML-DSA-44, or ML-DSA-65) MUST be used.
+
+### 10.4 Assertion Ordering
+
+The `assertions` array in the manifest is ordered. Implementations MUST
+preserve assertion ordering when reading and re-serializing a TDF. The
+assertion hash computation is independent of ordering (each assertion is hashed
+individually), but downstream applications MAY assign semantic meaning to
+assertion order.
+
+### 10.5 Key Selection Security
+
+When the JWS protected header contains a `jwk` or `x5c` parameter,
+implementations MUST exercise caution:
+
+- A `jwk` header provides a candidate public key but does NOT establish trust.
+  The verifier MUST validate the key against a trusted key store, certificate
+  authority, or pre-configured expectation before accepting the signature.
+- An `x5c` header provides a certificate chain. The verifier MUST validate the
+  chain against a trusted certificate authority.
+- Implementations MUST NOT blindly trust keys embedded in JWS headers without
+  external validation.
+
+### 10.6 Assertion Integrity and BaseTDF-SEC
+
+Assertion verification supports the following security invariants from
+BaseTDF-SEC:
+
+- **SI-5 (Payload Integrity Verification)**: The `assertionSig` claim
+  incorporates the payload-binding value, establishing a dependency between
+  assertion validity and payload integrity.
+- **SI-6 (Algorithm Validation)**: The JWS `alg` header MUST specify a
+  recognized algorithm from BaseTDF-ALG Section 3.4. Unrecognized algorithms
+  MUST be rejected.
+
+---
+
+## 11. Manifest Signature
+
+### 11.1 Purpose and requirement
+
+Detachment makes the manifest an independently fetched routing document. A manifest
+assertion authenticates all locator, payload, encryption, policy, KAO, integrity,
+and ordinary assertion fields before external access.
+
+Detached and sharded manifests MUST contain exactly one assertion whose `scope` is
+`"manifest"`. Attached manifests MAY contain one, but MUST NOT contain more than
+one. The assertion MUST have a JWS binding and SHOULD use `type: "other"` and
+`appliesToState: "encrypted"`.
+
+### 11.2 Algorithms and key trust
+
+A manifest assertion MUST use an asymmetric algorithm. BaseTDF 5.0 permits ES256
+(RECOMMENDED) and RS256. HS256 is PROHIBITED because DEK recovery occurs after
+locator validation. Other algorithms require a future suite revision.
+
+The protected JWS header MUST contain `alg` and `kid`. The verifier MUST resolve
+`kid` through a locally trusted publisher-key configuration and apply its rotation,
+revocation, validity, and intended-use policy. An inline `jwk` or `x5c` MAY supply a
+candidate key but MUST NOT establish trust by itself.
+
+### 11.3 Signing input
+
+The JWS payload is the exact UTF-8 RFC 8785 canonicalization of the manifest after
+removing the complete manifest assertion element from the `assertions` array. The
+array and every other field remain present; if removal leaves no elements,
+`"assertions": []` remains in the signing input. No field is otherwise inserted,
+removed, normalized, or default-expanded.
+
+The JWS uses Compact Serialization. Its payload segment is the base64url encoding of
+the canonical bytes and MUST NOT be detached (`b64: false` is not used). The
+assertion's `binding.signature` stores the complete compact JWS. This direct payload
+replaces the JWT claim form used by other assertion scopes.
+
+Example signing assertion shape:
+
+```json
+{
+  "id":"manifest-signature",
+  "type":"other",
+  "scope":"manifest",
+  "appliesToState":"encrypted",
+  "statement":{
+    "format":"string",
+    "schema":"urn:opentdf:manifest-signature:v1",
+    "value":"publisher manifest signature"
+  },
+  "binding":{
+    "method":"jws",
+    "signature":"<protected>.<canonical-manifest-payload>.<signature>"
+  }
+}
+```
+
+### 11.4 Signing procedure
+
+1. Complete every manifest field except the signing assertion's JWS string.
+2. Insert the complete assertion object with an empty temporary signature.
+3. Remove that assertion element from a copy of the manifest.
+4. Canonicalize the copy with RFC 8785 and use those bytes as the JWS payload.
+5. Sign using ES256 or RS256 and a protected `kid`.
+6. Store the compact JWS in the original assertion.
+
+### 11.5 Verification procedure
+
+Before any external locator is dereferenced, a verifier MUST:
+
+1. structurally parse and size-bound the manifest without resolving resources;
+2. require exactly one manifest assertion for detached/sharded packaging;
+3. validate its shape, protected algorithm, and protected `kid`;
+4. resolve an authorized publisher key through local trust policy;
+5. remove the assertion, retaining the now-possibly-empty array, and perform RFC
+   8785 canonicalization;
+6. require the decoded JWS payload to equal those canonical bytes exactly; and
+7. verify the JWS signature.
+
+Failure MUST stop locator processing. A valid manifest signature authenticates
+publisher provenance and manifest bytes, not fetched ciphertext; BaseTDF-INT root
+verification remains REQUIRED.
+
+### 11.6 Multiple signatures
+
+Version 5.0 permits only one manifest assertion to avoid circular coverage among
+signatures. A future version may define a signature-set envelope. Multiple ordinary
+assertions remain permitted and are covered by the manifest signature.
+
+---
+
+## 12. Normative References
+
+- <a id="rfc7515"></a>**[RFC 7515]** -- Jones, M., Bradley, J., and N.
+  Sakimura, "JSON Web Signature (JWS)", RFC 7515, May 2015.
+  https://www.rfc-editor.org/rfc/rfc7515
+
+- <a id="rfc7517"></a>**[RFC 7517]** -- Jones, M., "JSON Web Key (JWK)",
+  RFC 7517, May 2015.
+  https://www.rfc-editor.org/rfc/rfc7517
+
+- <a id="rfc7519"></a>**[RFC 7519]** -- Jones, M., Bradley, J., and N.
+  Sakimura, "JSON Web Token (JWT)", RFC 7519, May 2015.
+  https://www.rfc-editor.org/rfc/rfc7519
+
+- <a id="rfc8785"></a>**[RFC 8785]** -- Rundgren, A., Jordan, B., and S.
+  Erdtman, "JSON Canonicalization Scheme (JCS)", RFC 8785, June 2020.
+  https://www.rfc-editor.org/rfc/rfc8785
+
+- <a id="rfc4648"></a>**[RFC 4648]** -- Josefsson, S., "The Base16, Base32,
+  and Base64 Data Encodings", RFC 4648, October 2006.
+  https://www.rfc-editor.org/rfc/rfc4648
+
+- <a id="fips204"></a>**[NIST FIPS 204]** -- "Module-Lattice-Based Digital
+  Signature Standard", Federal Information Processing Standards Publication
+  204, August 2024.
+  https://csrc.nist.gov/publications/detail/fips/204/final
+
+- <a id="rfc2104"></a>**[RFC 2104]** -- Krawczyk, H., Bellare, M., and R.
+  Canetti, "HMAC: Keyed-Hashing for Message Authentication", RFC 2104,
+  February 1997.
+  https://www.rfc-editor.org/rfc/rfc2104
+
+- <a id="rfc2119"></a>**[BCP 14 / RFC 2119]** -- Bradner, S., "Key words for
+  use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997.
+  https://www.rfc-editor.org/rfc/rfc2119
+
+- <a id="rfc8174"></a>**[RFC 8174]** -- Leiba, B., "Ambiguity of Uppercase vs
+  Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, May 2017.
+  https://www.rfc-editor.org/rfc/rfc8174
+
+- <a id="rfc3339"></a>**[RFC 3339]** -- Klyne, G. and C. Newman, "Date and
+  Time on the Internet: Timestamps", RFC 3339, July 2002.
+  https://www.rfc-editor.org/rfc/rfc3339
+
+---
+
+[rfc7515]: https://www.rfc-editor.org/rfc/rfc7515
+[rfc7517]: https://www.rfc-editor.org/rfc/rfc7517
+[rfc7519]: https://www.rfc-editor.org/rfc/rfc7519
+[rfc8785]: https://www.rfc-editor.org/rfc/rfc8785
+[rfc4648]: https://www.rfc-editor.org/rfc/rfc4648
+[fips204]: https://csrc.nist.gov/publications/detail/fips/204/final
+[rfc2104]: https://www.rfc-editor.org/rfc/rfc2104
+[rfc2119]: https://www.rfc-editor.org/rfc/rfc2119
+[rfc8174]: https://www.rfc-editor.org/rfc/rfc8174
+[rfc3339]: https://www.rfc-editor.org/rfc/rfc3339

--- a/spec/basetdf/v5/basetdf-core.md
+++ b/spec/basetdf/v5/basetdf-core.md
@@ -112,7 +112,7 @@ using any BaseTDF-LOC locator.
 | `type` | string | REQUIRED | MUST be `split`. |
 | `keyAccess` | array | REQUIRED | One or more BaseTDF-KAO objects. |
 | `method` | object | REQUIRED | Content-encryption parameters. |
-| `keyDerivation` | object | OPTIONAL | Partition key derivation. |
+| `keyDerivation` | object | conditional | Partition key derivation; REQUIRED above the Section 4.3 volume limit. |
 | `integrityInformation` | object | REQUIRED | BaseTDF-INT profile. |
 | `policy` | string | REQUIRED | Base64 of the exact BaseTDF-POL JSON string. |
 
@@ -149,6 +149,43 @@ encryption and HS256 segment hashing use `K_p`; Merkle nodes and roots use the D
 Without this object, segments use the DEK as in version 4. Distributed workers MUST
 receive only assigned partition keys. Append checkpoints MUST end at a partition
 boundary unless `partitionSegments` is one.
+
+### 4.3 Volume limits
+
+No content-encryption key may protect more than `MAXKEYBYTES = 2^40` plaintext
+bytes (1099511627776). BaseTDF-SEC Section 6.7 gives the analysis; this section
+gives the manifest constraints. Writers MUST satisfy them and readers MUST reject a
+manifest that violates them.
+
+Let `T` be the total plaintext protected under one DEK: `plaintextSize` for a
+scalable layout, or the checked sum of `segments[].segmentSize` for an explicit
+one. For an append chain, `T` is the cumulative total at the current head
+(Section 7), not the increment.
+
+1. `keyDerivation` is REQUIRED when `T > MAXKEYBYTES`, because otherwise every
+   segment is encrypted under the DEK.
+2. When `keyDerivation` is present, no partition may cover more than
+   `MAXKEYBYTES` plaintext bytes. With `n = min(partitionSegments, segmentCount)`:
+
+```text
+uniform:  n * segmentSizeDefault <= MAXKEYBYTES
+indexed:  n * segmentSizeMax     <= MAXKEYBYTES
+explicit: for every p,
+          sum(segmentSize[i] : floor(i / partitionSegments) = p) <= MAXKEYBYTES
+```
+
+The uniform and indexed forms are conservative upper bounds computable from the
+manifest header alone, because `segmentSizeDefault` and `segmentSizeMax` bound
+every segment in their layouts. The explicit form is exact because every size is
+recorded. An indexed writer whose actual partition bytes fall under the ceiling but
+whose `segmentSizeMax` product does not MUST still lower `partitionSegments`; the
+check is on the manifest, not on the realized sizes.
+
+The DEK itself is unconstrained by `MAXKEYBYTES` when `keyDerivation` is present,
+since it then serves only as the HKDF PRK and the Merkle HMAC key.
+
+Each TDF object MUST use a freshly generated DEK; a DEK MUST NOT be reused across
+objects (BaseTDF-SEC Section 6.7.5).
 
 ## 5. Integrity Dispatch
 
@@ -218,7 +255,8 @@ publishers MUST serialize publication and retain fork evidence.
 A writer MUST:
 
 1. choose and validate packaging and layout;
-2. generate a 256-bit DEK and, for scalable layouts, a four-byte nonce prefix;
+2. generate a fresh 256-bit DEK and, for scalable layouts, a four-byte nonce
+   prefix, and select `keyDerivation` to satisfy Section 4.3;
 3. create policy, splits, and KAOs;
 4. encrypt ordered segments with unique/deterministic IVs and compute hashes;
 5. create the explicit aggregate root or scalable Merkle tree and root;
@@ -239,7 +277,7 @@ A reader MUST:
 3. verify detached/sharded manifest signatures before locators;
 4. validate locators and exact resource sizes;
 5. complete KAS authorization, verify policy bindings, and reconstruct the DEK;
-6. validate algorithms and integrity structure;
+6. validate algorithms, integrity structure, and the Section 4.3 volume limits;
 7. verify requested ciphertext under BaseTDF-INT, including IV, segment hash,
    Merkle path when applicable, sizes, count, root, and AEAD tag; and
 8. release only authenticated plaintext and verify applicable assertions.

--- a/spec/basetdf/v5/basetdf-core.md
+++ b/spec/basetdf/v5/basetdf-core.md
@@ -152,37 +152,68 @@ boundary unless `partitionSegments` is one.
 
 ### 4.3 Volume limits
 
-No content-encryption key may protect more than `MAXKEYBYTES = 2^40` plaintext
-bytes (1099511627776). BaseTDF-SEC Section 6.7 gives the analysis; this section
-gives the manifest constraints. Writers MUST satisfy them and readers MUST reject a
-manifest that violates them.
-
-Let `T` be the total plaintext protected under one DEK: `plaintextSize` for a
-scalable layout, or the checked sum of `segments[].segmentSize` for an explicit
-one. For an append chain, `T` is the cumulative total at the current head
-(Section 7), not the increment.
-
-1. `keyDerivation` is REQUIRED when `T > MAXKEYBYTES`, because otherwise every
-   segment is encrypted under the DEK.
-2. When `keyDerivation` is present, no partition may cover more than
-   `MAXKEYBYTES` plaintext bytes. With `n = min(partitionSegments, segmentCount)`:
+BaseTDF targets an object-wide AES-GCM confidentiality advantage no greater than
+`2^-57`. BaseTDF-SEC Section 6.7 derives the following block-square budget from
+RFC 9001 Appendix B.1:
 
 ```text
-uniform:  n * segmentSizeDefault <= MAXKEYBYTES
-indexed:  n * segmentSizeMax     <= MAXKEYBYTES
-explicit: for every p,
-          sum(segmentSize[i] : floor(i / partitionSegments) = p) <= MAXKEYBYTES
+CONFIDENTIALITY_BLOCK_BUDGET = 2^70
 ```
 
-The uniform and indexed forms are conservative upper bounds computable from the
-manifest header alone, because `segmentSizeDefault` and `segmentSizeMax` bound
-every segment in their layouts. The explicit form is exact because every size is
-recorded. An indexed writer whose actual partition bytes fall under the ceiling but
-whose `segmentSizeMax` product does not MUST still lower `partitionSegments`; the
-check is on the manifest, not on the realized sizes.
+For each content-encryption key `K_p`, let `sigma_p` be a conservative upper bound
+on the sum of `ceil(segmentSize / 16)` across invocations protected by that key.
+Writers MUST satisfy, and readers MUST verify:
 
-The DEK itself is unconstrained by `MAXKEYBYTES` when `keyDerivation` is present,
-since it then serves only as the HKDF PRK and the Merkle HMAC key.
+```text
+sum(sigma_p * sigma_p for every p) <= 2^70
+```
+
+All multiplication and accumulation for this check MUST use checked arithmetic
+wide enough to represent `2^70`; implementations MUST reject on overflow.
+
+Let `T` be the total plaintext: `plaintextSize` for a scalable layout, or the
+checked sum of `segments[].segmentSize` for an explicit one. For an append chain,
+`T` and every partition total are cumulative at the current head (Section 7), not
+just the latest increment.
+
+Without `keyDerivation`, calculate `sigma_0` across every segment as below and
+apply the same budget. Consequently, `keyDerivation` is always REQUIRED when
+`T > 2^39` bytes (512 GiB), and can be required below that size for layouts with
+many non-block-aligned segments.
+
+With `keyDerivation`, partition `p` covers segment indices
+`[p * partitionSegments, min((p + 1) * partitionSegments, segmentCount))`. Let
+`n_p` be the number of indices in that range and calculate `sigma_p` as follows:
+
+```text
+uniform:  sigma_p = n_p * ceil(segmentSizeDefault / 16)
+indexed:  sigma_p = n_p * ceil(segmentSizeMax / 16)
+explicit: sigma_p = sum(ceil(segmentSize[i] / 16)
+                        for every i in partition p)
+```
+
+The explicit form is exact. The uniform form conservatively charges a full default
+segment for a short final segment, and the indexed form charges `segmentSizeMax`
+for every segment. Both scalable forms are therefore computable from the manifest
+header. A writer whose actual partition blocks satisfy the budget but whose
+conservative bound does not MUST lower `partitionSegments`; the check is on the
+manifest, not on unauthenticated realized sizes.
+
+No individual `sigma_p` can exceed `2^35`, so no content-encryption key can protect
+more than `2^39` bytes (512 GiB). The DEK is not a content-encryption key when
+`keyDerivation` is present; it then serves only as the HKDF PRK and Merkle HMAC key.
+
+The RECOMMENDED partition size is 1 GiB. This is `partitionSegments: 512` at the
+2 MiB default segment size or `partitionSegments: 256` at 4 MiB. For a 50 TiB
+object, 51,200 such partitions keep the conservative object-wide advantage below
+`2^-59`, leaving margin beneath the `2^-57` target.
+
+Scalable-layout writers and readers MUST support `plaintextSize` values through at
+least `50 * 2^40` bytes (54,975,581,388,800 bytes, 50 TiB), plus the corresponding
+AEAD and packaging overhead in encrypted-size fields. This is a minimum required
+range, not a maximum object size. Implementations MAY enforce lower deployment
+resource limits, but MUST distinguish those local limits from format or
+cryptographic invalidity.
 
 Each TDF object MUST use a freshly generated DEK; a DEK MUST NOT be reused across
 objects (BaseTDF-SEC Section 6.7.5).

--- a/spec/basetdf/v5/basetdf-core.md
+++ b/spec/basetdf/v5/basetdf-core.md
@@ -1,0 +1,280 @@
+# BaseTDF-CORE: Manifest and End-to-End Processing
+
+| | |
+|---|---|
+| **Document** | BaseTDF-CORE |
+| **Version** | 5.0.0 |
+| **Status** | Standards Track |
+| **Date** | 2026-08 |
+| **Depends on** | BaseTDF-SEC, BaseTDF-ALG, BaseTDF-KAO, BaseTDF-INT, BaseTDF-POL, BaseTDF-ASN, BaseTDF-LOC, BaseTDF-PKG |
+| **Referenced by** | BaseTDF-EX |
+
+## 1. Introduction
+
+BaseTDF-CORE defines the logical BaseTDF manifest and end-to-end processing.
+Physical serialization is defined by [BaseTDF-PKG](basetdf-pkg.md), allowing the
+same protected object to be attached, detached, or sharded.
+
+### 1.1 Design principles
+
+1. **Self-description.** The manifest is authoritative about what is protected,
+   policy, key access, integrity, and protected-byte locations. Self-description
+   does not require every byte to share one container.
+2. **Separation.** Metadata, ciphertext, integrity artifacts, key services, and
+   storage transports have distinct validation boundaries.
+3. **Bounded processing.** Unknown-length input supports a forward-only write, and a
+   selected segment supports verification without O(payload size) metadata.
+4. **Fail closed.** Unsupported versions/profiles, invalid combinations, overflow,
+   unauthenticated locators, and cryptographic failures stop affected plaintext.
+
+BCP 14 terms are normative when capitalized. All count, size, range, and offset
+operations MUST use checked unsigned 64-bit arithmetic.
+
+## 2. Manifest Object
+
+### 2.1 Scalable attached example
+
+```json
+{
+  "schemaVersion":"5.0.0",
+  "payload":{
+    "type":"reference", "url":"0.payload", "protocol":"zip",
+    "mimeType":"application/octet-stream", "isEncrypted":true
+  },
+  "encryptionInformation":{
+    "type":"split",
+    "keyAccess":[{
+      "alg":"RSA-OAEP-256", "kas":"https://kas.example.com",
+      "kid":"kas-key-2026", "sid":"split-0", "protectedKey":"<base64>",
+      "policyBinding":{"alg":"HS256", "hash":"<base64>"}
+    }],
+    "method":{
+      "algorithm":"AES-256-GCM", "iv":"", "isStreamable":true,
+      "noncePrefix":"<base64-four-bytes>"
+    },
+    "keyDerivation":{"alg":"HKDF-SHA256", "partitionSegments":512},
+    "integrityInformation":{
+      "rootSignature":{"alg":"MERKLE-HS256", "sig":"<base64>"},
+      "segmentHashAlg":"GMAC",
+      "segmentSizeDefault":2097152,
+      "encryptedSegmentSizeDefault":2097180,
+      "layout":"uniform",
+      "segmentCount":524288,
+      "lastSegmentSize":2097152,
+      "plaintextSize":1099511627776,
+      "encryptedSize":1099526307840,
+      "hashTree":{
+        "nodeSize":32, "levels":20, "size":33554432,
+        "locator":{"uri":"zip:0.integrity", "size":33554432}
+      }
+    },
+    "policy":"<base64-policy-json>"
+  },
+  "assertions":[]
+}
+```
+
+`attached` and `explicit` are defaults when their fields are absent. Thus an
+explicit attached object retains the version 4 field shape apart from
+`schemaVersion`.
+
+### 2.2 Top-level fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `schemaVersion` | string | REQUIRED | New objects MUST use `"5.0.0"`. |
+| `packaging` | string | OPTIONAL | `attached`, `detached`, or `sharded`; default `attached`. |
+| `payload` | object | REQUIRED | Representation selected by packaging. |
+| `encryptionInformation` | object | REQUIRED | KAOs, method, integrity, policy, and optional key derivation. |
+| `assertions` | array | OPTIONAL | BaseTDF-ASN assertions; detached/sharded require one manifest signature. |
+| `extends` | object | OPTIONAL | Append predecessor and consistency proof. |
+
+A 5.0 reader MUST NOT assign security meaning to unknown fields. It MUST reject any
+future minor-version feature it cannot validate completely.
+
+## 3. Packaging Dispatch
+
+| Profile | Required payload fields | Forbidden payload fields |
+|---|---|---|
+| `attached` | `type: reference`, `url: 0.payload`, `protocol: zip`, `isEncrypted: true` | `locators`, `parts`, `size` |
+| `detached` | `type: detached`, `isEncrypted: true`, exact encrypted `size`, non-empty `locators` | `url`, `protocol`, `parts` |
+| `sharded` | `type: detached`, `isEncrypted: true`, exact encrypted `size`, non-empty `parts` | `url`, `protocol`, top-level `locators` |
+
+`mimeType` is OPTIONAL and defaults to `application/octet-stream`.
+`contentBinding` is OPTIONAL and defined by BaseTDF-PKG; it does not replace the
+root signature. Detached/sharded readers MUST verify the manifest assertion before
+using any BaseTDF-LOC locator.
+
+## 4. Encryption Information
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | string | REQUIRED | MUST be `split`. |
+| `keyAccess` | array | REQUIRED | One or more BaseTDF-KAO objects. |
+| `method` | object | REQUIRED | Content-encryption parameters. |
+| `keyDerivation` | object | OPTIONAL | Partition key derivation. |
+| `integrityInformation` | object | REQUIRED | BaseTDF-INT profile. |
+| `policy` | string | REQUIRED | Base64 of the exact BaseTDF-POL JSON string. |
+
+Policy, KAO, and KAS semantics are unchanged from BaseTDF 4.4.
+
+### 4.1 Method
+
+| Field | Required | Description |
+|---|---|---|
+| `algorithm` | yes | Registered content-encryption algorithm. |
+| `iv` | yes | Legacy method IV; MAY be empty because each segment carries an IV. |
+| `isStreamable` | yes | MUST be `true`. |
+| `noncePrefix` | scalable layouts only | Base64 encoding of exactly four random bytes. |
+
+For `uniform` and `indexed`, segment `i` MUST carry
+`noncePrefix || u64be(i)` and readers MUST reject a mismatch. Explicit layout keeps
+the version 4 unique-IV rules.
+
+### 4.2 Partition keys
+
+```json
+{"keyDerivation":{"alg":"HKDF-SHA256", "partitionSegments":512}}
+```
+
+`partitionSegments` MUST be positive. For `p = floor(i / partitionSegments)`:
+
+```text
+K_p = HKDF-Expand(PRK = DEK,
+                  info = UTF8("BaseTDF-part-v1") || u64be(p), L = 32)
+```
+
+This is RFC 5869 Expand with the DEK directly as PRK and no Extract step. Segment
+encryption and HS256 segment hashing use `K_p`; Merkle nodes and roots use the DEK.
+Without this object, segments use the DEK as in version 4. Distributed workers MUST
+receive only assigned partition keys. Append checkpoints MUST end at a partition
+boundary unless `partitionSegments` is one.
+
+## 5. Integrity Dispatch
+
+Common required fields are `rootSignature`, `segmentHashAlg`,
+`segmentSizeDefault`, and `encryptedSegmentSizeDefault`.
+
+| Layout | Additional required | MUST be absent |
+|---|---|---|
+| `explicit` (default) | `segments` | scalable count/total/tree fields |
+| `uniform` | `layout`, `segmentCount`, `lastSegmentSize`, `plaintextSize`, `encryptedSize`, `hashTree`, `MERKLE-HS256` root | `segments`, `segmentSizeMax` |
+| `indexed` | `layout`, `segmentCount`, `segmentSizeMax`, `plaintextSize`, `encryptedSize`, `hashTree`, `MERKLE-HS256` root | `segments`, `lastSegmentSize` |
+
+Counts, totals, and tree metadata MUST be validated before allocation.
+
+### 5.1 Hash tree
+
+| Field | Required | Description |
+|---|---|---|
+| `nodeSize` | yes | 32 for uniform, 48 for indexed. |
+| `levels` | yes | Stored levels including leaves and root. |
+| `size` | yes | Exact artifact bytes. |
+| `locator` | conditional | One BaseTDF-LOC locator. |
+| `inline` | conditional | Base64 complete artifact. |
+
+Exactly one of `locator` and `inline` is REQUIRED. The decoded/fetched length MUST
+equal `size`; its header and authenticated root MUST agree with the manifest.
+
+## 6. Assertions and Manifest Authentication
+
+BaseTDF-ASN defines assertions. Ordinary `tdo`/`payload` assertions bind to the
+explicit aggregate hash or scalable Merkle root. Detached and sharded manifests
+MUST have exactly one `scope: manifest` assertion with an asymmetric JWS. It signs
+the RFC 8785 canonical manifest after removing that assertion. The publisher key
+MUST be trusted by local policy before any locator is dereferenced. Attached
+manifests MAY include one such assertion.
+
+## 7. Append Extension
+
+```json
+{"extends":{
+  "sequence":41,
+  "manifestDigestAlg":"SHA-256",
+  "manifestDigest":"<base64-prior-canonical-manifest-digest>",
+  "segmentCount":262144,
+  "plaintextSize":549755813888,
+  "encryptedSize":549763153920,
+  "rootSignature":"<base64-prior-root>",
+  "consistencyProof":[
+    {"hash":"<base64>", "plaintextTotal":2097152,
+     "encryptedTotal":2097180}
+  ]
+}}
+```
+
+`sequence` increments by one, beginning at one. The predecessor digest is SHA-256
+over its RFC 8785 canonical manifest. Old counts/totals/root MUST authenticate and
+be smaller than the new values. BaseTDF-INT defines proof verification.
+
+The DEK, layout, content algorithm, nonce prefix, segment-size parameters, and KDF
+parameters MUST remain identical. Indexed short tails may become interior segments;
+a uniform predecessor is extendable only when its tail was full. A consistency
+proof proves a prefix, not freshness or the canonical head. Single-history
+publishers MUST serialize publication and retain fork evidence.
+
+## 8. Creation Flow
+
+A writer MUST:
+
+1. choose and validate packaging and layout;
+2. generate a 256-bit DEK and, for scalable layouts, a four-byte nonce prefix;
+3. create policy, splits, and KAOs;
+4. encrypt ordered segments with unique/deterministic IVs and compute hashes;
+5. create the explicit aggregate root or scalable Merkle tree and root;
+6. populate checked sizes, counts, and tree metadata;
+7. add the asymmetric manifest assertion after all other detached/sharded content;
+   and
+8. serialize using BaseTDF-PKG.
+
+A distributed reducer need only receive ordered fixed-size hashes and sizes from
+workers; it MUST NOT need ciphertext to construct Merkle commitments or the manifest.
+
+## 9. Reading Flow
+
+A reader MUST:
+
+1. obtain and size-bound the manifest;
+2. validate version and profile structure, normalizing default packaging/layout;
+3. verify detached/sharded manifest signatures before locators;
+4. validate locators and exact resource sizes;
+5. complete KAS authorization, verify policy bindings, and reconstruct the DEK;
+6. validate algorithms and integrity structure;
+7. verify requested ciphertext under BaseTDF-INT, including IV, segment hash,
+   Merkle path when applicable, sizes, count, root, and AEAD tag; and
+8. release only authenticated plaintext and verify applicable assertions.
+
+An API MUST distinguish selected-range verification from whole-object verification.
+
+## 10. Version Compatibility
+
+Writers MUST use `schemaVersion: "5.0.0"`. Readers MUST accept compatible 5.0.x
+patch versions, MAY accept a later 5.x minor only when every required feature is
+understood, and MUST reject an unsupported major. A 5.0 reader MUST read 4.3.x and
+4.4.x under version 4 rules and SHOULD treat an absent version as pre-4.3 legacy
+when legacy support is enabled. A 4.x reader is expected to reject major version 5.
+
+For version 4, packaging/layout normalize to attached/explicit. Legacy hash encoding
+and KAO aliases remain readable. A 5.0 writer MUST NOT create legacy encoding or
+deprecated KAO fields.
+
+## 11. Security Considerations
+
+The manifest is cleartext. Detachment compartmentalizes storage but does not hide
+policy, attributes, KAS URLs, assertions, MIME type, sizes, or locators from its
+host. The public manifest signature protects provenance and routing fields; the DEK
+root remains authoritative for ciphertext. Multiple manifests have union-policy
+semantics. Parsers and resolvers MUST bound resources and fail on arithmetic overflow.
+
+## 12. Normative References
+
+- [BaseTDF-SEC](basetdf-sec.md)
+- [BaseTDF-ALG](basetdf-alg.md)
+- [BaseTDF-POL](basetdf-pol.md)
+- [BaseTDF-KAO](basetdf-kao.md)
+- [BaseTDF-KAS](basetdf-kas.md)
+- [BaseTDF-INT](basetdf-int.md)
+- [BaseTDF-ASN](basetdf-asn.md)
+- [BaseTDF-LOC](basetdf-loc.md)
+- [BaseTDF-PKG](basetdf-pkg.md)
+- RFC 5869; RFC 8785

--- a/spec/basetdf/v5/basetdf-ex.md
+++ b/spec/basetdf/v5/basetdf-ex.md
@@ -1028,6 +1028,11 @@ wire bytes, expected outputs, and negative outcomes for:
 13. four-part sharding and a non-contiguous-parts negative;
 14. off-allowlist, non-HTTPS, redirect-to-unlisted, and oversized locator failures;
 15. aligned uniform and short-tail indexed consistency proofs, with changed-leaf,
-    immutable-parameter, partition-boundary, rollback, and fork negatives.
+    immutable-parameter, partition-boundary, rollback, and fork negatives;
+16. volume-limit negatives: a manifest above 2^40 plaintext bytes that omits
+    `keyDerivation`, and one whose partition size bound exceeds 2^40 plaintext
+    bytes (BaseTDF-CORE Section 4.3); and
+17. a segment size above the AES-GCM per-invocation limit of 68719476704 bytes,
+    rejected before allocation (BaseTDF-INT Section 2).
 
 Placeholder values in this document MUST NOT be used as conformance vectors.

--- a/spec/basetdf/v5/basetdf-ex.md
+++ b/spec/basetdf/v5/basetdf-ex.md
@@ -1,0 +1,1033 @@
+# BaseTDF-EX: Examples and Test Vectors
+
+| | |
+|---|---|
+| **Document** | BaseTDF-EX |
+| **Title** | Examples and Test Vectors |
+| **Version** | 5.0.0 |
+| **Status** | Informational |
+| **Date** | 2026-08 |
+| **Suite** | BaseTDF Specification Suite |
+| **References** | BaseTDF-ALG, BaseTDF-KAO, BaseTDF-INT, BaseTDF-ASN, BaseTDF-POL, BaseTDF-PKG, BaseTDF-LOC |
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Example: RSA-OAEP Key Protection (Legacy Compatibility)](#2-example-rsa-oaep-key-protection-legacy-compatibility)
+3. [Example: ECDH-HKDF Key Protection (Current EC Mode)](#3-example-ecdh-hkdf-key-protection-current-ec-mode)
+4. [Example: ML-KEM-768 Key Protection (Post-Quantum)](#4-example-ml-kem-768-key-protection-post-quantum)
+5. [Example: Multi-Split with Mixed Algorithms](#5-example-multi-split-with-mixed-algorithms)
+6. [Example: v4.3.0 Backward Compatibility Reading](#6-example-v430-backward-compatibility-reading)
+7. [Example: Assertion with ML-DSA-44 Signing](#7-example-assertion-with-ml-dsa-44-signing)
+8. [Test Vector Format Notes](#8-test-vector-format-notes)
+9. [Scalable Layout Examples](#9-scalable-layout-examples)
+10. [Detached and Sharded Examples](#10-detached-and-sharded-examples)
+11. [Version 5 Conformance Vector Set](#11-version-5-conformance-vector-set)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This document provides worked examples to assist implementers of the BaseTDF
+specification suite. Each example presents a complete, self-contained manifest
+(or relevant fragment) that illustrates a specific feature or algorithm
+combination defined in the normative documents.
+
+### 1.2 Non-Normative Status
+
+This document is **informational only**. It is NOT normative. The authoritative
+definitions of all structures, fields, algorithms, and procedures are found in
+the normative specifications:
+
+- **BaseTDF-ALG** -- Algorithm identifiers and parameters
+- **BaseTDF-KAO** -- Key Access Object schema and operations
+- **BaseTDF-INT** -- Integrity verification model
+- **BaseTDF-ASN** -- Assertions and binding mechanism
+- **BaseTDF-POL** -- Policy and attribute-based access control
+- **BaseTDF-CORE** -- Container format and manifest
+
+In the event of any discrepancy between this document and a normative
+specification, the normative specification takes precedence.
+
+### 1.3 Placeholder Values
+
+All examples use placeholder key material. Base64-encoded values are
+illustrative of the format and approximate size but are NOT real cryptographic
+outputs. Placeholder values are indicated by descriptive comments in the JSON
+or by trailing ellipsis (`...`) within base64 strings. Real implementations
+MUST use properly generated cryptographic material as specified in BaseTDF-ALG
+and BaseTDF-SEC.
+
+### 1.4 Conventions
+
+Throughout these examples, the following shorthand conventions are used:
+
+- `<N bytes of base64>` indicates a base64-encoded value of approximately N
+  raw bytes.
+- Segment hashes and signatures use truncated placeholder values for
+  readability. Real values are the full output length of the algorithm.
+- Policy objects are shown inline (decoded) for clarity, then shown as the
+  base64-encoded string that actually appears in the manifest's
+  `encryptionInformation.policy` field.
+
+---
+
+## 2. Example: RSA-OAEP Key Protection (Legacy Compatibility)
+
+This example shows a complete v5.0.0 explicit-layout manifest using RSA-OAEP key wrapping for
+backward compatibility with existing RSA-based KAS deployments. The manifest
+protects a small payload (a single segment) with one KAO addressed to a single
+KAS.
+
+### 2.1 Scenario
+
+- **Key protection**: `RSA-OAEP` (LEGACY algorithm, SHA-1 based OAEP)
+- **Single KAS**: `https://kas.example.com`
+- **Policy**: One attribute (`classification/value/confidential`) with an
+  `anyOf` rule and a two-person dissemination list
+- **Integrity**: `HS256` root signature, `GMAC` segment hashes
+- **Payload**: Single segment, 1 MiB default segment size
+
+### 2.2 Policy Object (Decoded)
+
+The following policy object is base64-encoded and stored in the manifest's
+`encryptionInformation.policy` field:
+
+```json
+{
+  "uuid": "b1e8e7a4-3c0d-4a5f-9b1e-2f8d4c6a7e09",
+  "body": {
+    "dataAttributes": [
+      {
+        "attribute": "https://example.com/attr/classification/value/confidential",
+        "displayName": "Classification: Confidential",
+        "isDefault": false,
+        "pubKey": "",
+        "kasURL": "https://kas.example.com"
+      }
+    ],
+    "dissem": [
+      "alice@example.com",
+      "bob@example.com"
+    ]
+  }
+}
+```
+
+### 2.3 Complete Manifest
+
+```json
+{
+  "schemaVersion": "5.0.0",
+  "encryptionInformation": {
+    "type": "split",
+    "policy": "eyJ1dWlkIjoiYjFlOGU3YTQtM2MwZC00YTVmLTliMWUtMmY4ZDRjNmE3ZTA5IiwiYm9keSI6eyJkYXRhQXR0cmlidXRlcyI6W3siYXR0cmlidXRlIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9hdHRyL2NsYXNzaWZpY2F0aW9uL3ZhbHVlL2NvbmZpZGVudGlhbCIsImRpc3BsYXlOYW1lIjoiQ2xhc3NpZmljYXRpb246IENvbmZpZGVudGlhbCIsImlzRGVmYXVsdCI6ZmFsc2UsInB1YktleSI6IiIsImthc1VSTCI6Imh0dHBzOi8va2FzLmV4YW1wbGUuY29tIn1dLCJkaXNzZW0iOlsiYWxpY2VAZXhhbXBsZS5jb20iLCJib2JAZXhhbXBsZS5jb20iXX19",
+    "keyAccess": [
+      {
+        "alg": "RSA-OAEP",
+        "type": "wrapped",
+        "kas": "https://kas.example.com",
+        "url": "https://kas.example.com",
+        "kid": "rsa-2048-legacy-2024",
+        "sid": "",
+        "protectedKey": "TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF2a3RyNnlvaGRiRjRXOHBPVFhPWlZxZE1mR0dYU3hGQnFmbVFDUHpBTHdFR01sUkkzbjdGdXI0RVRTNkNGTHI3Qm5IZXhSM3hoYjVCZ1grNHlhN2lFPQ==",
+        "wrappedKey": "TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF2a3RyNnlvaGRiRjRXOHBPVFhPWlZxZE1mR0dYU3hGQnFmbVFDUHpBTHdFR01sUkkzbjdGdXI0RVRTNkNGTHI3Qm5IZXhSM3hoYjVCZ1grNHlhN2lFPQ==",
+        "policyBinding": {
+          "alg": "HS256",
+          "hash": "ZjY4MDA2YTg0ZjczYzAyODk5MTJlOWIxNGRhNGIzNWE="
+        }
+      }
+    ],
+    "method": {
+      "algorithm": "A256GCM"
+    },
+    "integrityInformation": {
+      "rootSignature": {
+        "alg": "HS256",
+        "sig": "N2UzYjc2YjNhNjQ1NTdhMWRjOWIwNDcwOTgxYmFkNjc="
+      },
+      "segmentHashAlg": "GMAC",
+      "segmentSizeDefault": 1048576,
+      "encryptedSegmentSizeDefault": 1048604,
+      "segments": [
+        {
+          "hash": "SqCnCERZHCHvPeKB",
+          "segmentSize": 256,
+          "encryptedSegmentSize": 284
+        }
+      ]
+    }
+  },
+  "assertions": []
+}
+```
+
+### 2.4 Notes
+
+- The `alg` field (`"RSA-OAEP"`) is the canonical field introduced in v4.4.0. The `type`
+  field (`"wrapped"`) is included for backward compatibility with older readers
+  that do not recognize `alg`.
+- Both `kas` and `url` are present (with the same value) for backward
+  compatibility. The `kas` field is the current canonical name.
+- Both `protectedKey` and `wrappedKey` carry the same value. The `protectedKey`
+  field is canonical; `wrappedKey` is the deprecated alias.
+- No `ephemeralKey` is present because RSA-OAEP is a key wrapping algorithm
+  (the DEK share is directly encrypted under the KAS public key).
+- The `sid` field is empty because there is only a single KAO (no key
+  splitting).
+- The `segmentHashAlg` is `"GMAC"`, meaning the segment hash is the AES-GCM
+  authentication tag extracted from the encrypted segment.
+- The `rootSignature.alg` is `"HS256"` (HMAC-SHA256 over the aggregate hash).
+
+---
+
+## 3. Example: ECDH-HKDF Key Protection (Current EC Mode)
+
+This example shows a manifest using ECDH key agreement with HKDF key
+derivation, which is the current recommended classical key protection mode.
+
+### 3.1 Scenario
+
+- **Key protection**: `ECDH-HKDF` (P-256 curve)
+- **Single KAS**: `https://kas.example.com`
+- **Policy**: Two attributes with `anyOf` rules from the same authority
+- **Integrity**: `HS256` for both root signature and segment hashes
+- **Payload**: Two segments
+
+### 3.2 Policy Object (Decoded)
+
+```json
+{
+  "uuid": "a9c4e2f1-7b3d-48e6-a5f0-1d2c3b4a5e6f",
+  "body": {
+    "dataAttributes": [
+      {
+        "attribute": "https://example.com/attr/department/value/engineering",
+        "displayName": "Department: Engineering",
+        "isDefault": false,
+        "pubKey": "",
+        "kasURL": "https://kas.example.com"
+      },
+      {
+        "attribute": "https://example.com/attr/department/value/research",
+        "displayName": "Department: Research",
+        "isDefault": false,
+        "pubKey": "",
+        "kasURL": "https://kas.example.com"
+      }
+    ],
+    "dissem": []
+  }
+}
+```
+
+### 3.3 Complete Manifest
+
+```json
+{
+  "schemaVersion": "5.0.0",
+  "encryptionInformation": {
+    "type": "split",
+    "policy": "eyJ1dWlkIjoiYTljNGUyZjEtN2IzZC00OGU2LWE1ZjAtMWQyYzNiNGE1ZTZmIiwiYm9keSI6eyJkYXRhQXR0cmlidXRlcyI6W3siYXR0cmlidXRlIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9hdHRyL2RlcGFydG1lbnQvdmFsdWUvZW5naW5lZXJpbmciLCJkaXNwbGF5TmFtZSI6IkRlcGFydG1lbnQ6IEVuZ2luZWVyaW5nIiwiaXNEZWZhdWx0IjpmYWxzZSwicHViS2V5IjoiIiwia2FzVVJMIjoiaHR0cHM6Ly9rYXMuZXhhbXBsZS5jb20ifSx7ImF0dHJpYnV0ZSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYXR0ci9kZXBhcnRtZW50L3ZhbHVlL3Jlc2VhcmNoIiwiZGlzcGxheU5hbWUiOiJEZXBhcnRtZW50OiBSZXNlYXJjaCIsImlzRGVmYXVsdCI6ZmFsc2UsInB1YktleSI6IiIsImthc1VSTCI6Imh0dHBzOi8va2FzLmV4YW1wbGUuY29tIn1dLCJkaXNzZW0iOltdfX0=",
+    "keyAccess": [
+      {
+        "alg": "ECDH-HKDF",
+        "type": "ec-wrapped",
+        "kas": "https://kas.example.com",
+        "url": "https://kas.example.com",
+        "kid": "ec-p256-2025-01",
+        "sid": "",
+        "protectedKey": "qL3tOVFaWDRJHgT8Q5Y9x1BSeHOmkfLEwEv6JhPOWsV2c5Ra3d0a6rk=",
+        "wrappedKey": "qL3tOVFaWDRJHgT8Q5Y9x1BSeHOmkfLEwEv6JhPOWsV2c5Ra3d0a6rk=",
+        "ephemeralKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3rJVMzpBIYMBpGa8ckMNTGK2aSaQ\nhZkFnzLvM0+ZvP1FDhqscbQPaYKNsitEcLcpRnPOXQFwsu2vIC5HbWjJKA==\n-----END PUBLIC KEY-----",
+        "policyBinding": {
+          "alg": "HS256",
+          "hash": "YTczOTQ1NjEzOGJjN2JhOGVhMGRhNWIxZWQwNWY0Njk="
+        }
+      }
+    ],
+    "method": {
+      "algorithm": "A256GCM"
+    },
+    "integrityInformation": {
+      "rootSignature": {
+        "alg": "HS256",
+        "sig": "Mzk1ZjJlMjUzYmEwYjU4NjY5ODc5MTZjMjVhZjNjZjI="
+      },
+      "segmentHashAlg": "HS256",
+      "segmentSizeDefault": 1048576,
+      "encryptedSegmentSizeDefault": 1048604,
+      "segments": [
+        {
+          "hash": "MWM0ZGU2YTE0NjdlMWFiNQ==",
+          "segmentSize": 1048576,
+          "encryptedSegmentSize": 1048604
+        },
+        {
+          "hash": "ZWIxOWY2N2IzNjVlMjM2MA==",
+          "segmentSize": 512,
+          "encryptedSegmentSize": 540
+        }
+      ]
+    }
+  },
+  "assertions": []
+}
+```
+
+### 3.4 Notes
+
+- The `ephemeralKey` field contains the ephemeral EC public key in PEM format.
+  This is the public half of the ephemeral key pair generated by the TDF
+  creator during encryption. The KAS uses this key together with its own EC
+  private key to derive the shared secret via ECDH.
+- The HKDF parameters for `ECDH-HKDF` are: salt = `SHA256("TDF")` (a fixed
+  32-byte value), info = `""` (empty), output length = 32 bytes.
+- The `protectedKey` is the AES-256-GCM ciphertext of the DEK share encrypted
+  under the HKDF-derived key. This wire format is unchanged from v4.3.0; only
+  the field names differ (see Section 6).
+- Both `type: "ec-wrapped"` and `alg: "ECDH-HKDF"` are present. The `alg`
+  field takes precedence; `type` is included for older readers.
+- The two `anyOf` attributes share a single split (empty `sid`), meaning any
+  one matching attribute is sufficient for access.
+- Both segments use `HS256` hashing (HMAC-SHA256 with the DEK as key).
+
+---
+
+## 4. Example: ML-KEM-768 Key Protection (Post-Quantum)
+
+This example shows a manifest using the ML-KEM-768 key encapsulation mechanism
+for post-quantum key protection.
+
+### 4.1 Scenario
+
+- **Key protection**: `ML-KEM-768` (FIPS 203, NIST Level 3)
+- **Single KAS**: `https://kas-pqc.example.com`
+- **Policy**: One attribute (`classification/value/secret`)
+- **Integrity**: `HS256` root signature and segment hashes
+- **Payload**: Single segment
+
+### 4.2 Complete Manifest
+
+```json
+{
+  "schemaVersion": "5.0.0",
+  "encryptionInformation": {
+    "type": "split",
+    "policy": "eyJ1dWlkIjoiZDRlNWY2YTctOGIwYy00OWQxLWExZjItM2M0ZDVlNmY3YTg5IiwiYm9keSI6eyJkYXRhQXR0cmlidXRlcyI6W3siYXR0cmlidXRlIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9hdHRyL2NsYXNzaWZpY2F0aW9uL3ZhbHVlL3NlY3JldCIsImRpc3BsYXlOYW1lIjoiQ2xhc3NpZmljYXRpb246IFNlY3JldCIsImlzRGVmYXVsdCI6ZmFsc2UsInB1YktleSI6IiIsImthc1VSTCI6Imh0dHBzOi8va2FzLXBxYy5leGFtcGxlLmNvbSJ9XSwiZGlzc2VtIjpbXX19",
+    "keyAccess": [
+      {
+        "alg": "ML-KEM-768",
+        "type": "mlkem-wrapped",
+        "kas": "https://kas-pqc.example.com",
+        "kid": "kas-mlkem768-2025-03",
+        "sid": "",
+        "protectedKey": "MIIEgoCCBEBnFBfBXIO10t99MteIS4HwAHf0cfoGtqEogRnpwwl/AbE3xHCJ6aWZORiZeFBsPgu6Jl886QVhquJ4UbdJTnRZBIfM2b+pKtlgi7zmbbwaiYXSY4W2USdJrOMeA+PBeegn0MtDELLjL1sGQTTFSVwwlT3j61VcxASV1cNfPcxWwQ9hWRdjJoQX3mzbYvLfZ14ertjZJlCb2q21WLpsel3im8X90PC7LTcOsBmUI4iGjPZdQ91Z9Qm2FrYkMuSFJfF8YPIQXa8+BjDUZ39haW8JO++iPAzLGLm5Sb7dj2lOTaSBJrXh4YZCDpbam7aM3JFAWLAThI3pAyP2uo39lmfDWMH19VIOalcfOjGS+sMzJklNcGJlARaDZe2jw+MZy8GGiUR+CFeSaUMNh9CNnGuSVXNl6/lQygoviv/qTtaNA6TBYyMDJlp3BdjJ+hQo2WpsxsvPripYO9fP9GSYYsf675Ey5TewyP18hT4NJu0f0FJ+YfLopahflFkyQ8+J4kENDTuS9/CDuMCw3grV09vJqS98YNx43u2hQB6u+kuJokCXJ2qPJqHq6XutIdBfD/AA0ZhToiGnZseUmQBXbopmP8uOpr61/QWo0OxCLdIvP6GJWFt4PuDx6LkUhkbno8ytS538vwFUufe0P/NBddfRP8Ve8qRwprltMZx5ko0JqHMW4HH4H1w3AiczBPZ/sDm4bV2i9YEIr+vpTOFBpF+jxBLf94ozFtcw15xccyON7j+HZfRJEkMgrKSWXfmfImK/WuehMVmgtLpAwBRwRzL6+OQ7Leos8QVOwDvGSzhuK+46y9M7FUO4V6vaEW/H7kc/Tl7ad83VJu/ASXTO25scbsF3dXDMIYbRDFIm0PXKzrCLnnE5xc2tPfhDirfnPPrVwATniEc8z/ZodqzwhyM5+YkzcKzHv+DYWXKjXDu+HgyjXjANmOnlCmjIIA4tuL1eYHQrpp8MR4J/+3w058+gDA8PeCoVwEQyXjyw/uDJbfzBiapc6K91tr6dm3HUfJmO0ohCuADg619gSXbLPJQIuGBzfQqSU7vRR1+tkBdj0zVycAd4pKwhTnhm8l7Y1yVyek5pdm6sXk1OYXruvvdLy1zIbnwVn8LJkTQ9vaKDu8945POSvMU0JZlsGkFIYmXLddN7U1Q71BqHcE+TmJtJHeGiTDUJqds6C1dJwhnI4LUIDGj8/+7OHVObnU6joBMg18q6n2gXnnrxVjzRwAX+TQwtyLAM4hTlHJtyNHd3yrdgYD/pOC/0n/Gwmr5RSnJfWUvpJHm9X/JQg+DIhfG+NO+DhD8JZjmqjbc/xmugBkESdVTj6cXRyhNB4gqS88suhIVrGGOpwUCMvezC7mI2ojQcbi6Tb0cCaCMUIaa5yD0vpnNbJJB88jlRhKtPgsfFpvZsEcrGvAAqtsAzyPxPVQdn81uZvyz7mIkIS1ENo4E8h5ol3DZcri5nwMFoT0kdjQpB9OQS0T6LpYUXPn7Tyn4Jb456JSX3vzwLQ5nxSXhL/PUZ4WACsNr9ciS3",
+        "policyBinding": {
+          "alg": "HS256",
+          "hash": "NDE2OGMxMDZhNjQ4YTczOTFkY2UxZjI5ZGU5OGM5ZmI="
+        }
+      }
+    ],
+    "method": {
+      "algorithm": "A256GCM"
+    },
+    "integrityInformation": {
+      "rootSignature": {
+        "alg": "HS256",
+        "sig": "YjRkNzI5NTE1MGRhM2Q0NTkxMjRiNmVjMTcxZjRmZWI="
+      },
+      "segmentHashAlg": "HS256",
+      "segmentSizeDefault": 1048576,
+      "encryptedSegmentSizeDefault": 1048604,
+      "segments": [
+        {
+          "hash": "ZTEyYTk1NWQ4NDI4ZjBlMw==",
+          "segmentSize": 4096,
+          "encryptedSegmentSize": 4124
+        }
+      ]
+    }
+  },
+  "assertions": []
+}
+```
+
+### 4.3 Notes
+
+- There is no `ephemeralKey` field. For ML-KEM the KEM ciphertext travels
+  inside `protectedKey`, not in `ephemeralKey`.
+- The `protectedKey` field is the base64 encoding of a DER `MLKEMWrappedKey`
+  structure (BaseTDF-ALG Section 4.3), which decodes to:
+  - `mlkemCiphertext` (`[0]`, 1088 bytes): the output of
+    `ML-KEM.Encapsulate(kas_mlkem_pk)`. The KAS calls
+    `ML-KEM.Decapsulate(kas_mlkem_sk, ct)` to recover the 32-byte shared secret.
+  - `encryptedDEK` (`[1]`, 60 bytes here): a 12-byte GCM nonce, the AES-256-GCM
+    ciphertext of the 32-byte DEK share, and the 16-byte GCM tag. No AAD is
+    used.
+- No KDF is applied. The 32-byte ML-KEM shared secret is used directly as the
+  AES-256 key -- see BaseTDF-ALG Section 4.3.1 for the rationale.
+- The `type` field carries the legacy value `"mlkem-wrapped"` for readers that
+  do not recognize `alg`. Note that `"mlkem-wrapped"` alone does not distinguish
+  ML-KEM-768 from ML-KEM-1024; `alg` is authoritative (BaseTDF-KAO
+  Section 7.1).
+- The `kid` field (`"kas-mlkem768-2025-03"`) identifies the specific ML-KEM-768
+  key pair held by the KAS.
+
+---
+
+## 5. Example: Multi-Split with Mixed Algorithms
+
+This example demonstrates key splitting across two KAS instances using different
+algorithms, one classical and one post-quantum. The policy requires access
+authorization from both KAS instances (an `allOf` rule with attributes from
+different authorities).
+
+### 5.1 Scenario
+
+- **Policy**: Two `allOf` attributes from different authorities, each mapping
+  to a different KAS
+  - `classification/value/secret` at KAS-A (RSA-based)
+  - `project/value/quantum-safe` at KAS-B (ML-KEM-based)
+- **Split 0** (`sid: "s-0"`): `RSA-OAEP-256` to KAS-A
+- **Split 1** (`sid: "s-1"`): `ML-KEM-768` to KAS-B
+- **Integrity**: `HS256` root signature and segment hashes
+
+### 5.2 Policy Object (Decoded)
+
+```json
+{
+  "uuid": "c8d9e0f1-2a3b-4c5d-6e7f-8a9b0c1d2e3f",
+  "body": {
+    "dataAttributes": [
+      {
+        "attribute": "https://authority-a.example.com/attr/classification/value/secret",
+        "displayName": "Classification: Secret",
+        "isDefault": false,
+        "pubKey": "",
+        "kasURL": "https://kas-a.example.com"
+      },
+      {
+        "attribute": "https://authority-b.example.com/attr/project/value/quantum-safe",
+        "displayName": "Project: Quantum Safe",
+        "isDefault": false,
+        "pubKey": "",
+        "kasURL": "https://kas-b.example.com"
+      }
+    ],
+    "dissem": []
+  }
+}
+```
+
+### 5.3 Complete Manifest
+
+```json
+{
+  "schemaVersion": "5.0.0",
+  "encryptionInformation": {
+    "type": "split",
+    "policy": "eyJ1dWlkIjoiYzhkOWUwZjEtMmEzYi00YzVkLTZlN2YtOGE5YjBjMWQyZTNmIiwiYm9keSI6eyJkYXRhQXR0cmlidXRlcyI6W3siYXR0cmlidXRlIjoiaHR0cHM6Ly9hdXRob3JpdHktYS5leGFtcGxlLmNvbS9hdHRyL2NsYXNzaWZpY2F0aW9uL3ZhbHVlL3NlY3JldCIsImRpc3BsYXlOYW1lIjoiQ2xhc3NpZmljYXRpb246IFNlY3JldCIsImlzRGVmYXVsdCI6ZmFsc2UsInB1YktleSI6IiIsImthc1VSTCI6Imh0dHBzOi8va2FzLWEuZXhhbXBsZS5jb20ifSx7ImF0dHJpYnV0ZSI6Imh0dHBzOi8vYXV0aG9yaXR5LWIuZXhhbXBsZS5jb20vYXR0ci9wcm9qZWN0L3ZhbHVlL3F1YW50dW0tc2FmZSIsImRpc3BsYXlOYW1lIjoiUHJvamVjdDogUXVhbnR1bSBTYWZlIiwiaXNEZWZhdWx0IjpmYWxzZSwicHViS2V5IjoiIiwia2FzVVJMIjoiaHR0cHM6Ly9rYXMtYi5leGFtcGxlLmNvbSJ9XSwiZGlzc2VtIjpbXX19",
+    "keyAccess": [
+      {
+        "alg": "RSA-OAEP-256",
+        "type": "wrapped",
+        "kas": "https://kas-a.example.com",
+        "url": "https://kas-a.example.com",
+        "kid": "rsa-4096-kas-a-2025",
+        "sid": "s-0",
+        "protectedKey": "QUVTLTI1Ni1HQ00gY2lwaGVydGV4dCBvZiBERUsgc2hhcmUgMCBlbmNyeXB0ZWQgdW5kZXIgUlNBLU9BRVAtMjU2IHdpdGggdGhlIEtBUy1BIHB1YmxpYyBrZXkuIFRoaXMgaXMgYSBwbGFjZWhvbGRlci4=",
+        "wrappedKey": "QUVTLTI1Ni1HQ00gY2lwaGVydGV4dCBvZiBERUsgc2hhcmUgMCBlbmNyeXB0ZWQgdW5kZXIgUlNBLU9BRVAtMjU2IHdpdGggdGhlIEtBUy1BIHB1YmxpYyBrZXkuIFRoaXMgaXMgYSBwbGFjZWhvbGRlci4=",
+        "policyBinding": {
+          "alg": "HS256",
+          "hash": "YWJjZGVmMDEyMzQ1Njc4OTBhYmNkZWYwMTIzNDU2Nzg="
+        }
+      },
+      {
+        "alg": "ML-KEM-768",
+        "type": "mlkem-wrapped",
+        "kas": "https://kas-b.example.com",
+        "kid": "mlkem768-kas-b-2025",
+        "sid": "s-1",
+        "protectedKey": "MIIEgoCCBEDYogtwz+pWduYpaP6triGbS0fqjj9gG2mZT7RhOLbgtCjA48d2+YumwfA+6/5Yi0PGUCJPhm4w5aqFI/yAgMQdtb9lnzSANdtizfxFqLqrAbJhjUyvYPTa8GSNCMWoGR2mPcoVqPjFmTOdjmGRkDyJhkSa+sGj0hyTtvekXtmGlAYUxuWk9qEj3zHcHEB04n7C0LKupKaALcvJnVSoN84ylHCrd+/ghzQL5+tGwTwDrOpwgizIAex0V7Zpgi+XBQP8PmApbBk1Nmx/f8kuLs56jX+EsYwK1nyqfkwq54A+taMIKkWPFD1LavjsIwqwsPfTcwQjgVjC+nYQeMjmLpOx7MqEqdiuehMQP9vjmr31LqBN3OtaeLvc4pJLP9PI7YESA1kbrJcwIEiCbL8TGQ/KDLCVgjPH1UGl87rHnY3BTw7a908q72RrOi334QHVIT+93BKIgZ7NWfzPdBBvSszYgaD1qhmfoUuKgBPRx0bXOPkt7YZ/0T8/eaNzJvAb7qYstV/UKtSdOYxDxXY5imLL1eM5N/UHflx0wiAF223io8K09u27TnWwLSmxMi88aJsKBKk4HUQe/17f7Uv+gtioJubcizCZ3ZhWALcJMUjg+QpY2rnRvTEnsjQi64j41DBl99ZXEiMzYP6dUWRkHPGnRs4UU2/LkNjkfkEH4UJpFOlrEOytc79WzCmIuRJ0bcRLttb4QUu/P896NaUMegLtv9aMANXAdJ1h9HKEJc6EIfk/8PKYl/1X9ICZxTltf9R3u86PgWFdLZmzTZo3iFExHdJDsNA7ZqOxSKKmKE0C99VCHd3BoN5LnakdzuDiZEA+RnYtbCUH1onzqbIDzI6/SfFN7kJ0x74af5WMe3CD5Mj0cv62nq1eO83i/unLe8zMu5QRnjS5tmPV4Qh9USQgXMq9QU41n+wivVhZaa8a6lhnDcHN4SuJgIWSNvgTITxEL1xXEZX53+fp8sf89/NZ+XGef/8PNV77fnMQWOsxv+oCcZdzDxALsKBkA/7PGxVgGo24G2SoeghBSJCyuUkCvKdKdLQo+WV3unkl4OOVNz90AUozFCQ9t/KKGc2ZKUDJnSkZYOs6jM6fWDSKp8w7/RVJaUXxExAHXdg10FZxy5j01qe/kfpQHiqgmXBcayMjGZLGtKQ2YQy/R/R2WKUVA3ul/H/HCAMgKvKdTW9BhzrJ9GaM7yiAS+jLRPglV92afvKFiX0+3ovY4puTkzYrSCTIDqIuI75vblMTAJ0y3XB9sQoqHjIk33ocUGrYTcYezkmTQMuEAauqzyJhz1ZWa2s5Q1zDTB33QOjbwBwJBVN8Ez3xtIs1g2aZPN7EqXkS4YEz67t+VJi0CylwC2+55j/s6I1vuUTiVPqfkKkC46Ae5bCzzX/gohf7XvDZj/L/gWJSE8UOgGn9oLDwoD0AH+3BnzRi4R7E1WZaoCqAhYE8F4bTfxhSeo8M5/sk5zCv/oTadm7+tzkLKJXmHCobujI95MdO5+nRSraFjjx/enXSEiR/zpWy3juzMWpr",
+        "policyBinding": {
+          "alg": "HS256",
+          "hash": "ZmVkY2JhOTg3NjU0MzIxMGFiY2RlZjAxMjM0NTY3ODk="
+        }
+      }
+    ],
+    "method": {
+      "algorithm": "A256GCM"
+    },
+    "integrityInformation": {
+      "rootSignature": {
+        "alg": "HS256",
+        "sig": "YThiOWMwZDFlMmYzYTRiNWM2ZDdlOGY5MDAxMjIzMzQ="
+      },
+      "segmentHashAlg": "HS256",
+      "segmentSizeDefault": 1048576,
+      "encryptedSegmentSizeDefault": 1048604,
+      "segments": [
+        {
+          "hash": "ZjBmMWYyZjNmNGY1ZjZmNw==",
+          "segmentSize": 8192,
+          "encryptedSegmentSize": 8220
+        }
+      ]
+    }
+  },
+  "assertions": []
+}
+```
+
+### 5.4 Key Splitting Explanation
+
+The DEK is split into two shares using XOR-based n-of-n secret sharing
+(BaseTDF-KAO Section 3):
+
+```
+share_0 = random(32)                    // 32 random bytes from CSPRNG
+share_1 = DEK XOR share_0              // computed so that XOR reconstructs DEK
+```
+
+- **KAO 0** (`sid: "s-0"`): Protects `share_0` using `RSA-OAEP-256`, sent to
+  KAS-A. The `protectedKey` is the RSA-OAEP ciphertext of `share_0`.
+- **KAO 1** (`sid: "s-1"`): Protects `share_1` using `ML-KEM-768`, sent to
+  KAS-B. The `protectedKey` is the AES-256-GCM ciphertext of `share_1`
+  encrypted under the HKDF-derived key from the ML-KEM shared secret.
+
+To reconstruct the DEK, a reader must:
+
+1. Obtain `share_0` by sending KAO 0 to KAS-A for rewrap.
+2. Obtain `share_1` by sending KAO 1 to KAS-B for rewrap.
+3. Compute `DEK = share_0 XOR share_1`.
+
+Both KAS instances must independently authorize the request based on their
+respective attribute evaluations. This provides defense-in-depth: compromising
+one KAS alone reveals nothing about the DEK.
+
+### 5.5 Notes
+
+- The two KAOs have **different** `sid` values (`"s-0"` and `"s-1"`),
+  indicating they protect different shares of the DEK.
+- The first KAO (`RSA-OAEP-256`) has no `ephemeralKey` because RSA-OAEP is a
+  key wrapping algorithm.
+- The second KAO (`ML-KEM-768`) also has no `ephemeralKey`: its KEM ciphertext
+  is carried inside the `MLKEMWrappedKey` envelope in `protectedKey`.
+- The `policyBinding` in each KAO is computed over the **same** base64-encoded
+  policy string, but with **different** HMAC keys (each KAO uses its own DEK
+  share as the HMAC key).
+- The `allOf` attribute rule means the KAS authorization service requires the
+  requesting entity to satisfy BOTH attributes. The key splitting mechanism
+  enforces this cryptographically: the DEK cannot be recovered without both
+  shares.
+
+---
+
+## 6. Example: v4.3.0 Backward Compatibility Reading
+
+This section shows a v4.3.0-era manifest and explains how a v5.0.0 reader
+interprets it. The v4.3.0 manifest uses the legacy field names and encoding
+conventions.
+
+### 6.1 Legacy v4.3.0 Manifest
+
+```json
+{
+  "encryptionInformation": {
+    "type": "split",
+    "policy": "eyJ1dWlkIjoiMTIzNDU2NzgtYWJjZC1lZmdoLWlqa2wtbW5vcHFyc3R1dnd4IiwiYm9keSI6eyJkYXRhQXR0cmlidXRlcyI6W3siYXR0cmlidXRlIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9hdHRyL2NsYXNzaWZpY2F0aW9uL3ZhbHVlL2NvbmZpZGVudGlhbCIsImRpc3BsYXlOYW1lIjoiIiwiaXNEZWZhdWx0IjpmYWxzZSwicHViS2V5IjoiIiwia2FzVVJMIjoiaHR0cHM6Ly9rYXMuZXhhbXBsZS5jb20ifV0sImRpc3NlbSI6W119fQ==",
+    "keyAccess": [
+      {
+        "type": "ec-wrapped",
+        "url": "https://kas.example.com",
+        "protocol": "kas",
+        "wrappedKey": "cGxhY2Vob2xkZXItYWVzLTI1Ni1nY20td3JhcHBlZC1kZWstc2hhcmU=",
+        "ephemeralPublicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELegacyKeyValue0placeholder1\nabcdefghijklmnopqrstuvwxyz012345678ABCDEFGHIJKLMNOPQ==\n-----END PUBLIC KEY-----",
+        "policyBinding": "ZjY4MDA2YTg0ZjczYzAyODk5MTJlOWIxNGRhNGIzNWE2OGQ0ZDVjMWI1ZThlOWQxYjk4ZTc1MjY0NzQ4MzAwOA=="
+      }
+    ],
+    "method": {
+      "algorithm": "AES-256-GCM"
+    },
+    "integrityInformation": {
+      "rootSignature": {
+        "alg": "HS256",
+        "sig": "N2UzYjc2YjNhNjQ1NTdhMWRjOWIwNDcwOTgxYmFkNjc="
+      },
+      "segmentHashAlg": "GMAC",
+      "segmentSizeDefault": 1048576,
+      "encryptedSegmentSizeDefault": 1048604,
+      "segments": [
+        {
+          "hash": "SqCnCERZHCHvPeKB",
+          "segmentSize": 512,
+          "encryptedSegmentSize": 540
+        }
+      ]
+    }
+  }
+}
+```
+
+### 6.2 How a v5.0.0 Reader Interprets This Manifest
+
+A conformant v5.0.0 reader applies the backward compatibility rules from
+BaseTDF-KAO Section 7 as follows:
+
+| Legacy Field / Value | v5.0.0 Interpretation | Reference |
+|:---------------------|:----------------------|:----------|
+| No `schemaVersion` | Legacy TDF; apply hex-then-base64 decoding for both the policy binding and the integrity hashes | BaseTDF-KAO 7.3, BaseTDF-INT 8 |
+| `type: "ec-wrapped"` | Infer `alg: "ECDH-HKDF"` | BaseTDF-KAO 7.1 |
+| `url` | Treat as `kas` | BaseTDF-KAO 7.1 |
+| `wrappedKey` | Treat as `protectedKey` | BaseTDF-KAO 7.1 |
+| `ephemeralPublicKey` | Treat as `ephemeralKey` | BaseTDF-KAO 7.1 |
+| `policyBinding` (bare string) | Treat as `{ "alg": "HS256", "hash": "<value>" }` | BaseTDF-KAO 7.1 |
+| `protocol: "kas"` | Informational only; ignored | BaseTDF-KAO 2.3 |
+| `algorithm: "AES-256-GCM"` | Treat as `"A256GCM"` | Legacy algorithm name |
+
+This example has no `schemaVersion` at all, so hex-then-base64 applies to both
+the policy binding and the integrity hashes. Readers MUST NOT generalize from
+that: the two encodings changed at different versions. A manifest declaring
+`schemaVersion: "4.3.0"` carries raw-bytes-then-base64 integrity hashes but a
+hex-then-base64 policy binding. See BaseTDF-KAO Section 7.3.
+
+### 6.3 Policy Binding Verification with Legacy Encoding
+
+The legacy `policyBinding` value is a bare string (not an object). The v5.0.0
+reader treats it as:
+
+```json
+{
+  "alg": "HS256",
+  "hash": "ZjY4MDA2YTg0ZjczYzAyODk5MTJlOWIxNGRhNGIzNWE2OGQ0ZDVjMWI1ZThlOWQxYjk4ZTc1MjY0NzQ4MzAwOA=="
+}
+```
+
+To verify, the reader applies the hex-then-base64 detection logic from
+BaseTDF-KAO Section 5.5:
+
+1. Base64-decode the hash value. This produces 64 bytes.
+2. Check if the decoded bytes consist entirely of valid hexadecimal ASCII
+   characters (`0-9`, `a-f`, `A-F`). If so, this is the legacy
+   hex-then-base64 encoding.
+3. Hex-decode the 64 ASCII characters to obtain the 32-byte HMAC digest.
+4. Compare the result against the locally computed
+   `HMAC-SHA256(DEK_share, canonical_policy)` using constant-time comparison.
+
+### 6.4 Key Agreement
+
+The `ECDH-HKDF` unwrap procedure is identical to the v5.0.0 procedure in
+Section 3; only the field names differ. The reader derives
+`derived_key = HKDF-SHA256(salt=SHA256("TDF"), ikm=shared_secret, info="", len=32)`
+from `ephemeralPublicKey` and the KAS private key, then AES-256-GCM-decrypts
+`wrappedKey` under it.
+
+### 6.5 Notes
+
+- The absence of `schemaVersion` in the manifest is the primary signal that
+  this is a legacy TDF.
+- The `protocol` field (`"kas"`) is a legacy informational field and has no
+  effect on processing.
+- Real implementations should handle the `"AES-256-GCM"` legacy algorithm
+  name as equivalent to the current identifier `"A256GCM"`.
+
+---
+
+## 7. Example: Assertion with ML-DSA-44 Signing
+
+This example shows a handling assertion signed with the `ML-DSA-44`
+post-quantum signature algorithm (FIPS 204, NIST Level 2). ML-DSA-44 is the
+RECOMMENDED post-quantum algorithm for assertion signing.
+
+### 7.1 Scenario
+
+- **Assertion type**: `"handling"` -- a STANAG 5636 classification marking
+- **Signing algorithm**: `ML-DSA-44` (asymmetric, post-quantum)
+- **ML-DSA-44 signature size**: 2420 bytes
+- **Binding method**: JWS Compact Serialization
+
+### 7.2 Assertion Object
+
+```json
+{
+  "id": "7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d",
+  "type": "handling",
+  "scope": "tdo",
+  "appliesToState": "encrypted",
+  "statement": {
+    "format": "json+stanag5636",
+    "schema": "urn:nato:stanag:5636:A:1:elements:json",
+    "value": "{\"ocl\":{\"pol\":\"d4e5f6a7-8b0c-49d1-a1f2-3c4d5e6f7a89\",\"cls\":\"SECRET\",\"catl\":[{\"type\":\"P\",\"name\":\"Releasable To\",\"vals\":[\"usa\",\"gbr\"]}],\"dcr\":\"2025-06-15T00:00:00Z\"},\"context\":{\"@base\":\"urn:nato:stanag:5636:A:1:elements:json\"}}"
+  },
+  "binding": {
+    "method": "jws",
+    "signature": "eyJhbGciOiJNTC1EU0EtNDQifQ.eyJhc3NlcnRpb25IYXNoIjoiNGE0NDdhMTNjNWEzMjczMGQyMGJkZjdmZWVjYjlmZmUxNjY0OWJjNzMxOTE0YjU3NGQ4MDAzNWEzOTI3Zjg2MCIsImFzc2VydGlvblNpZyI6ImJHRnlaMlZmWW1GelpUWTBYM1poYkhWbFgyaGxjbVVfdGhpc19pc19hX3BsYWNlaG9sZGVyX2Zvcl90aGVfYmluZGluZ19pbnB1dF9jb25jYXRlbmF0aW9uIn0.ML-DSA-44-placeholder-signature-2420-bytes-base64url-encoded-the-actual-signature-would-be-approximately-3227-base64url-characters-representing-2420-bytes-of-ML-DSA-44-signature-data-per-FIPS-204-this-is-significantly-larger-than-classical-ECDSA-signatures-which-are-typically-64-bytes"
+  }
+}
+```
+
+### 7.3 JWS Structure Breakdown
+
+The JWS Compact Serialization has three parts separated by `.` (period):
+
+**Protected Header** (base64url-decoded):
+
+```json
+{
+  "alg": "ML-DSA-44"
+}
+```
+
+**Payload** (base64url-decoded):
+
+```json
+{
+  "assertionHash": "4a447a13c5a32730d20bdf7feecb9ffe16649bc731914b574d80035a3927f860",
+  "assertionSig": "bGFyZ2VfYmFzZTY0X3ZhbHVlX2hlcmVfdGhpc19pc19hX3BsYWNlaG9sZGVyX2Zvcl90aGVfYmluZGluZ19pbnB1dF9jb25jYXRlbmF0aW9u"
+}
+```
+
+Where:
+
+- `assertionHash`: The SHA-256 hash of the canonicalized assertion object
+  (with `binding` removed), encoded as lowercase hex (64 characters).
+- `assertionSig`: The base64-encoded concatenation of
+  `aggregateHash || assertionHashBytes`, where `aggregateHash` is the
+  concatenation of all decoded segment hashes, and `assertionHashBytes` is
+  the hex-decoded assertion hash (32 bytes).
+
+**Signature**: The third JWS component is the ML-DSA-44 signature
+(2420 bytes, base64url-encoded). This is substantially larger than classical
+signatures:
+
+| Algorithm | Signature Size | Base64url Size (approx.) |
+|:----------|:---------------|:-------------------------|
+| `HS256` | 32 bytes | 43 characters |
+| `ES256` | 64 bytes | 86 characters |
+| `RS256` (2048-bit) | 256 bytes | 342 characters |
+| `ML-DSA-44` | 2420 bytes | 3227 characters |
+| `ML-DSA-65` | 3309 bytes | 4412 characters |
+
+### 7.4 Complete Manifest with ML-DSA-44 Assertion
+
+```json
+{
+  "schemaVersion": "5.0.0",
+  "encryptionInformation": {
+    "type": "split",
+    "policy": "eyJ1dWlkIjoiZDRlNWY2YTctOGIwYy00OWQxLWExZjItM2M0ZDVlNmY3YTg5IiwiYm9keSI6eyJkYXRhQXR0cmlidXRlcyI6W3siYXR0cmlidXRlIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9hdHRyL2NsYXNzaWZpY2F0aW9uL3ZhbHVlL3NlY3JldCIsImRpc3BsYXlOYW1lIjoiQ2xhc3NpZmljYXRpb246IFNlY3JldCIsImlzRGVmYXVsdCI6ZmFsc2UsInB1YktleSI6IiIsImthc1VSTCI6Imh0dHBzOi8va2FzLmV4YW1wbGUuY29tIn1dLCJkaXNzZW0iOltdfX0=",
+    "keyAccess": [
+      {
+        "alg": "ML-KEM-1024",
+        "type": "mlkem-wrapped",
+        "kas": "https://kas.example.com",
+        "kid": "kas-mlkem1024-2025-02",
+        "sid": "",
+        "protectedKey": "MIIGYoCCBiAl5HPnFgYIvUecCXEqxhOxvjPfKzZP/1N3AFqOg8pzJAfScJlmRXuwJAgyPoSaNo4KgQm6El9nGwjrws3l6v0+9Uau+X0WNNSQ9NV+bhaf/PfjrTPRLkw8RNtbaONTgcfzDCI/6LvBw85MbU2VcmKabtf7qGnUDOdjVXxzXDkHHU6/CUA6hypz4cSldd79rYU1oJeJ0x4/La4sPs+sXVlmVhNxKqvJC8aUPQ7O8OJY4Aa1HI4vvGT/Ox5gvx8LKZtmGyjv0zP/Nn+PgdcAQF+QjaGljzsnU6IEOL9rDfSjIhvhyCBtL5aHdlVp1xZa1vybzQA2KR6rFaTfuiBxnIKBBycgbUelohofEauocKfci+tGkqSWgbLDIxBa6woM+N43eWgL+/L9FvKOoxhrDznZzSZWJ7iwm9NFTUQE6eRx3f5R537X2bpXytoBX6snqZSBs01wE7wJMR8ACYh5KQJvEAmYDYYXq//51DtxcM9BTld08HtdiZt/OH43PyoPX8uQ4IC6b8R3rrfQHP/0FCQsi8q22XwrmnJgLqTgEZ4RtEzA6+d2Dhx861uihbch/VMfYGgLdxf12wgVVJ9I79m8q80dM5ZYhAgApyp63Y9D7VUMFUoeaK4r6Dqkj00XLydpoy5pDj0pS0YeRazu8vc0Q97RDJitleeVQi/5/imuJH1JcsetTFVs3eMlqxUHjQ/6jTU4XBMOjnjqtBXYibzDYxBss4PZ6jRtokq8AH9Xwdrn3lA3uW8RHziE/ZozWqVFvhnc85bGa4MLC3lOuyJu+kL/+ycMc+lVfet9xbWLO8N1P8Sll7Vb6ohaJvuYSSk19xLI7BDFsQ5xdC+9JBXa386QwUUSd9zCfwnUBMR4JYkLQ31gwYyvEbsUI4W2ChwDrVmUpfHQcr1RshmjTze4eRA6Iboq4hjkvlBmNtnAfamGpCumFqlbdMEkFvQXFK4qMYN6KokyF9btDl9RI92jeZZRSDCYJRFNQMRandNmyZ0qGRj5c6SghjHwVS0HBSP7LqKQXl2UgeNlMmo4zyS7bEe2Ofgq5JsF+EPPAS53d3fEwC/2c/hyWjZoIdTOQvdP33QANaBNcGuWW9ggD1KUjcyQWjyYGWJHLM9VZfz/QUwwMxf62MGA9ftdzSmzPLaCIMlkV2qUvEd//IBPRxAaXUmagT8jbNqDPNg4lkBICfp4hoDtmVBMZGCb3MamGbx7oMDmnm/CBegm7kofqmq9nZbUKIL2+oNVTzbWB98tTMvZgtdGBShSAyvDImgOxJ6EHDs9Q+kFnEwEAY6yTTJMUqqX2RfNv6XrtfB785oHieaqyAp4oore3TTZquD2HW+HmCDLp0JTv8kl+uIlwSJiPaAxcYpt0B8Srwu9sSDeXYLGNlnaDvadpGhdhEbx5bEUhEhSXrSyGhNq/35Z/0spiNrEuLpiuioEV5dZ/4EVR3aHyMbc62ND7ZvlPQMKkPfRI2d5T8iKHN72ir1QFvwbeb0el1O9Hdvg2vTDJoXZ2XksViknSkIppn/brmKOCDNEVeNvfN/010aJJlFNBTovhWPh8f3fpOtubfUMGMrb4LbgK+nBqIJdxYVYGIxhk1K+t2us0xJaSpoWNnyUgl/6sl4+UBvotuk04h+XHnmKYhA0MU8vjrJ8Jc7RiTGEmt9GcOyWztjlrfGhbaGm4w2f2P2JfQxl+bUkMxGieIhbeyI0y4Y62DhDk/KAXPKwjGFnQ7XD0hPRPROKj7DzpSqi6y0QobZJ6q8Rc718v4MIsxTNzIpTZAfLxnvCz1u3QL/LSvIfHhdnwPGXvTZAhSXafop1ETZelwVt5z/3xPfyjDXGHDXafxqxyiXYxQoxSMoyPZjjwLGwvHCXPvv+09xfFppEB+8NyUhnmlJNqsvTWD80sn7ysdKwvgbEZTo3lH6Feco9iz3UPlfY7Y/Q8UUYxHM1wwAgkvPAKZaCXBwNB7AB/OGLowH0xcqX59L3I+Ggl6CLXpuYbWJ8x4JNzTL321G+Ajr1ryES6Rp6q/lVf/1P6rjMObwDT93YJ7gtED20nmqR83KD9xTwSTq11qhBSaKzGIA4UPSEiaLfl+FrEoE8YnqUCIsEtaYgUWA2pddx7gGN1kQ3vRAawdkPB8FJ/+LZd0SAaEfSa/32yFffc87ZorD1Um7ItNq56lTq",
+        "policyBinding": {
+          "alg": "HS256",
+          "hash": "OWEzYjRjNWQ2ZTdmOGExMjM0NTY3ODkwYWJjZGVmMDE="
+        }
+      }
+    ],
+    "method": {
+      "algorithm": "A256GCM"
+    },
+    "integrityInformation": {
+      "rootSignature": {
+        "alg": "HS256",
+        "sig": "ZGQ3MjkxODVmNThhYmMzZDRlNjdmODkwMTIzNGFiY2Q="
+      },
+      "segmentHashAlg": "HS256",
+      "segmentSizeDefault": 1048576,
+      "encryptedSegmentSizeDefault": 1048604,
+      "segments": [
+        {
+          "hash": "OTg3NjU0MzIxMGZlZGNiYQ==",
+          "segmentSize": 2048,
+          "encryptedSegmentSize": 2076
+        }
+      ]
+    }
+  },
+  "assertions": [
+    {
+      "id": "7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d",
+      "type": "handling",
+      "scope": "tdo",
+      "appliesToState": "encrypted",
+      "statement": {
+        "format": "json+stanag5636",
+        "schema": "urn:nato:stanag:5636:A:1:elements:json",
+        "value": "{\"ocl\":{\"pol\":\"d4e5f6a7-8b0c-49d1-a1f2-3c4d5e6f7a89\",\"cls\":\"SECRET\",\"catl\":[{\"type\":\"P\",\"name\":\"Releasable To\",\"vals\":[\"usa\",\"gbr\"]}],\"dcr\":\"2025-06-15T00:00:00Z\"},\"context\":{\"@base\":\"urn:nato:stanag:5636:A:1:elements:json\"}}"
+      },
+      "binding": {
+        "method": "jws",
+        "signature": "eyJhbGciOiJNTC1EU0EtNDQifQ.eyJhc3NlcnRpb25IYXNoIjoiNGE0NDdhMTNjNWEzMjczMGQyMGJkZjdmZWVjYjlmZmUxNjY0OWJjNzMxOTE0YjU3NGQ4MDAzNWEzOTI3Zjg2MCIsImFzc2VydGlvblNpZyI6ImJHRnlaMlZmWW1GelpUWTBYM1poYkhWbFgyaGxjbVVfdGhpc19pc19hX3BsYWNlaG9sZGVyX2Zvcl90aGVfYmluZGluZ19pbnB1dF9jb25jYXRlbmF0aW9uIn0.ML-DSA-44-placeholder-signature-2420-bytes-base64url-encoded-the-actual-signature-would-be-approximately-3227-base64url-characters-representing-2420-bytes-of-ML-DSA-44-signature-data-per-FIPS-204-this-is-significantly-larger-than-classical-ECDSA-signatures-which-are-typically-64-bytes"
+      }
+    }
+  ]
+}
+```
+
+### 7.5 Notes
+
+- The JWS `alg` header is `"ML-DSA-44"`, matching the identifier in
+  BaseTDF-ALG Section 3.4 and Section 6.5.
+- ML-DSA-44 signatures (2420 bytes) are significantly larger than classical
+  alternatives. Implementations should account for increased manifest size
+  when using post-quantum assertion signatures.
+- The ML-DSA-44 public key (1312 bytes) used for verification may be conveyed
+  out-of-band or referenced by a key identifier in the JWS header. The spec
+  permits including the public key in the JWS `jwk` header parameter
+  (base64-encoded raw bytes) but does not require it.
+- The `assertionHash` claim contains the SHA-256 hash of the assertion
+  content (excluding the `binding` field), computed using the JCS
+  canonicalization procedure from BaseTDF-ASN Section 6.
+- The `assertionSig` claim contains the base64-encoded concatenation of the
+  aggregate integrity hash (from segment hashes) and the decoded assertion
+  hash bytes. This creates a two-way binding between the assertion and the
+  specific TDF payload.
+- The key protection algorithm (`ML-KEM-1024`) and the assertion signing
+  algorithm (`ML-DSA-44`) are independent choices. This example demonstrates a
+  fully post-quantum TDF: PQC key encapsulation and PQC assertion signing.
+- The `protectedKey` envelope here carries a 1568-byte `mlkemCiphertext`, the
+  ML-KEM-1024 ciphertext size.
+
+---
+
+## 8. Test Vector Format Notes
+
+### 8.1 Placeholder Values
+
+All base64-encoded values in this document are illustrative placeholders. They
+demonstrate the correct structural format and approximate size of real values
+but are NOT computed from actual cryptographic operations. The following
+conventions are used:
+
+- **Policy strings**: Real base64-encoded JSON that can be decoded to read the
+  policy object.
+- **Protected keys**: Placeholder base64 values of representative length.
+- **Ephemeral keys**: EC PEM keys in Section 3 use syntactically valid PEM
+  headers but placeholder key data. ML-KEM ciphertexts use placeholder base64
+  of approximately correct decoded length (1088 bytes for ML-KEM-768).
+- **Policy binding hashes**: Placeholder base64 values of 32-byte HMAC-SHA256
+  output length.
+- **Segment hashes**: Placeholder base64 values of appropriate length for the
+  algorithm (32 bytes for HS256, 16 bytes for GMAC).
+- **Root signatures**: Placeholder base64 values of 32 bytes (HS256).
+- **JWS signatures**: Placeholder compact serialization with descriptive
+  text in the signature component.
+
+### 8.2 Real Test Vectors
+
+Full test vectors with actual computed cryptographic values -- including
+known key pairs, deterministic RNG output, and expected intermediate and
+final values -- are planned for a separate test suite document. Such vectors
+would include:
+
+- Known RSA, EC, ML-KEM, and ML-DSA key pairs (private and public).
+- Fixed plaintext payloads and policy objects.
+- Deterministically generated ephemeral keys and nonces.
+- Expected values at each step of the key protection procedure.
+- Expected segment hashes, aggregate hashes, and root signatures.
+- Expected policy binding HMAC values.
+- Complete JWS tokens with verifiable signatures.
+
+### 8.3 Implementer Guidance
+
+When implementing against these examples:
+
+1. **Validate structure**: Use the JSON schemas in `../../schema/BaseTDF/` to
+   validate that your implementation produces structurally correct manifests.
+2. **Validate field names**: Ensure your implementation uses canonical
+   field names (`alg`, `kas`, `kid`, `sid`, `protectedKey`, `ephemeralKey`)
+   and includes deprecated aliases (`type`, `url`, `wrappedKey`) where
+   specified for backward compatibility.
+3. **Validate base64 lengths**: For `ECDH-HKDF`, check that the base64-decoded
+   `ephemeralKey` is a PEM-encoded EC public key (65 bytes for an uncompressed
+   P-256 point). For ML-KEM, decode `protectedKey` as DER and check that
+   `mlkemCiphertext` is 1088 bytes (ML-KEM-768) or 1568 bytes (ML-KEM-1024).
+4. **Validate policy binding**: Verify that your policy binding computation
+   uses the base64-encoded policy string (not the decoded JSON) as the HMAC
+   message, and the DEK share (not the full DEK) as the HMAC key.
+5. **Test backward compatibility**: Verify that your reader correctly handles
+   the v4.3.0 manifest in Section 6, including `type`-to-`alg` inference,
+   field name aliasing, bare-string policy binding, and hex-then-base64
+   decoding.
+
+---
+
+## 9. Scalable Layout Examples
+
+These examples use placeholders for cryptographic values, as described in Section
+8. Exact values belong in the conformance fixtures listed in Section 11.
+
+### 9.1 Uniform 16 GiB payload
+
+At 2 MiB per segment, a 16 GiB plaintext has 8,192 segments. The manifest integrity
+object remains under 2 KiB; the range-readable tree is exactly 524,288 bytes.
+
+```json
+{
+  "rootSignature":{"alg":"MERKLE-HS256", "sig":"<base64-32-bytes>"},
+  "segmentHashAlg":"GMAC",
+  "segmentSizeDefault":2097152,
+  "encryptedSegmentSizeDefault":2097180,
+  "layout":"uniform",
+  "segmentCount":8192,
+  "lastSegmentSize":2097152,
+  "plaintextSize":17179869184,
+  "encryptedSize":17180098560,
+  "hashTree":{
+    "nodeSize":32,
+    "levels":14,
+    "size":524288,
+    "locator":{"uri":"zip:0.integrity", "size":524288}
+  }
+}
+```
+
+Plaintext offset `8589934593` is in segment `4096` at intra-segment offset `1`.
+Its encrypted payload offset is `4096 * 2097180 = 8590049280`.
+
+### 9.2 Indexed short interior segment
+
+For plaintext segment sizes `{2097152, 65536, 2097152, 1}`, the integrity object is:
+
+```json
+{
+  "rootSignature":{"alg":"MERKLE-HS256", "sig":"<base64-32-bytes>"},
+  "segmentHashAlg":"GMAC",
+  "segmentSizeDefault":2097152,
+  "encryptedSegmentSizeDefault":2097180,
+  "layout":"indexed",
+  "segmentCount":4,
+  "segmentSizeMax":2097152,
+  "plaintextSize":4259841,
+  "encryptedSize":4259953,
+  "hashTree":{
+    "nodeSize":48,
+    "levels":3,
+    "size":368,
+    "inline":"<base64-368-byte-integrity-artifact>"
+  }
+}
+```
+
+The authenticated first subtree totals direct offsets without a linear scan. The
+64 KiB second segment remains valid if later segments are appended.
+
+### 9.3 Partition and IV example
+
+With `partitionSegments: 512`, segment indices `0..511` use `K_0`, `512..1023`
+use `K_1`, and so on. Segment `4294967296` uses:
+
+```text
+IV = noncePrefix || 00 00 00 01 00 00 00 00
+```
+
+The reducer receives segment hashes and sizes, applies DEK-keyed leaf commitments,
+and assembles the tree without reading worker ciphertext.
+
+## 10. Detached and Sharded Examples
+
+### 10.1 Detached uniform payload
+
+The uniform object from Section 9.1 can store its payload and tree independently:
+
+```json
+{
+  "schemaVersion":"5.0.0",
+  "packaging":"detached",
+  "payload":{
+    "type":"detached", "isEncrypted":true,
+    "mimeType":"application/octet-stream",
+    "size":17180098560,
+    "locators":[
+      {"uri":"https://payload.example/object/9f2a", "priority":0,
+       "size":17180098560}
+    ]
+  },
+  "encryptionInformation":{
+    "type":"split", "keyAccess":["<KAO objects>"],
+    "method":{
+      "algorithm":"AES-256-GCM", "iv":"", "isStreamable":true,
+      "noncePrefix":"<base64-four-bytes>"
+    },
+    "integrityInformation":{
+      "rootSignature":{"alg":"MERKLE-HS256", "sig":"<base64>"},
+      "segmentHashAlg":"GMAC", "segmentSizeDefault":2097152,
+      "encryptedSegmentSizeDefault":2097180, "layout":"uniform",
+      "segmentCount":8192, "lastSegmentSize":2097152,
+      "plaintextSize":17179869184, "encryptedSize":17180098560,
+      "hashTree":{
+        "nodeSize":32, "levels":14, "size":524288,
+        "locator":{"uri":"https://integrity.example/tree/9f2a",
+                   "size":524288}
+      }
+    },
+    "policy":"<base64-policy>"
+  },
+  "assertions":[{
+    "id":"manifest-signature", "type":"other", "scope":"manifest",
+    "appliesToState":"encrypted",
+    "statement":{"format":"string",
+                 "schema":"urn:opentdf:manifest-signature:v1",
+                 "value":"publisher manifest signature"},
+    "binding":{"method":"jws", "signature":"<ES256 compact JWS>"}
+  }]
+}
+```
+
+The reader verifies the ES256 assertion with a trusted publisher key before either
+HTTPS request, then verifies tree nodes and ciphertext under the DEK root.
+
+### 10.2 Sharded payload
+
+Replacing the detached payload object with the following creates two equal,
+segment-aligned parts:
+
+```json
+{
+  "type":"detached", "isEncrypted":true, "size":17180098560,
+  "parts":[
+    {"index":0, "segmentRange":[0,4096], "size":8590049280,
+     "locators":[{"uri":"https://a.example/p0"}]},
+    {"index":1, "segmentRange":[4096,8192], "size":8590049280,
+     "locators":[{"uri":"https://b.example/p1"}]}
+  ]
+}
+```
+
+A gap, overlap, reordered index, non-segment boundary, or incorrect checked size sum
+invalidates the manifest.
+
+## 11. Version 5 Conformance Vector Set
+
+A release-quality fixture set MUST contain exact keys, inputs, intermediate values,
+wire bytes, expected outputs, and negative outcomes for:
+
+1. uniform and indexed Merkle trees at `N = 1, 2, 3, 5, 8, 1000`, including every
+   commitment and total (3 and 5 exercise promotion);
+2. inclusion proofs at `N = 1000`, indices `0, 1, 499, 998, 999`;
+3. a duplicated-final-leaf promotion attack rejected by count binding;
+4. the 16 GiB uniform manifest from Section 9.1;
+5. the indexed sizes from Section 9.2;
+6. byte-exact uniform and indexed integrity artifacts with level offsets;
+7. first/last-byte indexed lookup plus tampered sum, overflow, and root-total
+   failures;
+8. DEK-to-`K_0`, `K_1`, and `K_1023` HKDF vectors at partition size 512;
+9. deterministic IVs for indices `0`, `1`, and `2^32`;
+10. explicit/uniform/indexed round trips to identical plaintext;
+11. a streaming ZIP64 data-descriptor package readable by common ZIP libraries;
+12. detached payload and ES256 manifest-signature verification;
+13. four-part sharding and a non-contiguous-parts negative;
+14. off-allowlist, non-HTTPS, redirect-to-unlisted, and oversized locator failures;
+15. aligned uniform and short-tail indexed consistency proofs, with changed-leaf,
+    immutable-parameter, partition-boundary, rollback, and fork negatives.
+
+Placeholder values in this document MUST NOT be used as conformance vectors.

--- a/spec/basetdf/v5/basetdf-ex.md
+++ b/spec/basetdf/v5/basetdf-ex.md
@@ -1006,6 +1006,52 @@ segment-aligned parts:
 A gap, overlap, reordered index, non-segment boundary, or incorrect checked size sum
 invalidates the manifest.
 
+### 10.3 Sharded 50 TiB payload
+
+A 50 TiB plaintext with 4 MiB uniform segments and 1 GiB key partitions has the
+following authenticated scale parameters:
+
+```json
+{
+  "keyDerivation":{"alg":"HKDF-SHA256", "partitionSegments":256},
+  "integrityInformation":{
+    "rootSignature":{"alg":"MERKLE-HS256", "sig":"<base64-32-bytes>"},
+    "segmentHashAlg":"GMAC",
+    "segmentSizeDefault":4194304,
+    "encryptedSegmentSizeDefault":4194332,
+    "layout":"uniform",
+    "segmentCount":13107200,
+    "lastSegmentSize":4194304,
+    "plaintextSize":54975581388800,
+    "encryptedSize":54975948390400,
+    "hashTree":{
+      "nodeSize":32,
+      "levels":25,
+      "size":838860896,
+      "locator":{"uri":"https://integrity.example/tree/50tib",
+                 "size":838860896}
+    }
+  }
+}
+```
+
+There are 51,200 derived partition keys. The ciphertext is 367,001,600 bytes
+larger than the plaintext before packaging, so it cannot fit in a storage resource
+whose object limit equals the plaintext size.
+
+One valid sharded representation uses ten equal parts. For each part index `j` in
+`0..9`:
+
+```text
+segmentRange = [j * 1310720, (j + 1) * 1310720)
+size         = 5497594839040
+```
+
+Every part contains 5 TiB of plaintext, 5,120 complete key partitions, and
+1,310,720 segments. The signed manifest's checked part-size sum is
+54,975,948,390,400 bytes. Other shard sizes are valid when their ranges remain
+contiguous and segment-aligned; partition-aligned boundaries are recommended.
+
 ## 11. Version 5 Conformance Vector Set
 
 A release-quality fixture set MUST contain exact keys, inputs, intermediate values,
@@ -1029,10 +1075,13 @@ wire bytes, expected outputs, and negative outcomes for:
 14. off-allowlist, non-HTTPS, redirect-to-unlisted, and oversized locator failures;
 15. aligned uniform and short-tail indexed consistency proofs, with changed-leaf,
     immutable-parameter, partition-boundary, rollback, and fork negatives;
-16. volume-limit negatives: a manifest above 2^40 plaintext bytes that omits
-    `keyDerivation`, and one whose partition size bound exceeds 2^40 plaintext
-    bytes (BaseTDF-CORE Section 4.3); and
-17. a segment size above the AES-GCM per-invocation limit of 68719476704 bytes,
+16. confidentiality-budget vectors: a 50 TiB uniform manifest with 1 GiB
+    partitions accepted; the same object with 8 GiB partitions rejected; a
+    manifest above 2^39 plaintext bytes without `keyDerivation` rejected; and
+    checked-arithmetic overflow rejected (BaseTDF-CORE Section 4.3);
+17. the exact 50 TiB sizes, segment count, tree size, partition count, and ten-part
+    checked sum from Section 10.3; and
+18. a segment size above the AES-GCM per-invocation limit of 68719476704 bytes,
     rejected before allocation (BaseTDF-INT Section 2).
 
 Placeholder values in this document MUST NOT be used as conformance vectors.

--- a/spec/basetdf/v5/basetdf-int.md
+++ b/spec/basetdf/v5/basetdf-int.md
@@ -1,0 +1,339 @@
+# BaseTDF-INT: Integrity Verification and Scalable Layouts
+
+| | |
+|---|---|
+| **Document** | BaseTDF-INT |
+| **Version** | 5.0.0 |
+| **Status** | Standards Track |
+| **Date** | 2026-08 |
+| **Depends on** | BaseTDF-SEC, BaseTDF-ALG, BaseTDF-LOC |
+| **Referenced by** | BaseTDF-CORE, BaseTDF-ASN, BaseTDF-PKG |
+
+## 1. Introduction
+
+Payloads are independently encrypted segments concatenated in order. BaseTDF 5
+defines three layouts:
+
+| Layout | Metadata | Offset lookup | Partial proof |
+|---|---|---|---|
+| `explicit` | Version 4 JSON record per segment | prefix sum | root validation is O(N) |
+| `uniform` | constant manifest + binary Merkle tree | O(1) | O(log N) hashes |
+| `indexed` | constant manifest + Merkle sum tree | authenticated O(log N) | O(log N) commitments |
+
+Scalable layouts bind index, sizes, count, totals, and layout into a DEK-keyed root.
+`u64be`/`u64le` are unsigned 64-bit encodings; `||` is concatenation. All arithmetic
+MUST be checked for overflow.
+
+## 2. Segment Model
+
+Segments are numbered from zero and stored in plaintext order. Every payload has at
+least one segment. An empty payload is one zero-plaintext-byte segment; other
+zero-length segments are prohibited.
+
+```text
+encrypted_segment_i = IV_i || ciphertext_i || tag_i
+```
+
+AES-256-GCM uses a 12-byte IV and 16-byte tag, so encrypted size is plaintext size
+plus 28. The tag MUST be verified before segment plaintext is released.
+
+With no key derivation, a segment uses the DEK. Otherwise it uses `K_p` from CORE,
+where `p = floor(i / partitionSegments)`. Merkle nodes and roots always use the DEK.
+
+For `uniform` and `indexed`:
+
+```text
+IV_i = noncePrefix || u64be(i)
+```
+
+Writers MUST use this IV and readers MUST compare it with the 12-byte segment prefix.
+Explicit layout retains the version 4 unique-IV rule and MAY use this construction.
+
+## 3. Segment Hashes
+
+Let `SK_i` be the DEK or applicable partition key.
+
+```text
+HS256: segment_hash_i = HMAC-SHA256(SK_i, encrypted_segment_i)
+GMAC:  segment_hash_i = tag_i
+```
+
+HS256 produces 32 bytes. GMAC uses the final 16-byte AES-GCM tag and requires no
+second ciphertext pass. Manifest values are padded base64; constructions consume
+decoded bytes.
+
+## 4. Explicit Layout
+
+Absent `layout` means `explicit`. The version 4 shape is retained:
+
+```json
+{
+  "rootSignature":{"alg":"HS256", "sig":"<base64>"},
+  "segmentHashAlg":"GMAC",
+  "segmentSizeDefault":2097152,
+  "encryptedSegmentSizeDefault":2097180,
+  "segments":[
+    {"hash":"<base64>", "segmentSize":2097152,
+     "encryptedSegmentSize":2097180}
+  ]
+}
+```
+
+There is exactly one ordered record per segment. Every encrypted size MUST equal
+plaintext size plus 28. Interior sizes SHOULD equal the defaults, but arbitrary
+recorded sizes remain valid for version 4 compatibility.
+
+```text
+aggregate_hash = segment_hash_0 || ... || segment_hash_(N-1)
+HS256 root_signature = HMAC-SHA256(DEK, aggregate_hash)
+```
+
+The legacy `GMAC` root is the final 16 bytes of `aggregate_hash`. New writers SHOULD
+use HS256. Before explicit-layout decryption, a reader MUST validate the root over
+all recorded hashes. It then validates requested segment hash, IV, size, and AEAD
+tag before release. Readers SHOULD build a checked prefix-sum index once.
+
+## 5. Scalable Layouts
+
+Both require `rootSignature.alg: MERKLE-HS256`, `layout`, `segmentCount`,
+`plaintextSize`, `encryptedSize`, and `hashTree`, and MUST omit `segments`.
+`segmentCount` is positive and manifest totals MUST equal authenticated root totals.
+
+### 5.1 Uniform
+
+`lastSegmentSize` is REQUIRED and `segmentSizeMax` absent. Segments `0..N-2` MUST
+equal `segmentSizeDefault`. The last size is `1..segmentSizeDefault`, except zero for
+the single empty segment.
+
+```text
+encryptedSegmentSizeDefault = segmentSizeDefault + 28
+plaintextSize = (segmentCount - 1) * segmentSizeDefault + lastSegmentSize
+encryptedSize = plaintextSize + 28 * segmentCount
+```
+
+For plaintext offset `B < plaintextSize`:
+
+```text
+i             = floor(B / segmentSizeDefault)
+intraOffset   = B mod segmentSizeDefault
+payloadOffset = i * encryptedSegmentSizeDefault
+```
+
+This closed-form arithmetic is normative. Cross-segment ranges are split.
+
+### 5.2 Indexed
+
+`segmentSizeMax` is REQUIRED and `lastSegmentSize` absent. Any non-empty segment may
+be short, including interior segments. Each size MUST not exceed the manifest and
+reader limits. `segmentSizeDefault` is a writer target. Writers SHOULD coalesce tiny
+segments unless an application requests a checkpoint. Authenticated subtree sums
+provide O(log N) lookup (Section 8).
+
+## 6. Merkle Construction
+
+A commitment is `C = (H, P, E)`, with 32-byte `H` and plaintext/encrypted totals.
+
+### 6.1 Leaf
+
+```text
+H_i = HMAC-SHA256(DEK,
+    0x00 || u64be(i) || u64be(P_i) || u64be(E_i) || segment_hash_i)
+C_i = (H_i, P_i, E_i)
+```
+
+`E_i` MUST equal `P_i + 28`.
+
+### 6.2 Internal node
+
+```text
+P = P_L + P_R
+E = E_L + E_R
+H = HMAC-SHA256(DEK,
+    0x01 || u64be(P_L) || u64be(E_L) || H_L
+         || u64be(P_R) || u64be(E_R) || H_R)
+C = (H, P, E)
+```
+
+At each level, adjacent nodes pair from the left. An odd final commitment is
+promoted unchanged, not duplicated or self-hashed. Level 0 is the leaf array and
+the last level contains one root.
+
+### 6.3 Root signature
+
+`layoutCode` is byte `0x01` for uniform and `0x02` for indexed.
+
+```text
+root_signature = HMAC-SHA256(DEK,
+    0x02 || layoutCode || u64be(segmentCount)
+         || u64be(P_root) || u64be(E_root) || H_root)
+```
+
+The reader MUST compare MACs in constant time and require root totals to equal the
+manifest. Domain bytes prevent type confusion; the authenticated count prevents
+promotion/duplication ambiguity.
+
+### 6.4 Streaming build and assertion binding
+
+A writer can fold leaves using one stack slot per height, O(log N) resident state.
+Leaf records MAY spill to temporary storage. Final folding preserves left/right and
+promotion. `H_root` is the scalable payload-binding value used by ordinary ASN
+assertions; explicit layout retains `aggregate_hash`.
+
+## 7. Binary Integrity Artifact
+
+The complete tree is level-order. Header integers and indexed totals are
+little-endian; hashes are opaque.
+
+```text
+offset  size  field
+0       8     magic       42 54 44 46 4d 54 01 00 ("BTDFMT\x01\x00")
+8       4     version     u32le = 1
+12      1     nodeSize    32 uniform; 48 indexed
+13      1     levels      ceil(log2(leafCount)) + 1; 1 for one leaf
+14      1     layout      1 uniform; 2 indexed
+15      1     reserved    zero
+16      8     leafCount   u64le
+24      8     nodeCount   u64le
+32      ...   records     leaves, successive levels, root
+```
+
+Uniform record: `H[32]`. Indexed record:
+
+```text
+H[32] || u64le(plaintextTotal) || u64le(encryptedTotal)
+```
+
+For level `l`:
+
+```text
+levelCount(l) = ceil(leafCount / 2^l)
+levelOffset(l) = 32 + nodeSize * sum(levelCount(j), 0 <= j < l)
+recordOffset(l,j) = levelOffset(l) + nodeSize * j
+```
+
+`nodeCount` MUST be the checked sum of all level counts; artifact size MUST be
+exactly `32 + nodeSize * nodeCount`, without trailing bytes. Before allocation or
+access, readers MUST validate magic, version, reserved, layout, node size, levels,
+leaf/node counts, exact size, and manifest agreement. Parsed records remain
+untrusted until authenticated to the DEK root.
+
+## 8. Proofs and Indexed Lookup
+
+### 8.1 Inclusion proof shape
+
+For leaf `i` at level `l`:
+
+```text
+n_l = ceil(segmentCount / 2^l)
+j_l = floor(i / 2^l)
+```
+
+If `j_l` is odd, sibling `j_l-1` is left. If even and `j_l+1 < n_l`, sibling
+`j_l+1` is right. Otherwise the node is promoted and has no proof item. Direction
+and omissions derive from `(i, segmentCount)` and MUST NOT be trusted from an
+encoding. A proof contains only existing siblings from leaf to root.
+
+Uniform items contain hashes and derive totals. Indexed items contain `(H,P,E)`.
+A verifier MUST reject missing, extra, duplicated, or wrong-sized items, promote
+only at implied levels, combine in implied order, and verify the root signature.
+
+### 8.2 Uniform totals
+
+Node `(l,j)` covers:
+
+```text
+[j * 2^l, min((j + 1) * 2^l, segmentCount))
+```
+
+Its plaintext total is the sum of full default leaves plus the last size if covered;
+encrypted total adds 28 per covered leaf. These totals MUST be used in proof folding.
+
+### 8.3 Indexed offset lookup
+
+Require `B < plaintextSize`. Authenticate the root record and manifest totals. Set
+`payloadOffset=0`. At each non-leaf level:
+
+1. derive whether the node has one promoted child or two children;
+2. fetch the child or adjacent pair in a bounded range;
+3. recompute the parent for a pair, or require exact equality for promotion;
+4. descend left if `B < P_left`; otherwise subtract `P_left`, add `E_left` to
+   `payloadOffset`, and descend right; and
+5. reject zero invalid subtrees, limit violations, mismatch, or overflow.
+
+At the leaf, `B` is intra-segment offset and `payloadOffset` the encrypted offset.
+The authenticated leaf supplies exact sizes. The reader MUST retain or complete an
+equivalent root proof. Before the payload request, the path/root MUST authenticate.
+After fetching, recompute the actual segment hash and leaf before decryption/release.
+
+## 9. Verification Profiles
+
+### 9.1 Whole object
+
+A whole-object verifier reconstructs the DEK; validates manifest/tree bounds;
+processes every encrypted segment with IV, size, hash, and AEAD checks; rebuilds the
+aggregate or tree; and verifies count, totals, and root. Whole-object success MUST
+not be reported sooner. A streaming reader MAY release each authenticated segment,
+but on later failure releases no more and signals the failure.
+
+### 9.2 Selected range
+
+Partial verification is conformant only for scalable layouts. For every covering
+segment, the reader MUST:
+
+1. authenticate the tree leaf and proof, including layout, count, and totals;
+2. fetch exactly the authenticated encrypted range;
+3. validate deterministic IV;
+4. recompute segment hash and the index/size-bound leaf;
+5. compare it with the authenticated leaf;
+6. verify AES-GCM during decryption; and
+7. release only requested bytes from that segment.
+
+This authenticates returned bytes as the writer's bytes at that index in the rooted
+object. It does not verify unrequested segments. APIs MUST distinguish selected-
+range from whole-object verification.
+
+### 9.3 Failure
+
+Any parse, proof, size, hash, root, IV, tag, or arithmetic failure stops processing
+and further release. Non-streaming plaintext MUST be discarded. Implementations
+MUST NOT fall back to an unverified profile, locator, algorithm, or boundary.
+
+## 10. Consistency Proofs
+
+The append profile instantiates RFC 6962 Sections 2.1/2.2 tree shape and consistency
+algorithm with Section 6's keyed commitments. Proof entries are RFC-ordered hashes
+for uniform or full commitments for indexed. Verification MUST authenticate old and
+new roots, counts, and totals; establish unchanged strict prefix leaves; and enforce
+CORE's immutable chain parameters. Equality, changed leaves, promotion ambiguity,
+overflow, and total mismatch MUST fail.
+
+A uniform predecessor is extendable only if its final leaf was full. Indexed short
+tails remain unchanged as interior leaves. A KDF checkpoint ends on a partition
+boundary unless partition size is one. Consistency proves prefix inclusion to a DEK
+holder, not freshness or the latest canonical head.
+
+## 11. Legacy Encoding
+
+Pre-4.3 objects (absent version or semantic version below 4.3.0) base64-encode hex
+text rather than raw hash bytes. Legacy-capable readers MUST reproduce that explicit-
+layout behavior. Version 4.3+ uses raw-byte base64. New 5.0 writers MUST NOT create
+legacy encoding. Version 4 explicit roots, size flexibility, and KAO aliases remain
+readable; scalable layouts require major version 5+.
+
+## 12. Security Considerations
+
+The tree may live on untrusted storage and is safe only after nodes fold to the
+DEK-keyed root. Headers/reads still require pre-authentication bounds. GMAC segment
+hashes have 128-bit output, while every Merkle hash/root is HMAC-SHA256. Partition
+keys limit worker scope but are not forward-secret. Deterministic uniqueness still
+requires a fresh random nonce prefix for each DEK and no reuse of a
+`(segment key, nonce prefix, index)` tuple.
+
+## 13. Normative References
+
+- [BaseTDF-ALG](basetdf-alg.md)
+- [BaseTDF-CORE](basetdf-core.md)
+- [BaseTDF-LOC](basetdf-loc.md)
+- [BaseTDF-SEC](basetdf-sec.md)
+- NIST SP 800-38D; RFC 2104; RFC 5869; RFC 6962
+

--- a/spec/basetdf/v5/basetdf-int.md
+++ b/spec/basetdf/v5/basetdf-int.md
@@ -37,6 +37,14 @@ encrypted_segment_i = IV_i || ciphertext_i || tag_i
 AES-256-GCM uses a 12-byte IV and 16-byte tag, so encrypted size is plaintext size
 plus 28. The tag MUST be verified before segment plaintext is released.
 
+One segment is one AEAD invocation, so no segment may exceed the AES-GCM
+per-invocation plaintext limit of `2^36 - 32 = 68719476704` bytes (NIST SP 800-38D
+Section 5.2.1.1). Every `segmentSizeDefault`, `segmentSizeMax`, `lastSegmentSize`,
+and recorded `segmentSize` MUST satisfy that cap, and readers MUST reject a larger
+value before allocating. The cap is absolute; manifest and reader limits are
+normally far below it. The total plaintext under one segment key is limited
+separately by BaseTDF-CORE Section 4.3.
+
 With no key derivation, a segment uses the DEK. Otherwise it uses `K_p` from CORE,
 where `p = floor(i / partitionSegments)`. Merkle nodes and roots always use the DEK.
 
@@ -124,10 +132,10 @@ This closed-form arithmetic is normative. Cross-segment ranges are split.
 ### 5.2 Indexed
 
 `segmentSizeMax` is REQUIRED and `lastSegmentSize` absent. Any non-empty segment may
-be short, including interior segments. Each size MUST not exceed the manifest and
-reader limits. `segmentSizeDefault` is a writer target. Writers SHOULD coalesce tiny
-segments unless an application requests a checkpoint. Authenticated subtree sums
-provide O(log N) lookup (Section 8).
+be short, including interior segments. Each size MUST not exceed `segmentSizeMax`,
+the Section 2 cap, or reader limits. `segmentSizeDefault` is a writer target. Writers
+SHOULD coalesce tiny segments unless an application requests a checkpoint.
+Authenticated subtree sums provide O(log N) lookup (Section 8).
 
 ## 6. Merkle Construction
 
@@ -326,8 +334,11 @@ The tree may live on untrusted storage and is safe only after nodes fold to the
 DEK-keyed root. Headers/reads still require pre-authentication bounds. GMAC segment
 hashes have 128-bit output, while every Merkle hash/root is HMAC-SHA256. Partition
 keys limit worker scope but are not forward-secret. Deterministic uniqueness still
-requires a fresh random nonce prefix for each DEK and no reuse of a
-`(segment key, nonce prefix, index)` tuple.
+requires a fresh DEK and a fresh random nonce prefix for each object, and no reuse
+of a `(segment key, nonce prefix, index)` tuple. Partition keys are also the
+rekeying mechanism for the AEAD volume bound; segment size is not, because that
+bound counts total bytes under a key rather than invocations (BaseTDF-SEC
+Section 6.7).
 
 ## 13. Normative References
 

--- a/spec/basetdf/v5/basetdf-kao.md
+++ b/spec/basetdf/v5/basetdf-kao.md
@@ -1,0 +1,845 @@
+# BaseTDF-KAO: Key Access Object
+
+| | |
+|---|---|
+| **Document** | BaseTDF-KAO |
+| **Title** | Key Access Object |
+| **Version** | 5.0.0 |
+| **Status** | Standards Track |
+| **Date** | 2026-08 |
+| **Suite** | BaseTDF Specification Suite |
+| **Depends on** | BaseTDF-SEC, BaseTDF-ALG |
+| **Referenced by** | BaseTDF-CORE, BaseTDF-KAS |
+
+> **5.0 status:** Frozen. BaseTDF 5.0 republishes the BaseTDF 4.4 KAO
+> requirements without normative change. Packaging, integrity, and key-derivation
+> changes are defined by other suite documents.
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [KAO Schema](#2-kao-schema)
+3. [Key Splitting](#3-key-splitting)
+4. [Algorithm-Specific Operations](#4-algorithm-specific-operations)
+5. [Policy Binding](#5-policy-binding)
+6. [Encrypted Metadata](#6-encrypted-metadata)
+7. [Backward Compatibility](#7-backward-compatibility)
+8. [Security Considerations](#8-security-considerations)
+9. [Normative References](#9-normative-references)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+The Key Access Object (KAO) is the core cryptographic structure within a TDF
+manifest that binds a protected Data Encryption Key (DEK) share to a policy and
+a specific Key Access Service (KAS) instance. Each KAO carries sufficient
+information for its designated KAS to:
+
+1. Identify the KAS key pair needed for decapsulation or unwrapping.
+2. Recover the plaintext DEK share.
+3. Verify the integrity of the policy binding before any key release.
+
+A TDF manifest contains one or more KAOs in its `encryptionInformation.keyAccess`
+array. When key splitting is used (Section 3), multiple KAOs protect independent
+shares of the DEK, each addressed to a potentially different KAS. The full DEK
+can only be reconstructed when all shares are recovered.
+
+### 1.2 Scope
+
+This document defines:
+
+- The JSON schema and field semantics for the Key Access Object.
+- The XOR-based key splitting mechanism and its relationship to policy
+  attribute rules.
+- Algorithm-specific procedures for protecting DEK shares, referencing the
+  algorithm registry in BaseTDF-ALG.
+- The policy binding computation and verification procedure.
+- The encrypted metadata sub-structure.
+- Backward compatibility rules for reading and writing KAOs across TDF versions.
+
+This document does NOT define:
+
+- The wire protocol for communicating KAOs to the KAS (see BaseTDF-KAS).
+- The policy structure or ABAC evaluation rules (see BaseTDF-POL).
+- The container format in which KAOs are embedded (see BaseTDF-CORE).
+- The algorithm parameters themselves (see BaseTDF-ALG).
+
+### 1.3 Relationship to Other BaseTDF Documents
+
+- **BaseTDF-SEC** defines the security invariants that the KAO mechanism
+  implements, including policy binding integrity (SI-1), algorithm validation
+  (SI-6), and key material hygiene (SI-7).
+- **BaseTDF-ALG** defines the algorithm identifiers, parameters, and key
+  protection categories referenced by the KAO `alg` field.
+- **BaseTDF-POL** defines the policy object whose integrity is protected by the
+  KAO policy binding.
+- **BaseTDF-KAS** defines the rewrap protocol through which a KAS processes KAOs
+  and returns re-encrypted DEK shares to authorized clients.
+- **BaseTDF-CORE** defines the manifest structure in which KAOs are embedded.
+
+### 1.4 Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in [BCP 14][RFC2119] [RFC
+8174][RFC8174] when, and only when, they appear in ALL CAPITALS, as shown here.
+
+---
+
+## 2. KAO Schema
+
+### 2.1 v4.4.0 Schema
+
+The following JSON illustrates a complete v4.4.0 Key Access Object using the
+ML-KEM-768 key encapsulation mechanism:
+
+```json
+{
+  "alg": "ML-KEM-768",
+  "kas": "https://kas.example.com",
+  "kid": "kas-mlkem-key-2025",
+  "sid": "split-0",
+  "protectedKey": "<base64-encoded MLKEMWrappedKey DER envelope>",
+  "policyBinding": {
+    "alg": "HS256",
+    "hash": "<base64-encoded HMAC-SHA256 digest>"
+  },
+  "encryptedMetadata": "<base64-encoded AES-256-GCM ciphertext>"
+}
+```
+
+### 2.2 Field Definitions
+
+#### `alg` (string, REQUIRED)
+
+Algorithm identifier from the BaseTDF-ALG key protection registry (BaseTDF-ALG
+Section 3.2). This field unambiguously identifies the cryptographic mechanism
+used to protect the DEK share.
+
+Valid values include: `RSA-OAEP`, `RSA-OAEP-256`, `ECDH-HKDF`, `ML-KEM-768`,
+`ML-KEM-1024`.
+
+Implementations MUST include this field when creating new KAOs. Implementations
+MUST reject KAOs whose `alg` value is not recognized (see SI-6 in BaseTDF-SEC).
+
+#### `type` (string, DEPRECATED)
+
+Legacy key type field from BaseTDF v4.3.0. Accepted values: `"wrapped"`,
+`"ec-wrapped"`, `"mlkem-wrapped"`, `"remote"`.
+
+Note that `"mlkem-wrapped"` does not distinguish ML-KEM-768 from ML-KEM-1024;
+see Section 7.1 for the resolution rules that apply when `alg` is absent.
+
+When both `alg` and `type` are present, `alg` takes precedence. When only `type`
+is present (legacy KAOs), the algorithm is inferred per the backward
+compatibility mapping in Section 7. Implementations SHOULD NOT produce
+conflicting `type` and `alg` values.
+
+#### `kas` (string, REQUIRED)
+
+Fully qualified URL of the Key Access Service that holds the private key
+corresponding to the public key used to protect the DEK share. This URL
+identifies the KAS endpoint to which rewrap requests for this KAO MUST be
+directed.
+
+Example: `"https://kas.example.com"`
+
+This field is the v4.4.0 canonical name for the KAS URL. See `url` below for
+the deprecated alias.
+
+#### `url` (string, DEPRECATED)
+
+Legacy name for the `kas` field. When reading a KAO, implementations MUST treat
+`url` as equivalent to `kas`. When both are present, `kas` takes precedence.
+When writing new KAOs, implementations SHOULD use `kas` and MAY additionally
+include `url` for backward compatibility with older readers.
+
+#### `kid` (string, REQUIRED)
+
+Key identifier for the KAS key pair used to protect the DEK share. The KAS uses
+this value to select the correct private key for decapsulation or unwrapping.
+
+Implementations MUST include `kid` when creating new KAOs. KAS implementations
+MUST support KAOs that omit `kid` for backward compatibility with legacy TDFs,
+but SHOULD log a warning when processing such KAOs (see BaseTDF-SEC
+Section 4.4).
+
+#### `sid` (string, REQUIRED)
+
+Split identifier. Groups KAOs that protect the same DEK share within a key
+splitting configuration. All KAOs with the same `sid` value protect the same
+DEK share and represent alternative paths to recover that share (i.e., any one
+of them is sufficient).
+
+When key splitting is not used (single KAS), the `sid` field MAY be empty or
+omitted. When key splitting is used, each distinct split MUST have a unique
+`sid` value. See Section 3 for the key splitting mechanism.
+
+#### `protectedKey` (string, REQUIRED)
+
+Base64-encoded algorithm-specific protected DEK share. The contents and
+structure of this field depend on the algorithm identified by `alg`:
+
+- For key wrapping algorithms (`RSA-OAEP`, `RSA-OAEP-256`): the RSA-OAEP
+  ciphertext.
+- For key agreement algorithms (`ECDH-HKDF`): the AES-256-GCM ciphertext of
+  the DEK share encrypted under the HKDF-derived key.
+- For key encapsulation algorithms (`ML-KEM-768`, `ML-KEM-1024`): the DER
+  encoding of an `MLKEMWrappedKey` structure, which carries both the KEM
+  ciphertext and the AES-256-GCM ciphertext of the DEK share. See
+  Section 4.3 and BaseTDF-ALG Section 4.3.
+
+#### `wrappedKey` (string, DEPRECATED)
+
+Legacy name for the `protectedKey` field. When reading a KAO, implementations
+MUST treat `wrappedKey` as equivalent to `protectedKey`. When both are present,
+`protectedKey` takes precedence. When writing new KAOs, implementations MUST use
+`protectedKey` and MAY additionally include `wrappedKey` for backward
+compatibility.
+
+#### `ephemeralKey` (string, CONDITIONAL)
+
+Base64-encoded ephemeral public key. This field is REQUIRED for key agreement
+algorithms; it is not used for key wrapping or key encapsulation algorithms.
+
+The contents depend on the algorithm:
+
+| Algorithm | `ephemeralKey` Contents |
+|:----------|:-----------------------|
+| `RSA-OAEP`, `RSA-OAEP-256` | Not used; SHOULD be omitted |
+| `ECDH-HKDF` | Ephemeral EC public key in PEM format |
+| `ML-KEM-768`, `ML-KEM-1024` | Not used; SHOULD be omitted. The KEM ciphertext travels inside the `protectedKey` envelope. See Section 4.3. |
+
+Legacy KAOs use the JSON field name `ephemeralPublicKey` instead of
+`ephemeralKey`. Implementations MUST accept both field names when reading.
+
+#### `policyBinding` (object, REQUIRED)
+
+Policy binding verification data. This object cryptographically binds the KAO to
+the policy embedded in the TDF manifest. See Section 5 for the computation and
+verification procedure.
+
+```json
+{
+  "alg": "HS256",
+  "hash": "<base64-encoded HMAC-SHA256 digest>"
+}
+```
+
+- `policyBinding.alg` (string, REQUIRED): The MAC algorithm used for the
+  binding. MUST be `"HS256"` (HMAC-SHA256). Implementations MUST reject unknown
+  values (SI-6).
+- `policyBinding.hash` (string, REQUIRED): Base64-encoded MAC digest.
+
+Legacy KAOs MAY represent the policy binding as a bare string (the hash value
+alone) instead of an object. See Section 7 for handling legacy formats.
+
+#### `encryptedMetadata` (string, OPTIONAL)
+
+Base64-encoded encrypted metadata. When present, this field contains metadata
+encrypted with the DEK share using AES-256-GCM. See Section 6 for the structure
+and security requirements.
+
+### 2.3 Additional Fields
+
+The following fields are recognized for compatibility but are not part of the
+core v4.4.0 schema:
+
+- `protocol` (string): Legacy field, value `"kas"`. Informational only.
+- `schemaVersion` (string): Legacy field indicating the KAO schema version
+  (e.g., `"1.0"`). The TDF manifest-level `schemaVersion` field is the
+  authoritative version indicator in v4.4.0.
+
+---
+
+## 3. Key Splitting
+
+### 3.1 Overview
+
+Key splitting divides the DEK into multiple independent shares using XOR-based
+n-of-n secret sharing. Each share is protected in its own KAO, potentially
+addressed to a different KAS. All shares are required to reconstruct the DEK;
+compromise of fewer than all shares reveals no information about the DEK.
+
+### 3.2 Formal Definition
+
+Given a DEK of length L bytes (32 bytes for AES-256), key splitting produces
+n shares such that:
+
+```
+DEK = share_0 XOR share_1 XOR ... XOR share_(n-1)
+```
+
+**Share generation procedure**:
+
+1. For i = 0 to n-2:
+   - Generate `share_i` as L bytes from a CSPRNG (see BaseTDF-SEC Section 6.5).
+2. Compute the final share:
+   - `share_(n-1) = DEK XOR share_0 XOR share_1 XOR ... XOR share_(n-2)`
+
+**DEK reconstruction procedure**:
+
+1. Obtain all n shares from their respective KAOs via the rewrap protocol.
+2. Compute: `DEK = share_0 XOR share_1 XOR ... XOR share_(n-1)`
+
+**Security property**: Each individual share is uniformly random and
+statistically independent of the DEK. An adversary who obtains any strict subset
+of shares gains zero information about the DEK. This is information-theoretic
+security, not computational security -- it holds regardless of the adversary's
+computational power.
+
+### 3.3 Split Assignment from Policy Attribute Rules
+
+The mapping from policy attribute rules to key splits determines which KAS
+instances must authorize access. The following rules govern split assignment:
+
+| Attribute Rule | Split Assignment | Semantic |
+|:---------------|:-----------------|:---------|
+| `allOf` | Each attribute value gets a SEPARATE split (`sid`) | ALL KASes associated with the attribute values must independently authorize access |
+| `anyOf` | All attribute values share ONE split (`sid`) | ANY one KAS associated with the attribute values can authorize access |
+| `hierarchy` | Treated as `anyOf` (single split) | Same as `anyOf`; hierarchical ordering is enforced by the KAS authorization logic, not by the split structure |
+
+**Example**: A policy with two `allOf` attributes and one `anyOf` attribute
+(with three values) produces two splits:
+
+```
+Split 0 (sid: "s-0"): allOf attribute #1 → KAS A
+Split 1 (sid: "s-1"): allOf attribute #2 → KAS B
+                       anyOf values 1,2,3 → KAS C, KAS D, KAS E (same split)
+```
+
+In this example, Split 0 has one KAO (to KAS A), and Split 1 has four KAOs (one
+to KAS B for the allOf attribute, and one each to KAS C, KAS D, KAS E for the
+anyOf attribute values). Reconstruction requires one KAO from Split 0 AND one
+KAO from Split 1.
+
+### 3.4 Split Identifier Generation
+
+Split identifiers (`sid`) MUST be unique within a single TDF manifest.
+Implementations MAY use any scheme that guarantees uniqueness, including:
+
+- Sequential identifiers: `"s-0"`, `"s-1"`, `"s-2"`, ...
+- UUID-based identifiers.
+
+When a TDF has only a single KAO (no splitting), the `sid` field MAY be empty
+or omitted.
+
+### 3.5 Same-KAS Split Warning
+
+Implementations SHOULD warn when all splits in a key splitting configuration
+resolve to the same KAS URL. While this configuration is functionally correct,
+it reduces the defense-in-depth benefit of key splitting to a single point of
+compromise (see BaseTDF-SEC Section 4.4).
+
+---
+
+## 4. Algorithm-Specific Operations
+
+This section describes how each key protection category (defined in BaseTDF-ALG
+Section 4) is applied to produce the `protectedKey` and `ephemeralKey` fields in
+a KAO. For full algorithm parameters and implementation requirements, see
+BaseTDF-ALG Section 5.
+
+### 4.1 Key Wrapping (RSA-OAEP, RSA-OAEP-256)
+
+Key wrapping directly encrypts the DEK share under the KAS RSA public key.
+
+**Encryption** (TDF creation):
+
+```
+protectedKey = Base64(RSA-OAEP(kas_rsa_pk, DEK_share))
+```
+
+**Decryption** (KAS rewrap):
+
+```
+DEK_share = RSA-OAEP-Decrypt(kas_rsa_sk, Base64Decode(protectedKey))
+```
+
+**KAO fields**:
+
+| Field | Value |
+|:------|:------|
+| `alg` | `"RSA-OAEP"` or `"RSA-OAEP-256"` |
+| `protectedKey` | Base64-encoded RSA-OAEP ciphertext |
+| `ephemeralKey` | Not used; SHOULD be omitted |
+
+**Example** (RSA-OAEP-256):
+
+```json
+{
+  "alg": "RSA-OAEP-256",
+  "kas": "https://kas.example.com",
+  "kid": "rsa-4096-2025",
+  "sid": "s-0",
+  "protectedKey": "TUlJQ...base64-encoded RSA-OAEP ciphertext...",
+  "policyBinding": {
+    "alg": "HS256",
+    "hash": "YTgz...base64-encoded HMAC..."
+  }
+}
+```
+
+### 4.2 Key Agreement (ECDH-HKDF)
+
+Key agreement uses an ephemeral ECDH exchange to derive a symmetric key, which
+then protects the DEK share.
+
+**Encryption** (TDF creation):
+
+```
+1. ephemeral_ec = generate_ec_keypair(curve)
+2. shared_secret = ECDH(ephemeral_ec.sk, kas_ec_pk)
+3. derived_key = HKDF-SHA256(
+     salt = SHA256("TDF"),
+     ikm  = shared_secret,
+     info = "",
+     len  = 32
+   )
+4. protectedKey = Base64(AES-256-GCM(derived_key, DEK_share))
+5. ephemeralKey = PEM(ephemeral_ec.pk)
+```
+
+**Decryption** (KAS rewrap):
+
+```
+1. shared_secret = ECDH(kas_ec_sk, PEM_parse(ephemeralKey))
+2. derived_key = HKDF-SHA256(
+     salt = SHA256("TDF"),
+     ikm  = shared_secret,
+     info = "",
+     len  = 32
+   )
+3. DEK_share = AES-256-GCM-Decrypt(derived_key, Base64Decode(protectedKey))
+```
+
+**KAO fields**:
+
+| Field | Value |
+|:------|:------|
+| `alg` | `"ECDH-HKDF"` |
+| `protectedKey` | Base64-encoded AES-256-GCM ciphertext |
+| `ephemeralKey` | Ephemeral EC public key in PEM format |
+
+**Implementation note**: The HKDF salt is `SHA256("TDF")` -- the SHA-256 hash
+of the three ASCII bytes `0x54 0x44 0x46`. This is a fixed 32-byte value. The
+info parameter is empty by default.
+
+**Version compatibility**: The `ECDH-HKDF` wire format is identical in v4.3.0
+and v4.4.0; only the field names differ (`wrappedKey`/`ephemeralPublicKey` in
+v4.3.0). See BaseTDF-ALG Section 4.2 for details.
+
+**Example** (ECDH-HKDF):
+
+```json
+{
+  "alg": "ECDH-HKDF",
+  "kas": "https://kas.example.com",
+  "kid": "ec-p256-2025",
+  "sid": "",
+  "protectedKey": "dGhl...base64-encoded AES-GCM ciphertext...",
+  "ephemeralKey": "-----BEGIN PUBLIC KEY-----\nMFkw...\n-----END PUBLIC KEY-----",
+  "policyBinding": {
+    "alg": "HS256",
+    "hash": "YTgz...base64-encoded HMAC..."
+  }
+}
+```
+
+### 4.3 Key Encapsulation (ML-KEM-768, ML-KEM-1024)
+
+Key encapsulation uses a lattice-based KEM to establish a 32-byte shared secret,
+which is used directly as the AES-256 key protecting the DEK share. Both the KEM
+ciphertext and the encrypted DEK share travel together in a single DER-encoded
+envelope carried in `protectedKey`; the `ephemeralKey` field is not used.
+
+**Encryption** (TDF creation):
+
+```
+1. (ct, ss)     = ML-KEM.Encapsulate(kas_mlkem_pk)
+2. encryptedDEK = AES-256-GCM(key = ss, DEK_share)
+3. protectedKey = Base64(DER(MLKEMWrappedKey {
+                    mlkemCiphertext = ct,
+                    encryptedDEK    = encryptedDEK
+                  }))
+```
+
+**Decryption** (KAS rewrap):
+
+```
+1. env       = DER_parse(Base64Decode(protectedKey)) as MLKEMWrappedKey
+2. ss        = ML-KEM.Decapsulate(kas_mlkem_sk, env.mlkemCiphertext)
+3. DEK_share = AES-256-GCM-Decrypt(key = ss, env.encryptedDEK)
+```
+
+**Envelope structure**:
+
+```asn1
+MLKEMWrappedKey ::= SEQUENCE {
+    mlkemCiphertext  [0] IMPLICIT OCTET STRING,
+    encryptedDEK     [1] IMPLICIT OCTET STRING
+}
+```
+
+`encryptedDEK` is the AES-256-GCM output with the nonce prepended and the tag
+appended:
+
+| Offset | Length | Contents |
+|:-------|:-------|:---------|
+| 0 | 12 | GCM nonce (randomly generated per wrap) |
+| 12 | n | Ciphertext of the DEK share |
+| 12 + n | 16 | GCM authentication tag |
+
+No additional authenticated data (AAD) is supplied.
+
+**KAO fields**:
+
+| Field | Value |
+|:------|:------|
+| `alg` | `"ML-KEM-768"` or `"ML-KEM-1024"` |
+| `protectedKey` | Base64-encoded `MLKEMWrappedKey` DER envelope |
+| `ephemeralKey` | Not used; SHOULD be omitted |
+
+**Requirements**:
+
+- ML-KEM operations MUST conform to [NIST FIPS 203][FIPS203].
+- The 32-byte shared secret MUST be used directly as the AES-256 key.
+  Implementations MUST NOT apply HKDF or any other KDF. See BaseTDF-ALG
+  Section 4.3.1 for the rationale.
+- Implementations MUST reject a KAO whose `mlkemCiphertext` length does not
+  match the parameter set named by `alg` (1088 bytes for ML-KEM-768, 1568 bytes
+  for ML-KEM-1024).
+- Implementations MUST reject an envelope with trailing bytes after the DER
+  `SEQUENCE`.
+- Implementations MUST NOT use `ephemeralKey` for ML-KEM algorithms. A reader
+  that encounters a populated `ephemeralKey` on an ML-KEM KAO MUST ignore it.
+
+**Example** (ML-KEM-768):
+
+```json
+{
+  "alg": "ML-KEM-768",
+  "kas": "https://kas.example.com",
+  "kid": "kas-mlkem-key-2025",
+  "sid": "split-0",
+  "protectedKey": "base64...MLKEMWrappedKey DER: 1088-byte ciphertext + wrapped DEK...",
+  "policyBinding": {
+    "alg": "HS256",
+    "hash": "base64...HMAC-SHA256 digest..."
+  }
+}
+```
+
+---
+
+## 5. Policy Binding
+
+### 5.1 Purpose
+
+The policy binding cryptographically ties a KAO to the specific policy embedded
+in the TDF manifest. It prevents an adversary from substituting, modifying, or
+transplanting a policy without detection. The KAS MUST verify the policy binding
+before releasing any key material (SI-1 in BaseTDF-SEC).
+
+### 5.2 Computation
+
+The policy binding is computed as follows:
+
+```
+canonical_policy = encryptionInformation.policy
+    (the base64-encoded policy string exactly as it appears in the manifest)
+
+hmac_digest = HMAC-SHA256(key = DEK_share, message = canonical_policy)
+
+policyBinding = {
+  "alg": "HS256",
+  "hash": Base64(hmac_digest)
+}
+```
+
+**Detailed procedure**:
+
+1. Obtain the base64-encoded policy string from
+   `encryptionInformation.policy`. This is the canonical form of the policy.
+   Implementations MUST NOT decode, re-encode, re-serialize, or otherwise
+   transform the policy string before computing the HMAC. The exact byte
+   sequence of the base64-encoded string is the HMAC message.
+2. Compute the HMAC-SHA256 digest using the DEK share as the HMAC key and the
+   canonical policy string (as raw bytes of the base64-encoded string) as the
+   message.
+3. Encode the resulting 32-byte digest as standard Base64 (RFC 4648 Section 4).
+4. Store the result in `policyBinding.hash`.
+5. Set `policyBinding.alg` to `"HS256"`.
+
+### 5.3 Verification
+
+The KAS MUST verify the policy binding as part of the rewrap operation. The
+verification procedure is:
+
+1. After unwrapping the DEK share from the KAO, compute the expected HMAC:
+   `expected = HMAC-SHA256(key = DEK_share, message = canonical_policy)`
+   where `canonical_policy` is the base64-encoded policy string from the
+   rewrap request.
+2. Decode the `policyBinding.hash` value from the KAO using Base64.
+3. Compare the computed digest with the decoded hash using constant-time
+   comparison (e.g., `hmac.Equal` in Go, `crypto.timingSafeEqual` in Node.js).
+4. If the comparison fails, the KAS MUST reject the KAO and MUST NOT return
+   any key material derived from the corresponding DEK share.
+
+### 5.4 Algorithm Requirements
+
+- `policyBinding.alg` MUST be `"HS256"` (HMAC-SHA256).
+- The KAS MUST validate the `policyBinding.alg` field against the set of
+  supported binding algorithms before performing verification.
+- The KAS MUST reject KAOs whose `policyBinding.alg` specifies an unrecognized
+  or unsupported algorithm (SI-6 in BaseTDF-SEC).
+- When the policy binding is a bare string (legacy format without an `alg`
+  field), the binding algorithm MUST default to HMAC-SHA256.
+
+### 5.5 Legacy Policy Binding Formats
+
+In v4.3.0 and earlier, the policy binding hash was computed using a
+hex-then-base64 encoding:
+
+```
+hmac_digest = HMAC-SHA256(DEK_share, canonical_policy)
+hex_string  = hex.Encode(hmac_digest)        // 64 ASCII hex characters
+legacy_hash = Base64(hex_string)             // Base64 of the hex string
+```
+
+Additionally, the policy binding could be expressed as either:
+
+- An object: `{ "alg": "HS256", "hash": "<value>" }`
+- A bare string: `"<value>"` (the hash value directly)
+
+KAS implementations MUST support both formats when reading KAOs:
+
+1. Decode the `policyBinding.hash` (or bare string) from Base64.
+2. If the decoded result is 64 bytes and consists entirely of valid hexadecimal
+   ASCII characters (`0-9`, `a-f`, `A-F`), treat it as hex-encoded and decode
+   again to obtain the 32-byte HMAC digest.
+3. If the decoded result is 32 bytes, treat it as the raw HMAC digest directly.
+4. Compare using constant-time comparison.
+
+When writing new v4.4.0 KAOs, implementations MUST use direct Base64 encoding
+(not hex-then-base64) and MUST use the object form with an explicit `alg` field.
+
+---
+
+## 6. Encrypted Metadata
+
+### 6.1 Purpose
+
+The `encryptedMetadata` field provides an OPTIONAL mechanism for the TDF creator
+to attach freeform metadata to a KAO that is only readable by the KAS. This
+metadata is encrypted with the DEK share, ensuring it is only accessible after
+the KAS has unwrapped the key.
+
+### 6.2 Structure
+
+The encrypted metadata is a Base64-encoded JSON structure:
+
+```json
+{
+  "ciphertext": "<base64-encoded AES-256-GCM ciphertext>",
+  "iv": "<base64-encoded initialization vector>"
+}
+```
+
+This JSON structure is itself Base64-encoded to produce the value stored in the
+`encryptedMetadata` field of the KAO.
+
+### 6.3 Encryption Procedure
+
+1. Serialize the metadata as a JSON string: `plaintext = JSON.stringify(metadata)`.
+2. Generate a 12-byte random IV using a CSPRNG.
+3. Encrypt: `ciphertext = AES-256-GCM(key = DEK_share, iv = IV, plaintext)`.
+   The ciphertext includes the GCM authentication tag.
+4. Construct the encrypted metadata JSON object with the Base64-encoded
+   ciphertext and IV.
+5. Base64-encode the entire JSON object.
+6. Store the result in the KAO `encryptedMetadata` field.
+
+### 6.4 Security Requirements
+
+- The KAS MUST NOT decrypt or process `encryptedMetadata` before successful
+  policy binding verification (SI-1 in BaseTDF-SEC) and authorization
+  (SI-2 in BaseTDF-SEC).
+- The contents of `encryptedMetadata` are freeform JSON. Implementations MUST
+  treat decrypted metadata as untrusted input subject to validation.
+- The contents of `encryptedMetadata` MUST NOT be used for access control
+  decisions. Access control is determined solely by the policy object and
+  the authorization service.
+
+---
+
+## 7. Backward Compatibility
+
+### 7.1 Reading v4.3.0 KAOs
+
+When reading a KAO that was created under v4.3.0 or earlier, implementations
+MUST apply the following transformations:
+
+| v4.3.0 Field / Value | v4.4.0 Interpretation |
+|:----------------------|:----------------------|
+| `type: "wrapped"` | Infer `alg: "RSA-OAEP"` |
+| `type: "ec-wrapped"` | Infer `alg: "ECDH-HKDF"` |
+| `type: "mlkem-wrapped"` | Infer `alg: "ML-KEM-768"` or `alg: "ML-KEM-1024"` (ambiguous -- see below) |
+| `wrappedKey` | Treat as `protectedKey` |
+| `url` | Treat as `kas` |
+| `ephemeralPublicKey` | Treat as `ephemeralKey` |
+| `policyBinding` as bare string | Treat as `{ "alg": "HS256", "hash": "<value>" }` |
+| Policy binding in hex-then-base64 | Decode hex after base64 to recover raw HMAC (see Section 5.5) |
+
+When a KAO contains a `type` field but no `alg` field, the type-to-algorithm
+mapping in the table above is the sole mechanism for determining the algorithm.
+These mappings are exhaustive for all v4.3.0 KAOs.
+
+The `"mlkem-wrapped"` type value is the one exception: it does not distinguish
+ML-KEM-768 from ML-KEM-1024. This is not a practical obstacle, because the KAS
+must resolve `kid` against its key registry in any case in order to select a
+private key, and that lookup yields the parameter set. A reader that has no
+access to the key registry MAY instead infer the parameter set from the length
+of `mlkemCiphertext` in the decoded `protectedKey` envelope (1088 bytes implies
+ML-KEM-768, 1568 bytes implies ML-KEM-1024).
+
+### 7.2 Writing v4.4.0 KAOs
+
+When creating new KAOs, implementations MUST observe the following:
+
+1. MUST include the `alg` field with a valid algorithm identifier from
+   BaseTDF-ALG.
+2. SHOULD include the `type` field for backward compatibility with older readers
+   that do not recognize `alg`. If included, the `type` value MUST be consistent
+   with the `alg` value:
+   - `alg: "RSA-OAEP"` or `alg: "RSA-OAEP-256"` -> `type: "wrapped"`
+   - `alg: "ECDH-HKDF"` -> `type: "ec-wrapped"`
+   - `alg: "ML-KEM-768"` or `alg: "ML-KEM-1024"` -> `type: "mlkem-wrapped"`
+   - All other `alg` values have no `type` equivalent; `type` SHOULD be omitted.
+3. MUST use `protectedKey` as the field name. MAY additionally include
+   `wrappedKey` as an alias with the same value for backward compatibility.
+4. MUST use `kas` as the KAS URL field name. MAY additionally include `url`
+   with the same value for backward compatibility.
+5. MUST use the object form for `policyBinding` with explicit `alg` and `hash`
+   fields.
+6. MUST use direct Base64 encoding for the policy binding hash (not
+   hex-then-base64).
+7. MUST include the `kid` field.
+8. MUST include the `sid` field when key splitting is used.
+
+### 7.3 Version Detection
+
+Implementations MAY use the following heuristics to determine the KAO version:
+
+- Presence of `alg` field: v4.4.0 or later.
+- Presence of `type` field without `alg`: v4.3.0 or earlier.
+- Integrity hashes (segment hashes and the root signature) use hex-then-base64
+  encoding when the manifest-level `schemaVersion` is absent or less than
+  `"4.3.0"`, and raw-bytes-then-base64 otherwise. See BaseTDF-INT Section 8.
+- Policy binding hashes use hex-then-base64 encoding when the manifest-level
+  `schemaVersion` is less than `"4.4.0"` (including absent), and direct Base64
+  otherwise.
+
+Note that these two boundaries differ: the integrity hash encoding changed in
+v4.3.0, the policy binding encoding changes in v4.4.0. A reader that applies
+the integrity hash rule to the policy binding will fail to verify every v4.3.0
+manifest. Readers SHOULD prefer the version-independent length check in
+Section 5.5 over version-based detection for the policy binding, and MUST NOT
+treat a v4.3.0 manifest's hex-then-base64 binding as malformed.
+
+---
+
+## 8. Security Considerations
+
+### 8.1 Policy Binding Integrity (SI-1)
+
+The policy binding is the primary mechanism preventing policy tampering. An
+adversary who modifies the base64-encoded policy in the manifest cannot
+recompute a valid HMAC without knowledge of the DEK share, which is protected by
+the KAS public key. The KAS MUST verify the binding before any key release.
+Failure to verify the policy binding allows an adversary to substitute arbitrary
+policies on existing TDFs. See BaseTDF-SEC Section 5, SI-1.
+
+### 8.2 Algorithm Validation (SI-6)
+
+The KAS MUST reject KAOs with unrecognized `alg` or `policyBinding.alg` values.
+Accepting unknown algorithms could lead to downgrade attacks, where an adversary
+substitutes a weak or broken algorithm. The algorithm registry in BaseTDF-ALG is
+the authoritative source for valid identifiers. See BaseTDF-SEC Section 5, SI-6.
+
+### 8.3 Key Material Hygiene (SI-7)
+
+DEK shares MUST be securely erased from memory after use, on both the client and
+KAS side. Specifically:
+
+- After the KAS verifies the policy binding and re-encrypts the DEK share to
+  the client's ephemeral public key, the plaintext DEK share MUST be erased
+  from KAS memory.
+- After the client reconstructs the DEK from its shares, all individual shares
+  MUST be erased from client memory.
+- After decryption is complete, the reconstructed DEK MUST be erased from
+  client memory.
+
+See BaseTDF-SEC Section 5, SI-7.
+
+### 8.4 Key Splitting Security
+
+XOR-based n-of-n secret sharing provides information-theoretic security:
+knowledge of any proper subset of shares reveals no information about the DEK.
+However, this guarantee depends on each share being generated from a CSPRNG
+with full entropy. Implementations MUST NOT use deterministic or low-entropy
+sources for share generation.
+
+### 8.5 KAO Substitution
+
+An adversary who replaces a KAO in the manifest with one they created faces
+the following constraints:
+
+- If the adversary wraps to their own KAS, the legitimate KAS will not have the
+  corresponding private key and cannot unwrap.
+- If the adversary wraps a different key to the legitimate KAS, the policy
+  binding will fail verification because the HMAC was computed with a different
+  DEK share.
+- If the adversary wraps a different key and recomputes the policy binding, the
+  DEK reconstructed from the modified share will not match the DEK used to
+  encrypt the payload, and decryption will fail or produce garbage.
+
+### 8.6 Cross-TDF Replay
+
+Each KAO's policy binding is computed using the specific DEK share and the
+specific policy of the TDF it belongs to. Transplanting a KAO from one TDF to
+another will fail policy binding verification because the target TDF has a
+different policy and potentially different DEK shares.
+
+---
+
+## 9. Normative References
+
+| Reference | Title |
+|---|---|
+| [BaseTDF-SEC][BaseTDF-SEC] | Security Model and Zero Trust Architecture, v4.4.0 |
+| [BaseTDF-ALG][BaseTDF-ALG] | Algorithm Registry, v4.4.0 |
+| [NIST FIPS 203][FIPS203] | Module-Lattice-Based Key-Encapsulation Mechanism Standard (ML-KEM) |
+| [NIST SP 800-38D][SP800-38D] | Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC |
+| [NIST SP 800-56A][SP800-56A] | Recommendation for Pair-Wise Key-Establishment Schemes Using Discrete Logarithm Cryptography |
+| [RFC 2104][RFC2104] | HMAC: Keyed-Hashing for Message Authentication |
+| [RFC 2119][RFC2119] | Key words for use in RFCs to Indicate Requirement Levels |
+| [RFC 4648][RFC4648] | The Base16, Base32, and Base64 Data Encodings |
+| [RFC 5869][RFC5869] | HMAC-based Extract-and-Expand Key Derivation Function (HKDF) |
+| [RFC 8017][RFC8017] | PKCS #1: RSA Cryptography Specifications Version 2.2 |
+| [RFC 8174][RFC8174] | Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words |
+
+[BaseTDF-SEC]: basetdf-sec.md
+[BaseTDF-ALG]: basetdf-alg.md
+[FIPS203]: https://doi.org/10.6028/NIST.FIPS.203
+[SP800-38D]: https://doi.org/10.6028/NIST.SP.800-38D
+[SP800-56A]: https://doi.org/10.6028/NIST.SP.800-56Ar3
+[RFC2104]: https://www.rfc-editor.org/rfc/rfc2104
+[RFC2119]: https://www.rfc-editor.org/rfc/rfc2119
+[RFC4648]: https://www.rfc-editor.org/rfc/rfc4648
+[RFC5869]: https://www.rfc-editor.org/rfc/rfc5869
+[RFC8017]: https://www.rfc-editor.org/rfc/rfc8017
+[RFC8174]: https://www.rfc-editor.org/rfc/rfc8174

--- a/spec/basetdf/v5/basetdf-kas.md
+++ b/spec/basetdf/v5/basetdf-kas.md
@@ -1,0 +1,1090 @@
+# BaseTDF-KAS: Key Access Service Protocol
+
+| | |
+|---|---|
+| **Document** | BaseTDF-KAS |
+| **Title** | Key Access Service Protocol |
+| **Version** | 5.0.0 |
+| **Status** | Standards Track |
+| **Date** | 2026-08 |
+| **Suite** | BaseTDF Specification Suite |
+| **Depends on** | BaseTDF-SEC, BaseTDF-ALG, BaseTDF-KAO, BaseTDF-POL |
+| **Referenced by** | BaseTDF-CORE |
+
+> **5.0 status:** Frozen. BaseTDF 5.0 republishes the BaseTDF 4.4 KAS protocol
+> without normative change. Partition-key derivation remains a client-side
+> operation and does not alter the KAS wire protocol.
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Service Discovery](#2-service-discovery)
+3. [Rewrap Endpoint](#3-rewrap-endpoint)
+4. [Authentication Requirements](#4-authentication-requirements)
+5. [Error Semantics](#5-error-semantics)
+6. [Audit Requirements](#6-audit-requirements)
+7. [Rate Limiting](#7-rate-limiting)
+8. [Bulk Operations](#8-bulk-operations)
+9. [Algorithm Negotiation for PQC Transition](#9-algorithm-negotiation-for-pqc-transition)
+10. [Key Management](#10-key-management)
+11. [Security Considerations](#11-security-considerations)
+12. [Normative References](#12-normative-references)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+The Key Access Service (KAS) is the trusted intermediary in the BaseTDF
+architecture that enforces access control on TDF-protected data. The KAS holds
+(or has delegated access to) the private keys corresponding to the KAS public
+keys used to protect DEK shares in Key Access Objects (KAOs). When an
+authorized entity requests access to TDF-protected data, the KAS:
+
+1. Verifies the identity of the requesting entity.
+2. Unwraps the DEK share from the KAO using its private key.
+3. Verifies the integrity of the policy binding (SI-1).
+4. Evaluates the TDF's policy against the entity's current entitlements via the
+   authorization service (SI-2).
+5. Enforces dissemination restrictions (SI-3).
+6. Re-encrypts (rewraps) the DEK share to the client's ephemeral public key.
+7. Logs the access attempt (SI-8).
+
+The KAS is the root of trust for key release decisions. Compromise of the KAS
+private key material allows decryption of any TDF whose KAO references that
+key. Implementations SHOULD use hardware security modules (HSMs) or equivalent
+key protection mechanisms (see BaseTDF-SEC Section 3.1.1).
+
+### 1.2 Scope
+
+This document defines:
+
+- The public key discovery endpoint for algorithm and key negotiation.
+- The rewrap endpoint: request format, processing flow, and response format.
+- Authentication requirements, including DPoP binding.
+- Error semantics and their security rationale.
+- Audit logging requirements for rewrap operations.
+- Rate limiting recommendations.
+- Bulk operation semantics for processing multiple KAOs and policies.
+- Algorithm negotiation for PQC transition scenarios.
+- Key management requirements for KAS key pairs.
+
+This document does NOT define:
+
+- The KAO structure or policy binding computation (see BaseTDF-KAO).
+- The policy object schema or ABAC evaluation rules (see BaseTDF-POL).
+- The algorithm parameters or key protection categories (see BaseTDF-ALG).
+- The container format in which KAOs are embedded (see BaseTDF-CORE).
+- The security model, threat analysis, or security invariant definitions
+  (see BaseTDF-SEC).
+
+### 1.3 Relationship to Other BaseTDF Documents
+
+- **BaseTDF-SEC** defines the security invariants (SI-1 through SI-8) that the
+  KAS protocol enforces. This document describes HOW the KAS satisfies each
+  invariant; BaseTDF-SEC defines WHAT each invariant requires.
+- **BaseTDF-ALG** defines the algorithm identifiers and parameters that the KAS
+  advertises through its public key endpoint and validates during rewrap
+  operations.
+- **BaseTDF-KAO** defines the Key Access Object structure that the KAS
+  processes during rewrap, including the policy binding that the KAS verifies.
+- **BaseTDF-POL** defines the policy object and ABAC evaluation rules that the
+  KAS applies during policy evaluation.
+- **BaseTDF-CORE** defines the manifest structure that carries KAOs and policy
+  data to the KAS via the client.
+
+### 1.4 Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in [BCP 14][RFC2119] [RFC
+8174][RFC8174] when, and only when, they appear in ALL CAPITALS, as shown here.
+
+### 1.5 Terminology
+
+| Term | Definition |
+|---|---|
+| **DEK** | Data Encryption Key. The symmetric key used to encrypt the TDF payload. |
+| **DEK share** | One share of a split DEK, protected within a single KAO. |
+| **DPoP** | Demonstrating Proof of Possession. An OAuth 2.0 mechanism for binding access tokens to client-held cryptographic keys ([RFC 9449][RFC9449]). |
+| **KAO** | Key Access Object. The cryptographic structure in a TDF manifest that carries a protected DEK share and its policy binding (see BaseTDF-KAO). |
+| **KAS** | Key Access Service. The trusted service that unwraps DEK shares and rewraps them to authorized clients. |
+| **Rewrap** | The operation of unwrapping a DEK share using the KAS private key, then re-encrypting it to the client's ephemeral public key. |
+| **SRT** | Signed Request Token. A JWT signed with the client's DPoP key that contains the rewrap request payload. |
+| **kid** | Key identifier. A string that identifies a specific KAS key pair. |
+
+---
+
+## 2. Service Discovery
+
+### 2.1 Public Key Endpoint
+
+The KAS MUST expose a public key endpoint that allows clients to discover the
+KAS's supported algorithms and retrieve public keys for TDF creation.
+
+**Endpoint**: `GET /kas/v2/kas_public_key`
+
+This endpoint is idempotent and has no side effects. It does NOT require
+authentication.
+
+### 2.2 Request Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `algorithm` | string | OPTIONAL | Algorithm identifier requesting a specific key type. Format: `rsa:<keysize>` or `ec:<curvename>`. Defaults to `rsa:2048` if omitted. |
+| `fmt` | string | OPTIONAL | Desired response format. Values: `pkcs8` (PEM-encoded PKCS#8 public key, default), `jwk` (JSON Web Key). |
+| `v` | string | OPTIONAL | Protocol version. When set to `"1"`, the response omits the `kid` field for backward compatibility with legacy clients. |
+
+### 2.3 Response Format
+
+```json
+{
+  "publicKey": "<PEM-encoded public key or JWK>",
+  "kid": "<key identifier>"
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `publicKey` | string | The KAS public key in the requested format. For `pkcs8` (default): PEM-encoded SPKI public key. For `jwk`: JSON Web Key representation. |
+| `kid` | string | Key identifier for this public key. Clients MUST include this `kid` value in KAOs created with this key. Omitted when `v=1` is requested. |
+
+### 2.4 Algorithm Support
+
+The KAS MUST advertise support for at least the following algorithms:
+
+| Algorithm Identifier | Key Type | Status |
+|---|---|---|
+| `rsa:2048` | RSA 2048-bit | REQUIRED (backward compatibility) |
+| `ec:secp256r1` | EC P-256 | RECOMMENDED |
+
+The KAS MAY additionally support:
+
+| Algorithm Identifier | Key Type | Status |
+|---|---|---|
+| `rsa:4096` | RSA 4096-bit | OPTIONAL |
+| `ec:secp384r1` | EC P-384 | OPTIONAL |
+| `ec:secp521r1` | EC P-521 | OPTIONAL |
+| `mlkem:768` | ML-KEM-768 | OPTIONAL (PQC) |
+| `mlkem:1024` | ML-KEM-1024 | OPTIONAL (PQC) |
+
+ML-KEM public keys are returned as SubjectPublicKeyInfo in PEM format; see
+BaseTDF-ALG Section 5.6 for the encoding. See Section 9 for algorithm
+negotiation during PQC transition.
+
+### 2.5 Error Responses
+
+| Condition | Status Code | gRPC Code |
+|---|---|---|
+| Invalid or unrecognized algorithm | 404 | `NOT_FOUND` |
+| No key configured for requested algorithm | 404 | `NOT_FOUND` |
+| Internal configuration error | 500 | `INTERNAL` |
+
+### 2.6 Example
+
+**Request**:
+
+```
+GET /kas/v2/kas_public_key?algorithm=ec:secp256r1&fmt=pkcs8
+```
+
+**Response**:
+
+```json
+{
+  "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...\n-----END PUBLIC KEY-----\n",
+  "kid": "ec-p256-2025-01"
+}
+```
+
+### 2.7 Legacy Public Key Endpoint
+
+For backward compatibility, the KAS SHOULD also expose:
+
+**Endpoint**: `GET /kas/kas_public_key` (DEPRECATED)
+
+This legacy endpoint returns the public key as a plain string value instead of
+a structured response. For RSA keys, the response is a PEM-encoded PKCS#8
+public key. For EC keys, the response is a PEM-encoded certificate.
+
+New implementations MUST use the `/kas/v2/kas_public_key` endpoint. The legacy
+endpoint MAY be removed in a future version.
+
+---
+
+## 3. Rewrap Endpoint
+
+### 3.1 Overview
+
+The rewrap endpoint is the primary operational endpoint of the KAS. It receives
+a request containing one or more KAOs and their associated policies, evaluates
+access control, and returns re-encrypted DEK shares to authorized clients.
+
+**Endpoint**: `POST /kas/v2/rewrap`
+
+### 3.2 Request Format
+
+The rewrap request contains a single field: the Signed Request Token (SRT).
+
+```json
+{
+  "signedRequestToken": "<JWT string>"
+}
+```
+
+The `signedRequestToken` is a JWT signed by the client's DPoP private key. The
+JWT payload contains a `requestBody` claim whose value is a JSON-serialized
+`UnsignedRewrapRequest` (see Section 3.3).
+
+### 3.3 Unsigned Rewrap Request
+
+The `requestBody` claim within the SRT contains the following structure:
+
+```json
+{
+  "clientPublicKey": "<PEM-encoded client ephemeral public key>",
+  "requests": [
+    {
+      "policy": {
+        "id": "<policy-identifier>",
+        "body": "<base64-encoded policy JSON>"
+      },
+      "keyAccessObjects": [
+        {
+          "keyAccessObjectId": "<kao-identifier>",
+          "keyAccessObject": { ... }
+        }
+      ],
+      "algorithm": "<algorithm-identifier>"
+    }
+  ]
+}
+```
+
+#### 3.3.1 Top-Level Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `clientPublicKey` | string | REQUIRED | The client's ephemeral public key in PEM format. The KAS uses this key to re-encrypt DEK shares for secure delivery to the client. |
+| `requests` | array | REQUIRED | Array of policy requests. MUST contain at least one entry. Each entry groups a policy with its associated KAOs. |
+
+#### 3.3.2 Policy Request Fields
+
+Each entry in the `requests` array contains:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `policy` | object | REQUIRED | Policy metadata with `id` (unique identifier within the request) and `body` (base64-encoded policy JSON). |
+| `keyAccessObjects` | array | REQUIRED | Array of KAO wrappers, each with a `keyAccessObjectId` and a `keyAccessObject`. MUST contain at least one entry. |
+| `algorithm` | string | OPTIONAL | Algorithm identifier for this group. Defaults to `rsa:2048` if omitted. Values: `ec:secp256r1`, `rsa:2048`, or other identifiers from BaseTDF-ALG. |
+
+#### 3.3.3 Key Access Object Wrapper
+
+Each entry in `keyAccessObjects` contains:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `keyAccessObjectId` | string | REQUIRED | An ephemeral identifier for this KAO, unique within the request. Used to correlate request KAOs with response results. |
+| `keyAccessObject` | object | REQUIRED | The Key Access Object as defined in BaseTDF-KAO Section 2. Contains `wrappedKey` (or `protectedKey`), `policyBinding`, `kid`, and other fields. |
+
+#### 3.3.4 Example Request Body
+
+```json
+{
+  "clientPublicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYH...\n-----END PUBLIC KEY-----",
+  "requests": [
+    {
+      "policy": {
+        "id": "policy-0",
+        "body": "eyJ1dWlkIjoiNWUyZjdmYTYtYTkzZS00YjliLThmNzMtMmZkNjk0YzBiNGQ4IiwiYm9keSI6ey4uLn19"
+      },
+      "keyAccessObjects": [
+        {
+          "keyAccessObjectId": "kao-0",
+          "keyAccessObject": {
+            "type": "wrapped",
+            "kid": "rsa-2048-2025-01",
+            "url": "https://kas.example.com",
+            "wrappedKey": "TUlJQ0lqQU5CZ2txaGtpRzl3...",
+            "policyBinding": {
+              "alg": "HS256",
+              "hash": "YTgzNWQ2ZjRlN2IxNDg5OGJjZjQ3..."
+            }
+          }
+        }
+      ],
+      "algorithm": "rsa:2048"
+    }
+  ]
+}
+```
+
+### 3.4 Processing Flow
+
+For each policy request in the `requests` array, the KAS MUST perform the
+following steps. Each policy request is processed independently; a failure in
+one policy request MUST NOT affect the processing of other policy requests.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ 1. Extract and verify Signed Request Token (SRT)         │
+│    - Parse JWT from signedRequestToken                   │
+│    - Validate temporal claims (iat, exp)                 │
+│    - Verify SRT signature against DPoP key (Section 4)   │
+│    - Extract UnsignedRewrapRequest from requestBody      │
+└────────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│ 2. Verify entity identity                                │
+│    - Extract entity info from authenticated context      │
+│    - Verify DPoP binding to access token (SI-4)          │
+└────────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼
+        ┌────────────────┴────────────────┐
+        │  FOR EACH policy request:       │
+        └────────────────┬────────────────┘
+                         │
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│ 3. For each KAO in the policy request:                   │
+│    a. Look up KAS private key by kid                     │
+│    b. Unwrap DEK share using KAS private key             │
+│    c. Verify policy binding (SI-1):                      │
+│       - Compute HMAC-SHA256(DEK_share, policy_base64)    │
+│       - Constant-time compare with policyBinding.hash    │
+│       - REJECT KAO if mismatch                          │
+│    d. Record KAO result (success or per-KAO error)       │
+└────────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│ 4. Evaluate policy via authorization service (SI-2)      │
+│    - Submit data attributes + entity token               │
+│    - Receive PERMIT or DENY decision                     │
+│    - DENY if authorization service unavailable           │
+└────────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│ 5. Check dissemination list (SI-3)                       │
+│    - If dissem list is non-empty:                        │
+│      verify entity identity appears in list              │
+│    - DENY if entity not found                            │
+└────────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│ 6. For each verified KAO where access is PERMITTED:      │
+│    - Rewrap DEK share to client's ephemeral public key   │
+│    - Record rewrapped key in result                      │
+│ 7. Log audit event for each KAO (SI-8)                   │
+│    - Entity identity, policy UUID, algorithm, kid        │
+│    - permit/deny result                                  │
+│    - Erase plaintext DEK share from memory (SI-7)        │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 3.5 Rewrap Operation
+
+The rewrap operation re-encrypts a DEK share from the KAS's private key domain
+to the client's ephemeral public key domain. The specific procedure depends on
+the client's public key type:
+
+**RSA client key**: The DEK share is encrypted using the client's RSA public
+key with RSA-OAEP.
+
+**EC client key**: The KAS generates an ephemeral key pair, performs ECDH key
+agreement with the client's public key, derives a symmetric key via HKDF, and
+encrypts the DEK share with AES-256-GCM. The KAS's ephemeral public key is
+returned in the `sessionPublicKey` field of the response.
+
+In both cases, the plaintext DEK share MUST be securely erased from KAS memory
+immediately after the rewrap operation completes (SI-7).
+
+### 3.6 Response Format
+
+```json
+{
+  "sessionPublicKey": "<PEM-encoded KAS ephemeral public key>",
+  "responses": [
+    {
+      "policyId": "policy-0",
+      "results": [
+        {
+          "keyAccessObjectId": "kao-0",
+          "status": "permit",
+          "kasWrappedKey": "<base64-encoded rewrapped DEK share>"
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### 3.6.1 Top-Level Response Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `sessionPublicKey` | string | KAS's ephemeral session public key in PEM format. REQUIRED for EC-based rewrap operations. Empty for RSA-based rewrap. The client uses this key to perform ECDH key agreement and derive the symmetric key needed to decrypt the `kasWrappedKey` values. |
+| `responses` | array | Array of per-policy results. One entry per policy request in the original request. |
+
+#### 3.6.2 Policy Result Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `policyId` | string | Matches the `policy.id` from the corresponding request entry. |
+| `results` | array | Array of per-KAO results for this policy. One entry per KAO in the original request. |
+
+#### 3.6.3 KAO Result Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `keyAccessObjectId` | string | Matches the `keyAccessObjectId` from the corresponding request entry. |
+| `status` | string | `"permit"` if the rewrap succeeded, `"fail"` if it did not. |
+| `kasWrappedKey` | bytes | Present when `status` is `"permit"`. The DEK share re-encrypted to the session key derived from the client's ephemeral public key. |
+| `error` | string | Present when `status` is `"fail"`. A human-readable error description. See Section 5 for error semantics. |
+| `metadata` | object | OPTIONAL. Key-value metadata associated with this result. MAY contain `X-Required-Obligations` with an array of obligation FQNs that the client MUST fulfill. |
+
+#### 3.6.4 Example Response
+
+```json
+{
+  "sessionPublicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYH...\n-----END PUBLIC KEY-----",
+  "responses": [
+    {
+      "policyId": "policy-0",
+      "results": [
+        {
+          "keyAccessObjectId": "kao-0",
+          "status": "permit",
+          "kasWrappedKey": "dGhlIHJld3JhcHBlZCBrZXkgbWF0ZXJpYWw..."
+        },
+        {
+          "keyAccessObjectId": "kao-1",
+          "status": "fail",
+          "error": "permission denied"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 3.7 Legacy V1 Request Format
+
+For backward compatibility, the KAS MUST support a legacy single-KAO request
+format where the `requestBody` within the SRT contains:
+
+```json
+{
+  "authToken": "<access token>",
+  "keyAccess": { ... },
+  "policy": "<base64-encoded policy>",
+  "clientPublicKey": "<PEM-encoded public key>",
+  "algorithm": "<algorithm identifier>"
+}
+```
+
+When the KAS receives an SRT whose `requestBody` has no `requests` array, it
+MUST interpret the request as a v1 legacy request and convert it internally to
+the v2 bulk format with a single policy request containing a single KAO.
+
+The legacy response format uses the `entityWrappedKey` field (a single
+rewrapped key) instead of the structured `responses` array. The KAS MUST
+return the legacy response format when processing a v1 request.
+
+---
+
+## 4. Authentication Requirements
+
+### 4.1 DPoP-Bound Access Tokens (SI-4)
+
+For production deployments, rewrap requests MUST include DPoP (Demonstrating
+Proof of Possession) binding per [RFC 9449][RFC9449]. DPoP provides a
+cryptographic proof that the client presenting the access token possesses the
+private key associated with the token, preventing token theft and replay
+attacks.
+
+The authentication chain for a rewrap request is:
+
+```
+DPoP private key
+    │
+    ├── signs DPoP proof ──────────── presented with access token
+    │
+    └── signs SRT ─────────────────── contains rewrap request body
+                                       (clientPublicKey, KAOs, policies)
+```
+
+### 4.2 DPoP Verification
+
+The KAS MUST perform the following verification steps:
+
+1. **Extract DPoP key**: The KAS MUST extract the DPoP public key (JWK) from
+   the authenticated request context. This key is established during the DPoP
+   proof verification performed by the authentication layer.
+
+2. **Verify SRT signature**: The KAS MUST verify that the SRT (the
+   `signedRequestToken` JWT) is signed with the same key as the DPoP proof.
+   This binds the rewrap request body to the authenticated entity.
+
+3. **Validate SRT claims**: The KAS MUST validate the temporal claims in the
+   SRT:
+   - `iat` (issued at): MUST be present. The KAS SHOULD reject tokens issued
+     more than a reasonable skew window in the past (implementation-specific,
+     typically 5 minutes).
+   - `exp` (expiration): If present, the KAS MUST reject expired tokens.
+
+### 4.3 Non-DPoP Deployments
+
+Deployments that do not enforce DPoP MUST document this as a known deviation
+from the security model (see BaseTDF-SEC Section 5, SI-4). When DPoP is not
+available:
+
+- The KAS MUST still verify the SRT structure and extract the request body.
+- The KAS SHOULD log a warning indicating that the request lacks DPoP binding.
+- The KAS MUST implement compensating controls such as short-lived access
+  tokens and network-level access restrictions.
+
+### 4.4 Entity Identity Extraction
+
+The KAS MUST extract the entity identity from the authenticated access token.
+The following claims are used:
+
+| Claim | Purpose |
+|---|---|
+| `sub` | The entity's unique identifier. Used for dissemination list checks (SI-3) and audit logging (SI-8). |
+| `clientId` | The client application identifier, where available. Used for audit logging. |
+
+---
+
+## 5. Error Semantics
+
+### 5.1 Design Principle: Uniform Denial
+
+The KAS error response design is driven by a security requirement: an attacker
+MUST NOT be able to distinguish between different denial reasons through error
+codes or messages. Specifically, the KAS MUST NOT reveal whether a failure was
+caused by:
+
+- Policy binding verification failure (SI-1).
+- Authorization denial (SI-2).
+- Dissemination list exclusion (SI-3).
+
+If these failures returned distinguishable error codes, an attacker with valid
+credentials could use the KAS as a **chosen-policy oracle**: by crafting TDFs
+with known policies and observing the specific error code returned, the
+attacker could determine whether a policy binding is valid (revealing
+information about the DEK share) or whether specific attribute entitlements are
+held (enabling attribute enumeration).
+
+### 5.2 Error Code Mapping
+
+| HTTP Status | gRPC Code | Condition | Description |
+|---|---|---|---|
+| 400 | `INVALID_ARGUMENT` | Malformed request | Missing required fields, unparseable SRT, invalid JSON structure, invalid client public key, missing KAOs. |
+| 401 | `UNAUTHENTICATED` | Authentication failure | Invalid access token, expired token, missing DPoP proof, DPoP key mismatch, invalid SRT signature. |
+| 403 | `PERMISSION_DENIED` | Access denied | Policy binding failure, authorization denial, dissemination exclusion, or any combination thereof. |
+| 500 | `INTERNAL` | Server error | Unexpected internal errors, HSM failures, authorization service communication failures. |
+
+### 5.3 Uniform 403 Requirement
+
+**CRITICAL**: The KAS MUST return the same error code (`403` /
+`PERMISSION_DENIED`) for ALL of the following conditions:
+
+1. Policy binding verification failure (HMAC mismatch).
+2. Authorization service denial (entity lacks required entitlements).
+3. Dissemination list exclusion (entity not in `dissem` list).
+
+The error message accompanying a 403 response MUST NOT contain information
+that distinguishes between these conditions. A generic message such as
+`"permission denied"` or `"access denied"` MUST be used.
+
+The KAS MAY log detailed failure reasons internally for operational
+diagnostics (see Section 6), but these details MUST NOT be exposed to the
+client.
+
+### 5.4 Per-KAO Error Reporting
+
+In bulk requests, each KAO result carries its own `status` and optional
+`error` field. Per-KAO errors follow the same uniformity principle:
+
+- A KAO with status `"fail"` and error `"permission denied"` does not reveal
+  whether the failure was due to binding, authorization, or dissemination.
+- KAOs that fail due to structural issues (missing `kid`, unrecognized
+  algorithm) MAY return more specific error messages, as these do not reveal
+  information about policy evaluation or key material.
+
+### 5.5 Request-Level vs. KAO-Level Errors
+
+Errors are reported at two levels:
+
+1. **Request-level errors** (HTTP status codes): Returned when the entire
+   request is invalid. Examples: malformed SRT, authentication failure,
+   unparseable request body. When a request-level error occurs, no per-KAO
+   results are returned.
+
+2. **KAO-level errors** (per-result status): Returned within the structured
+   response when individual KAOs fail while others may succeed. The HTTP
+   response code is 200 even when individual KAOs have `status: "fail"`.
+
+---
+
+## 6. Audit Requirements
+
+### 6.1 Audit Obligation (SI-8)
+
+The KAS MUST log an audit event for every rewrap attempt. Audit logging is a
+normative requirement defined in BaseTDF-SEC Section 5, SI-8. Failure to
+produce audit records for rewrap operations is a conformance violation.
+
+### 6.2 Audit Event Structure
+
+Each audit record MUST include at minimum the following fields:
+
+| Field | Description | Source |
+|---|---|---|
+| **Entity identity** | The `sub` claim from the authenticated access token. | Access token |
+| **Policy UUID** | The unique identifier of the policy being evaluated. | Policy `uuid` field |
+| **Algorithm** | The key access algorithm identifier (e.g., `rsa:2048`, `ec:secp256r1`). | Request `algorithm` field |
+| **KAS key identifier** | The `kid` of the KAS key used for unwrapping. When a legacy KAO omits `kid`, an indication that legacy key lookup was used. | KAO `kid` field |
+| **Policy binding** | The `policyBinding.hash` value from the KAO. | KAO `policyBinding.hash` |
+| **Access decision** | `permit` or `deny` (recorded as action result). | Evaluation outcome |
+| **Timestamp** | The time of the rewrap attempt in [RFC 3339][RFC3339] format. | System clock |
+| **Request context** | The requesting client's IP address and user agent, where available. | Request headers |
+
+### 6.3 Audit Event Example
+
+```json
+{
+  "object": {
+    "type": "key_object",
+    "id": "5e2f7fa6-a93e-4b9b-8f73-2fd694c0b4d8",
+    "attributes": {
+      "attrs": [
+        "https://example.com/attr/classification/value/secret"
+      ],
+      "assertions": [],
+      "permissions": []
+    }
+  },
+  "action": {
+    "type": "rewrap",
+    "result": "success"
+  },
+  "actor": {
+    "id": "alice@example.com",
+    "attributes": []
+  },
+  "eventMetaData": {
+    "keyID": "rsa-2048-2025-01",
+    "policyBinding": "YTgzNWQ2ZjRlN2IxNDg5OGJjZjQ3...",
+    "tdfFormat": "tdf3",
+    "algorithm": "rsa:2048"
+  },
+  "clientInfo": {
+    "platform": "kas",
+    "userAgent": "opentdf-sdk-js/4.4.0",
+    "requestIP": "192.0.2.1"
+  },
+  "requestId": "req-abc123",
+  "timestamp": "2025-02-15T14:32:00Z"
+}
+```
+
+### 6.4 Key Material Exclusion
+
+Audit records MUST NOT contain key material under any circumstances:
+
+- Audit records for **denied** requests MUST NOT include the wrapped key,
+  unwrapped DEK share, or rewrapped key.
+- Audit records for **permitted** requests MUST NOT include the plaintext DEK
+  share or the rewrapped key. The `policyBinding.hash` MAY be included as it
+  is a one-way function output and does not reveal key material.
+
+### 6.5 Audit Record Format
+
+Audit records SHOULD be emitted as structured data (JSON) suitable for
+ingestion by SIEM (Security Information and Event Management) platforms.
+Implementations MAY additionally emit audit records in other formats (e.g.,
+syslog, OpenTelemetry spans) as appropriate for the deployment environment.
+
+---
+
+## 7. Rate Limiting
+
+### 7.1 Recommendation
+
+The KAS SHOULD implement rate limiting on the rewrap endpoint to mitigate:
+
+- **Oracle attacks**: An attacker with valid credentials probing policy
+  evaluation by submitting crafted TDFs at high volume (see BaseTDF-SEC
+  Section 4.3).
+- **Attribute enumeration**: Systematic probing to discover which attributes
+  an entity holds (see BaseTDF-SEC Section 4.3).
+- **Denial of service**: Overwhelming the KAS with rewrap requests to degrade
+  service for legitimate users.
+
+### 7.2 Per-Entity Rate Limiting
+
+Rate limits SHOULD be applied per authenticated entity, not globally. Global
+rate limits do not prevent a single attacker from consuming the entire budget,
+and they impose unnecessary restrictions on legitimate concurrent access
+patterns.
+
+### 7.3 Implementation Guidance
+
+The specific rate limit thresholds are deployment-dependent and outside the
+scope of this specification. Implementations SHOULD consider:
+
+- The expected volume of legitimate rewrap requests per entity per time
+  window.
+- The computational cost of each rewrap operation (asymmetric decryption and
+  encryption).
+- The detection latency for anomalous access patterns from audit logs.
+
+Rate limit responses SHOULD use HTTP 429 (Too Many Requests) with a
+`Retry-After` header indicating when the client may retry.
+
+---
+
+## 8. Bulk Operations
+
+### 8.1 Overview
+
+The v2 rewrap endpoint supports bulk operations: multiple policy requests, each
+containing multiple KAOs, in a single rewrap request. Bulk operations improve
+efficiency by amortizing the authentication overhead and reducing round trips
+between the client and KAS.
+
+### 8.2 Multiple Policies per Request
+
+A single rewrap request MAY contain multiple policy requests in the `requests`
+array. Each policy request is evaluated independently:
+
+- A policy that fails authorization does not affect other policies in the same
+  request.
+- The KAS MUST return per-policy results for all policies in the request.
+
+### 8.3 Multiple KAOs per Policy
+
+Each policy request MAY contain multiple KAOs in the `keyAccessObjects` array.
+KAOs within the same policy request share the same policy and algorithm
+identifier but represent different key splits or alternative KAS paths.
+
+Each KAO is processed independently:
+
+- A KAO that fails binding verification does not block processing of other
+  KAOs in the same policy request.
+- Each KAO result carries its own `status` (permit or fail) and either a
+  `kasWrappedKey` or an `error`.
+
+### 8.4 Result Correlation
+
+Clients correlate request entries with response results using the identifiers:
+
+- `policy.id` in the request maps to `policyId` in the response.
+- `keyAccessObjectId` in the request maps to `keyAccessObjectId` in the
+  response.
+
+These identifiers are ephemeral (scoped to the request) and carry no semantic
+meaning beyond correlation.
+
+### 8.5 Partial Success
+
+A bulk rewrap response MAY contain a mix of successful and failed results. The
+HTTP response code is 200 even when individual KAOs or policies fail. Clients
+MUST inspect the per-KAO `status` field to determine which DEK shares were
+successfully rewrapped.
+
+### 8.6 Authorization Batching
+
+When a request contains multiple policies, the KAS MAY batch the authorization
+queries to the authorization service for efficiency. However, each policy MUST
+be independently evaluated; the KAS MUST NOT merge or combine policy
+evaluations across different policy requests.
+
+---
+
+## 9. Algorithm Negotiation for PQC Transition
+
+### 9.1 Discovery-Based Negotiation
+
+Algorithm negotiation in BaseTDF is discovery-based: the client queries the KAS
+public key endpoint (Section 2) to determine which algorithms and key types the
+KAS supports, then selects an algorithm at TDF creation time.
+
+The negotiation flow is:
+
+```
+1. Client queries  GET /kas/v2/kas_public_key?algorithm=<preferred>
+2. If the KAS supports the algorithm, it returns the public key and kid.
+3. If the KAS does not support the algorithm, it returns 404 (NOT_FOUND).
+4. Client falls back to a different algorithm and retries.
+5. Client creates the TDF using the negotiated algorithm and the returned kid.
+```
+
+### 9.2 PQC Transition Requirements
+
+During the transition from classical to post-quantum cryptography (see
+BaseTDF-SEC Section 8), the KAS MUST support the following:
+
+1. **Concurrent algorithm support**: The KAS MUST support classical and
+   post-quantum algorithms simultaneously. A KAS that only supports
+   post-quantum algorithms cannot process existing TDFs created with classical
+   algorithms.
+
+2. **Algorithm validation**: The KAS MUST reject KAOs with unrecognized
+   algorithm identifiers (SI-6). The KAS MUST NOT silently downgrade or
+   substitute algorithms.
+
+3. **Key type coexistence**: The KAS MUST maintain key pairs for all supported
+   algorithm families concurrently. For example, during the PQC transition, the
+   KAS needs RSA key pairs (for legacy TDFs), EC key pairs (for ECDH-based
+   TDFs), and ML-KEM key pairs (for post-quantum TDFs).
+
+### 9.3 ML-KEM Algorithm Support
+
+BaseTDF defines no hybrid PQ/T key protection algorithms (BaseTDF-ALG
+Section 3.2), so post-quantum support requires only an ML-KEM key pair -- no
+paired classical key and no combined operation.
+
+A KAS that supports ML-KEM MUST:
+
+- Hold an ML-KEM-768 and/or ML-KEM-1024 key pair, each with its own `kid`.
+- Advertise those keys through the public key endpoint under the `mlkem:768`
+  and `mlkem:1024` algorithm identifiers (Section 2.4).
+- Recover the DEK share by decoding the `MLKEMWrappedKey` envelope from
+  `protectedKey`, decapsulating, and decrypting -- see BaseTDF-ALG Section 4.3
+  and BaseTDF-KAO Section 4.3.
+
+The KAS MUST NOT expect an `ephemeralKey` value on an ML-KEM KAO; the KEM
+ciphertext is carried inside `protectedKey`.
+
+A KAS whose ML-KEM private keys live in an HSM performs decapsulation inside
+the module. Because BaseTDF applies no KDF to the ML-KEM shared secret
+(BaseTDF-ALG Section 4.3.1), the decapsulated secret can remain a sensitive,
+non-extractable AES key object for the duration of the unwrap.
+
+### 9.4 Client Algorithm Selection
+
+Clients SHOULD select algorithms based on the following priority:
+
+1. ML-KEM (`ML-KEM-768` or `ML-KEM-1024`) if the KAS supports it and the data's
+   confidentiality requirements warrant quantum resistance.
+2. EC-based (ECDH-HKDF) for new TDFs when ML-KEM is not available.
+3. RSA-based (RSA-OAEP) for maximum backward compatibility.
+
+A client that needs both post-quantum and classical protection SHOULD split the
+DEK across an ML-KEM KAO and a classical KAO under distinct `sid` values, rather
+than seeking a hybrid algorithm (see BaseTDF-SEC Section 8.3).
+
+The client's algorithm choice is recorded in the KAO's `alg` field and the
+request's `algorithm` field, enabling the KAS to select the correct processing
+path during rewrap.
+
+---
+
+## 10. Key Management
+
+### 10.1 Key Identification
+
+Every KAS key pair MUST be assigned a unique key identifier (`kid`). The `kid`
+is:
+
+- Included in the public key endpoint response (Section 2.3).
+- Recorded in the KAO by the client at TDF creation time (see BaseTDF-KAO
+  Section 2.2).
+- Used by the KAS during rewrap to select the correct private key for
+  unwrapping.
+
+Key identifiers MUST be unique within a KAS instance and SHOULD be unique
+across KAS instances in a deployment.
+
+### 10.2 Supported Key Types
+
+The KAS MUST support the following key types:
+
+| Key Type | Algorithm Family | Status |
+|---|---|---|
+| RSA 2048-bit | RSA-OAEP | REQUIRED (backward compatibility) |
+| EC P-256 | ECDH-HKDF | RECOMMENDED |
+
+The KAS MAY additionally support:
+
+| Key Type | Algorithm Family | Status |
+|---|---|---|
+| RSA 4096-bit | RSA-OAEP-256 | OPTIONAL |
+| EC P-384 | ECDH-HKDF | OPTIONAL |
+| EC P-521 | ECDH-HKDF | OPTIONAL |
+| ML-KEM-768 | ML-KEM | OPTIONAL (PQC) |
+| ML-KEM-1024 | ML-KEM | OPTIONAL (PQC) |
+
+### 10.3 Key Rotation
+
+The KAS MUST support key rotation -- the process of introducing new key pairs
+while maintaining the ability to process KAOs created with older keys.
+
+Key rotation requirements:
+
+1. **Multiple active keys**: The KAS MUST support multiple active key pairs
+   concurrently. During rotation, both the old and new keys MUST be available
+   for unwrapping.
+
+2. **New key preference**: The public key endpoint SHOULD return the newest
+   non-legacy key for a given algorithm. This ensures new TDFs are created with
+   current keys while old TDFs remain accessible.
+
+3. **Legacy key support**: Keys that are no longer advertised via the public
+   key endpoint MUST remain available for unwrap operations until all TDFs
+   referencing those keys have either expired or been re-encrypted.
+
+4. **Key decommissioning**: When a key pair is decommissioned, the private key
+   MUST be securely destroyed per SI-7. Organizations SHOULD re-encrypt
+   affected TDFs to active keys before decommissioning.
+
+### 10.4 Key Delegation
+
+The KAS MAY delegate key storage and cryptographic operations to an external
+key management system (e.g., HSM, cloud KMS, or a key index service). When
+delegation is used:
+
+- The KAS MUST resolve key identifiers through the delegator before falling
+  back to local key storage.
+- The delegator MUST support the same `kid`-based key lookup semantics.
+- Cryptographic operations (unwrap, rewrap) MAY be performed by the delegator
+  or by the KAS after retrieving key material from the delegator, depending on
+  the security requirements of the deployment.
+
+### 10.5 Legacy KAOs Without `kid`
+
+KAOs created by older TDF implementations MAY omit the `kid` field. When
+processing a KAO without a `kid`:
+
+1. The KAS MUST attempt to unwrap the DEK share using available keys for the
+   indicated algorithm, trying non-legacy keys first.
+2. The KAS SHOULD log a warning when processing `kid`-less KAOs, as this
+   increases computational cost and the surface for potential oracle attacks
+   (see BaseTDF-SEC Section 4.4).
+3. New TDF implementations MUST include a `kid` field in all KAOs.
+
+---
+
+## 11. Security Considerations
+
+### 11.1 KAS as Root of Trust
+
+The KAS operates as the root of trust for key release decisions in the BaseTDF
+architecture (see BaseTDF-SEC Section 3.1.1). All access control enforcement
+depends on the KAS correctly implementing the security invariants. A
+compromised KAS can release key material to unauthorized entities. Deployments
+MUST protect the KAS with appropriate physical, logical, and operational
+security controls.
+
+### 11.2 Security Invariant Compliance
+
+The following table maps BaseTDF-SEC security invariants to the KAS protocol
+mechanisms that enforce them:
+
+| Invariant | Requirement | KAS Mechanism |
+|---|---|---|
+| **SI-1** | Policy binding integrity | KAS verifies HMAC-SHA256 binding before key release (Section 3.4, step 3c). Constant-time comparison prevents timing side channels. |
+| **SI-2** | Authorization before key release | KAS submits policy to authorization service and requires explicit PERMIT before rewrapping (Section 3.4, step 4). |
+| **SI-3** | Dissemination enforcement | KAS checks entity identity against `dissem` list when non-empty (Section 3.4, step 5). |
+| **SI-4** | DPoP binding | SRT is signed with DPoP key; KAS verifies signature chain (Section 4). |
+| **SI-5** | Payload integrity | Not directly enforced by KAS (client-side); KAS verifies KAO integrity via policy binding. |
+| **SI-6** | Algorithm validation | KAS validates KAO algorithm fields against supported set; rejects unrecognized algorithms (Section 9.2). |
+| **SI-7** | Key material hygiene | Plaintext DEK shares erased from KAS memory after rewrap (Section 3.5). |
+| **SI-8** | Audit logging | Every rewrap attempt logged with required fields (Section 6). |
+
+### 11.3 Transport Security
+
+All communication with the KAS MUST be protected by TLS. However, the security
+model does not depend solely on TLS:
+
+- The SRT is signed by the client's DPoP key, providing request integrity
+  independent of TLS.
+- Rewrapped key material is encrypted to the client's ephemeral public key,
+  providing end-to-end key confidentiality even when TLS is terminated at an
+  intermediary (reverse proxy, load balancer, or CDN node).
+
+This layered approach ensures that a TLS-terminating proxy cannot observe
+plaintext key material in transit.
+
+### 11.4 Oracle Attack Mitigation
+
+The uniform error semantics (Section 5) are the primary defense against oracle
+attacks:
+
+- **Chosen-policy oracle**: By returning identical error codes for binding
+  failure, authorization denial, and dissemination exclusion, the KAS prevents
+  an attacker from distinguishing these conditions and thereby probing policy
+  evaluation or key material validity.
+- **Timing oracle**: Policy binding verification MUST use constant-time
+  comparison. Implementations SHOULD ensure that the total processing time
+  for denied requests does not systematically differ from permitted requests,
+  though this is challenging to achieve perfectly.
+
+Rate limiting (Section 7) provides a complementary defense by limiting the
+volume of probing attempts.
+
+### 11.5 SRT Replay Prevention
+
+The SRT contains temporal claims (`iat`, `exp`) that bound its validity window.
+The KAS validates these claims with an acceptable clock skew to prevent replay
+attacks. Even if an SRT is replayed within the validity window, the rewrapped
+key is encrypted to the client's ephemeral public key from the original
+request; an attacker who replays the SRT cannot decrypt the response without
+the corresponding private key.
+
+### 11.6 Client Public Key Validation
+
+The KAS MUST validate the `clientPublicKey` provided in the rewrap request
+before using it for key encapsulation. Invalid or malicious public keys could
+cause cryptographic errors or, in pathological cases, enable key recovery
+attacks. The KAS MUST reject requests with malformed or unsupported client
+public keys with a 400 error.
+
+### 11.7 Fail-Closed Behavior
+
+The KAS MUST implement fail-closed behavior throughout:
+
+- If the authorization service is unreachable, the KAS MUST deny access.
+- If policy binding verification encounters an error (not just a mismatch),
+  the KAS MUST deny access.
+- If a KAO contains an unrecognized algorithm, the KAS MUST deny access.
+- If the DPoP verification fails, the KAS MUST deny access.
+
+The KAS MUST NOT fall back to a default-permit decision under any failure
+condition.
+
+---
+
+## 12. Normative References
+
+| Reference | Title |
+|---|---|
+| [BaseTDF-SEC][BaseTDF-SEC] | Security Model and Zero Trust Architecture, v4.4.0 |
+| [BaseTDF-ALG][BaseTDF-ALG] | Algorithm Registry, v4.4.0 |
+| [BaseTDF-KAO][BaseTDF-KAO] | Key Access Object, v4.4.0 |
+| [BaseTDF-POL][BaseTDF-POL] | Policy and Attribute-Based Access Control, v4.4.0 |
+| [RFC 2119][RFC2119] | Key words for use in RFCs to Indicate Requirement Levels |
+| [RFC 3339][RFC3339] | Date and Time on the Internet: Timestamps |
+| [RFC 8174][RFC8174] | Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words |
+| [RFC 9449][RFC9449] | OAuth 2.0 Demonstrating Proof of Possession (DPoP) |
+| [NIST FIPS 203][FIPS203] | Module-Lattice-Based Key-Encapsulation Mechanism Standard (ML-KEM) |
+| [NIST SP 800-38D][SP800-38D] | Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC |
+
+[BaseTDF-SEC]: basetdf-sec.md
+[BaseTDF-ALG]: basetdf-alg.md
+[BaseTDF-KAO]: basetdf-kao.md
+[BaseTDF-POL]: basetdf-pol.md
+[RFC2119]: https://www.rfc-editor.org/rfc/rfc2119
+[RFC3339]: https://www.rfc-editor.org/rfc/rfc3339
+[RFC8174]: https://www.rfc-editor.org/rfc/rfc8174
+[RFC9449]: https://www.rfc-editor.org/rfc/rfc9449
+[FIPS203]: https://doi.org/10.6028/NIST.FIPS.203
+[SP800-38D]: https://doi.org/10.6028/NIST.SP.800-38D

--- a/spec/basetdf/v5/basetdf-loc.md
+++ b/spec/basetdf/v5/basetdf-loc.md
@@ -1,0 +1,135 @@
+# BaseTDF-LOC: Resource Locators and Fetch Policy
+
+| | |
+|---|---|
+| **Document** | BaseTDF-LOC |
+| **Version** | 5.0.0 |
+| **Status** | Standards Track |
+| **Date** | 2026-08 |
+| **Depends on** | BaseTDF-SEC, BaseTDF-ASN |
+| **Referenced by** | BaseTDF-PKG, BaseTDF-CORE, BaseTDF-INT |
+
+## 1. Introduction
+
+BaseTDF 5 permits payload and integrity artifacts to be stored separately from a
+manifest. A locator is attacker-influenced input to a network client and creates
+SSRF, redirect, resource-exhaustion, and confused-deputy risks. This document
+defines locator syntax and default-deny resolution. It does not define discovery,
+object-store credentials, or a catalog service.
+
+## 2. Locator Object
+
+```json
+{"uri": "https://payload.example/objects/9f2a", "priority": 0,
+ "size": 1073756160}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `uri` | string | REQUIRED | Absolute resource URI, except the reserved attached URI in Section 3.4. |
+| `priority` | non-negative integer | OPTIONAL | Lower values are preferred; default `0`. |
+| `size` | non-negative integer | OPTIONAL | Exact resource size in bytes. |
+
+Locator arrays MUST NOT be empty and writers MUST order them by ascending priority.
+Equal-priority locators retain array order. A reader MAY try the next allowed
+locator after failure but MUST NOT use a disallowed locator as fallback.
+
+Security policy MUST be evaluated against a standards-compliant parsed URI, not a
+substring or suffix match on the source text.
+
+## 3. Schemes and Origins
+
+### 3.1 Network schemes
+
+The default enabled network scheme is `https`. Object-store schemes such as `s3`,
+`gs`, or `az` MAY be supported only when explicitly enabled. Plain `http`, `file`,
+`data`, and process-launching schemes MUST be disabled by default.
+
+For HTTP, an origin is `(scheme, host, effective-port)`. Matching MUST compare the
+complete normalized host and port. `example.com` MUST NOT match
+`example.com.attacker.invalid`. Wildcards, if supported, MUST match whole DNS labels
+and MUST NOT match a public suffix. Object-store resolvers MUST document how account,
+bucket, container, region, and endpoint form an origin.
+
+### 3.2 Credentials
+
+Credentials MUST be scoped to the approved origin. Authorization headers, cookies,
+signed query parameters, and object-store credentials MUST NOT be forwarded to a
+different origin after redirect or failover. URI userinfo MUST be rejected.
+
+### 3.3 Network addresses
+
+Implementations able to enforce address policy SHOULD reject loopback, link-local,
+multicast, unspecified, and deployment-denied private addresses after DNS
+resolution. They SHOULD repeat the check for every connection to resist DNS
+rebinding. Address checks supplement, not replace, origin allowlisting.
+
+### 3.4 Attached URI
+
+`zip:0.integrity` is reserved for the `0.integrity` entry of the currently open
+attached package. It is not a network locator. No other `zip:` URI is defined.
+
+## 4. Resolver Policy
+
+Before dereferencing any external locator, a reader MUST:
+
+1. parse and structurally validate the complete manifest;
+2. verify the BaseTDF-ASN manifest signature with a publisher key trusted by local
+   policy;
+3. validate scheme and origin against explicit resolver configuration;
+4. validate declared sizes and ranges against safety limits; and
+5. bind credentials to the approved origin.
+
+The default MUST be deny. An empty allowlist permits no external fetch. Arbitrary
+origins supplied by a manifest MUST NOT be accepted.
+
+### 4.1 Redirects
+
+Redirects MUST be disabled or all scheme, origin, address, credential, and size
+checks MUST be reapplied at each hop. A redirect to a non-allowlisted origin MUST be
+rejected. Implementations MUST impose a finite hop limit.
+
+### 4.2 Size and range enforcement
+
+Resolvers MUST enforce the locator size, enclosing payload/part/tree size,
+authenticated `encryptedSize`, and local request/object limits. A full response
+must exactly match an exact declared size. A range response MUST match the requested
+range and stay within the resource. If a server ignores a range, the reader MUST
+stop at its bound rather than consume an unbounded full object.
+
+Routing metadata may direct only bounded reads. BaseTDF-INT MUST authenticate the
+selected leaf, proof, counts, sizes, root, and actual ciphertext before plaintext is
+released.
+
+### 4.3 Fail closed
+
+URI parse failures, disallowed origins, redirects, size mismatches, short reads,
+proof failures, and payload-integrity failures MUST fail closed. Errors MUST NOT
+expose credentials or key material.
+
+## 5. Host Separation
+
+A detached payload intentionally carries no manifest back-pointer. Discovery is an
+application concern so the payload host does not learn the metadata location. The
+manifest signature authenticates publisher provenance and locator selection. The
+DEK-keyed root remains the authoritative binding to ciphertext.
+
+## 6. Conformance and Security
+
+A conformant resolver MUST be deny-by-default, verify the manifest before fetch,
+revalidate or disable redirects, enforce exact sizes and bounded ranges, and test
+off-allowlist, disabled-scheme, cross-origin redirect, and oversized-response cases.
+
+Signed locators remain subject to local policy because a publisher can be
+compromised. Timing and network metadata may correlate separate manifest and
+payload fetches. Mirrors improve availability, not integrity.
+
+## 7. Normative References
+
+- [BaseTDF-ASN](basetdf-asn.md)
+- [BaseTDF-INT](basetdf-int.md)
+- [BaseTDF-SEC](basetdf-sec.md)
+- RFC 3986, URI Generic Syntax
+- RFC 8785, JSON Canonicalization Scheme
+- RFC 9110, HTTP Semantics
+

--- a/spec/basetdf/v5/basetdf-pkg.md
+++ b/spec/basetdf/v5/basetdf-pkg.md
@@ -1,0 +1,157 @@
+# BaseTDF-PKG: Packaging Profiles
+
+| | |
+|---|---|
+| **Document** | BaseTDF-PKG |
+| **Version** | 5.0.0 |
+| **Status** | Standards Track |
+| **Date** | 2026-08 |
+| **Depends on** | BaseTDF-INT, BaseTDF-ASN, BaseTDF-LOC |
+| **Referenced by** | BaseTDF-CORE, BaseTDF-EX |
+
+## 1. Introduction
+
+Packaging defines where the manifest, ciphertext, and optional integrity tree are
+serialized. It does not change policy, KAOs, the DEK, encryption, or integrity.
+
+| `packaging` | Representation |
+|---|---|
+| `attached` | One ZIP containing payload, optional tree, and manifest. |
+| `detached` | Standalone manifest referencing one payload object. |
+| `sharded` | Standalone manifest referencing ordered payload parts. |
+
+`packaging` MAY be omitted and defaults to `attached`, preserving the version 4
+field shape for small attached objects.
+
+## 2. Attached Profile
+
+### 2.1 Entries
+
+Entries use `STORE`, no ZIP encryption, and this order:
+
+| Order | Entry | Presence |
+|---:|---|---|
+| 1 | `0.payload` | REQUIRED |
+| 2 | `0.integrity` | REQUIRED for `uniform`/`indexed`; absent for `explicit` |
+| 3 | `0.manifest.json` | REQUIRED |
+
+Writers MUST NOT add other entries. The explicit profile therefore has exactly two
+entries and scalable profiles have exactly three. The attached payload object MUST
+be:
+
+```json
+{"type":"reference", "url":"0.payload", "protocol":"zip",
+ "mimeType":"application/octet-stream", "isEncrypted":true}
+```
+
+For scalable layouts, `hashTree.locator.uri` MUST be `zip:0.integrity`.
+
+### 2.2 Hardening
+
+Readers MUST reject duplicate names, paths, `..`, overlapping records, unsupported
+compression, ZIP encryption, and sizes above configured bounds. The central
+directory is authoritative when it disagrees with a local header. ZIP64 parsing and
+range arithmetic MUST use checked unsigned 64-bit operations. Readers MUST NOT
+extract entries to filesystem paths derived from entry names.
+
+### 2.3 Unknown-length streaming
+
+A writer without advance payload length MUST:
+
+1. use ZIP64 unconditionally;
+2. set general-purpose bit 3 on the `0.payload` local header;
+3. put zero in its local CRC-32 and size fields and include a ZIP64 extra field;
+4. compute CRC-32 incrementally over encrypted bytes;
+5. emit a signed ZIP64 data descriptor with CRC-32 and two 8-byte sizes immediately
+   after payload data;
+6. write the known-size integrity and manifest entries without descriptors; and
+7. write ZIP64 central-directory, EOCD, and locator records.
+
+Readers MUST support this form and prefer authoritative central-directory values.
+A known-size writer SHOULD use ordinary size-prefixed entries, adding ZIP64 when
+required. Payload-first ordering permits one forward pass; tree leaf records MAY
+spill to temporary storage while the O(log N) root stack stays resident.
+
+## 3. Detached Profile
+
+```json
+{
+  "packaging":"detached",
+  "payload":{
+    "type":"detached", "mimeType":"application/octet-stream",
+    "isEncrypted":true, "size":1099526307840,
+    "locators":[{"uri":"https://payload.example/o/9f2a", "priority":0,
+                 "size":1099526307840}]
+  }
+}
+```
+
+`payload.type`, `isEncrypted`, exact encrypted `size`, and non-empty `locators` are
+REQUIRED. `size` MUST equal `integrityInformation.encryptedSize`. `url`, `protocol`,
+and `parts` MUST be absent. Exactly one asymmetric `scope: "manifest"` assertion is
+REQUIRED.
+
+A scalable hash tree MUST have its own allowed locator or be base64-encoded in
+`hashTree.inline`; those fields are mutually exclusive. Writers SHOULD inline trees
+no larger than 64 KiB.
+
+## 4. Sharded Profile
+
+```json
+{
+  "packaging":"sharded",
+  "payload":{
+    "type":"detached", "isEncrypted":true, "size":2147512320,
+    "parts":[
+      {"index":0, "segmentRange":[0,512], "size":1073756160,
+       "locators":[{"uri":"https://a.example/p0"}]},
+      {"index":1, "segmentRange":[512,1024], "size":1073756160,
+       "locators":[{"uri":"https://b.example/p1"}]}
+    ]
+  }
+}
+```
+
+Ranges are half-open. Parts MUST have consecutive indices from zero, non-empty
+locators, and ordered contiguous non-overlapping ranges covering
+`[0, segmentCount)`. Boundaries MUST be segment-aligned. Checked part-size sums
+MUST equal payload `size` and authenticated `encryptedSize`; indexed part sizes
+MUST equal authenticated subtree sums. Boundaries SHOULD align with key partitions.
+
+Top-level payload `locators`, `url`, and `protocol` MUST be absent. Exactly one
+manifest assertion is REQUIRED.
+
+## 5. Content Binding and Multiple Manifests
+
+The payload MAY contain `"contentBinding":{"alg":"SHA-256","hash":"<base64>"}`,
+computed over the complete encrypted byte sequence independent of sharding. It is
+useful for deduplication but is a stable cross-tenant correlation handle, so writers
+SHOULD omit it by default. The DEK-keyed root is authoritative.
+
+Multiple standalone manifests MAY wrap the same DEK for one payload. Their effective
+access policy is the union of all published policies. A less restrictive new
+manifest widens access to the original ciphertext. Writers MUST NOT claim this
+provides differentiated access; genuine separation requires a distinct DEK and
+re-encryption. A payload carries no manifest pointer; discovery is out of scope.
+
+## 6. Processing and Security
+
+Detached/sharded readers MUST verify the manifest signature before resolving an
+external locator and use BaseTDF-LOC. In all profiles, ciphertext and tree nodes are
+untrusted until verified by BaseTDF-INT.
+
+Attached storage exposes metadata and ciphertext together. Detached storage lets a
+payload host see opaque ciphertext while a manifest host sees policy, KAS and
+attribute identifiers, assertions, MIME type, sizes, and locators. It does not hide
+metadata from the manifest host, and traffic analysis may correlate fetches.
+
+Destroying every detached manifest can remove stored KAOs and the path to the DEK,
+but cannot revoke plaintext or DEKs already obtained.
+
+## 7. Normative References
+
+- [BaseTDF-ASN](basetdf-asn.md)
+- [BaseTDF-CORE](basetdf-core.md)
+- [BaseTDF-INT](basetdf-int.md)
+- [BaseTDF-LOC](basetdf-loc.md)
+- APPNOTE 6.3.10, ZIP File Format Specification

--- a/spec/basetdf/v5/basetdf-pkg.md
+++ b/spec/basetdf/v5/basetdf-pkg.md
@@ -118,6 +118,22 @@ locators, and ordered contiguous non-overlapping ranges covering
 MUST equal payload `size` and authenticated `encryptedSize`; indexed part sizes
 MUST equal authenticated subtree sums. Boundaries SHOULD align with key partitions.
 
+The sharded profile is REQUIRED when a logical BaseTDF exceeds any individual
+storage resource's object-size limit. A storage limit applies to encrypted bytes,
+not plaintext bytes: every AES-GCM segment adds 28 bytes, and attached packaging
+also carries integrity and ZIP metadata. Consequently, a maximum-sized plaintext
+object generally cannot be encrypted into one resource having the same maximum
+size. Writers MUST calculate encrypted sizes before selecting part boundaries and
+MUST NOT assume that a provider's advertised plaintext-scale limit includes AEAD
+overhead.
+
+Scalable implementations MUST support a logical 50 TiB plaintext using sharded
+packaging even when no individual locator can hold the complete encrypted payload.
+Shards MAY contain many key partitions; aligning each shard boundary with both a
+segment boundary and a key-partition boundary is RECOMMENDED. Multipart-upload part
+numbers and retry order are transport details and MUST NOT be used as AES-GCM IVs
+or BaseTDF segment indices.
+
 Top-level payload `locators`, `url`, and `protocol` MUST be absent. Exactly one
 manifest assertion is REQUIRED.
 

--- a/spec/basetdf/v5/basetdf-pol.md
+++ b/spec/basetdf/v5/basetdf-pol.md
@@ -1,0 +1,1019 @@
+# BaseTDF-POL: Policy and Attribute-Based Access Control
+
+| | |
+|---|---|
+| **Document** | BaseTDF-POL |
+| **Title** | Policy and Attribute-Based Access Control |
+| **Version** | 5.0.0 |
+| **Status** | Standards Track |
+| **Date** | 2026-08 |
+| **Suite** | BaseTDF Specification Suite |
+| **Depends on** | BaseTDF-SEC, BaseTDF-ALG |
+| **Referenced by** | BaseTDF-KAO, BaseTDF-KAS, BaseTDF-CORE |
+
+> **5.0 status:** Frozen. BaseTDF 5.0 republishes the BaseTDF 4.4 policy and
+> authorization requirements without normative change.
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Policy Object Schema](#2-policy-object-schema)
+3. [Attribute Representation](#3-attribute-representation)
+4. [Attribute Rule Types and Evaluation Semantics](#4-attribute-rule-types-and-evaluation-semantics)
+5. [Dissemination List](#5-dissemination-list)
+6. [Canonical Serialization and Policy Binding](#6-canonical-serialization-and-policy-binding)
+7. [KAS Grant Resolution](#7-kas-grant-resolution)
+8. [Key Splitting and Rule Interaction](#8-key-splitting-and-rule-interaction)
+9. [Policy Evaluation Flow](#9-policy-evaluation-flow)
+10. [Security Considerations](#10-security-considerations)
+11. [Normative References](#11-normative-references)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This document defines the **policy object** embedded in Trusted Data Format
+(TDF) containers and the **attribute-based access control (ABAC) evaluation
+rules** that govern key release by the Key Access Service (KAS). The policy
+object is the mechanism by which data creators express who may access protected
+data and under what conditions.
+
+BaseTDF implements a data-centric ABAC model inspired by [NIST SP 800-162][SP800-162]
+(Guide to Attribute Based Access Control). In this model:
+
+- **Data attributes** attached to the TDF represent the security properties
+  of the protected content (the *resource attributes*).
+- **Entity entitlements** provisioned by the identity provider and attribute
+  authority represent the clearances, roles, or properties of the requesting
+  entity (the *subject attributes*).
+- **Attribute rules** (allOf, anyOf, hierarchy) define how resource attributes
+  are compared against subject attributes to reach an access decision.
+
+The policy object is embedded in the TDF manifest and is cryptographically
+bound to the encrypted key material via the policy binding (see BaseTDF-KAO).
+This binding ensures that the policy cannot be separated from, substituted on,
+or tampered with for the data it governs.
+
+### 1.2 Scope
+
+This document covers:
+
+- The JSON schema of the policy object.
+- The format and semantics of attribute URIs.
+- The three attribute rule types (allOf, anyOf, hierarchy) and their precise
+  evaluation semantics.
+- The dissemination list and its enforcement requirements.
+- Canonical serialization of the policy for binding computation.
+- KAS grant resolution: how attribute values map to KAS instances.
+- The interaction between attribute rules and key splitting.
+- The end-to-end policy evaluation flow.
+
+This document does NOT cover:
+
+- The cryptographic construction of the policy binding (see BaseTDF-KAO).
+- The wire protocol for the rewrap endpoint (see BaseTDF-KAS).
+- The container format in which the policy is carried (see BaseTDF-CORE).
+
+### 1.3 Relationship to Other BaseTDF Documents
+
+- **BaseTDF-SEC**: Defines the security invariants that this document
+  operationalizes. SI-2 (Authorization Before Key Release) requires the policy
+  evaluation described in Section 9. SI-3 (Dissemination Enforcement) requires
+  the dissemination checks described in Section 5.
+- **BaseTDF-KAO**: Defines the Key Access Object, which carries the policy
+  binding that cryptographically ties the policy object to the wrapped DEK
+  share. The policy binding is computed over the canonical serialization
+  defined in Section 6.
+- **BaseTDF-KAS**: Defines the rewrap protocol through which the KAS receives
+  the policy, evaluates it, and releases key material.
+- **BaseTDF-ALG**: Defines the algorithm identifiers referenced by attribute
+  objects and key protection.
+- **BaseTDF-CORE**: Carries the policy object in the manifest's
+  `encryptionInformation.policy` field.
+
+### 1.4 Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in [BCP 14][RFC2119] [RFC
+8174][RFC8174] when, and only when, they appear in ALL CAPITALS, as shown here.
+
+### 1.5 Terminology
+
+| Term | Definition |
+|---|---|
+| **Attribute authority** | The organizational authority that defines attribute namespaces, attribute definitions, and attribute values. Identified by a fully qualified domain name (FQDN). |
+| **Attribute definition** | A named attribute within an authority's namespace, along with its rule type and set of permissible values. |
+| **Attribute value** | A specific value within an attribute definition. Represented as a URI. |
+| **Data attribute** | An attribute value attached to a TDF's policy object, representing a security requirement of the protected data. |
+| **Entity entitlement** | An attribute value held by an entity, representing a clearance, role, or property granted by the attribute authority. |
+| **Dissemination list** | A list of entity identifiers that restricts who may access the protected data, independent of attribute-based checks. |
+| **KAS grant** | The association between an attribute value (or definition, or namespace) and a KAS instance that holds the corresponding key material. |
+
+---
+
+## 2. Policy Object Schema
+
+The policy object is a JSON structure that expresses the access requirements for
+a TDF-protected data object. It is serialized, base64-encoded, and stored in the
+manifest's `encryptionInformation.policy` field (see BaseTDF-CORE).
+
+### 2.1 Structure
+
+```json
+{
+  "uuid": "unique-policy-identifier",
+  "body": {
+    "dataAttributes": [ ... ],
+    "dissem": [ ... ]
+  }
+}
+```
+
+### 2.2 Fields
+
+#### 2.2.1 `uuid`
+
+- **Type**: String
+- **Required**: REQUIRED
+- **Description**: A unique identifier for this policy instance. This
+  identifier is used in audit logs (SI-8) to correlate rewrap requests with
+  specific TDF policies.
+- **Format**: UUIDv4 ([RFC 9562][RFC9562]) is RECOMMENDED. Implementations MAY
+  use other globally unique identifier formats, but the value MUST be unique
+  across all policies produced by the implementation.
+
+#### 2.2.2 `body`
+
+- **Type**: Object
+- **Required**: REQUIRED
+- **Description**: Contains the access control rules for this policy.
+
+#### 2.2.3 `body.dataAttributes`
+
+- **Type**: Array of attribute objects (see Section 3.2)
+- **Required**: REQUIRED (MAY be empty)
+- **Description**: The set of attribute values that define the access
+  requirements for the protected data. Each attribute object identifies a
+  specific attribute value and the KAS instance responsible for the
+  corresponding key material.
+- **Semantics**: When this array is non-empty, the KAS MUST evaluate the
+  entity's entitlements against these attributes using the rules defined in
+  Section 4. When this array is empty, no attribute-based access control is
+  applied (dissemination checks per Section 5 still apply if configured).
+
+#### 2.2.4 `body.dissem`
+
+- **Type**: Array of strings
+- **Required**: REQUIRED (MAY be empty)
+- **Description**: A list of entity identifiers (typically email addresses)
+  that restricts access to the listed entities. See Section 5 for enforcement
+  semantics.
+
+### 2.3 Complete Example
+
+```json
+{
+  "uuid": "5e2f7fa6-a93e-4b9b-8f73-2fd694c0b4d8",
+  "body": {
+    "dataAttributes": [
+      {
+        "attribute": "https://example.com/attr/classification/value/secret",
+        "displayName": "Classification: Secret",
+        "isDefault": false,
+        "pubKey": "",
+        "kasURL": "https://kas.example.com"
+      },
+      {
+        "attribute": "https://example.com/attr/department/value/engineering",
+        "displayName": "Department: Engineering",
+        "isDefault": false,
+        "pubKey": "",
+        "kasURL": "https://kas.example.com"
+      }
+    ],
+    "dissem": [
+      "alice@example.com",
+      "bob@example.com"
+    ]
+  }
+}
+```
+
+In this example, an entity requesting access must:
+
+1. Satisfy the attribute rules for both `classification/value/secret` and
+   `department/value/engineering` (evaluated per the rule types of their
+   respective attribute definitions; see Section 4).
+2. Have an identity matching either `alice@example.com` or `bob@example.com`
+   (see Section 5).
+
+---
+
+## 3. Attribute Representation
+
+### 3.1 Attribute URI Format
+
+Attribute values are identified by fully qualified names (FQNs) expressed as
+URIs. The canonical form is:
+
+```
+https://{authority}/attr/{name}/value/{value}
+```
+
+| Component | Description | Example |
+|---|---|---|
+| `{authority}` | FQDN of the attribute authority, optionally including a path prefix | `example.com` or `ns.example.com/org` |
+| `{name}` | The attribute definition name | `classification` |
+| `{value}` | The specific attribute value | `secret` |
+
+**Normalization requirements**:
+
+- The scheme MUST be `https` for production deployments. The scheme `http` MAY
+  be used in development or testing environments.
+- The authority component SHOULD be treated as case-insensitive for matching
+  purposes. Implementations SHOULD normalize to lowercase.
+- The name and value components are case-sensitive unless the attribute
+  authority specifies otherwise.
+- The URI MUST NOT contain a trailing slash after the value component.
+- The name and value components MUST NOT contain unescaped forward slashes.
+  If a name or value naturally contains a slash, it MUST be percent-encoded
+  per [RFC 3986][RFC3986].
+
+**Attribute definition FQN**: The parent attribute definition is identified by
+truncating the URI at the `/value/` segment:
+
+```
+https://{authority}/attr/{name}
+```
+
+This prefix groups all values of the same attribute definition and is used to
+determine which rule type (allOf, anyOf, hierarchy) governs evaluation.
+
+### 3.2 Attribute Object
+
+Each entry in `body.dataAttributes` is an attribute object with the following
+fields:
+
+```json
+{
+  "attribute": "https://example.com/attr/classification/value/secret",
+  "displayName": "Classification: Secret",
+  "isDefault": false,
+  "pubKey": "",
+  "kasURL": "https://kas.example.com"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `attribute` | String | REQUIRED | The fully qualified attribute value URI (see Section 3.1). |
+| `displayName` | String | OPTIONAL | A human-readable label for this attribute value. Used for display purposes only; MUST NOT affect access control evaluation. |
+| `isDefault` | Boolean | OPTIONAL | Indicates whether this is the default value for the attribute definition. Informational only; MUST NOT affect access control evaluation. |
+| `pubKey` | String | OPTIONAL | Legacy field. Was previously used to carry the KAS public key. New implementations SHOULD set this to an empty string. KAS public keys are resolved through the grant system or the KAS discovery endpoint. |
+| `kasURL` | String | REQUIRED | The URL of the KAS instance that holds the key material associated with this attribute value. See Section 7 for grant resolution. |
+
+### 3.3 Attribute Object Validation
+
+Implementations MUST validate attribute objects according to the following
+rules:
+
+1. The `attribute` field MUST be present and MUST be a syntactically valid
+   attribute value URI matching the format in Section 3.1.
+2. The `kasURL` field MUST be present and MUST be a valid HTTPS URL (or HTTP
+   in development environments).
+3. Implementations SHOULD reject attribute objects where the `attribute` field
+   is an empty string.
+4. Implementations SHOULD treat `displayName` and `isDefault` as purely
+   informational and MUST NOT use them in access control decisions.
+
+---
+
+## 4. Attribute Rule Types and Evaluation Semantics
+
+Attribute definitions are configured with a **rule type** that determines how
+the KAS authorization service evaluates entity entitlements against the data
+attributes present in a TDF policy. The rule type is a property of the
+**attribute definition** (not of individual attribute values or of the policy
+object itself). The authorization service resolves the rule type from its
+attribute definition registry at evaluation time.
+
+Three rule types are defined: **allOf** (conjunctive), **anyOf** (disjunctive),
+and **hierarchy** (ordered). Each rule type is evaluated independently per
+attribute definition. When a policy contains attribute values from multiple
+attribute definitions, the results are combined conjunctively: the entity MUST
+satisfy the rule for **every** attribute definition represented in the policy.
+
+### 4.1 allOf (Conjunctive)
+
+**Semantics**: The entity MUST possess entitlements for ALL listed attribute
+values of this definition to satisfy the rule.
+
+**Formal definition**: Given a set of data attribute values
+$V = \{v_1, v_2, \ldots, v_n\}$ from a single attribute definition with rule
+type `allOf`, and a set of entity entitlements $E$, the rule is satisfied if
+and only if:
+
+$$\forall v_i \in V : v_i \in E$$
+
+**Evaluation procedure**:
+
+1. For each attribute value FQN in the policy that belongs to this definition,
+   verify that the entity holds an entitlement for that exact FQN with the
+   requested action (typically `decrypt` / `read`).
+2. If ANY attribute value is not found in the entity's entitlements, the rule
+   FAILS and access MUST be denied.
+3. If ALL attribute values are found, the rule PASSES.
+
+**Key splitting implication**: Each attribute value in an allOf group maps to a
+**separate key split** (see Section 8). This means that every KAS associated
+with an allOf value independently authorizes access and releases its key share.
+All shares are required to reconstruct the DEK.
+
+**Example**:
+
+Policy contains:
+- `https://example.com/attr/clearance/value/gamma`
+- `https://example.com/attr/clearance/value/delta`
+
+Where `clearance` is defined with rule type `allOf`.
+
+The entity MUST hold entitlements for BOTH `gamma` AND `delta` to gain access.
+If the entity holds only `gamma`, access is denied.
+
+### 4.2 anyOf (Disjunctive)
+
+**Semantics**: The entity MUST possess an entitlement for AT LEAST ONE of the
+listed attribute values of this definition to satisfy the rule.
+
+**Formal definition**: Given a set of data attribute values
+$V = \{v_1, v_2, \ldots, v_n\}$ from a single attribute definition with rule
+type `anyOf`, and a set of entity entitlements $E$, the rule is satisfied if
+and only if:
+
+$$\exists v_i \in V : v_i \in E$$
+
+**Evaluation procedure**:
+
+1. For each attribute value FQN in the policy that belongs to this definition,
+   check whether the entity holds an entitlement for that FQN with the
+   requested action.
+2. If AT LEAST ONE attribute value is found in the entity's entitlements, the
+   rule PASSES.
+3. If NONE of the attribute values are found, the rule FAILS and access MUST
+   be denied.
+
+**Key splitting implication**: All attribute values in an anyOf group share a
+**single key split** (see Section 8). Any KAS in the group can authorize access
+and release the shared key share.
+
+**Example**:
+
+Policy contains:
+- `https://example.com/attr/department/value/engineering`
+- `https://example.com/attr/department/value/research`
+
+Where `department` is defined with rule type `anyOf`.
+
+The entity MUST hold an entitlement for EITHER `engineering` OR `research` (or
+both). If the entity holds `engineering` but not `research`, access is granted.
+If the entity holds neither, access is denied.
+
+### 4.3 hierarchy (Ordered)
+
+**Semantics**: Attribute values are ordered from highest to lowest. An entity
+that possesses an entitlement at a given level is also entitled to access data
+at that level and all levels below it.
+
+**Formal definition**: Given an ordered sequence of attribute values
+$H = (h_1, h_2, \ldots, h_m)$ where $h_1$ is the highest level and $h_m$ is
+the lowest, and a set of data attribute values
+$V = \{v_1, v_2, \ldots, v_n\} \subseteq H$ from the policy, and a set of
+entity entitlements $E$, the rule is satisfied if and only if:
+
+Let $v^* = \min_{\text{index}}(V)$ be the highest-level data attribute value
+in the policy. The rule passes if:
+
+$$\exists h_j \in E : \text{index}(h_j) \leq \text{index}(v^*)$$
+
+That is, the entity holds an entitlement at or above the highest level
+required by the policy.
+
+**Evaluation procedure**:
+
+1. Determine the ordering of values from the attribute definition. The order
+   is defined by the sequence of values in the attribute definition, where
+   index 0 is the highest level and increasing indices represent lower levels.
+2. Among the data attribute values in the policy that belong to this
+   definition, identify the value with the lowest index (the highest level
+   required).
+3. Check whether the entity holds an entitlement for that value or for any
+   value with a lower index (higher level) in the hierarchy.
+4. If such an entitlement is found, the rule PASSES.
+5. If no such entitlement is found, the rule FAILS and access MUST be denied.
+
+**Key splitting implication**: Hierarchy rules are treated identically to anyOf
+for key splitting purposes: all values share a **single key split** (see
+Section 8).
+
+**Example**:
+
+Attribute definition `classification` with rule type `hierarchy` and ordered
+values:
+
+| Index | Value | Level |
+|---|---|---|
+| 0 | `top_secret` | Highest |
+| 1 | `secret` | |
+| 2 | `confidential` | |
+| 3 | `unclassified` | Lowest |
+
+Policy contains:
+- `https://example.com/attr/classification/value/secret` (index 1)
+
+An entity with entitlement for `top_secret` (index 0) satisfies the rule
+because index 0 < index 1. An entity with entitlement for `secret` (index 1)
+also satisfies the rule because index 1 = index 1. An entity with entitlement
+for only `confidential` (index 2) does NOT satisfy the rule because
+index 2 > index 1.
+
+### 4.4 Cross-Definition Conjunction
+
+When a policy contains attribute values from multiple distinct attribute
+definitions, the access decision is the **conjunction** (logical AND) of the
+per-definition rule evaluations:
+
+$$\text{access} = \bigwedge_{d \in D} \text{rule}_d(V_d, E)$$
+
+Where $D$ is the set of distinct attribute definitions represented in the
+policy, $V_d$ is the subset of data attribute values belonging to definition
+$d$, and $\text{rule}_d$ is the evaluation function for definition $d$'s rule
+type.
+
+**Example**:
+
+A policy contains:
+- `https://example.com/attr/classification/value/secret` (hierarchy rule)
+- `https://example.com/attr/department/value/engineering` (anyOf rule)
+- `https://example.com/attr/department/value/research` (anyOf rule)
+
+For access to be granted, the entity MUST:
+1. Hold a `classification` entitlement at `secret` level or higher, AND
+2. Hold a `department` entitlement for `engineering` OR `research`.
+
+### 4.5 Empty Data Attributes
+
+When `body.dataAttributes` is an empty array, no attribute-based access control
+is applied. In this case:
+
+- If `body.dissem` is non-empty, only the dissemination check (Section 5)
+  determines access.
+- If both `body.dataAttributes` and `body.dissem` are empty, the KAS SHOULD
+  grant access to any authenticated entity. This configuration is NOT
+  RECOMMENDED for production use as it provides no access restriction beyond
+  authentication.
+
+### 4.6 Unregistered Attribute Values
+
+If the policy contains an attribute value FQN that is not registered in the
+authorization service's attribute definition registry, the KAS MUST deny access
+to the resource. Unknown attribute values MUST NOT be silently ignored.
+
+---
+
+## 5. Dissemination List
+
+### 5.1 Purpose
+
+The dissemination list (`body.dissem`) provides an **identity-based access
+control** mechanism that operates in addition to, not as a replacement for,
+the attribute-based access control described in Section 4. It allows data
+creators to restrict access to a specific set of named entities regardless of
+their attribute entitlements.
+
+### 5.2 Enforcement Requirements
+
+**Reference**: BaseTDF-SEC, SI-3 (Dissemination Enforcement).
+
+1. When `body.dissem` is a non-empty array, the KAS MUST verify that the
+   authenticated entity's identity matches at least one entry in the
+   dissemination list BEFORE releasing any key material.
+
+2. The entity's identity MUST be determined from the authenticated access
+   token's `sub` claim or equivalent identity assertion. The identity
+   determination mechanism is the same as that used for attribute entitlement
+   resolution.
+
+3. If the entity's identity does not match any entry in the dissemination
+   list, the KAS MUST deny the rewrap request and MUST NOT return any key
+   material.
+
+4. The dissemination check is **in addition to** the attribute-based access
+   control evaluation (SI-2). Both checks MUST pass for key material to be
+   released:
+
+   ```
+   access = attributeCheck(policy, entity) AND dissemCheck(policy, entity)
+   ```
+
+5. A passing attribute check does NOT override a failing dissemination check,
+   and vice versa.
+
+### 5.3 Matching Algorithm
+
+1. Dissemination list entries are typically email addresses (e.g.,
+   `alice@example.com`).
+
+2. Matching SHOULD be case-insensitive for email-format identifiers, as
+   specified by [RFC 5321][RFC5321] Section 2.4. For example,
+   `Alice@Example.COM` and `alice@example.com` SHOULD be considered
+   equivalent.
+
+3. The KAS MUST perform an exact match (modulo case normalization) between the
+   entity's identity and the dissemination list entries. Wildcard matching,
+   domain-level matching, and regular expression matching are NOT defined by
+   this specification.
+
+4. If the entity has multiple identity claims (e.g., multiple email addresses
+   or aliases), the KAS SHOULD check all available identity claims against the
+   dissemination list.
+
+### 5.4 Empty Dissemination List
+
+When `body.dissem` is an empty array, no dissemination restriction is applied.
+Attribute-based access control checks (Section 4) still apply if
+`body.dataAttributes` is non-empty.
+
+### 5.5 Example
+
+```json
+{
+  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "body": {
+    "dataAttributes": [],
+    "dissem": [
+      "alice@example.com",
+      "bob@example.com",
+      "carol@example.com"
+    ]
+  }
+}
+```
+
+In this example, no attribute-based checks are applied (empty
+`dataAttributes`), but only `alice@example.com`, `bob@example.com`, and
+`carol@example.com` may access the data.
+
+---
+
+## 6. Canonical Serialization and Policy Binding
+
+### 6.1 Policy String
+
+The policy object is serialized to JSON and then base64-encoded. This
+base64-encoded string is stored in the manifest's
+`encryptionInformation.policy` field. The **exact base64 string** as stored in
+the manifest is the canonical representation used for policy binding
+computation.
+
+### 6.2 Binding Computation Input
+
+The policy binding (defined in BaseTDF-KAO) is computed over the raw base64
+string from `encryptionInformation.policy`:
+
+```
+binding = HMAC-SHA256(key=DEK_share, message=policy_base64_string)
+```
+
+The input to the HMAC is the **literal base64 string**, not the decoded JSON.
+
+### 6.3 No Re-Serialization
+
+Implementations MUST NOT re-encode, re-serialize, normalize, or otherwise
+transform the policy string before computing or verifying the policy binding.
+The binding is over the exact bytes of the base64 string as they appear in the
+manifest.
+
+**Rationale**: JSON serialization is not canonical -- different serializers may
+produce different byte sequences for semantically identical JSON objects (e.g.,
+different key ordering, different whitespace, different Unicode escaping). By
+binding to the literal base64 string, the specification avoids requiring a
+canonical JSON serialization algorithm and prevents a class of canonicalization
+attacks where an attacker modifies the serialization without changing the
+semantic content.
+
+### 6.4 Implications for Implementations
+
+- When creating a TDF, the implementation serializes the policy object to JSON,
+  base64-encodes it, stores the result in `encryptionInformation.policy`, and
+  uses that same string as the HMAC input.
+- When verifying a policy binding, the KAS reads the
+  `encryptionInformation.policy` string verbatim and uses it as the HMAC input.
+  The KAS MUST NOT decode the base64, parse the JSON, re-serialize, and
+  re-encode before verification.
+- If the policy string is modified in transit (even by a semantically neutral
+  transformation such as re-serializing the JSON with different whitespace),
+  the policy binding verification will fail, and the KAS will correctly reject
+  the KAO (SI-1).
+
+---
+
+## 7. KAS Grant Resolution
+
+### 7.1 Overview
+
+Each attribute value in a policy is associated with a KAS instance that holds
+the corresponding key material. This association is called a **KAS grant**. KAS
+grants determine which KAS a client must contact to obtain each key share
+during the rewrap process.
+
+### 7.2 Grant Hierarchy
+
+KAS grants are resolved through a hierarchical lookup. When determining which
+KAS holds the key for a given attribute value, the system checks for grants in
+the following order of precedence:
+
+1. **Value-level grant**: A KAS grant directly associated with the specific
+   attribute value. This is the most specific grant and takes precedence.
+2. **Definition-level grant**: A KAS grant associated with the attribute
+   definition (parent of the value). Used when no value-level grant exists.
+3. **Namespace-level grant**: A KAS grant associated with the attribute
+   authority's namespace. Used as a fallback when neither value-level nor
+   definition-level grants exist.
+
+The first non-empty grant found in this hierarchy is used. If no grant is
+found at any level, the implementation falls back to the default KAS
+configuration.
+
+### 7.3 Attribute Object `kasURL` Field
+
+The `kasURL` field in the attribute object (Section 3.2) records the KAS URL
+resolved at TDF creation time. During rewrap, the client uses this URL to
+determine which KAS to contact for the corresponding key share.
+
+When KAS grants are resolved from the policy service at TDF creation time:
+
+1. The client queries the attribute service for the attribute definitions
+   corresponding to the data attributes.
+2. For each attribute value, the client resolves the KAS grant using the
+   hierarchy in Section 7.2.
+3. The resolved KAS URL is recorded in the attribute object's `kasURL` field.
+4. The KAS URL is also recorded in the KAO's `url` field (see BaseTDF-KAO),
+   which is the authoritative source for the rewrap client.
+
+### 7.4 Multi-KAS Scenarios
+
+Different attribute values MAY be associated with different KAS instances.
+This is the basis for the split-key architecture:
+
+- Attribute values from different authorities may naturally point to different
+  KASes.
+- Even within the same authority, value-level grants can direct specific
+  values to different KASes.
+- Each KAS independently holds a key share and independently authorizes
+  access. An entity must obtain all required key shares from all relevant
+  KASes to reconstruct the DEK.
+
+### 7.5 KAS Key Identification
+
+Each KAS grant includes (or resolves to) the KAS's public key, identified by
+a key identifier (`kid`). The `kid` allows the KAS to select the correct
+private key for unwrapping during rewrap. See BaseTDF-KAO for the `kid` field
+specification.
+
+---
+
+## 8. Key Splitting and Rule Interaction
+
+### 8.1 Overview
+
+The attribute rule type determines how key material is split across KAS
+instances. This section defines the relationship between attribute rules and
+the key splitting topology. For the cryptographic details of key splitting
+(XOR-based splitting), see BaseTDF-KAO.
+
+### 8.2 Split Topology by Rule Type
+
+#### 8.2.1 allOf: Separate Splits
+
+For attribute definitions with rule type `allOf`, each attribute value maps to
+a **separate key split**. Each split is independently wrapped to the KAS
+associated with that attribute value.
+
+```
+Policy:  attr/clearance/value/gamma  (allOf)
+         attr/clearance/value/delta  (allOf)
+
+Splits:  Split A  ──>  KAS for gamma
+         Split B  ──>  KAS for delta
+
+DEK = Split A XOR Split B
+```
+
+Both KASes must independently authorize the entity and release their respective
+key shares. The entity must obtain ALL shares to reconstruct the DEK. This
+provides a cryptographic enforcement of the conjunctive access requirement: even
+if one KAS is compromised or misconfigured, the DEK remains protected as long
+as the other KAS correctly enforces its authorization.
+
+#### 8.2.2 anyOf: Shared Split
+
+For attribute definitions with rule type `anyOf`, all attribute values share a
+**single key split**. The same key split is wrapped to each KAS associated with
+any value in the group.
+
+```
+Policy:  attr/department/value/engineering  (anyOf)
+         attr/department/value/research     (anyOf)
+
+Splits:  Split C  ──>  KAS for engineering
+         Split C  ──>  KAS for research
+
+(Split C is the same material, wrapped to different KASes)
+```
+
+Any single KAS in the group can authorize the entity and release the key share.
+This implements the disjunctive access requirement: the entity needs
+authorization from only one of the KASes.
+
+#### 8.2.3 hierarchy: Shared Split
+
+For attribute definitions with rule type `hierarchy`, all attribute values
+share a **single key split**, identical to the anyOf behavior.
+
+```
+Policy:  attr/classification/value/secret  (hierarchy)
+
+Splits:  Split D  ──>  KAS for classification values
+
+The same split is available from any KAS in the hierarchy group.
+```
+
+### 8.3 Cross-Definition Splitting
+
+When a policy contains attribute values from multiple attribute definitions,
+the key splits from each definition are combined conjunctively:
+
+```
+Policy:  attr/classification/value/secret      (hierarchy, Definition 1)
+         attr/department/value/engineering      (anyOf, Definition 2)
+         attr/department/value/research         (anyOf, Definition 2)
+
+Splits:  Split 1 (from Definition 1)  AND  Split 2 (from Definition 2)
+
+DEK = Split 1 XOR Split 2
+```
+
+Split 1 is shared across the KASes for the hierarchy definition. Split 2 is
+shared across the KASes for the anyOf definition. The entity must obtain both
+Split 1 and Split 2 to reconstruct the DEK.
+
+### 8.4 Split ID
+
+Each key split is identified by a **split ID** (`sid` field in the KAO). KAOs
+that share the same split ID contain the same DEK share wrapped to different
+KASes. The client uses the split ID to determine which KAOs are alternatives
+(same split, different KAS) versus which represent independent shares that must
+all be collected.
+
+- KAOs with the **same** split ID: any ONE of them suffices (disjunction).
+- KAOs with **different** split IDs: ALL of them are required (conjunction).
+
+### 8.5 Deduplication
+
+When the split plan is constructed, the implementation SHOULD deduplicate
+splits that resolve to the same KAS. If two allOf values both resolve to the
+same KAS URL, they MAY be merged into a single split to avoid redundant
+wrapping. However, the deduplication MUST NOT change the access control
+semantics: if two values from an allOf definition resolve to different KASes,
+they MUST remain as separate splits.
+
+---
+
+## 9. Policy Evaluation Flow
+
+This section describes the end-to-end flow for policy evaluation during a
+rewrap request. This flow implements the security invariants SI-1, SI-2, and
+SI-3 from BaseTDF-SEC.
+
+### 9.1 Prerequisite: Policy Binding Verification (SI-1)
+
+Before policy evaluation begins, the KAS MUST verify the policy binding as
+specified in BaseTDF-KAO and SI-1. This step ensures the policy has not been
+tampered with. If the policy binding verification fails, the KAS MUST reject
+the request and MUST NOT proceed to policy evaluation.
+
+### 9.2 Evaluation Steps
+
+The following steps MUST be performed for each rewrap request:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ 1. Client presents rewrap request to KAS            │
+│    - Signed Request Token (SRT) with KAO + policy   │
+│    - DPoP-bound access token (entity identity)      │
+└───────────────────────┬─────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────┐
+│ 2. KAS verifies policy binding (SI-1)               │
+│    - Unwrap DEK share from KAO                      │
+│    - Compute HMAC-SHA256(DEK_share, policy_base64)  │
+│    - Compare with policyBinding.hash                │
+│    - REJECT if mismatch                             │
+└───────────────────────┬─────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────┐
+│ 3. KAS extracts data attributes from policy         │
+│    - Decode policy from base64                      │
+│    - Parse body.dataAttributes                      │
+│    - Extract attribute value FQNs                   │
+└───────────────────────┬─────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────┐
+│ 4. KAS submits authorization request (SI-2)         │
+│    - Attribute value FQNs (resource attributes)     │
+│    - Entity token (subject identity)                │
+│    - Requested action (decrypt/read)                │
+│    - Fulfillable obligation FQNs (if applicable)    │
+└───────────────────────┬─────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────┐
+│ 5. Authorization service evaluates rules            │
+│    - Resolve entity entitlements from identity      │
+│    - Group resource attributes by definition        │
+│    - Evaluate allOf/anyOf/hierarchy per definition  │
+│    - Conjoin per-definition results                 │
+│    - Return PERMIT or DENY                          │
+└───────────────────────┬─────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────┐
+│ 6. KAS enforces dissemination list (SI-3)           │
+│    - If body.dissem is non-empty:                   │
+│      - Verify entity identity in dissem list        │
+│      - DENY if not found                            │
+└───────────────────────┬─────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────┐
+│ 7. KAS makes final access decision                  │
+│    - PERMIT only if:                                │
+│      - Policy binding verified (step 2)             │
+│      - Attribute check passed (step 5)              │
+│      - Dissem check passed (step 6)                 │
+│    - DENY otherwise                                 │
+└───────────────────────┬─────────────────────────────┘
+                        │
+                ┌───────┴───────┐
+                │               │
+             PERMIT           DENY
+                │               │
+                ▼               ▼
+┌──────────────────┐  ┌──────────────────┐
+│ 8a. Rewrap key   │  │ 8b. Return error │
+│     share to     │  │     Log denial   │
+│     client's     │  │     (SI-8)       │
+│     ephemeral    │  └──────────────────┘
+│     public key   │
+│     Log permit   │
+│     (SI-8)       │
+└──────────────────┘
+```
+
+### 9.3 Authorization Service Interaction
+
+The KAS communicates with the authorization service to evaluate attribute-based
+access control. The authorization service:
+
+1. **Resolves entity entitlements**: Determines which attribute values the
+   entity is entitled to, based on the entity's identity token and the
+   configured subject mappings.
+
+2. **Groups resource attributes by definition**: The data attribute FQNs from
+   the policy are grouped by their parent attribute definition. Each group is
+   evaluated independently according to the definition's rule type.
+
+3. **Evaluates rules**: For each definition group, the authorization service
+   evaluates the appropriate rule (allOf, anyOf, or hierarchy) as defined in
+   Section 4.
+
+4. **Returns a decision**: The authorization service returns a PERMIT or DENY
+   decision for each resource (policy). The KAS MUST receive an explicit
+   PERMIT decision before proceeding.
+
+### 9.4 Per-Request Evaluation
+
+Policy evaluation MUST occur for every rewrap request. The KAS MUST NOT cache
+authorization decisions across requests. This ensures that changes to entity
+entitlements, attribute definitions, or subject mappings take effect immediately
+on the next rewrap request (see BaseTDF-SEC Section 2.2, Tenet 4: Dynamic
+Policy).
+
+### 9.5 Unavailable Authorization Service
+
+If the authorization service is unavailable or returns an error, the KAS MUST
+deny the rewrap request. The KAS MUST NOT fall back to a default-permit
+decision when the authorization service cannot be reached. This fail-closed
+behavior ensures that network partitions or service outages do not result in
+unauthorized access.
+
+---
+
+## 10. Security Considerations
+
+### 10.1 Policy Integrity (SI-1)
+
+The policy object is integrity-protected via the policy binding mechanism
+defined in BaseTDF-KAO. The binding is an HMAC-SHA256 computed over the
+base64-encoded policy string using the DEK share as the key. Because the DEK
+share is encrypted to the KAS public key, an attacker without the KAS private
+key cannot forge a valid binding for a modified policy.
+
+Any modification to the policy -- including semantically neutral changes such
+as whitespace normalization or key reordering -- will cause the binding
+verification to fail, and the KAS will reject the request (see Section 6.3).
+
+### 10.2 Authorization Before Key Release (SI-2)
+
+The KAS MUST evaluate the policy's data attributes against the entity's
+entitlements before releasing any key material. This evaluation MUST be
+performed by the authorization service for every rewrap request. The KAS MUST
+NOT release key material based on cached decisions, local policy overrides, or
+any other mechanism that bypasses the authorization service.
+
+If the policy's `dataAttributes` array is empty, the attribute check is
+trivially satisfied, but the dissemination check (SI-3) still applies.
+
+### 10.3 Dissemination Enforcement (SI-3)
+
+When the policy contains a non-empty dissemination list, the KAS MUST verify
+the entity's identity against the list as an additional access control check.
+This check is not a substitute for attribute evaluation and MUST be performed
+even when the attribute check passes. Conversely, a passing dissemination
+check does not bypass a failing attribute check.
+
+Implementations that do not enforce the dissemination list when it is present
+are non-conformant with this specification and with SI-3.
+
+### 10.4 Dynamic Evaluation
+
+Policy evaluation occurs at rewrap time, not at TDF creation time. This means:
+
+- Revoking an entity's attribute entitlement takes effect on the next rewrap
+  request, without requiring re-encryption of existing TDFs.
+- Adding new attribute values to an entity's entitlements grants access to
+  TDFs whose policies require those values, without re-encryption.
+- Changes to attribute definitions (e.g., changing a rule type from anyOf to
+  allOf) take effect on the next rewrap request.
+
+This dynamic evaluation model is a core property of the BaseTDF zero trust
+architecture (see BaseTDF-SEC Section 2.2, Tenet 4).
+
+### 10.5 Attribute Enumeration
+
+An attacker with valid credentials could systematically create TDFs with
+different attribute combinations and observe rewrap success or failure to
+enumerate which attributes they hold. The KAS SHOULD implement rate limiting
+on rewrap requests and SHOULD return uniform error responses for all denial
+reasons to mitigate this attack (see BaseTDF-SEC Section 4.3).
+
+### 10.6 Policy Object in Cleartext
+
+The policy object is stored in the TDF manifest, which is not encrypted. An
+attacker with access to the TDF can read the policy and learn:
+
+- Which attribute values are required for access.
+- Which entities are in the dissemination list.
+- Which KAS instances are involved.
+
+This metadata exposure is an inherent trade-off of the BaseTDF design: the
+policy must be readable by the client and KAS to perform the rewrap protocol.
+Organizations that consider this metadata sensitive SHOULD apply transport-level
+and storage-level access controls to TDF objects in addition to the
+data-centric protections.
+
+---
+
+## 11. Normative References
+
+| Reference | Title |
+|---|---|
+| [NIST SP 800-162][SP800-162] | Guide to Attribute Based Access Control (ABAC) Definition and Considerations |
+| [RFC 2119][RFC2119] | Key words for use in RFCs to Indicate Requirement Levels |
+| [RFC 8174][RFC8174] | Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words |
+| [RFC 9562][RFC9562] | Universally Unique IDentifiers (UUIDs) |
+| [RFC 3986][RFC3986] | Uniform Resource Identifier (URI): Generic Syntax |
+| [RFC 5321][RFC5321] | Simple Mail Transfer Protocol |
+
+[SP800-162]: https://doi.org/10.6028/NIST.SP.800-162
+[RFC2119]: https://www.rfc-editor.org/rfc/rfc2119
+[RFC8174]: https://www.rfc-editor.org/rfc/rfc8174
+[RFC9562]: https://www.rfc-editor.org/rfc/rfc9562
+[RFC3986]: https://www.rfc-editor.org/rfc/rfc3986
+[RFC5321]: https://www.rfc-editor.org/rfc/rfc5321

--- a/spec/basetdf/v5/basetdf-sec.md
+++ b/spec/basetdf/v5/basetdf-sec.md
@@ -638,17 +638,32 @@ For AES-GCM:
 
 ### 6.7 AEAD Usage Bounds
 
-AES-GCM security degrades with the volume of data protected under one key. Two
-bounds apply, from the analysis of [Iwata, Ohashi, and Minematsu][IOM12] as
-applied to TLS by [Luykx and Paterson][LP17]. [RFC 8446][RFC8446] Section 5.5
-derives its record limits from the same analysis.
+AES-GCM security degrades with the volume of data protected under one key and with
+the number and size of forgery attempts. [RFC 8446][RFC8446] Section 5.5 adopted
+an approximately `2^-57` overall AE target using the analysis of [Luykx and
+Paterson][LP17]. BaseTDF adopts `2^-57` as its maximum object-wide confidentiality
+advantage and accounts for integrity separately.
 
-**Confidentiality (IND-CPA).** For `sigma` total 16-byte plaintext blocks and `q`
-encryption invocations under one key:
+**Confidentiality.** [RFC 9001][RFC9001] Appendix B.1 applies the tighter
+multi-user GCM analysis of [Hoang, Tessaro, and Thiruvengadam][HTT18]. For a
+single user with unique nonces, its dominant confidentiality term is
+`2 * (q * l)^2 / 2^128`. Writing `sigma_p` for the total number of plaintext
+blocks protected under content-encryption key `K_p`, and applying a conservative
+hybrid argument across the independently derived partition keys, BaseTDF uses:
 
 ```text
-Adv_IND-CPA <= (sigma + q + 1)^2 / 2^129
+Adv_conf(object) <= 2 * sum(sigma_p^2 for every p) / 2^128
 ```
+
+Therefore an object meets the `2^-57` target when:
+
+```text
+sum(sigma_p^2 for every p) <= 2^70
+```
+
+This mode-level bound assumes AES is a secure pseudorandom permutation, HKDF-SHA256
+produces pseudorandom partition keys, and every nonce is unique under its key. The
+corresponding primitive and KDF advantages are additional negligible terms.
 
 **Integrity (INT-CTXT).** For `v` forgery attempts against messages of at most
 `l` blocks, with a `tau`-bit tag:
@@ -659,39 +674,32 @@ Adv_INT-CTXT <= 2 * v * (l + 1) / 2^tau
 
 #### 6.7.1 Volume Limit
 
-`sigma` dominates `q` at every segment size BaseTDF permits, so the
-confidentiality bound is a function of total bytes under one key:
+For one content-encryption key, the block-square budget implies an absolute
+plaintext ceiling of `2^35` blocks, or `2^39` bytes (512 GiB). Reaching that ceiling
+spends the entire object-wide `2^-57` confidentiality budget on that key, so a
+multi-partition object needs substantially smaller partitions.
 
-| Total plaintext under one key | IND-CPA advantage |
-|---:|---:|
-| 2^38 B (256 GiB) | 2^-61 |
-| 2^40 B (1 TiB) | 2^-57 |
-| 2^42 B (4 TiB) | 2^-53 |
-| 2^43 B (8 TiB) | 2^-51 |
-| 2^45 B (32 TiB) | 2^-47 |
+For an object containing `B` plaintext bytes divided into equal `b`-byte
+partitions, the dominant term simplifies to approximately:
 
-RFC 8446 Section 5.5 targets an advantage of approximately 2^-57 for AES-GCM; its
-record limit of 2^24.5 records of 2^14 bytes is 2^38.5 bytes, about 389 GB.
-BaseTDF adopts the same margin at the round volume that attains it exactly.
+```text
+Adv_conf(object) <= B * b / 2^135
+```
 
-**A single content-encryption key -- the DEK when `keyDerivation` is absent, or an
-individual partition key `K_p` when it is present -- MUST NOT protect more than
-2^40 bytes (1 TiB) of plaintext.**
-
-The limit is cumulative over the life of the key, including every segment added by
-the append extension (BaseTDF-CORE Section 7). BaseTDF-CORE Section 4.3 states the
-manifest constraints that enforce it.
+At 50 TiB this permits partitions no larger than approximately 5.12 GiB. BaseTDF
+RECOMMENDS 1 GiB partitions, which yield an object-wide advantage below `2^-59`
+under this bound. The limit is cumulative over the life of every partition key,
+including segments added by the append extension. BaseTDF-CORE Section 4.3 defines
+the normative, conservatively checkable manifest constraints.
 
 When `keyDerivation` is present the DEK performs no AES-GCM encryption at all: it
 is the HKDF PRK and the Merkle HMAC key, neither of which is subject to this bound.
 
-#### 6.7.2 Segmentation Does Not Improve the Bound
+#### 6.7.2 Segmentation Does Not Improve a Key's Bound
 
-`sigma` counts plaintext blocks regardless of how they are divided into segments,
-and `q` is negligible beside it. At a 2 MiB segment size, 2^40 bytes under one key
-is `sigma = 2^36` blocks and `q = 2^19` invocations, so `q` shifts the bound by
-less than one bit. Halving the segment size doubles `q` and leaves `sigma`
-unchanged; the bound does not move.
+`sigma_p` counts plaintext blocks regardless of how they are divided into segments.
+Halving the segment size while retaining the same partition bytes leaves
+`sigma_p` unchanged and does not improve confidentiality.
 
 Smaller segments therefore do NOT extend the volume a key may protect. Rekeying is
 the only mechanism that does, and in BaseTDF that mechanism is partition key
@@ -699,16 +707,28 @@ derivation (BaseTDF-CORE Section 4.2).
 
 #### 6.7.3 Scale Example
 
-A 5 TiB object -- the Amazon S3 single-object maximum -- placed under one key gives
-`sigma = 5 * 2^36` blocks and an advantage of about 2^-52.4, past the target
-margin. At the 1 TiB ceiling it requires five partition keys, and no `K_p` exceeds
-the limit. Nothing in BaseTDF caps the number of partitions, so this scales
-linearly.
+[Amazon S3 multipart limits][S3LIMITS] specify an advertised 50 TB object, with an
+exact ceiling of 50,000 GiB (approximately 48.83 TiB). BaseTDF's required scalable
+range is 50 TiB so the format also covers that ceiling after allowing
+deployment-specific sharding.
 
-The `partitionSegments: 512` default at a 2 MiB `segmentSizeDefault` places 1 GiB
-under each `K_p`, a factor of 1024 below the ceiling. Reaching the ceiling at that
-segment size requires `partitionSegments` of 2^19 (524288). Default writers are far
-inside the limit at any object size.
+A 50 TiB plaintext encrypted under one key has `sigma = 50 * 2^36` blocks and a
+confidentiality advantage of approximately `2^-43.7`, well past the target. Merely
+using fifty 1 TiB keys would satisfy the former per-key rule but would still give a
+conservative object-wide advantage of approximately `2^-49.4` under the newer
+bound.
+
+At the RECOMMENDED 1 GiB partition size, the same 50 TiB object has 51,200
+partition keys. Each protects `2^26` blocks, and:
+
+```text
+Adv_conf(object) <= 2 * 51,200 * (2^26)^2 / 2^128 < 2^-59
+```
+
+At 4 MiB per segment this is 13,107,200 segments and
+`partitionSegments: 256`; at the 2 MiB default it is 26,214,400 segments and
+`partitionSegments: 512`. Partition keys are derived on demand from one DEK and do
+not enlarge the manifest or require additional KAOs.
 
 #### 6.7.4 Integrity Bound
 
@@ -1060,6 +1080,7 @@ need freshness require a trusted catalog, checkpoint, or equivalent external sta
 | [RFC 9449][RFC9449] | OAuth 2.0 Demonstrating Proof of Possession (DPoP) |
 | [RFC 3339][RFC3339] | Date and Time on the Internet: Timestamps |
 | [RFC 8446][RFC8446] | The Transport Layer Security (TLS) Protocol Version 1.3 |
+| [RFC 9001][RFC9001] | Using TLS to Secure QUIC |
 
 ---
 
@@ -1069,6 +1090,8 @@ need freshness require a trusted catalog, checkpoint, or equivalent external sta
 |---|---|
 | [Luykx and Paterson 2017][LP17] | Limits on Authenticated Encryption Use in TLS |
 | [Iwata, Ohashi, and Minematsu 2012][IOM12] | Breaking and Repairing GCM Security Proofs (CRYPTO 2012) |
+| [Hoang, Tessaro, and Thiruvengadam 2018][HTT18] | The Multi-user Security of GCM, Revisited |
+| [Amazon S3 multipart limits][S3LIMITS] | Multipart upload sizes and part counts |
 
 [SP800-207]: https://doi.org/10.6028/NIST.SP.800-207
 [SP800-38D]: https://doi.org/10.6028/NIST.SP.800-38D
@@ -1081,5 +1104,8 @@ need freshness require a trusted catalog, checkpoint, or equivalent external sta
 [RFC9449]: https://www.rfc-editor.org/rfc/rfc9449
 [RFC3339]: https://www.rfc-editor.org/rfc/rfc3339
 [RFC8446]: https://www.rfc-editor.org/rfc/rfc8446
+[RFC9001]: https://www.rfc-editor.org/rfc/rfc9001
 [LP17]: https://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf
 [IOM12]: https://eprint.iacr.org/2012/438
+[HTT18]: https://eprint.iacr.org/2018/993
+[S3LIMITS]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html

--- a/spec/basetdf/v5/basetdf-sec.md
+++ b/spec/basetdf/v5/basetdf-sec.md
@@ -21,6 +21,7 @@
 8. [Post-Quantum Cryptography Migration](#8-post-quantum-cryptography-migration)
 9. [Packaging and Scale Security](#9-packaging-and-scale-security)
 10. [Normative References](#10-normative-references)
+11. [Informative References](#11-informative-references)
 
 ---
 
@@ -635,7 +636,117 @@ For AES-GCM:
   confidentiality and integrity. Implementations MUST ensure uniqueness
   through deterministic construction or verified-random generation.
 
-### 6.7 Minimum Key Sizes
+### 6.7 AEAD Usage Bounds
+
+AES-GCM security degrades with the volume of data protected under one key. Two
+bounds apply, from the analysis of [Iwata, Ohashi, and Minematsu][IOM12] as
+applied to TLS by [Luykx and Paterson][LP17]. [RFC 8446][RFC8446] Section 5.5
+derives its record limits from the same analysis.
+
+**Confidentiality (IND-CPA).** For `sigma` total 16-byte plaintext blocks and `q`
+encryption invocations under one key:
+
+```text
+Adv_IND-CPA <= (sigma + q + 1)^2 / 2^129
+```
+
+**Integrity (INT-CTXT).** For `v` forgery attempts against messages of at most
+`l` blocks, with a `tau`-bit tag:
+
+```text
+Adv_INT-CTXT <= 2 * v * (l + 1) / 2^tau
+```
+
+#### 6.7.1 Volume Limit
+
+`sigma` dominates `q` at every segment size BaseTDF permits, so the
+confidentiality bound is a function of total bytes under one key:
+
+| Total plaintext under one key | IND-CPA advantage |
+|---:|---:|
+| 2^38 B (256 GiB) | 2^-61 |
+| 2^40 B (1 TiB) | 2^-57 |
+| 2^42 B (4 TiB) | 2^-53 |
+| 2^43 B (8 TiB) | 2^-51 |
+| 2^45 B (32 TiB) | 2^-47 |
+
+RFC 8446 Section 5.5 targets an advantage of approximately 2^-57 for AES-GCM; its
+record limit of 2^24.5 records of 2^14 bytes is 2^38.5 bytes, about 389 GB.
+BaseTDF adopts the same margin at the round volume that attains it exactly.
+
+**A single content-encryption key -- the DEK when `keyDerivation` is absent, or an
+individual partition key `K_p` when it is present -- MUST NOT protect more than
+2^40 bytes (1 TiB) of plaintext.**
+
+The limit is cumulative over the life of the key, including every segment added by
+the append extension (BaseTDF-CORE Section 7). BaseTDF-CORE Section 4.3 states the
+manifest constraints that enforce it.
+
+When `keyDerivation` is present the DEK performs no AES-GCM encryption at all: it
+is the HKDF PRK and the Merkle HMAC key, neither of which is subject to this bound.
+
+#### 6.7.2 Segmentation Does Not Improve the Bound
+
+`sigma` counts plaintext blocks regardless of how they are divided into segments,
+and `q` is negligible beside it. At a 2 MiB segment size, 2^40 bytes under one key
+is `sigma = 2^36` blocks and `q = 2^19` invocations, so `q` shifts the bound by
+less than one bit. Halving the segment size doubles `q` and leaves `sigma`
+unchanged; the bound does not move.
+
+Smaller segments therefore do NOT extend the volume a key may protect. Rekeying is
+the only mechanism that does, and in BaseTDF that mechanism is partition key
+derivation (BaseTDF-CORE Section 4.2).
+
+#### 6.7.3 Scale Example
+
+A 5 TiB object -- the Amazon S3 single-object maximum -- placed under one key gives
+`sigma = 5 * 2^36` blocks and an advantage of about 2^-52.4, past the target
+margin. At the 1 TiB ceiling it requires five partition keys, and no `K_p` exceeds
+the limit. Nothing in BaseTDF caps the number of partitions, so this scales
+linearly.
+
+The `partitionSegments: 512` default at a 2 MiB `segmentSizeDefault` places 1 GiB
+under each `K_p`, a factor of 1024 below the ceiling. Reaching the ceiling at that
+segment size requires `partitionSegments` of 2^19 (524288). Default writers are far
+inside the limit at any object size.
+
+#### 6.7.4 Integrity Bound
+
+The integrity bound is not a constraint at BaseTDF parameters. With 128-bit tags
+and 2 MiB segments (`l = 2^17` blocks), 2^32 forgery attempts bound the forgery
+probability by `2 * 2^32 * (2^17 + 1) / 2^128`, approximately 2^-78. Even at the
+largest segment BaseTDF permits (`l = 2^32` blocks, Section 6.7.6) the same
+expression is about 2^-63. Integrity imposes no rekeying requirement.
+
+#### 6.7.5 DEK Uniqueness
+
+**A DEK MUST be freshly generated for each TDF object and MUST NOT be reused across
+objects.**
+
+`noncePrefix` is only 32 bits. Reusing one DEK across `N` objects makes some pair
+of them share a prefix with probability about `N^2 / 2^33`: roughly 0.2% at 4096
+objects and 50% at 2^16 objects. Two objects sharing a DEK and a `noncePrefix`
+repeat the exact `(key, nonce)` pair at every common segment index, which is the
+catastrophic failure Section 6.6 forbids. Partition derivation does not reduce this
+risk: `K_p` is a deterministic function of the DEK alone, so a repeated DEK repeats
+every partition key.
+
+This does not prohibit several manifests over one protected object and one DEK;
+that case is a single object, and its union-policy semantics are in Section 9.3.
+
+#### 6.7.6 Per-Invocation Limit
+
+[NIST SP 800-38D][SP800-38D] Section 5.2.1.1 caps a single GCM invocation at
+2^39 - 256 bits, that is 68,719,476,704 bytes (64 GiB - 32 B). No segment may
+exceed it; BaseTDF-INT Section 2 states the normative segment size cap.
+
+BaseTDF constructs IVs deterministically per SP 800-38D Section 8.2.1, with
+`noncePrefix` as the 32-bit fixed field and `u64be(segmentIndex)` as the 64-bit
+invocation field. The 2^32-invocation cap of SP 800-38D Section 8.3 applies to
+RBG-based IV construction and therefore does not apply here; the invocation field
+admits 2^64 distinct segment indices under one key.
+
+### 6.8 Minimum Key Sizes
 
 | Key Type | Minimum | Recommended | Maximum |
 |---|---|---|---|
@@ -657,6 +768,7 @@ BaseTDF system.
 
 - The DEK MUST be generated using a CSPRNG (Section 6.5).
 - The DEK MUST be at least 256 bits for AES-256-GCM.
+- A fresh DEK MUST be generated for each TDF object (Section 6.7.5).
 - The DEK MUST have full entropy (i.e., generated uniformly at random, not
   derived from low-entropy sources such as passwords).
 
@@ -671,7 +783,7 @@ BaseTDF system.
 **KAS Key Pairs**:
 
 - KAS asymmetric key pairs MUST be generated using a CSPRNG with key sizes
-  meeting the minimums in Section 6.7.
+  meeting the minimums in Section 6.8.
 - Key generation SHOULD occur within an HSM or equivalent trusted key
   management system.
 
@@ -947,6 +1059,16 @@ need freshness require a trusted catalog, checkpoint, or equivalent external sta
 | [RFC 8017][RFC8017] | PKCS #1: RSA Cryptography Specifications Version 2.2 |
 | [RFC 9449][RFC9449] | OAuth 2.0 Demonstrating Proof of Possession (DPoP) |
 | [RFC 3339][RFC3339] | Date and Time on the Internet: Timestamps |
+| [RFC 8446][RFC8446] | The Transport Layer Security (TLS) Protocol Version 1.3 |
+
+---
+
+## 11. Informative References
+
+| Reference | Title |
+|---|---|
+| [Luykx and Paterson 2017][LP17] | Limits on Authenticated Encryption Use in TLS |
+| [Iwata, Ohashi, and Minematsu 2012][IOM12] | Breaking and Repairing GCM Security Proofs (CRYPTO 2012) |
 
 [SP800-207]: https://doi.org/10.6028/NIST.SP.800-207
 [SP800-38D]: https://doi.org/10.6028/NIST.SP.800-38D
@@ -958,3 +1080,6 @@ need freshness require a trusted catalog, checkpoint, or equivalent external sta
 [RFC8017]: https://www.rfc-editor.org/rfc/rfc8017
 [RFC9449]: https://www.rfc-editor.org/rfc/rfc9449
 [RFC3339]: https://www.rfc-editor.org/rfc/rfc3339
+[RFC8446]: https://www.rfc-editor.org/rfc/rfc8446
+[LP17]: https://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf
+[IOM12]: https://eprint.iacr.org/2012/438

--- a/spec/basetdf/v5/basetdf-sec.md
+++ b/spec/basetdf/v5/basetdf-sec.md
@@ -1,0 +1,960 @@
+# BaseTDF-SEC: Security Model and Zero Trust Architecture
+
+| | |
+|---|---|
+| **Document** | BaseTDF-SEC |
+| **Title** | Security Model and Zero Trust Architecture |
+| **Version** | 5.0.0 |
+| **Status** | Standards Track |
+| **Date** | 2026-08 |
+| **Suite** | BaseTDF Specification Suite |
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [NIST SP 800-207 Zero Trust Alignment](#2-nist-sp-800-207-zero-trust-alignment)
+3. [Trust Assumptions and Boundaries](#3-trust-assumptions-and-boundaries)
+4. [Threat Model and Attack Analysis](#4-threat-model-and-attack-analysis)
+5. [Security Invariants](#5-security-invariants)
+6. [Cryptographic Requirements](#6-cryptographic-requirements)
+7. [Key Lifecycle](#7-key-lifecycle)
+8. [Post-Quantum Cryptography Migration](#8-post-quantum-cryptography-migration)
+9. [Packaging and Scale Security](#9-packaging-and-scale-security)
+10. [Normative References](#10-normative-references)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This document defines the security model for the Trusted Data Format (TDF) as
+specified by the BaseTDF suite. It establishes the threat model, trust
+assumptions, security invariants, and cryptographic requirements that all other
+documents in the suite depend upon.
+
+All normative security requirements in the BaseTDF suite trace back to this
+document. Implementers MUST satisfy the security invariants defined herein
+(Section 5) to claim conformance with any BaseTDF specification.
+
+### 1.2 Scope
+
+BaseTDF provides **data-centric zero trust security** for data objects that
+travel through untrusted channels. The security model addresses:
+
+- Protection of data at rest and in transit, independent of network or storage
+  security controls.
+- Cryptographic binding of access policy to encrypted content, such that policy
+  cannot be separated from or substituted on protected data.
+- Authorization decisions enforced at the point of key release, not at the
+  point of data access.
+- Algorithm agility to support migration from classical to post-quantum
+  cryptographic primitives.
+
+The scope explicitly includes data objects that may be copied, forwarded,
+stored on untrusted media, or transmitted over untrusted networks. The security
+model does NOT depend on the trustworthiness of any storage or transport layer.
+
+### 1.3 Relationship to Other BaseTDF Documents
+
+This document is the **foundation layer** of the BaseTDF specification suite.
+All other documents in the suite reference this document for their security
+requirements:
+
+- **BaseTDF-ALG** (Algorithm Registry) implements the cryptographic
+  requirements defined in Section 6 and the algorithm agility framework
+  described in Section 8.
+- **BaseTDF-POL** (Policy and ABAC) defines the policy structures whose
+  integrity is protected by the security invariants in Section 5.
+- **BaseTDF-KAO** (Key Access Object) implements the key protection and policy
+  binding mechanisms analyzed in Section 4.
+- **BaseTDF-KAS** (Key Access Service Protocol) implements the authorization
+  and key release protocol subject to the trust boundaries defined in
+  Section 3.
+- **BaseTDF-INT** (Integrity Verification) provides the payload integrity
+  mechanisms required by SI-5.
+- **BaseTDF-ASN** (Assertions) provides verifiable claims subject to the
+  cryptographic requirements in Section 6.
+- **BaseTDF-LOC** defines the default-deny policy for attacker-influenced
+  external resource locators.
+- **BaseTDF-PKG** defines attached, detached, and sharded storage profiles.
+- **BaseTDF-CORE** (Manifest and End-to-End Processing) defines the structure that
+  carries all security-relevant metadata.
+
+### 1.4 Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in [BCP 14][RFC2119] [RFC
+8174][RFC8174] when, and only when, they appear in ALL CAPITALS, as shown here.
+
+---
+
+## 2. NIST SP 800-207 Zero Trust Alignment
+
+BaseTDF implements a data-centric zero trust architecture aligned with NIST SP
+800-207. This section maps BaseTDF components to the NIST reference
+architecture and enumerates how BaseTDF satisfies each zero trust tenet.
+
+### 2.1 Component Mapping
+
+| NIST SP 800-207 Component | BaseTDF Equivalent |
+|---|---|
+| Policy Engine (PE) | KAS authorization logic: attribute evaluation combined with the trust algorithm (see BaseTDF-KAS Section 4) |
+| Policy Administrator (PA) | KAS key release via the rewrap endpoint; issues rewrapped key material only after successful policy evaluation |
+| Policy Enforcement Point (PEP) | Client SDK: performs encrypt and decrypt operations, enforces local integrity checks |
+| Trust Algorithm | ABAC evaluation: attribute rules, entity entitlements, dissemination list checks, and obligation resolution |
+| Subject Identity | Authenticated entity, identified by a DPoP-bound access token (see [RFC 9449][RFC9449]) |
+| Resource | The TDF-protected data object (manifest, encrypted payload, and associated metadata) |
+| Resource Requirements | The policy object embedded in the TDF: `dataAttributes` and `dissem` list (see BaseTDF-POL Section 3) |
+| Session Credentials | Rewrapped key share, scoped to a single rewrap session and bound to the client's ephemeral public key |
+| CDM / Posture Assessment | Entity attribute entitlements, externally provisioned by the identity provider and attribute authority |
+| Control Plane | KAS protocol: key management, policy evaluation, and audit (see BaseTDF-KAS) |
+| Data Plane | Encrypted TDF payload: traverses untrusted channels without requiring control plane availability |
+
+### 2.2 Zero Trust Tenets
+
+The following enumerates the seven zero trust tenets from NIST SP 800-207
+Section 2.1 and describes how BaseTDF satisfies each.
+
+#### Tenet 1: All data sources and computing services are considered resources
+
+Every TDF-protected object is a self-describing resource. Its manifest remains the
+complete authoritative record of what is protected, which policy and key-access
+paths govern it, how integrity is verified, and where protected artifacts reside.
+Version 5 may separate those bytes across storage hosts, but it does not require an
+external policy catalog. Payload discovery from a bare detached object is an
+application concern and does not weaken the manifest's authority.
+
+#### Tenet 2: All communication is secured regardless of network location
+
+BaseTDF separates data-plane security from transport-layer security. The
+encrypted payload is protected by authenticated encryption (AES-256-GCM; see
+Section 6) independent of any network controls. Key shares are protected by
+asymmetric encryption to the KAS public key. The rewrap protocol operates over
+TLS-protected channels, and the rewrapped key material is re-encrypted to the
+client's ephemeral public key, providing end-to-end protection of key material
+even if TLS is terminated at an intermediary.
+
+#### Tenet 3: Access to individual enterprise resources is granted on a per-session basis
+
+Each rewrap request is independently authorized. The KAS evaluates the entity's
+current entitlements against the TDF's policy at the time of each rewrap
+request. There is no session token or cached authorization that permits
+subsequent access without re-evaluation. The rewrapped key share is bound to
+the client's ephemeral public key and MUST NOT be reusable across sessions.
+
+#### Tenet 4: Access to resources is determined by dynamic policy
+
+Policy evaluation occurs at rewrap time, not at creation time. When an entity
+requests access to a TDF, the KAS evaluates the policy embedded in the TDF
+against the entity's **current** attribute entitlements as reported by the
+authorization service. Changes to entity entitlements, attribute definitions, or
+policy rules take effect on the next rewrap request without requiring
+re-encryption of the TDF.
+
+#### Tenet 5: The enterprise monitors and measures the integrity and security posture of all owned and associated assets
+
+The KAS MUST log every rewrap attempt (see SI-8). These audit records include
+the entity identity, policy UUID, algorithm, KAS key identifier, and the
+permit/deny result. These records provide the observability surface required for
+security monitoring, anomaly detection, and compliance reporting.
+
+#### Tenet 6: All resource authentication and authorization are dynamic and strictly enforced before access is allowed
+
+Entity authentication uses DPoP-bound access tokens ([RFC 9449][RFC9449]),
+which provide proof-of-possession binding between the access token and the
+client's cryptographic key. The KAS verifies the DPoP proof, validates the
+access token, evaluates the policy, and only then releases the rewrapped key
+material. The Signed Request Token (SRT) further binds the rewrap request
+payload to the DPoP key, preventing token replay and request substitution.
+
+#### Tenet 7: The enterprise collects as much information as possible about the current state of assets, network infrastructure, and communications and uses it to improve its security posture
+
+Rewrap audit events (SI-8) provide structured data suitable for ingestion into
+SIEM and analytics platforms. Each event captures the entity, the policy, the
+access decision, the algorithm used, and the KAS key involved. Aggregation of
+these events enables detection of anomalous access patterns, policy
+misconfiguration, and credential compromise.
+
+---
+
+## 3. Trust Assumptions and Boundaries
+
+### 3.1 Trusted Components
+
+The following components are assumed to operate in a trusted environment with
+adequate physical, logical, and operational security controls.
+
+#### 3.1.1 Key Access Service (KAS)
+
+The KAS is the root of trust for key release. It holds or has delegated access
+to the private keys corresponding to the KAS public keys used to wrap DEK
+shares. The KAS:
+
+- Operates in a trusted execution environment with access controls on its
+  private key material.
+- Is trusted to correctly evaluate policy and enforce authorization decisions.
+- Is trusted to correctly perform cryptographic operations (unwrap, rewrap,
+  HMAC verification).
+- Is trusted to produce accurate and complete audit logs.
+
+Compromise of the KAS private key material allows an attacker to decrypt any
+TDF whose KAO references that key. Implementations SHOULD use hardware
+security modules (HSMs) or equivalent key protection mechanisms for KAS private
+keys.
+
+#### 3.1.2 Authorization Service
+
+The authorization service (policy decision point) is trusted to:
+
+- Correctly resolve entity attribute entitlements from the identity provider.
+- Correctly evaluate attribute-based access control rules.
+- Return accurate permit/deny decisions to the KAS.
+
+The authorization service operates within the same trust boundary as the KAS
+and communicates with it over authenticated, integrity-protected channels.
+
+#### 3.1.3 Identity Provider
+
+The identity provider is trusted to:
+
+- Correctly authenticate entities.
+- Issue access tokens that accurately represent entity identity and, where
+  applicable, bind to DPoP keys.
+- Maintain the confidentiality of signing keys used for token issuance.
+
+### 3.2 Partially Trusted Components
+
+#### 3.2.1 Client SDK
+
+The client SDK is trusted to:
+
+- Correctly implement encryption and integrity operations during TDF creation.
+- Correctly implement decryption, integrity verification, and policy binding
+  validation during TDF consumption.
+- Enforce local security controls, including withholding or stopping plaintext
+  release on integrity failure per SI-5.
+
+The client SDK is NOT trusted to:
+
+- Hold decrypted key material beyond the duration of a single operation. Key
+  material MUST be securely erased after use (SI-7).
+- Cache or persist authorization decisions. Each access MUST result in a new
+  rewrap request.
+- Make access control decisions independently of the KAS.
+
+### 3.3 Untrusted Components
+
+The following components are considered untrusted. The security model provides
+confidentiality and integrity guarantees even when these components are fully
+compromised.
+
+#### 3.3.1 Storage
+
+TDF objects MAY be stored on any medium, including public cloud storage,
+removable media, email systems, or shared file systems. The storage layer is
+not trusted for confidentiality or integrity. The authenticated encryption of
+the payload and the cryptographic binding of the policy provide these
+guarantees independent of storage.
+
+#### 3.3.2 Network
+
+TDF objects MAY traverse any network, including the public internet, without
+loss of confidentiality or integrity. While TLS SHOULD be used for rewrap
+protocol communications, the security model does not depend solely on transport
+encryption: key material in transit during rewrap is protected by asymmetric
+encryption to the client's public key.
+
+#### 3.3.3 Intermediaries
+
+Any entity that handles, forwards, caches, or indexes TDF objects (e.g., email
+gateways, CDN nodes, search indexers) is untrusted. These intermediaries can
+observe the encrypted payload and the cleartext manifest metadata, but cannot
+access the plaintext content or modify the payload without detection.
+
+### 3.4 Trust Boundaries
+
+```
+                    TRUSTED BOUNDARY
+   ┌─────────────────────────────────────────────┐
+   │                                             │
+   │  ┌──────────┐    ┌────────────────────┐     │
+   │  │   KAS    │◄──►│ Authorization Svc  │     │
+   │  │          │    │ (Policy Decision)  │     │
+   │  └────▲─────┘    └────────────────────┘     │
+   │       │                                     │
+   └───────┼─────────────────────────────────────┘
+           │ Boundary B1: rewrap protocol (TLS + DPoP)
+           │
+   ┌───────┼─────────────────────────────────────┐
+   │       │         PARTIALLY TRUSTED            │
+   │  ┌────▼─────┐                               │
+   │  │  Client  │                               │
+   │  │  SDK     │                               │
+   │  └────┬─────┘                               │
+   └───────┼─────────────────────────────────────┘
+           │ Boundary B2: data plane (no trust required)
+           │
+   ┌───────┼─────────────────────────────────────┐
+   │       ▼              UNTRUSTED              │
+   │  ┌──────────┐  ┌──────────┐  ┌──────────┐  │
+   │  │ Storage  │  │ Network  │  │ Intermed. │  │
+   │  └──────────┘  └──────────┘  └──────────┘  │
+   └─────────────────────────────────────────────┘
+```
+
+**Boundary B1** (Client to KAS): This is the critical trust boundary. The
+rewrap protocol crosses this boundary. Communications MUST be protected by TLS.
+Entity authentication MUST use DPoP-bound access tokens for production
+deployments (SI-4). The SRT binds the request payload to the authenticated
+entity.
+
+**Boundary B2** (Client to Untrusted): TDF objects cross this boundary. No
+trust is required. The encrypted payload and cryptographic policy binding
+provide the necessary security guarantees.
+
+---
+
+## 4. Threat Model and Attack Analysis
+
+### 4.1 Adversary Model
+
+The adversary is assumed to have the following capabilities:
+
+- Full read access to all TDF objects (encrypted payload, manifest, metadata).
+- Full control of the network between the client and any service (active
+  man-in-the-middle), subject to TLS protections.
+- Ability to create, modify, and replay TDF objects and rewrap requests.
+- Access to their own valid credentials and entitlements for the KAS.
+- Computational resources bounded by classical (and, for Section 8,
+  quantum) computing limits.
+
+The adversary does NOT have:
+
+- Access to the KAS private key material.
+- Access to another entity's valid credentials or private keys.
+- The ability to compromise the authorization service's decision logic.
+
+### 4.2 Attacks That Are Mitigated
+
+| Attack | Description | Why It Fails |
+|---|---|---|
+| **Policy tampering** | Attacker modifies the base64-encoded policy object in the manifest to alter access rules. | The policy binding (HMAC of the policy computed with the DEK share as key) detects any modification. KAS verifies the binding before key release (SI-1). The attacker cannot recompute the HMAC without the DEK share, which is encrypted to the KAS public key. |
+| **KAO substitution** | Attacker replaces a KAO with one they created, wrapping a known key to a KAS they control or to the legitimate KAS. | If the attacker wraps to their own KAS, the legitimate KAS will not have the corresponding private key and cannot unwrap. If the attacker wraps to the legitimate KAS, the DEK share they chose will not reconstruct the correct DEK (the other splits remain unknown), and the policy binding will not match the original policy unless the attacker also controls all other splits. |
+| **Split manipulation** | Attacker attempts to recover the DEK by manipulating or observing individual key splits. | XOR-based key splitting is information-theoretically secure: any individual split is uniformly random and independent of the DEK. An attacker must obtain all splits to reconstruct the DEK. Each split is independently encrypted to a different KAS key. |
+| **Cross-TDF replay** | Attacker copies a KAO from one TDF and inserts it into another TDF's manifest to gain unauthorized access. | Each KAO contains a policy binding that is an HMAC computed over the specific policy of the TDF it belongs to, keyed by the DEK share. Since different TDFs have different policies and different DEK shares, the binding will not verify against the target TDF's policy. |
+| **Policy binding forgery** | Attacker attempts to forge a valid policy binding for a modified policy without knowing the DEK share. | The DEK share is protected by IND-CCA2 asymmetric encryption (RSA-OAEP or ECIES). Without the KAS private key, the attacker cannot recover the DEK share and therefore cannot compute a valid HMAC for any policy. |
+| **Algorithm downgrade** | Attacker modifies algorithm identifiers in the manifest to force use of weaker algorithms. | Algorithm fields are validated by the KAS against the algorithm registry (see BaseTDF-ALG). KAS MUST reject KAOs with unrecognized algorithm identifiers (SI-6). For implicit key types (e.g., `wrapped` implies RSA, `ec-wrapped` implies ECDH), the algorithm is determined by the key type and cannot be overridden by manifest fields. |
+| **Rewrap request replay** | Attacker captures a valid rewrap request and replays it to obtain the rewrapped key. | The SRT contains temporal claims (`iat`, `exp`) and is signed with the DPoP key. The KAS validates these claims with a bounded acceptable skew. Replayed requests will fail temporal validation. The rewrapped key is encrypted to the client's ephemeral public key from the original request; even if replay succeeds, the attacker cannot decrypt the response without the corresponding private key. |
+| **Payload modification** | Attacker modifies the encrypted payload (ciphertext, segment data). | AES-GCM authenticated encryption detects any modification of ciphertext or associated data. Segment hashes and the root signature provide additional integrity verification (SI-5). Clients MUST verify integrity before returning decrypted data. |
+
+### 4.3 Attacks with Residual Risk
+
+| Attack | Risk Level | Description | Mitigation |
+|---|---|---|---|
+| **MITM without DPoP** | MEDIUM | If DPoP is not enforced, an attacker who compromises a bearer access token can perform rewrap requests on behalf of the token holder. The attacker obtains the rewrapped key encrypted to their chosen public key. | DPoP MUST be required for production deployments (SI-4). Without DPoP, access tokens are bearer tokens and susceptible to theft via token exfiltration, log leakage, or TLS interception. |
+| **Chosen-policy oracle** | LOW | An attacker with valid credentials creates TDFs with crafted policies and observes whether rewrap succeeds or fails, potentially mapping the attribute entitlements of other entities if the KAS returns distinguishable error responses for policy evaluation failures versus other failures. | KAS SHOULD return uniform error responses for all access denial reasons. Specifically, policy evaluation failures, dissemination check failures, and attribute resolution failures SHOULD produce identical error codes and messages to the client. The KAS MAY log detailed failure reasons internally for audit purposes. |
+| **Encrypted metadata processing** | LOW | The `encryptedMetadata` field in a KAO is encrypted with the DEK share. If a KAS implementation decrypts and processes this metadata before verifying the policy binding, a crafted TDF could exploit parsing vulnerabilities in the metadata processor. | `encryptedMetadata` MUST NOT be decrypted or processed until after successful policy binding verification (SI-1) and authorization (SI-2). Implementations SHOULD treat decrypted metadata as untrusted input subject to validation. |
+| **Timing side channels** | LOW | Timing differences in HMAC comparison or cryptographic operations could leak information about key material or policy binding values. | Policy binding verification MUST use constant-time comparison (SI-1). Implementations SHOULD use constant-time cryptographic primitives throughout the rewrap path. |
+| **Entity attribute enumeration** | LOW | An attacker with valid credentials systematically probes the KAS with TDFs containing different attribute combinations to map which attributes they hold. | KAS SHOULD implement rate limiting on rewrap requests per entity (see Section 4.4). Rewrap audit logs (SI-8) enable detection of enumeration patterns. |
+
+### 4.4 Identified Implementation Gaps
+
+The following gaps represent areas where the specification requires behavior
+that implementations MUST or SHOULD address but where current practice may be
+inconsistent.
+
+| Gap | Severity | Specification Treatment |
+|---|---|---|
+| **Dissemination list not enforced** | CRITICAL | When the policy body contains a non-empty `dissem` list, the KAS MUST verify that the authenticated entity's identity appears in the dissemination list before releasing any key material (SI-3). Implementations that skip this check are non-conformant. See BaseTDF-POL Section 4. |
+| **`policyBinding.alg` not validated** | MEDIUM | When the policy binding is expressed as an object with `alg` and `hash` fields, the KAS MUST validate the `alg` field against the set of supported binding algorithms (currently: `HS256` for HMAC-SHA256). The KAS MUST reject KAOs whose `policyBinding.alg` specifies an unrecognized or unsupported algorithm (SI-6). When the policy binding is a bare string (legacy format), the binding algorithm MUST default to `HS256`. |
+| **No rate limiting on rewrap** | LOW | Implementations SHOULD enforce rate limits on rewrap requests per authenticated entity to mitigate credential abuse and attribute enumeration attacks. The specific rate limits are deployment-dependent and outside the scope of this specification. |
+| **All splits assigned to the same KAS** | LOW | When all KAOs in a split key configuration reference the same KAS URL, the security benefit of key splitting is reduced to a single point of compromise. Implementations SHOULD warn when creating TDFs where all splits are assigned to a single KAS. This does not affect correctness but reduces the defense-in-depth benefit of the split key architecture. |
+| **Legacy KAOs without `kid` field** | MEDIUM | KAOs that omit the `kid` (key identifier) field force the KAS to attempt decryption with multiple legacy keys, increasing computational cost and potential for oracle attacks. New TDF implementations MUST include a `kid` field in all KAOs. KAS implementations MUST support `kid`-less KAOs for backward compatibility but SHOULD log a warning. |
+
+---
+
+## 5. Security Invariants
+
+The following security invariants are normative requirements. Other documents
+in the BaseTDF suite reference these invariants by their identifiers (SI-1
+through SI-8). An implementation MUST satisfy all security invariants to claim
+conformance with this specification.
+
+### SI-1: Policy Binding Integrity
+
+**KAS MUST verify that the policy binding matches the policy before any key
+release.**
+
+Specifically:
+
+1. The KAS MUST compute HMAC-SHA256 over the base64-encoded policy body using
+   the unwrapped DEK share as the HMAC key.
+2. The KAS MUST compare the computed HMAC with the `policyBinding.hash` value
+   from the KAO.
+3. The comparison MUST use a constant-time algorithm (e.g., `hmac.Equal` in Go,
+   `crypto.timingSafeEqual` in Node.js) to prevent timing side-channel attacks.
+4. If the comparison fails, the KAS MUST reject the KAO and MUST NOT return
+   any key material derived from the corresponding DEK share.
+5. The KAS MUST NOT decrypt or process `encryptedMetadata` before successful
+   policy binding verification.
+
+### SI-2: Authorization Before Key Release
+
+**KAS MUST evaluate the policy against the entity's current entitlements
+BEFORE returning any rewrapped key material.**
+
+Specifically:
+
+1. The KAS MUST extract the data attributes from the TDF's policy object.
+2. The KAS MUST submit the data attributes and the entity's token to the
+   authorization service for evaluation.
+3. The KAS MUST receive an explicit permit decision before proceeding with
+   key rewrap.
+4. If the authorization service returns a deny decision or is unavailable,
+   the KAS MUST NOT return any key material.
+5. Authorization evaluation MUST occur for every rewrap request. Caching of
+   authorization decisions across requests is NOT RECOMMENDED, as it defeats
+   the dynamic policy evaluation principle (Section 2.2, Tenet 4).
+
+### SI-3: Dissemination Enforcement
+
+**When the policy body contains a non-empty `dissem` list, the KAS MUST verify
+that the authenticated entity is in the dissemination list.**
+
+Specifically:
+
+1. The KAS MUST extract the `dissem` array from the policy body.
+2. If the `dissem` array is non-empty, the KAS MUST verify that the
+   authenticated entity's identity (as determined from the access token's
+   `sub` claim or equivalent) matches at least one entry in the `dissem` list.
+3. The matching algorithm SHOULD be case-insensitive for email-format
+   identifiers.
+4. If the entity is not in the dissemination list, the KAS MUST deny the
+   rewrap request and MUST NOT return any key material.
+5. Dissemination checks are in addition to, not a replacement for, attribute-
+   based access control evaluation (SI-2).
+
+### SI-4: DPoP Binding
+
+**For production deployments, rewrap requests MUST include DPoP proof binding
+the client's public key to the access token.**
+
+Specifically:
+
+1. The client MUST include a DPoP proof as defined in [RFC 9449][RFC9449] with
+   the rewrap request.
+2. The KAS MUST verify that the DPoP proof is bound to the access token
+   presented with the request.
+3. The KAS MUST verify the DPoP proof signature using the public key embedded
+   in the DPoP proof header.
+4. The Signed Request Token (SRT) MUST be signed with the same key as the DPoP
+   proof, establishing a binding chain: DPoP key -> access token -> SRT ->
+   rewrap request body.
+5. Deployments that do not enforce DPoP MUST document this as a known
+   deviation from the security model and MUST implement compensating controls
+   (e.g., short-lived tokens, network-level access controls).
+
+### SI-5: Payload Integrity Verification
+
+**Clients MUST authenticate every released plaintext segment to the DEK-keyed root.
+They MUST distinguish selected-range verification from whole-object verification.**
+
+Specifically:
+
+1. For an explicit layout, the client MUST authenticate the complete hash table and
+   root before decrypting a segment.
+2. For a scalable layout, a selected segment MUST have its index/size-bound leaf,
+   inclusion path, layout, count, total sizes, and root signature authenticated
+   before its plaintext is released.
+3. The client MUST recompute the segment hash from actual ciphertext, validate the
+   deterministic IV when required, and verify the AEAD tag during decryption.
+4. Whole-object success MUST be reported only after every segment and the complete
+   root have been verified. Selected-range success MUST identify its narrower scope.
+5. Any failure MUST stop further plaintext. A non-streaming operation MUST discard
+   buffered plaintext. A streaming operation MUST signal the failure; already
+   released, previously authenticated segments cannot be recalled.
+6. BaseTDF-INT defines the detailed verification and release order.
+
+### SI-6: Algorithm Validation
+
+**KAS MUST reject KAOs with unrecognized `alg` or `policyBinding.alg` values.**
+
+Specifically:
+
+1. The KAS MUST maintain a set of supported algorithms consistent with the
+   BaseTDF-ALG registry.
+2. When processing a KAO, the KAS MUST validate that the key type (`type`
+   field: `wrapped`, `ec-wrapped`) is recognized and supported.
+3. When the `policyBinding` is an object, the KAS MUST validate that the
+   `alg` field is a recognized policy binding algorithm.
+4. The KAS MUST reject the KAO and return an error if any algorithm field
+   contains an unrecognized value.
+5. The KAS MUST NOT fall back to a default algorithm when an explicitly
+   specified algorithm is unrecognized.
+
+### SI-7: Key Material Hygiene
+
+**Plaintext DEK shares MUST be securely erased from memory after use, on both
+the client and KAS side.**
+
+Specifically:
+
+1. After the KAS has verified the policy binding and re-encrypted the DEK
+   share to the client's public key, the plaintext DEK share MUST be erased
+   from KAS memory.
+2. After the client has reconstructed the DEK from its shares and decrypted
+   the payload, the DEK and all individual shares MUST be erased from client
+   memory.
+3. Secure erasure MUST overwrite the memory occupied by key material with
+   zeros or random data before deallocation.
+4. Implementations SHOULD use language-specific secure erasure facilities
+   (e.g., `crypto/subtle.XORBytes` with zeroing in Go, `SecureZeroMemory` on
+   Windows, `explicit_bzero` on POSIX systems) to prevent compiler
+   optimizations from eliding the erasure.
+5. Key material MUST NOT be written to persistent storage in plaintext, logged,
+   or included in error messages.
+
+### SI-8: Audit Logging
+
+**KAS MUST log every rewrap attempt with sufficient detail for security
+monitoring and forensic analysis.**
+
+Each audit record MUST include at minimum:
+
+1. **Entity identity**: The `sub` claim from the authenticated access token,
+   and the client identifier where available.
+2. **Policy UUID**: The unique identifier of the policy being evaluated.
+3. **Algorithm**: The key access algorithm (e.g., `rsa:2048`, `ec:secp256r1`).
+4. **KAS key identifier**: The `kid` of the KAS key used for unwrapping (or
+   an indication that legacy key lookup was used).
+5. **Policy binding**: The `policyBinding.hash` value from the KAO.
+6. **Access decision**: `permit` or `deny`.
+7. **Timestamp**: The time of the rewrap attempt in [RFC 3339][RFC3339] format.
+8. **Request context**: The requesting client's IP address and user agent,
+   where available.
+
+Audit records for denied requests MUST NOT include any key material. Audit
+records for permitted requests MUST NOT include the plaintext DEK share or the
+rewrapped key.
+
+Audit records SHOULD be emitted as structured data (e.g., JSON) suitable for
+ingestion by SIEM platforms.
+
+---
+
+## 6. Cryptographic Requirements
+
+### 6.1 Symmetric Encryption
+
+The payload MUST be encrypted using an AEAD (Authenticated Encryption with
+Associated Data) algorithm.
+
+| Algorithm | Key Size | Status | Reference |
+|---|---|---|---|
+| AES-256-GCM | 256 bits | REQUIRED | [NIST SP 800-38D][SP800-38D] |
+| AES-128-GCM | 128 bits | NOT RECOMMENDED | [NIST SP 800-38D][SP800-38D] |
+
+Implementations MUST support AES-256-GCM. AES-128-GCM MAY be supported for
+backward compatibility but MUST NOT be used for new TDF creation.
+
+See BaseTDF-ALG Section 3 for the complete algorithm registry.
+
+### 6.2 Asymmetric Key Encapsulation
+
+DEK shares are encapsulated (wrapped) using the KAS public key. The following
+algorithms are defined:
+
+| Algorithm | Minimum Key Size | Status | Reference |
+|---|---|---|---|
+| RSA-OAEP (SHA-1 MGF) | 2048 bits | REQUIRED (legacy) | [RFC 8017][RFC8017] |
+| RSA-OAEP (SHA-256 MGF) | 4096 bits | RECOMMENDED | [RFC 8017][RFC8017] |
+| ECDH + HKDF-SHA256 + AES-256-GCM | P-256 / P-384 / P-521 | RECOMMENDED | [NIST SP 800-56A][SP800-56A] |
+
+- RSA key sizes below 2048 bits MUST NOT be used.
+- RSA-2048 MUST be supported for backward compatibility with existing TDFs.
+- RSA-4096 is RECOMMENDED for new deployments.
+- ECDH with NIST P-256 or stronger curves is RECOMMENDED for new TDF creation.
+- See BaseTDF-ALG Section 4 for algorithm identifiers and detailed parameters.
+
+### 6.3 Policy Binding
+
+| Algorithm | Identifier | Status |
+|---|---|---|
+| HMAC-SHA256 | `HS256` | REQUIRED |
+
+The policy binding MUST be computed as:
+
+```
+HMAC-SHA256(key=DEK_share, message=base64encode(policy))
+```
+
+The result is hex-encoded and then base64-encoded for storage in the
+`policyBinding.hash` field. See BaseTDF-KAO Section 5 for the detailed
+procedure.
+
+### 6.4 Integrity
+
+| Purpose | Algorithm | Status |
+|---|---|---|
+| Segment hashing | GMAC (from AES-GCM) or HMAC-SHA256 | REQUIRED |
+| Explicit root signature | HMAC-SHA256 | REQUIRED |
+| Scalable root signature | `MERKLE-HS256` | REQUIRED |
+| Partition key derivation | `HKDF-SHA256` | REQUIRED when present |
+
+See BaseTDF-INT for the detailed integrity verification scheme.
+
+### 6.5 Random Number Generation
+
+All key generation and nonce/IV generation MUST use a cryptographically secure
+pseudorandom number generator (CSPRNG) seeded from an operating system entropy
+source.
+
+Specifically:
+
+- Go implementations MUST use `crypto/rand`.
+- JavaScript implementations MUST use `crypto.getRandomValues()` or the Node.js
+  `crypto.randomBytes()` API.
+- Implementations MUST NOT use non-cryptographic PRNGs (e.g., `math/rand` in
+  Go, `Math.random()` in JavaScript) for any security-relevant purpose.
+
+### 6.6 IV/Nonce Uniqueness
+
+For AES-GCM:
+
+- The IV/nonce MUST be 96 bits (12 bytes).
+- The IV/nonce MUST be unique for every encryption operation under the same
+  key.
+- For `uniform` and `indexed`, writers MUST use
+  `noncePrefix[4] || u64be(segmentIndex)` and readers MUST verify the prepended IV.
+  `noncePrefix` MUST be generated by a CSPRNG for each TDF.
+- For `explicit`, each segment MUST use a distinct IV; the deterministic scalable
+  construction MAY be used.
+- Nonce reuse under the same key catastrophically compromises both
+  confidentiality and integrity. Implementations MUST ensure uniqueness
+  through deterministic construction or verified-random generation.
+
+### 6.7 Minimum Key Sizes
+
+| Key Type | Minimum | Recommended | Maximum |
+|---|---|---|---|
+| AES (payload encryption) | 256 bits | 256 bits | 256 bits |
+| RSA (key encapsulation) | 2048 bits | 4096 bits | -- |
+| EC (key encapsulation) | P-256 (256 bits) | P-384 (384 bits) | P-521 (521 bits) |
+| HMAC (policy binding) | 256 bits (from DEK share) | 256 bits | -- |
+
+---
+
+## 7. Key Lifecycle
+
+This section defines the lifecycle stages for cryptographic key material in the
+BaseTDF system.
+
+### 7.1 Generation
+
+**DEK (Data Encryption Key)**:
+
+- The DEK MUST be generated using a CSPRNG (Section 6.5).
+- The DEK MUST be at least 256 bits for AES-256-GCM.
+- The DEK MUST have full entropy (i.e., generated uniformly at random, not
+  derived from low-entropy sources such as passwords).
+
+**DEK Shares**:
+
+- When key splitting is used (see BaseTDF-KAO Section 3), the DEK MUST be
+  split into N shares using XOR-based splitting.
+- Each share MUST be the same size as the DEK.
+- All shares except the last MUST be generated independently using a CSPRNG.
+  The last share is computed as the XOR of the DEK and all preceding shares.
+
+**KAS Key Pairs**:
+
+- KAS asymmetric key pairs MUST be generated using a CSPRNG with key sizes
+  meeting the minimums in Section 6.7.
+- Key generation SHOULD occur within an HSM or equivalent trusted key
+  management system.
+
+### 7.2 Wrapping
+
+- Each DEK share MUST be wrapped (encrypted) to the public key of the KAS
+  identified in the KAO's `url` field.
+- The wrapping algorithm is determined by the KAO `type` field: `wrapped` for
+  RSA-OAEP, `ec-wrapped` for ECDH-based key encapsulation.
+- The wrapped key MUST be stored in the KAO's `wrappedKey` field.
+- The wrapping operation MUST use the algorithm parameters specified in
+  BaseTDF-ALG for the indicated key type.
+- A policy binding MUST be computed and stored alongside the wrapped key, as
+  specified in BaseTDF-KAO Section 5.
+
+### 7.3 Storage
+
+- Wrapped DEK shares are stored within the TDF manifest as part of the KAO.
+  They are encrypted and MAY be stored on untrusted media.
+- Plaintext DEK material (the DEK itself and unwrapped shares) MUST NOT be
+  persisted to any storage medium.
+- KAS private keys MUST be stored encrypted at rest when not in active use.
+  HSM-based storage is RECOMMENDED.
+
+### 7.4 Rewrap
+
+- During a rewrap operation, the KAS unwraps the DEK share using its private
+  key, then re-encrypts (rewraps) the share to the client's ephemeral public
+  key.
+- The rewrap operation MUST follow the procedure specified in BaseTDF-KAS.
+- The rewrapped key is scoped to the single rewrap session: it is encrypted
+  to the client's ephemeral public key provided in the rewrap request.
+- The KAS MUST NOT return the plaintext DEK share; it MUST only return the
+  re-encrypted form.
+
+### 7.5 Destruction
+
+- After the KAS completes the rewrap operation, the plaintext DEK share MUST
+  be securely erased from KAS memory (SI-7).
+- After the client reconstructs the DEK and completes decryption, the DEK and
+  all shares MUST be securely erased from client memory (SI-7).
+- When KAS key pairs are rotated or decommissioned, the private key material
+  MUST be securely destroyed after a transition period during which existing
+  TDFs are either re-encrypted to the new key or archived.
+- Key destruction MUST follow the same secure erasure requirements as SI-7.
+
+---
+
+## 8. Post-Quantum Cryptography Migration
+
+### 8.1 Harvest-Now-Decrypt-Later (HNDL) Threat
+
+Adversaries with access to TDF objects today may store the encrypted data and
+the accompanying manifest (including wrapped DEK shares) with the intent of
+decrypting them once a cryptographically relevant quantum computer (CRQC)
+becomes available. This "harvest-now-decrypt-later" (HNDL) threat applies to
+any TDF whose confidentiality requirements extend beyond the expected timeline
+for CRQC development.
+
+Organizations SHOULD assess their data's confidentiality lifetime against
+current CRQC timelines. Data with confidentiality requirements exceeding 10
+years SHOULD be protected with post-quantum algorithms.
+
+### 8.2 Quantum-Vulnerable Components
+
+The following BaseTDF components rely on classical asymmetric cryptography that
+is vulnerable to quantum attacks:
+
+| Component | Classical Algorithm | Quantum Vulnerability |
+|---|---|---|
+| DEK share wrapping (RSA) | RSA-OAEP | Shor's algorithm breaks RSA |
+| DEK share wrapping (EC) | ECDH + HKDF | Shor's algorithm breaks ECDH |
+| DPoP proof signatures | RS256, ES256 | Shor's algorithm breaks RSA/ECDSA |
+| Assertion signatures (JWS) | RS256, ES256 | Shor's algorithm breaks RSA/ECDSA |
+
+The following components are NOT vulnerable to quantum attacks at their
+specified security levels:
+
+| Component | Algorithm | Quantum Security |
+|---|---|---|
+| Payload encryption | AES-256-GCM | Grover's algorithm reduces to 128-bit (sufficient) |
+| Policy binding | HMAC-SHA256 | Quantum-resistant |
+| Segment hashing | HMAC-SHA256 / GMAC | Quantum-resistant |
+
+### 8.3 Direct Post-Quantum Transition Strategy
+
+To mitigate the HNDL threat, BaseTDF adopts a **direct transition strategy**:
+deployments move from a classical key protection algorithm to a pure ML-KEM
+algorithm, without an intervening hybrid PQ/T step.
+
+BaseTDF-ALG deliberately defines no hybrid post-quantum/traditional (PQ/T) key
+protection algorithms (BaseTDF-ALG Section 3.2). BaseTDF targets the algorithm
+set supported by existing FIPS 203-compliant hardware security modules, which
+do not currently -- and may never -- support composite PQ/T KEM constructions.
+A hybrid algorithm that cannot be executed inside the HSM would force the KAS
+private key material into software, trading a speculative cryptanalytic risk
+for a concrete key-custody one.
+
+The security consequences of this choice are:
+
+1. **No classical floor**: A pure ML-KEM KAO derives all of its confidentiality
+   from ML-KEM. A cryptanalytic break of ML-KEM would expose the DEK share with
+   no classical algorithm underneath it. Deployments that judge this risk
+   unacceptable can obtain a comparable property at the manifest layer by
+   splitting the DEK (Section 3 of BaseTDF-KAO) across one ML-KEM KAO and one
+   classical KAO, which requires an attacker to break both.
+2. **No downgrade path**: Because no hybrid identifier exists, an attacker
+   cannot substitute a hybrid KAO for a pure ML-KEM one to force a weaker
+   construction. Unrecognized `alg` values MUST be rejected (SI-6).
+3. **Migration is per-KAS-key**: Transitioning a deployment means provisioning
+   ML-KEM key pairs on the KAS and re-encrypting or re-keying existing TDFs, not
+   negotiating a combined algorithm.
+
+Should HSM support for composite PQ/T KEMs materialize, hybrid algorithms can be
+added to the BaseTDF-ALG registry without structural changes to the manifest.
+
+### 8.4 Algorithm Agility
+
+The BaseTDF-ALG registry provides the algorithm agility framework. New
+algorithms (including post-quantum algorithms) can be added to the registry
+without modifying the core TDF structure. The `type` field of the KAO and the
+`alg` fields throughout the manifest serve as extension points for new
+algorithms.
+
+Implementations MUST be prepared to encounter KAOs with algorithm identifiers
+they do not recognize. Unrecognized algorithms MUST be rejected (SI-6), not
+silently ignored or downgraded.
+
+### 8.5 Recommended Migration Path
+
+The recommended migration path for key encapsulation algorithms is:
+
+```
+Phase 1 (Classical)        Phase 2 (Post-Quantum)
+───────────────────        ──────────────────────
+ECDH + HKDF (P-256+)   →   ML-KEM-768 / ML-KEM-1024
+RSA-OAEP (2048+)       →   (pure PQC)
+```
+
+**Phase 1** (classical): Classical algorithms as specified in Section 6.2.
+Suitable for data with confidentiality requirements under 10 years or where
+PQC support is not yet available in the deployment's KAS hardware.
+
+**Phase 2** (post-quantum): Pure post-quantum algorithms -- `ML-KEM-768` or
+`ML-KEM-1024`, defined in BaseTDF-ALG Section 5. This is the RECOMMENDED
+configuration for new deployments concerned with HNDL threats. Its timeline
+depends on ML-KEM availability in the KAS key store (including HSM firmware
+support for `CKM_ML_KEM_KEY_DECAP` or equivalent).
+
+A deployment MAY run both phases concurrently: the KAS can hold classical and
+ML-KEM key pairs simultaneously, and different TDFs -- or different KAOs within
+one TDF -- can use different algorithms. Splitting a DEK across an ML-KEM KAO
+and a classical KAO under distinct `sid` values yields a manifest-layer
+equivalent of hybrid protection (see Section 8.3).
+
+### 8.6 Signature Migration
+
+For assertion signatures and DPoP proofs, the migration path is:
+
+```
+Phase 1 (Classical)    Phase 2 (Post-Quantum)
+───────────────────    ──────────────────────
+ES256 / RS256      →   ML-DSA-44 / ML-DSA-65
+```
+
+ML-DSA (FIPS 204) is the RECOMMENDED post-quantum signature algorithm for
+BaseTDF. The registered identifiers are `ML-DSA-44` and `ML-DSA-65`
+(BaseTDF-ALG Sections 6.5 and 6.6). As with key protection, BaseTDF-ALG defines
+no composite (hybrid) signature algorithms; a deployment requiring both a
+classical and a post-quantum signature can attach two assertions, each signed
+under a different algorithm.
+
+### 8.7 Timeline Considerations
+
+This specification does not mandate specific migration deadlines. The
+following NIST publications inform timeline planning:
+
+- **FIPS 203** (ML-KEM): Finalized August 2024. Implementations MAY begin
+  adoption.
+- **FIPS 204** (ML-DSA): Finalized August 2024. Implementations MAY begin
+  adoption.
+- **NIST deprecation timeline**: NIST has indicated intent to deprecate
+  112-bit classical security (RSA-2048, P-256) by 2030 and disallow by 2035.
+
+Organizations SHOULD develop PQC migration plans that align with their data
+retention and confidentiality requirements.
+
+---
+
+## 9. Packaging and Scale Security
+
+### 9.1 Compartmentalization
+
+Detachment changes which storage role observes which bytes:
+
+| Role/profile | Attached | Detached or sharded |
+|---|---|---|
+| Attached storage host | Ciphertext plus manifest metadata | Not applicable |
+| Payload host | Not separate | Ciphertext, encrypted sizes, request timing; no policy, KAS URLs, attribute identifiers, assertions, or plaintext MIME type |
+| Manifest host | Not separate | Policy, KAOs, KAS URLs, attribute identifiers, assertions, MIME type, sizes, and payload/tree locators; no ciphertext |
+| Authorized reader | Manifest, ciphertext, and recovered plaintext | Manifest, fetched ciphertext, and recovered plaintext |
+
+By storage role alone, neither detached host has enough material to reconstruct the
+protected object. This is compartmentalization, not metadata confidentiality: the
+manifest host sees cleartext metadata. An actor that also gains authorization,
+credentials, locators, and the missing artifact may cross these boundaries.
+
+### 9.2 Manifest tampering, locators, and SSRF
+
+Detached and sharded manifests require an asymmetric publisher signature before
+locator use. It authenticates provenance and routing fields but does not make a
+publisher-supplied origin safe. Readers MUST additionally apply the default-deny
+scheme/origin, redirect, credential, address, and size rules in BaseTDF-LOC.
+Arbitrary fetches from unauthenticated or merely self-signed manifests are an SSRF
+vulnerability.
+
+The DEK-keyed root, not the publisher signature, binds fetched ciphertext to the
+manifest. Both checks are required.
+
+### 9.3 Multiple manifests
+
+Every manifest over one ciphertext must ultimately recover the same DEK. Therefore
+the effective access set is the union of every policy in every published manifest
+that wraps that DEK. A less restrictive second manifest widens access to the
+original payload; it does not coexist as a separately enforced view. Differentiated
+cryptographic access requires a distinct DEK and re-encryption.
+
+### 9.4 Correlation
+
+Manifest and payload fetches often occur close together and may be relinked through
+timing, client identity, IP address, credentials, or object size. Detachment does not
+prevent traffic analysis. The optional unkeyed `contentBinding` is an additional
+stable correlation handle across tenants and copies; writers SHOULD omit it unless
+deduplication or content addressing justifies the privacy cost.
+
+### 9.5 Crypto-shredding limits
+
+Destroying all copies and backups of a detached manifest removes its stored KAOs
+and can remove the remaining path to the DEK without deleting a very large payload.
+This is useful crypto-shredding, not retroactive revocation. It does not affect a
+party that retained the manifest, recovered DEK, key shares, or plaintext, nor a
+separate manifest wrapping the same DEK.
+
+### 9.6 Distributed writers
+
+Partition derivation limits a worker to assigned segment partitions when it receives
+only `K_p`. It is not forward secrecy and provides no protection if the worker also
+obtains the DEK. `partitionSegments` exposes producer partition granularity and may
+reveal job topology. Checkpoints must respect partition boundaries so retained keys
+cannot decrypt later-appended segments in the same partition.
+
+### 9.7 Append rollback and forks
+
+A consistency proof establishes that one authenticated leaf sequence is a prefix of
+another. It does not prove freshness or identify the canonical latest head. A
+publisher claiming a single history MUST serialize publication, protect the current
+head from rollback, and retain conflicting signed predecessor evidence. Readers that
+need freshness require a trusted catalog, checkpoint, or equivalent external state.
+
+---
+
+## 10. Normative References
+
+| Reference | Title |
+|---|---|
+| [NIST SP 800-207][SP800-207] | Zero Trust Architecture |
+| [NIST SP 800-38D][SP800-38D] | Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC |
+| [NIST SP 800-56A][SP800-56A] | Recommendation for Pair-Wise Key-Establishment Schemes Using Discrete Logarithm Cryptography |
+| [NIST FIPS 203][FIPS203] | Module-Lattice-Based Key-Encapsulation Mechanism Standard (ML-KEM) |
+| [NIST FIPS 204][FIPS204] | Module-Lattice-Based Digital Signature Standard (ML-DSA) |
+| [RFC 2119][RFC2119] | Key words for use in RFCs to Indicate Requirement Levels |
+| [RFC 8174][RFC8174] | Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words |
+| [RFC 8017][RFC8017] | PKCS #1: RSA Cryptography Specifications Version 2.2 |
+| [RFC 9449][RFC9449] | OAuth 2.0 Demonstrating Proof of Possession (DPoP) |
+| [RFC 3339][RFC3339] | Date and Time on the Internet: Timestamps |
+
+[SP800-207]: https://doi.org/10.6028/NIST.SP.800-207
+[SP800-38D]: https://doi.org/10.6028/NIST.SP.800-38D
+[SP800-56A]: https://doi.org/10.6028/NIST.SP.800-56Ar3
+[FIPS203]: https://doi.org/10.6028/NIST.FIPS.203
+[FIPS204]: https://doi.org/10.6028/NIST.FIPS.204
+[RFC2119]: https://www.rfc-editor.org/rfc/rfc2119
+[RFC8174]: https://www.rfc-editor.org/rfc/rfc8174
+[RFC8017]: https://www.rfc-editor.org/rfc/rfc8017
+[RFC9449]: https://www.rfc-editor.org/rfc/rfc9449
+[RFC3339]: https://www.rfc-editor.org/rfc/rfc3339

--- a/spec/goals/scale-improvements.md
+++ b/spec/goals/scale-improvements.md
@@ -106,7 +106,7 @@ explicitly. In scope: **packaging, integrity, and key derivation.**
 | Document | 5.0 status |
 |---|---|
 | BaseTDF-CORE | Refactored — abstract manifest; packaging moves out |
-| BaseTDF-INT | Extended — Merkle, uniform layout, partial verification |
+| BaseTDF-INT | Extended — Merkle, uniform/indexed layouts, partial verification |
 | BaseTDF-SEC | Extended — compartmentalization model, Tenet 1 rewrite |
 | BaseTDF-ALG | Extended — new registry entries only |
 | BaseTDF-ASN | Extended — `scope: "manifest"` |
@@ -155,7 +155,8 @@ Reading `k` bytes at an arbitrary offset in an `L`-byte payload MUST cost
 
 - Cold single-byte read at offset `L/2` of a 1 TiB TDF: ≤ 64 KiB of I/O beyond the
   KAS rewrap round trip and the segment itself.
-- Plaintext-offset → payload-offset is closed-form arithmetic, not a scan.
+- Plaintext-offset → payload-offset is closed-form arithmetic for a uniform layout
+  or an authenticated `O(log N)` lookup for an indexed layout — never a linear scan.
 - Integrity for returned bytes is equivalent to a full sequential read: the segment
   is provably the one the writer placed at that index, in an object whose total
   segment count is authenticated.
@@ -332,7 +333,7 @@ else builds on; B delivers distribution; C delivers detachment.
 | ID | Proposal | Goals | Family |
 |---|---|---|---|
 | P1 | Merkle root signature | G1, G3 | A |
-| P2 | Uniform layout: implicit segment index | G1, G3, G4 | A |
+| P2 | Scalable layouts: uniform and indexed | G1, G3, G4 | A |
 | P3 | Externalized hash tree | G1, G3 | A |
 | P4 | Partition key derivation | G2 | B |
 | P5 | Normative deterministic IV | G2 | B |
@@ -371,34 +372,55 @@ single segment.
 
 New `rootSignature.alg` value: `MERKLE-HS256`.
 
-Leaves preserve the existing segment hash (so GMAC stays free) and add index binding:
+Every tree node is a commitment `C = (H, P, E)`, where `H` is a 32-byte hash and
+`P`/`E` are the total plaintext/encrypted byte counts below the node. Leaves preserve
+the existing segment hash (so GMAC stays free) while binding the index and both sizes:
 
 ```
-L_i = HMAC-SHA256(DEK, 0x00 || u32be(i) || segment_hash_i)
+H_i = HMAC-SHA256(DEK,
+    0x00 || u64be(i) || u64be(P_i) || u64be(E_i) || segment_hash_i)
+C_i = (H_i, P_i, E_i)
 ```
 
 `segment_hash_i` is exactly the value from
 [`basetdf-int.md §4`](../basetdf/basetdf-int.md) — GMAC tag or HMAC — unchanged.
-Index binding prevents transplanting a valid segment to a different position.
+Index binding prevents transplanting a valid segment to a different position; size
+binding makes the offset index part of payload integrity rather than trusted routing
+metadata.
 
-Internal nodes:
-
-```
-N = HMAC-SHA256(DEK, 0x01 || left || right)
-```
-
-All nodes 32 bytes. On an odd level the last node is **promoted** unchanged (not
-duplicated). Promotion is safe only because the leaf count is bound into the root:
+For children `C_L` and `C_R`, an internal node is:
 
 ```
-root_signature = HMAC-SHA256(DEK, 0x02 || u64be(segmentCount) || tree_root)
+P = P_L + P_R
+E = E_L + E_R
+H = HMAC-SHA256(DEK,
+    0x01 || u64be(P_L) || u64be(E_L) || H_L
+         || u64be(P_R) || u64be(E_R) || H_R)
+C = (H, P, E)
 ```
 
-Base64-encoded into `rootSignature.sig` as today. Domain separators
+All additions and offset calculations use checked unsigned 64-bit arithmetic. A
+writer or reader MUST fail on overflow rather than wrap a size or range.
+
+On an odd level the last commitment is **promoted** unchanged (not duplicated).
+The root signature binds the layout, leaf count, and totals:
+
+```
+root_signature = HMAC-SHA256(DEK,
+    0x02 || layoutCode || u64be(segmentCount)
+         || u64be(P_root) || u64be(E_root) || H_root)
+```
+
+`layoutCode` is `0x01` for `uniform` and `0x02` for `indexed`. The result is
+base64-encoded into `rootSignature.sig` as today. Domain separators
 `0x00`/`0x01`/`0x02` prevent leaf/internal/root confusion.
 
-**Inclusion proof:** `ceil(log2(N))` sibling nodes — 20 nodes (640 bytes) for 1 TiB
-at 2 MiB segments.
+**Inclusion proof:** at most `ceil(log2(N))` sibling commitments — 20 siblings for
+1 TiB at 2 MiB segments. Promotion means some paths contain fewer siblings (for
+example, the last leaf of a five-leaf tree has one). Proof position and omitted
+siblings are derived from `(i, segmentCount)`; proof encodings MUST NOT use dummy or
+duplicated siblings. A `uniform` proof carries sibling hashes because sizes are
+derivable. An `indexed` proof carries each sibling's `(H, P, E)` commitment.
 
 **Streaming build:** a stack of at most `ceil(log2(N))` partial internal nodes; fold
 each leaf as produced. Root available at finalize with O(log N) resident state.
@@ -407,24 +429,38 @@ each leaf as produced. Root available at finalize with O(log N) resident state.
 when `alg` is `MERKLE-HS256`):
 
 - *Full read:* recompute leaves, rebuild tree, compare. Same cost as today.
-- *Partial read:* fetch the inclusion proof for segment `i`, recompute `L_i` from
-  fetched ciphertext, fold the proof, bind `segmentCount`, compare. Readers MUST
-  reject if proof length disagrees with the length implied by `segmentCount`
-  accounting for promotions.
+- *Partial read:* fetch the segment and its inclusion proof, recompute `C_i`, fold
+  the proof, bind the layout/count/totals, and compare. Readers MUST reject a proof
+  whose sibling presence, direction, size totals, or length disagrees with the path
+  implied by `(i, segmentCount)`.
 
-#### P2 — Uniform layout: implicit segment index
+#### P2 — Scalable layouts: uniform and indexed
 
-**Problem:** the inline `segments` array is the entire manifest-size problem, and
-under uniform segmentation it is fully derivable.
+**Problem:** the inline `segments` array is the entire manifest-size problem. A
+uniform layout can derive all offsets arithmetically, but append checkpoints can
+leave a short segment that later becomes an interior segment. Supporting arbitrary
+checkpoints requires variable segment sizes without restoring an O(N) manifest.
 
-Add `integrityInformation.layout`: `"explicit"` (default, current behavior) or
-`"uniform"`. When `"uniform"`:
+Add `integrityInformation.layout` with three values:
+
+| Value | Meaning | Offset lookup |
+|---|---|---|
+| `"explicit"` | Current 4.x `segments` array; default when absent | Prefix table or scan |
+| `"uniform"` | Fixed-size interior segments; compact Merkle tree | Closed-form, O(1) |
+| `"indexed"` | Variable-size segments; Merkle sum tree | Authenticated O(log N) |
+
+Both scalable layouts require `segmentCount`, `plaintextSize`, `encryptedSize`, and
+`hashTree`; they MUST omit `segments`. The root commitment's totals MUST equal the
+manifest totals before any plaintext is released.
+
+When `layout` is `"uniform"`:
 
 - Segments `0 … N-2` MUST be exactly `segmentSizeDefault` bytes — upgrade the SHOULD
   at [`basetdf-int.md:340-342`](../basetdf/basetdf-int.md) to MUST for this layout.
-- `segmentCount` and `lastSegmentSize` become REQUIRED.
-- `segments` becomes OPTIONAL and SHOULD be omitted.
-- Segment hashes come from the hash tree (P3).
+- `lastSegmentSize` is REQUIRED and MUST be in `1 … segmentSizeDefault`, except that
+  the single segment representing an empty payload has size zero.
+- All node sizes are derived from `segmentSizeDefault`, `lastSegmentSize`, the
+  per-segment encryption overhead, and node position; only hashes are stored in P3.
 
 The manifest becomes **constant size** regardless of payload:
 
@@ -436,7 +472,9 @@ The manifest becomes **constant size** regardless of payload:
   "encryptedSegmentSizeDefault": 2097180,
   "layout": "uniform",
   "segmentCount": 524288,
-  "lastSegmentSize": 1048576,
+  "lastSegmentSize": 2097152,
+  "plaintextSize": 1099511627776,
+  "encryptedSize": 1099526307840,
   "hashTree": { "nodeSize": 32, "levels": 20, "locator": { "...": "see P9" } }
 }
 ```
@@ -452,8 +490,42 @@ physOffset  = payloadStart + i * encryptedSegmentSizeDefault
 Closed form, O(1). Stating this normatively is what lets a reader skip the segments
 array entirely — the property G3 depends on.
 
+When `layout` is `"indexed"`:
+
+- Any segment MAY be shorter than `segmentSizeDefault`, including interior segments.
+  `segmentSizeDefault` is the writer's target size, not an invariant.
+- `segmentSizeMax` is REQUIRED and no segment may exceed it. Implementations MUST
+  bound `segmentCount` and tree size before allocation; writers SHOULD coalesce tiny
+  segments except where an application explicitly requests a checkpoint.
+- Readers MUST reject `segmentSizeMax` above their configured safety limit and MUST
+  reject a leaf whose authenticated size exceeds either bound.
+- Zero-length segments are prohibited except for the sole segment representing an
+  empty payload.
+- `lastSegmentSize` MUST be omitted; each leaf's authenticated `P_i` and `E_i`
+  supply the sizes.
+- P3 stores the subtree plaintext/encrypted totals next to every hash.
+
+**Authenticated offset lookup (normative for `indexed`).** To locate plaintext
+offset `B`, start at the root with `payloadOffset = 0`. At each non-promoted node,
+fetch and validate the two child records. If `B < P_left`, descend left. Otherwise
+set `B = B - P_left`, add `E_left` to `payloadOffset`, and descend right. A promoted
+node has one child and descends without changing either value. At the leaf,
+`payloadOffset` is the encrypted segment offset and `B` is the intra-segment
+plaintext offset. The reader MUST verify the resulting inclusion proof and root
+signature before releasing plaintext.
+
+Unauthenticated sums MAY direct only bounded reads within the integrity artifact.
+The reader MUST authenticate the selected leaf and path before using the resulting
+offset and size to fetch payload bytes; after fetching, it MUST recompute the leaf
+from the actual ciphertext before decrypting or releasing plaintext.
+
+This is O(log N) metadata I/O and compute. It deliberately relaxes G3's closed-form
+requirement for appendable objects while retaining the no-scan guarantee.
+
 **Writer guidance:** select `explicit` below a configurable threshold (RECOMMENDED
-4,096 segments ≈ 8 GiB), `uniform` above.
+4,096 segments ≈ 8 GiB), `uniform` for immutable or segment-aligned content, and
+`indexed` when arbitrary append checkpoints or application-defined segment boundaries
+are required.
 
 #### P3 — Externalized hash tree
 
@@ -469,42 +541,47 @@ Attached entry order MUST be `0.payload`, `0.integrity`, `0.manifest.json` — p
 first so streaming readers are unaffected; the tree is written at finalize when the
 leaf set is complete.
 
-**Binary format** (little-endian; nodes are opaque 32-byte values):
+**Binary format** (little-endian fields; hashes are opaque 32-byte values):
 
 ```
 offset  size  field
 0       8     magic       "BTDFMT\x01\x00"
 8       4     version     u32 = 1
-12      1     nodeSize    u8 = 32
+12      1     nodeSize    u8 = 32 (uniform) or 48 (indexed)
 13      1     levels      u8 = ceil(log2(leafCount)) + 1
-14      2     reserved    MUST be zero
+14      1     layout      u8 = 1 (uniform) or 2 (indexed)
+15      1     reserved    MUST be zero
 16      8     leafCount   u64
 24      8     nodeCount   u64
 32      ...   nodes       level-order: level 0 (leaves), then level 1, ...
 ```
 
-Level `l` has `ceil(leafCount / 2^l)` nodes; its byte offset is
-`32 + 32 * Σ_{j<l} ceil(leafCount / 2^j)`. Both closed-form, so a reader computes
-any proof node's byte range arithmetically with no index.
+For `uniform`, a node record is its 32-byte hash. For `indexed`, a node record is
+`hash[32] || plaintextTotal(u64) || encryptedTotal(u64)`, making the record 48
+bytes. Level `l` has `ceil(leafCount / 2^l)` nodes; its byte offset is
+`32 + nodeSize * Σ_{j<l} ceil(leafCount / 2^j)`. Both are closed-form, so a reader
+computes any proof or traversal node's byte range arithmetically with no secondary
+index.
 
-**Sizing.** ~`2N` nodes = 64 bytes/segment stored — comparable to today's 89-byte
-JSON entry — but the reader **fetches** only `O(log N)`:
+**Sizing.** A full tree has approximately `2N` nodes: about 64 bytes/segment for
+`uniform`, or 96 bytes/segment for `indexed`. The reader fetches only `O(log N)`:
 
-| Payload | Tree stored | Fetched per random read |
-|---|---|---|
-| 1 GiB | 33 KB | 320 B (10 nodes) |
-| 1 TiB | 34 MB | 640 B (20 nodes) |
-| 1 PiB | 34 GB | 960 B (30 nodes) |
+| Payload | Uniform tree | Indexed tree | Max inclusion proof |
+|---|---:|---:|---:|
+| 1 GiB | 33 KB | 49 KB | 480 B (10 indexed nodes) |
+| 1 TiB | 34 MB | 50 MB | 960 B (20 indexed nodes) |
+| 1 PiB | 34 GB | 52 GB | 1,440 B (30 indexed nodes) |
 
 **Trust.** The tree is unauthenticated on its own — fine, because every node
 consumed folds into a computation checked against `rootSignature.sig`, HMAC'd under
 the DEK. A tampered tree yields a root mismatch. Readers MUST bound reads by the
-header's `nodeCount` and MUST validate `nodeCount` against `leafCount` before
-allocating.
+header's `nodeCount`, MUST validate `nodeCount` against `leafCount` before
+allocating, and MUST require the header layout, node size, leaf count, levels, and
+root totals to match the manifest.
 
-**Streaming write.** Buffer leaf hashes (32 B/segment — 16 MB per TiB) and emit the
-tree at finalize. Per G1 this MAY spill to temporary storage; only the O(log N)
-folding stack must be resident.
+**Streaming write.** Buffer leaf records (32 B/segment for `uniform`, 48 B/segment
+for `indexed`) and emit the tree at finalize. Per G1 this MAY spill to temporary
+storage; only the O(log N) folding stack must be resident.
 
 ---
 
@@ -531,14 +608,21 @@ under `K_p` — still free. With `HS256` the segment HMAC is keyed with `K_p`.
 
 Merkle leaves, internal nodes, and the root signature stay keyed under the **DEK**,
 so integrity remains a whole-object property and no worker can forge a root. A
-worker computes its segments' *hashes* but not their leaves; the reducer, holding
-the DEK, applies `L_i = HMAC-SHA256(DEK, 0x00 || u32be(i) || segment_hash_i)` — one
-HMAC over 20 bytes per segment, ~500k HMACs for 1 TiB, well under a second.
+worker computes its segments' *hashes* and sizes but not their leaf commitments; the
+reducer, holding the DEK, applies the P1 leaf construction — one small HMAC per
+segment, ~500k HMACs for 1 TiB.
 
 **Security property delivered:** a worker assigned partition `p` receives only
-`K_p`, decrypting exactly `partitionSegments × segmentSizeDefault` bytes — its
-assigned range and nothing more. This is what G2 requires. At 512 × 2 MiB = 1 GiB
-per partition, a 1 TiB job is 1,024 workers each holding a 1 GiB-scoped key.
+`K_p`, decrypting its assigned segment range and nothing outside that KDF partition.
+For `uniform`, that is exactly `partitionSegments × segmentSizeDefault` bytes (apart
+from a final short segment). At 512 × 2 MiB = 1 GiB per partition, a 1 TiB job is
+1,024 workers each holding a 1 GiB-scoped key. For `indexed`, the byte count is the
+authenticated sum of the partition's segment sizes.
+
+An append checkpoint created with P4 MUST end on a KDF-partition boundary, or set
+`partitionSegments` to `1`. Otherwise a worker retaining the current partition key
+could decrypt later-appended segments that fall into the same partition, violating
+G2's range-scoping requirement.
 
 Not forward-secret; no protection against a worker that separately obtains the DEK.
 It scopes *distribution*, which is the actual operational risk.
@@ -549,7 +633,8 @@ It scopes *distribution*, which is the actual operational risk.
 writers cannot rely on stateless IV assignment interoperating, and readers cannot
 detect nonce reuse.
 
-Upgrade to MUST for `layout: "uniform"`, using NIST SP 800-38D §8.2.1:
+Upgrade to MUST for `layout: "uniform"` and `layout: "indexed"`, using NIST SP
+800-38D §8.2.1:
 
 ```
 IV_i = noncePrefix (4 bytes) || u64be(i)
@@ -736,26 +821,58 @@ a footnote — it is exactly the mistake a reasonable implementer will make.
 
 #### P11 — Consistency proofs and append-only payloads
 
-With P1's Merkle tree, RFC 6962 §2.2 consistency proofs let a reader verify that
-manifest v2's payload is a strict **extension** of manifest v1's. Combined with
-detachment, that makes live-appended payloads tractable: append segments, publish a
-new manifest with a larger `segmentCount`, and prior manifests still verify against
-the prefix.
+With P1's Merkle tree, the RFC 6962 §2.2 consistency-proof algorithm, instantiated
+with P1's keyed leaf/internal-node constructions, lets a reader verify that manifest
+v2's payload is a strict **segment extension** of manifest v1's. Existing leaves are
+immutable; an extension adds new leaves and publishes a manifest with larger
+authenticated counts and totals.
+
+The two scalable layouts have deliberately different append semantics:
+
+- **Indexed:** arbitrary checkpoints are supported. A short checkpoint tail remains
+  a valid short interior segment after later leaves are appended. No ciphertext is
+  rewritten and offset lookup remains O(log N) through the authenticated sums. If
+  P4 partition derivation is enabled, the checkpoint restriction stated in P4 still
+  applies.
+- **Uniform:** a checkpoint is extendable only when its final segment is exactly
+  `segmentSizeDefault`. Publishing a short final segment seals that payload against
+  strict extension. Writers MAY buffer an uncommitted tail until it fills, or switch
+  to `indexed` before publishing the first checkpoint; layouts MUST NOT change within
+  an extension chain.
 
 ```json
 "extends": {
+  "sequence": 41,
+  "manifestDigestAlg": "SHA-256",
+  "manifestDigest": "<digest of prior canonical manifest>",
   "segmentCount": 262144,
+  "plaintextSize": 549755813888,
+  "encryptedSize": 549763153920,
   "rootSignature": "<base64 of prior root signature>",
-  "consistencyProof": ["<base64 node>", "..."]
+  "consistencyProof": [
+    { "hash": "<base64 node>", "plaintextTotal": 2097152,
+      "encryptedTotal": 2097180 }
+  ]
 }
 ```
 
-Verification requires the DEK (nodes are DEK-keyed), so this proves extension to a
-key holder, not to the public. Sufficient for the intended use — a reader confirming
-the object it read yesterday was not rewritten.
+For `uniform`, proof entries carry only `hash`; their totals are derived. For
+`indexed`, every proof entry carries `(hash, plaintextTotal, encryptedTotal)` and the
+verifier MUST authenticate the old and new roots, counts, and totals. The DEK,
+layout, content-encryption algorithm, `noncePrefix`, segment-size parameters, and
+key-derivation parameters MUST be identical across the chain.
 
-Lowest-priority proposal; include the manifest field in 5.0 so the shape is
-reserved, and defer full writer support to 5.1 if schedule pressure demands.
+Verification requires the DEK (nodes are DEK-keyed), so this proves extension to a
+key holder, not to the public. `sequence` and the signed predecessor-manifest digest
+make rollback and fork evidence explicit, but consistency proofs do not identify the
+canonical latest manifest. A publishing system claiming a single history MUST use
+atomic compare-and-swap publication or an equivalently serialized catalog and MUST
+retain fork evidence.
+
+This remains the lowest-priority proposal. The optional 5.0 append profile MUST NOT
+be published until both layouts, promoted-node consistency proofs, fork negatives,
+and short-interior-segment vectors are complete. Full writer orchestration MAY remain
+a 5.1 SDK feature.
 
 ---
 
@@ -780,6 +897,12 @@ optional.
    the KAOs and hence the path to the DEK, giving a revocation primitive 4.x lacks.
    State its limits: it is not retroactive against a party who already rewrapped.
 6. **Add the SSRF surface** (P9) to the threat model.
+7. **Rewrite SI-5 for partial verification.** Distinguish full-object verification
+   from a segment whose AEAD tag, index/size-bound leaf, inclusion path, counts, and
+   root have been authenticated. The current invariant's blanket prohibition on
+   partial plaintext conflicts with G3.
+8. **Add append-chain rollback and fork risk.** A consistency proof establishes a
+   prefix relationship; it does not establish freshness or select a canonical head.
 
 ### 6.11 Goal coverage
 
@@ -787,12 +910,13 @@ optional.
 |---|---|
 | G1 | P2 caps manifest size; P1 gives O(log N) write state; P3 permits spilling; P6 removes the length requirement |
 | G2 | P4 scopes keys per partition; P5 makes IV assignment stateless; P1 trees are per-partition buildable and mergeable |
-| G3 | P2 gives closed-form offsets; P1+P3 give O(log N) authenticated single-segment reads |
+| G3 | P2 gives O(1) uniform offsets or O(log N) authenticated indexed lookup; P1+P3 give O(log N) authenticated single-segment reads |
 | G4 | P7 defines the profiles; P8 authenticates the manifest; P9 constrains dereferencing; P2 makes manifests small enough to serve |
 | G5 | P7 (standalone manifests) + P10 (semantics) |
 
 **G3 after the change, 1 TiB cold single-byte read:** ~2 KB manifest + 32 B tree
-header + 640 B proof + one 2 MiB segment. Meets the ≤ 64 KiB criterion for
+header + at most 640 B (`uniform`) of proof records or about 1,920 B (`indexed`) for
+the sum-tree traversal plus proof + one segment. Meets the ≤ 64 KiB criterion for
 everything except the segment, which is inherent to segment size.
 
 ---
@@ -810,9 +934,9 @@ write profile (P6); the `0.integrity` entry.
 **BaseTDF-LOC (new)** — locator object, URI schemes, allowlisting, redirect and
 size-bound rules, SSRF threat model (P9).
 
-**BaseTDF-INT** — extended: Merkle construction (P1), `layout` and closed-form
-offsets (P2), hash tree format (P3), partial-verification conformance profile,
-consistency proofs (P11).
+**BaseTDF-INT** — extended: Merkle construction (P1), uniform closed-form offsets
+and indexed authenticated sum traversal (P2), hash tree format (P3),
+partial-verification conformance profile, consistency proofs (P11).
 
 **BaseTDF-SEC** — extended per §6.10.
 
@@ -845,33 +969,56 @@ package merkle
 // Builder folds leaves in streaming order with O(log N) resident state.
 type Builder struct{ /* stack []node; count uint64; dek []byte */ }
 
-func NewBuilder(dek []byte) *Builder
-func (b *Builder) Add(index uint64, segmentHash []byte) error
+type Layout uint8
+
+const (
+    LayoutUniform Layout = 1
+    LayoutIndexed Layout = 2
+)
+
+type Commitment struct {
+    Hash           [32]byte
+    PlaintextTotal uint64
+    EncryptedTotal uint64
+}
+
+type SegmentInput struct {
+    Hash                         []byte
+    PlaintextSize, EncryptedSize uint64
+}
+
+func NewBuilder(dek []byte, layout Layout) *Builder
+func (b *Builder) Add(index, plaintextSize, encryptedSize uint64, segmentHash []byte) error
 func (b *Builder) Count() uint64
-func (b *Builder) Root() ([]byte, error)
-func (b *Builder) RootSignature() ([]byte, error) // HMAC(dek, 0x02||u64be(count)||root)
+func (b *Builder) Root() (Commitment, error)
+func (b *Builder) RootSignature() ([]byte, error)
 
 type Tree struct{ /* levels [][]byte; leafCount uint64 */ }
 
-func BuildTree(dek []byte, segmentHashes [][]byte) (*Tree, error)
+func BuildTree(dek []byte, layout Layout, segments []SegmentInput) (*Tree, error)
 func (t *Tree) WriteTo(w io.Writer) (int64, error)
-func (t *Tree) Proof(index uint64) ([][]byte, error)
+func (t *Tree) Proof(index uint64) ([]Commitment, error)
 
-// ProofReader fetches only the sibling path via ranged reads.
+// ProofReader fetches proof paths and indexed-layout sum traversals via ranged reads.
 type ProofReader struct{ /* ra io.ReaderAt; leafCount uint64; levels uint8 */ }
 
 func OpenProofReader(ra io.ReaderAt) (*ProofReader, error)
-func (p *ProofReader) Proof(index uint64) ([][]byte, error)
+func (p *ProofReader) Proof(index uint64) ([]Commitment, error)
+func (p *ProofReader) Locate(plaintextOffset uint64) (
+    index, intraOffset, encryptedOffset uint64, leaf Commitment,
+    proof []Commitment, err error,
+)
 
-func VerifyInclusion(dek []byte, index, leafCount uint64, segmentHash []byte,
-    proof [][]byte, wantRootSig []byte) error
+func VerifyInclusion(dek []byte, layout Layout, index, leafCount uint64,
+    leaf Commitment, segmentHash []byte, proof []Commitment, wantRootSig []byte) error
 
-func Merge(dek []byte, partitions []*Tree) (*Tree, error)         // reducer
-func ConsistencyProof(t *Tree, oldLeafCount uint64) ([][]byte, error) // P11
+func Merge(dek []byte, partitions []*Tree) (*Tree, error) // reducer
+func ConsistencyProof(t *Tree, oldLeafCount uint64) ([]Commitment, error) // P11
 ```
 
-Node offsets must be closed-form so `ProofReader` issues exactly `levels` ranged
-reads.
+Node offsets must be closed-form. Promotion-aware proofs issue at most `levels - 1`
+sibling reads; indexed lookup may fetch both child records per traversed level and
+SHOULD coalesce adjacent records into one range request.
 
 ### 8.2 `sdk/manifest.go`
 
@@ -883,10 +1030,13 @@ serialization is byte-identical to today:
 ```go
 type IntegrityInformation struct {
     // ... existing ...
-    Layout          string       `json:"layout,omitempty"`
-    SegmentCount    int64        `json:"segmentCount,omitempty"`
-    LastSegmentSize int64        `json:"lastSegmentSize,omitempty"`
-    HashTree        *HashTreeRef `json:"hashTree,omitempty"`
+    Layout          string        `json:"layout,omitempty"`
+    SegmentCount    *int64        `json:"segmentCount,omitempty"`
+    LastSegmentSize *int64        `json:"lastSegmentSize,omitempty"`
+    SegmentSizeMax  *int64        `json:"segmentSizeMax,omitempty"`
+    PlaintextSize   *int64        `json:"plaintextSize,omitempty"`
+    EncryptedSize   *int64        `json:"encryptedSize,omitempty"`
+    HashTree        *HashTreeRef  `json:"hashTree,omitempty"`
 }
 
 type Locator struct {
@@ -902,6 +1052,9 @@ type PayloadPart struct {
     Locators     []Locator `json:"locators"`
 }
 ```
+
+The scalable-layout scalar fields are pointers so an empty payload's required zero
+values remain distinguishable from fields absent on an explicit-layout manifest.
 
 Plus `Packaging string` on `Manifest`; `Locators []Locator` and `Parts []PayloadPart`
 on `Payload`; `KeyDerivation *KeyDerivation` on `EncryptionInformation`;
@@ -919,24 +1072,28 @@ Add accessors that normalize the zero value so call sites never branch on `""`:
 - `CreateTDFContext` (`tdf.go:164`) keeps its signature and behavior; add layout
   selection above the threshold.
 - **New** `CreateTDFStream(ctx, w io.Writer, r io.Reader, opts ...TDFOption)` — no
-  seek, always uniform layout, always the P6 ZIP profile. The G1 entry point. Do not
-  overload `CreateTDFContext`; the size-known path has different optimal behavior
-  and conflating them produces a function nobody can reason about.
+  seek, `uniform` by default, always the P6 ZIP profile. `WithLayout("indexed")`
+  permits application-requested variable boundaries and records their actual sizes.
+  This is the G1 entry point. Do not overload `CreateTDFContext`; the size-known path
+  has different optimal behavior and conflating them produces a function nobody can
+  reason about.
 - Replace the `strings.Builder` aggregate hash (`tdf.go:233-294`) with
-  `merkle.Builder` under uniform layout; keep the existing path for explicit.
+  `merkle.Builder` under both scalable layouts; keep the existing path for explicit.
 - Assertion binding (`tdf.go:362`) concatenates the aggregate hash. Under Merkle,
   substitute the 32-byte tree root. **This changes assertion signatures** — gate on
   layout and cover with a fixture per profile.
 
 ### 8.4 `sdk/tdf.go` — reader
 
-- `Reader.ReadAt` (`tdf.go:994`) — rewrite. Uniform layout: closed-form offsets plus
-  `merkle.ProofReader`, no segments scan. Explicit layout: keep the scan but build a
-  prefix-sum offset table **once** at `LoadTDF` instead of rescanning per call. That
-  fix is independently valuable and lands first (Phase 0).
-- Root validation (`tdf.go:1317-1327`) — under uniform layout there is no segments
-  array to fold; verify lazily per segment via inclusion proof rather than eagerly
-  materializing the tree.
+- `Reader.ReadAt` (`tdf.go:994`) — rewrite. Uniform layout uses closed-form offsets;
+  indexed layout uses `ProofReader.Locate`; neither scans segments. Explicit layout
+  keeps the scan semantics but builds a prefix-sum offset table **once** at `LoadTDF`
+  instead of rescanning per call. That fix is independently valuable and lands first
+  (Phase 0).
+- Root validation (`tdf.go:1317-1327`) — scalable layouts have no segments array to
+  fold; verify lazily per segment via an inclusion proof rather than eagerly
+  materializing the tree. Indexed lookup totals are untrusted until that proof and
+  the root signature validate.
 - Add `Reader.VerifyWhole(ctx) error` for callers wanting today's all-or-nothing
   guarantee explicitly, since partial reads no longer imply it.
 - Derive `K_p` in `buildKey` (`tdf.go:1249`) when `keyDerivation` is present; cache
@@ -948,8 +1105,8 @@ Add accessors that normalize the zero value so call sites never branch on `""`:
 - Reader: accept and validate data descriptors; prefer central directory values.
 - Third entry `0.integrity` with a ranged `ReadIntegrity(offset, length int64)`
   accessor mirroring `ReadPayload`.
-- `manifestMaxSize` stays at 10 MB (`tdf3_reader.go:15`). Under uniform layout it is
-  no longer a payload-size ceiling. **Document it** — the current limit is
+- `manifestMaxSize` stays at 10 MB (`tdf3_reader.go:15`). Under either scalable
+  layout it is no longer a payload-size ceiling. **Document it** — the current limit is
   undocumented and surprising.
 
 ### 8.6 New packages
@@ -989,7 +1146,7 @@ func Plan(spec JobSpec) ([]Partition, error)
 
 type PartitionResult struct {
     Index         int64
-    SegmentHashes [][]byte
+    Segments      []SegmentInput
     CiphertextLen int64
 }
 func EncryptPartition(p Partition, spec JobSpec, r io.Reader, w io.Writer) (*PartitionResult, error)
@@ -1009,33 +1166,45 @@ reduce time.
 ### 8.7 Schema and test vectors
 
 Update [`spec/schema/BaseTDF/manifest.schema.json`](../schema/BaseTDF/manifest.schema.json):
-conditionals on `layout` (uniform requires `segmentCount`/`lastSegmentSize`/
-`hashTree`, forbids `segments`) and on `packaging` (detached/sharded require
-`payload.locators` or `payload.parts` and a manifest signature; forbid
-`payload.url`). Use `if`/`then`/`else`, not `oneOf`, so errors name the actual
-missing field.
+conditionals on `layout`: both scalable layouts require `segmentCount`,
+`plaintextSize`, `encryptedSize`, and `hashTree`, and forbid `segments`; `uniform`
+also requires `lastSegmentSize` and forbids `segmentSizeMax`, while `indexed`
+requires `segmentSizeMax` and forbids `lastSegmentSize`. Packaging conditionals make
+detached/sharded require `payload.locators` or `payload.parts` and a manifest
+signature, and forbid `payload.url`. Use nested `if`/`then`/`else`, not `oneOf`, so
+errors name the actual missing field.
 
 Vectors in [`basetdf-ex.md`](../basetdf/basetdf-ex.md) with fixtures under
 `sdk/testdata/basetdf-v5/`:
 
-1. Merkle trees, N ∈ {1, 2, 3, 5, 8, 1000}, fixed DEK, all nodes shown. N=3 and N=5
-   exercise promotion.
-2. Inclusion proofs for N=1000 at i ∈ {0, 1, 499, 998, 999}.
+1. Uniform and indexed Merkle trees, N ∈ {1, 2, 3, 5, 8, 1000}, fixed DEK, all
+   hashes and totals shown. N=3 and N=5 exercise promotion.
+2. Inclusion proofs for both layouts at N=1000 and i ∈ {0, 1, 499, 998, 999}.
 3. **Promotion-attack negative vector** — a forged tree duplicating the last leaf to
    reach N+1, proving count binding rejects it.
 4. Uniform manifest for a 16 GiB TDF, demonstrating it is under 2 KB.
-5. `0.integrity` fixture, byte-for-byte, with annotated level offsets.
-6. Partition key vectors: DEK → `K_0`, `K_1`, `K_1023` at `partitionSegments: 512`.
-7. Deterministic IV vectors: `noncePrefix` → `IV_0`, `IV_1`, `IV_{2^32}`.
-8. Cross-profile round trip: same plaintext, explicit and uniform, identical output.
-9. Streaming-write ZIP fixture, verified against `unzip`, Go `archive/zip`, and
+5. Indexed manifest with sizes `{2 MiB, 64 KiB, 2 MiB, 1 B}`, demonstrating a short
+   interior segment and a constant-size manifest.
+6. Uniform and indexed `0.integrity` fixtures, byte-for-byte, with annotated level
+   offsets and records.
+7. Indexed offset lookup at the first/last byte of every segment, plus negative
+   vectors for a tampered subtree sum, integer overflow, and a root-total mismatch.
+8. Partition key vectors: DEK → `K_0`, `K_1`, `K_1023` at `partitionSegments: 512`.
+9. Deterministic IV vectors: `noncePrefix` → `IV_0`, `IV_1`, `IV_{2^32}`.
+10. Cross-profile round trip: explicit, uniform, and indexed serialize differently
+    but decrypt to identical plaintext.
+11. Streaming-write ZIP fixture, verified against `unzip`, Go `archive/zip`, and
    Python `zipfile`.
-10. Detached manifest + separate payload object, with a signature vector.
-11. Sharded manifest with 4 parts, including a negative vector for a non-contiguous
+12. Detached manifest + separate payload object, with a signature vector.
+13. Sharded manifest with 4 parts, including a negative vector for a non-contiguous
     `parts` array.
-12. **Locator negative vectors** — off-allowlist origin, non-https scheme,
+14. **Locator negative vectors** — off-allowlist origin, non-https scheme,
     redirect-to-unlisted, oversize response.
-13. Consistency proof: manifest at N=1000 extending N=512.
+15. Consistency proofs: an aligned uniform checkpoint and an indexed checkpoint with
+    a short tail, plus negatives for extending a short-tail uniform checkpoint,
+    changing an existing leaf, changing immutable chain parameters, and forking a
+    predecessor sequence. With P4 enabled, also reject a checkpoint inside a
+    multi-segment KDF partition.
 
 ---
 
@@ -1045,6 +1214,7 @@ Each phase is a separately reviewable change with tests. Phases 1 and 2 are
 independent after Phase 0.
 
 **Phase 0 — Non-breaking prerequisites.** No format change; ship against 4.4.
+
 - Fix the O(N)-per-call scan in `Reader.ReadAt` (`tdf.go:994`) with a prefix-sum
   table built at `LoadTDF`.
 - Document the `manifestMaxSize` ceiling and its payload-size implication; surface
@@ -1055,17 +1225,17 @@ independent after Phase 0.
 **Phase 1 — Merkle core.** `sdk/internal/merkle`, BaseTDF-INT §5.4, ALG rows,
 vectors 1–3. Pure library, no format change.
 
-**Phase 2 — ZIP streaming profile (P6).** BaseTDF-PKG, zipstream changes, vector 9.
+**Phase 2 — ZIP streaming profile (P6).** BaseTDF-PKG, zipstream changes, vector 11.
 
-**Phase 3 — Uniform layout (P2 + P3).** Manifest fields, `0.integrity`, schema,
-closed-form offsets, partial verification. Depends on 1, 2. Vectors 4, 5, 8.
-**Meets G3.**
+**Phase 3 — Scalable layouts (P2 + P3).** Manifest fields, both `0.integrity`
+record forms, schema, uniform closed-form offsets, indexed sum traversal, and partial
+verification. Depends on 1, 2. Vectors 4–7 and 10. **Meets G3.**
 
 **Phase 4 — Streaming writer.** `CreateTDFStream`. Depends on 2, 3. **Meets G1.**
 Acceptance: encrypt from a pipe with no length; assert bounded RSS via
 `runtime.MemStats` across payload sizes spanning three orders of magnitude.
 
-**Phase 5 — Partition keys and IVs (P4 + P5).** Vectors 6, 7.
+**Phase 5 — Partition keys and IVs (P4 + P5).** Vectors 8, 9.
 
 **Phase 6 — Distributed writer.** `sdk/distributed`. Depends on 3, 5. **Meets G2.**
 Acceptance: plan a job, run partitions in separate goroutines holding only their
@@ -1076,15 +1246,16 @@ cannot decrypt partition `p+1`.
 README dependency graph. Spec-only, no code. Can run in parallel with 4–6.
 
 **Phase 8 — Manifest signature (P8).** `sdk/manifestsig`, ASN `scope: "manifest"`,
-vector 10's signature. Depends on 7.
+vector 12's signature. Depends on 7.
 
 **Phase 9 — Detached and sharded packaging (P7 + P9).** `sdk/packaging`,
-`sdk/locator`, schema conditionals, vectors 10–12. Depends on 3, 8. **Meets G4.**
+`sdk/locator`, schema conditionals, vectors 12–14. Depends on 3, 8. **Meets G4.**
 
 **Phase 10 — Multi-manifest (P10).** Largely spec text plus a helper to mint an
 additional manifest against an existing payload. **Meets G5.**
 
-**Phase 11 — Consistency proofs (P11).** Vector 13. Deferrable to 5.1.
+**Phase 11 — Consistency proofs (P11).** Vector 15. The optional wire profile and
+vectors are part of 5.0; full append-writer orchestration is deferrable to 5.1.
 
 **Phase 12 — Interop and release.** Cross-implementation vectors, 4.4→5.0 migration
 guide, explicit statement of 4.x reader behavior on a 5.0 object, SEC changes from
@@ -1098,8 +1269,10 @@ guide, explicit statement of 4.x reader behavior on a 5.0 object, SEC changes fr
 |---|---|
 | **Scope creep** — a major version invites reopening POL, KAS, PQC | The §3.4 charter is normative for the release. Frozen documents republish unchanged. |
 | **PKI dependency** (P8) — signer key distribution, rotation, revocation | Required only for detached/sharded. Attached users never encounter it. |
-| **SSRF** in detached readers | P9 default-deny plus negative vectors 12. Treat a permissive default as a release blocker. |
+| **SSRF** in detached readers | P9 default-deny plus negative vectors 14. Treat a permissive default as a release blocker. |
 | **Multi-manifest misuse** (P10) — implementers assume differentiated access | Numbered SEC consideration, not a footnote. Consider an SDK-level warning when minting a second manifest. |
+| **Indexed-layout amplification** — many tiny segments inflate the tree and range-request count | Signed `segmentSizeMax`/`segmentCount`, reader allocation limits, writer coalescing by default, and tiny-segment negative/load vectors. |
+| **Append rollback or forks** — consistency does not establish the latest canonical head | Signed predecessor digest and sequence, fork detection, and atomic compare-and-swap publication by catalogs claiming a single history. |
 | **Multi-SDK migration** (Go, JS, Java, Python) | Attached+explicit stays byte-identical, so most of the matrix is a version-string change. Gate 5.0 GA on two independent implementations passing the vectors. |
 | **Tenet 1 rewrite** reads as weakening zero trust | Land the SEC rewrite in the same change as the CORE refactor, with the self-description framing argued explicitly. |
 
@@ -1111,10 +1284,11 @@ guide, explicit statement of 4.x reader behavior on a 5.0 object, SEC changes fr
    3 siblings = 30 nodes — worse in bytes, better in round trips if the tree is not
    contiguously fetchable. Since levels are contiguous and range-readable, binary
    looks right. Confirm against real object-store latency before freezing.
-2. **Full tree or leaves only in `0.integrity`?** Full tree is 64 B/segment with
-   O(log N) fetch; leaves only is 32 B/segment but O(N) to reconstruct any internal
-   node. Full tree proposed; revisit if storage cost dominates read latency for a
-   known workload.
+2. **Full tree or leaves only in `0.integrity`?** A full tree is approximately 64
+   B/segment for `uniform` or 96 B/segment for `indexed`, with O(log N) fetch.
+   Leaves-only storage halves that cost but requires O(N) work to reconstruct an
+   internal node. Full tree proposed; revisit if storage dominates read latency for
+   a known workload.
 3. **`contentBinding` default (P7).** Unkeyed digest gives dedup and content
    addressing but is a stable cross-tenant correlation handle. Recommendation: omit
    by default, OPTIONAL for dedup-oriented deployments. **This is a product decision
@@ -1138,6 +1312,9 @@ guide, explicit statement of 4.x reader behavior on a 5.0 object, SEC changes fr
    that a catalog service becomes a de facto dependency.
 9. **Interaction with nano TDF.** Out of scope; confirm nothing here forecloses a
    future shared integrity model.
+10. **Indexed checkpoint granularity.** Arbitrary one-byte checkpoints are valid but
+    expensive. Choose SDK defaults for minimum checkpoint growth and automatic
+    coalescing without turning them into wire-format restrictions.
 
 ---
 
@@ -1147,12 +1324,13 @@ guide, explicit statement of 4.x reader behavior on a 5.0 object, SEC changes fr
 |---|---|
 | `L` | Plaintext payload length in bytes |
 | `S` | `segmentSizeDefault` |
-| `N` | Segment count = `ceil(L / S)` |
+| `N` | Segment count (`ceil(L / S)` for `uniform`; explicitly committed for `indexed`) |
 | `DEK` | Data Encryption Key, 256 bits |
 | `K_p` | Partition key for partition `p` (P4) |
 | `h_i` | Segment hash of segment `i` per [`basetdf-int.md §4`](../basetdf/basetdf-int.md) |
-| `L_i` | Merkle leaf for segment `i` (P1) |
-| `u32be(x)` / `u64be(x)` | Big-endian fixed-width integer encoding |
+| `P_i` / `E_i` | Plaintext/encrypted size of segment `i` |
+| `C_i` | Merkle leaf commitment `(H_i, P_i, E_i)` for segment `i` (P1) |
+| `u64be(x)` | Big-endian 64-bit integer encoding |
 | `‖` | Byte concatenation |
 
 ---

--- a/spec/goals/scale-improvements.md
+++ b/spec/goals/scale-improvements.md
@@ -1,0 +1,1175 @@
+# BaseTDF 5.0 — Scale and Detached Storage
+
+| | |
+|---|---|
+| **Status** | Draft / Design Goals |
+| **Target** | BaseTDF suite v5.0.0 |
+| **Baseline** | TDF 4.x, as specified by the BaseTDF suite v4.4.0 in [`spec/basetdf/`](../basetdf/) |
+| **Audience** | Spec editors, SDK implementers, and agents tasked with executing the work below |
+
+> **On version numbering:** every gap identified here is present throughout the 4.x
+> line — the integrity model is explicitly unchanged since 4.3.0
+> ([`basetdf-int.md:56-60`](../basetdf/basetdf-int.md)) — so "current spec" means
+> all of 4.x unless a specific minor version is named. Section 3 argues for why this
+> work must ship as a major version rather than 4.5.0.
+
+---
+
+## 1. Purpose
+
+BaseTDF today assumes a TDF is produced by one process, from a source of known
+length, into one file, and consumed by one process reading it end to end. That
+assumption is nowhere stated but is baked into the container format, the integrity
+model, and the reference SDK.
+
+This document defines five goals that break that assumption, analyzes precisely
+where the current format fails each, and specifies the format changes and
+reference-implementation work needed to close the gap.
+
+It is written to be executable: Section 6 contains normative-draft text and wire
+formats concrete enough to amend the spec from, Section 7 maps the change onto
+suite documents, Section 8 maps it onto specific files and symbols in the Go SDK,
+and Section 9 sequences the work.
+
+---
+
+## 2. Summary of the change
+
+Two independent problems, one release:
+
+**Scale.** The manifest carries one JSON record per payload segment. At the 2 MiB
+default segment size that fixes the manifest at ~1/23,000 of payload size — a 1 TiB
+object needs a ~47 MB manifest — and the root signature is a flat MAC over all N
+segment hashes that must be verified before *any* segment is decrypted. Streaming,
+distributed writes, and random access all break on this.
+
+**Coupling.** The manifest and payload are welded into a single ZIP. That forces
+every party who touches the object to touch all of it: whoever stores the payload
+also stores the policy, the attribute FQNs, and the KAS URLs. Detaching them lets
+a manifest host and a payload host each hold half, with neither able to reconstruct
+the object alone.
+
+The two are related. Detached manifests are only useful if a manifest is small
+enough to serve as an API-scale object, which is exactly what the scale work
+delivers. And a detached manifest makes a manifest-level signature necessary, which
+is a requirement that does not exist today.
+
+---
+
+## 3. Why 5.0
+
+### 3.1 The existing version rules make 4.5 worse than 5.0
+
+[`basetdf-core.md:366-367`](../basetdf/basetdf-core.md) requires readers to reject a
+manifest whose major version is not `4`. But
+[`basetdf-core.md:544`](../basetdf/basetdf-core.md) instructs readers to treat an
+unknown *minor* version within major 4 as "the closest known version."
+
+So an incompatible 4.5.0 object handed to a 4.4 reader is silently coerced into a
+4.4 interpretation and then fails somewhere confusing — a missing `segments` array,
+a `payload.url` that isn't `0.payload`. Whereas a 5.0.0 object is rejected cleanly
+by a rule that is already written and already implemented.
+
+The version rules already give correct negotiation behavior for a major bump. Use it.
+
+### 3.2 The changes are breaking by any reading
+
+- `payload.url` MUST be `"0.payload"`, `payload.protocol` MUST be `"zip"`,
+  `payload.type` MUST be `"reference"` ([`basetdf-core.md:230-232`](../basetdf/basetdf-core.md)).
+- The archive MUST contain exactly two entries and writers MUST NOT add extras
+  ([`basetdf-core.md:125-127`](../basetdf/basetdf-core.md)).
+- `integrityInformation.segments` is REQUIRED ([`basetdf-int.md:156`](../basetdf/basetdf-int.md)).
+- Design Principle 1 is self-containment ([`basetdf-core.md:69-72`](../basetdf/basetdf-core.md)),
+  and [`basetdf-sec.md:118-122`](../basetdf/basetdf-sec.md) grounds NIST SP 800-207
+  Tenet 1 in it specifically.
+
+Each of these has to move. That last one in particular means the security model
+document changes, not just the container document — reviewers will notice, so the
+rewrite should land in the same change (see §6.10).
+
+### 3.3 The suite's own framing points here
+
+[`README.md:4-7`](../basetdf/README.md) states the suite is factored after JOSE.
+The right precedent is JWS: **one object, multiple serializations** (compact and
+JSON). BaseTDF 5.0 should say exactly that — one manifest, several *packagings*:
+attached, detached, sharded.
+
+This framing matters practically. It keeps the self-contained ZIP as a first-class
+5.0 profile rather than a deprecated legacy mode, so the majority of users who never
+need detachment get a mechanical 4.4→5.0 migration.
+
+### 3.4 Charter — what 5.0 does NOT touch
+
+A major version is an invitation to reopen everything. It should be refused
+explicitly. In scope: **packaging, integrity, and key derivation.**
+
+| Document | 5.0 status |
+|---|---|
+| BaseTDF-CORE | Refactored — abstract manifest; packaging moves out |
+| BaseTDF-INT | Extended — Merkle, uniform layout, partial verification |
+| BaseTDF-SEC | Extended — compartmentalization model, Tenet 1 rewrite |
+| BaseTDF-ALG | Extended — new registry entries only |
+| BaseTDF-ASN | Extended — `scope: "manifest"` |
+| BaseTDF-PKG | **New** — packaging profiles |
+| BaseTDF-LOC | **New** — resource locators |
+| BaseTDF-KAO | **Frozen** |
+| BaseTDF-POL | **Frozen** |
+| BaseTDF-KAS | **Frozen** |
+
+Policy language changes, KAS protocol changes, and new PQC work are explicitly
+out of scope and MUST NOT be bundled. They can ship as 5.1.
+
+---
+
+## 4. Goals
+
+### G1 — Large-scale streaming writes
+
+A writer MUST be able to produce a TDF in a single forward pass over a plaintext
+source **of unknown length**, using memory bounded independently of payload size,
+without buffering the payload or rewriting any part of the output.
+
+- `encrypt(io.Reader) -> io.Writer`; no `Seek`, no `Stat`, no content-length.
+- Resident memory O(log N) in segment count for integrity state, plus one segment
+  buffer. O(N) state MAY spill to temporary storage but MUST NOT be resident.
+- A 100 TiB TDF is representable and readable by a conformant reader.
+- Valid output on the first pass; no finalize-time seek-back to patch headers.
+
+### G2 — Distributed (map/reduce) writes
+
+N workers with no shared state beyond a job description MUST each be able to
+encrypt a disjoint plaintext range, and a reducer MUST assemble a valid TDF from
+their outputs without reading ciphertext.
+
+- Worker for range `[a, b)` needs no communication with other workers.
+- Reduce input is O(1) metadata per worker plus fixed-size hashes — never ciphertext.
+- Assembly is expressible as an S3 multipart upload using `UploadPartCopy`
+  (server-side, no egress through the reducer).
+- **No worker holds a key capable of decrypting a range it was not assigned.**
+- Result is a single TDF, not N TDFs.
+
+### G3 — Constant-overhead random access reads
+
+Reading `k` bytes at an arbitrary offset in an `L`-byte payload MUST cost
+`O(k) + O(polylog(L/S))` bytes of I/O and compute, for segment size `S`.
+
+- Cold single-byte read at offset `L/2` of a 1 TiB TDF: ≤ 64 KiB of I/O beyond the
+  KAS rewrap round trip and the segment itself.
+- Plaintext-offset → payload-offset is closed-form arithmetic, not a scan.
+- Integrity for returned bytes is equivalent to a full sequential read: the segment
+  is provably the one the writer placed at that index, in an object whose total
+  segment count is authenticated.
+
+### G4 — Detached manifest and payload
+
+A manifest MUST be publishable and servable as a standalone document, referencing a
+payload stored and served independently, such that:
+
+- The **payload host** observes opaque ciphertext and nothing else — no policy, no
+  attribute FQNs, no KAS URLs, no assertions, no MIME type.
+- The **manifest host** observes metadata and never observes ciphertext.
+- Neither party alone can reconstruct the protected object.
+- Manifest→payload binding is cryptographic and survives detachment: substituting
+  the payload MUST fail verification.
+- A reader MUST be able to validate a manifest's integrity and provenance
+  **before** dereferencing any locator it contains.
+
+> **Scoping note.** G4 delivers *compartmentalization between hosts*. It does **not**
+> make metadata confidential from the manifest host — policy, attribute FQNs, and
+> KAS URLs remain cleartext to whoever serves the manifest
+> ([`basetdf-core.md:585-600`](../basetdf/basetdf-core.md)). Confidential policy is
+> a distinct problem requiring encrypted policy objects, and is **out of scope for
+> 5.0**. This distinction must be stated plainly in BaseTDF-SEC so the property is
+> not oversold.
+
+### G5 — Multiple manifests over one payload
+
+It MUST be possible to publish additional manifests against an existing payload,
+each with its own policy and KAO set, without re-encrypting the payload.
+
+- Re-sharing a 1 PiB dataset to a new audience costs a rewrap and a small manifest.
+- The security semantics of doing so must be specified, not left implicit (see
+  §6.10.2 — the effective access set is the *union* across manifests).
+
+---
+
+## 5. Gap analysis
+
+### 5.1 Summary
+
+| Goal | Verdict | Root cause |
+|---|---|---|
+| G1 Streaming writes | Partially met | Manifest grows O(N); ZIP streaming unspecified |
+| G2 Distributed writes | Partially met | Every worker needs the full DEK; single-blob container |
+| G3 Random access | **Not met** | Flat root signature over all N hashes, verified before any decrypt |
+| G4 Detached storage | **Not possible** | Container rules forbid it; manifest is unauthenticated as a whole |
+| G5 Multi-manifest | **Not possible** | Manifest is welded into the payload's container |
+
+### 5.2 Manifest size scales with payload size
+
+Segment size is capped at 4 MiB, default 2 MiB
+([`basetdf-int.md:352-358`](../basetdf/basetdf-int.md)). A `segments[i]` entry
+serializes to ~89 bytes with GMAC, ~109 with HS256 — a manifest-to-payload ratio of
+roughly **1:23,000**:
+
+| Payload | Segments @ 2 MiB | Manifest (GMAC) | Aggregate hash to MAC |
+|---|---|---|---|
+| 1 GiB | 512 | ~46 KB | 8 KiB |
+| 100 GiB | 51,200 | ~4.6 MB | 800 KiB |
+| 1 TiB | 524,288 | **~47 MB** | 8 MiB |
+| 100 TiB | 52,428,800 | **~4.7 GB** | 800 MiB |
+| 1 PiB | 536,870,912 | **~48 GB** | 8 GiB |
+
+Raising to the 4 MiB maximum buys exactly 2×.
+
+This contradicts [`basetdf-core.md:615`](../basetdf/basetdf-core.md), which tells
+implementations to "enforce a maximum manifest size to prevent memory exhaustion."
+The spec offers no reconciliation.
+
+**The reference SDK has already hit this.** `sdk/internal/zipstream/tdf3_reader.go:15`
+sets `manifestMaxSize = 10 MB`. At ~89 bytes/segment and 2 MiB segments that is a
+hard ceiling of roughly **230 GiB per TDF** (~190 GiB with HS256 segment hashes)
+before `LoadTDF` refuses the object. A real, shipped limit that no part of the
+specification acknowledges.
+
+It is also what makes G4 non-viable today: a 47 MB manifest cannot be served as an
+API-scale document.
+
+### 5.3 Random access requires full metadata ingestion
+
+Both verification procedures — non-streaming
+([`basetdf-int.md:378-388`](../basetdf/basetdf-int.md)) and streaming
+([`basetdf-int.md:416-422`](../basetdf/basetdf-int.md)) — require root signature
+verification *before any segment is decrypted*, and the root signature needs all N
+segment hashes. There is no sanctioned mode for verifying one segment in isolation.
+
+A cold one-byte read from a 1 TiB TDF therefore costs a 47 MB range GET, a 47 MB
+JSON parse, 524,288 base64 decodes, and an HMAC over 8 MiB — before touching the
+payload. Payload I/O is O(1); metadata is not.
+
+Secondary:
+
+- [`basetdf-int.md:340-342`](../basetdf/basetdf-int.md) uses **SHOULD**, not MUST,
+  for interior segments matching `segmentSizeDefault`, so a strictly conformant
+  reader cannot use closed-form offset arithmetic.
+- [`basetdf-int.md:390`](../basetdf/basetdf-int.md) says "for each segment `i` **in
+  order**." Reading segment 40,000 alone is neither described nor blessed.
+
+The reference SDK shows the cost: `Reader.ReadAt` (`sdk/tdf.go:994`) loops
+`for index, seg := range r.manifest.Segments` from index 0 on **every call** — an
+O(N) scan per read. It also mixes models, computing `start`/`startIndex` from
+`DefaultSegmentSize` arithmetic while deriving physical offsets from the per-segment
+`EncryptedSize` scan. Those disagree the moment an interior segment is short, which
+the spec currently permits.
+
+### 5.4 Streaming writes: ZIP mechanics unspecified
+
+A ZIP local file header carries CRC-32 and both sizes *before* the entry data.
+Unknown-length entries require general-purpose bit 3 and a trailing data descriptor.
+The spec never mentions this. It cites "local file headers precede file data,
+enabling progressive reading" ([`basetdf-core.md:112`](../basetdf/basetdf-core.md))
+while mandating ZIP64 above 4 GiB
+([`basetdf-core.md:128-130`](../basetdf/basetdf-core.md)) — a threshold a streaming
+writer cannot evaluate in advance.
+
+The reference SDK does not attempt it: `CreateTDFContext` takes an `io.ReadSeeker`
+and immediately does `reader.Seek(0, io.SeekEnd)` (`sdk/tdf.go:164-176`).
+
+### 5.5 Distributed writes: the DEK is not divisible
+
+Every segment is encrypted directly under the DEK
+([`basetdf-int.md:96`](../basetdf/basetdf-int.md)). No per-segment or per-range
+derivation exists. A 1,000-worker fan-out distributes a key that decrypts the
+*entire* object to 1,000 processes. The XOR split model splits trust across KAS
+instances, not writers, and does not help. For a format premised on zero trust this
+is the sharpest mismatch.
+
+### 5.6 What already works — preserve these
+
+- **The reduce is cheap and correct.** `root_sig = HMAC(DEK, h₀‖…‖h_{N-1})` needs
+  only ordered fixed-size hashes; the reducer never touches ciphertext.
+- **The payload is a pure concatenation**, so assembly maps onto S3 multipart upload
+  with server-side `UploadPartCopy`.
+- **IV derivation is already partition-friendly** — `basetdf-sec.md:622-624`
+  RECOMMENDS `base IV + segment index`.
+- **GMAC segment hashing is free** ([`basetdf-int.md:215-219`](../basetdf/basetdf-int.md)).
+- **Manifest→payload binding already survives detachment.** This is the most
+  under-appreciated fact in the current design: the root signature is an HMAC over
+  hashes of the actual ciphertext, keyed with the DEK. That binding never depended
+  on the ZIP. Substitute the payload and verification fails. **The format is already
+  cryptographically detachable; only the container rules forbid it.**
+
+### 5.7 Detachment: the manifest is unauthenticated as a whole
+
+Policy binding covers the policy per-KAO
+([`basetdf-kao.md`](../basetdf/basetdf-kao.md)); the root signature covers the
+payload. **Nothing covers** `payload.url`, the KAS URL list, `segmentSizeDefault`,
+`mimeType`, or the assertion array's membership.
+
+Inside a ZIP this is tolerable — an attacker who can rewrite the manifest can
+usually replace the whole file, and the outcome is a failed verification either way.
+Detached, the manifest becomes an independently-fetched, independently-tamperable
+document, and `payload.url` becomes a **redirect primitive**: an SSRF gadget and a
+DoS vector. It is not a confidentiality break — the DEK-keyed root signature still
+catches a substituted payload — but it is a new attack surface that detachment
+creates and that 5.0 must answer (P8).
+
+### 5.8 Container rigidity
+
+`payload.type` MUST be `"reference"`, `url` MUST be `"0.payload"`, `protocol` MUST
+be `"zip"` ([`basetdf-core.md:230-232`](../basetdf/basetdf-core.md)); exactly two
+entries, no extras ([`basetdf-core.md:125-127`](../basetdf/basetdf-core.md)). There
+is no representation for a manifest without a payload, a payload without a manifest,
+or a payload in more than one piece. G4 and G5 are simply unexpressible.
+
+---
+
+## 6. Proposals
+
+Eleven proposals in three families. Family A is the integrity substrate everything
+else builds on; B delivers distribution; C delivers detachment.
+
+| ID | Proposal | Goals | Family |
+|---|---|---|---|
+| P1 | Merkle root signature | G1, G3 | A |
+| P2 | Uniform layout: implicit segment index | G1, G3, G4 | A |
+| P3 | Externalized hash tree | G1, G3 | A |
+| P4 | Partition key derivation | G2 | B |
+| P5 | Normative deterministic IV | G2 | B |
+| P6 | ZIP streaming-write profile | G1 | B |
+| P7 | Packaging profiles | G4, G5 | C |
+| P8 | Manifest signature | G4 | C |
+| P9 | Resource locators and fetch policy | G4 | C |
+| P10 | Multi-manifest semantics | G5 | C |
+| P11 | Consistency proofs / append-only payloads | G4 | C |
+
+### Design constraints
+
+1. **Existing TDFs remain readable.** No change may invalidate a 4.3.0 or 4.4.0
+   object. Legacy hex-encoding handling
+   ([`basetdf-int.md:457-509`](../basetdf/basetdf-int.md)) stays.
+2. **The DEK remains the root of trust for payload integrity.** New constructions
+   are keyed from the DEK, not a new independent secret. P8 is the deliberate
+   exception and is scoped to *manifest* integrity, not payload integrity.
+3. **No new pre-decryption trust surface.** Anything consumed before verification
+   must be authenticated under the DEK, or size-bounded and structurally validated,
+   or covered by P8.
+4. **Small TDFs must not get worse.** The common case is a payload under 100 MB.
+   New machinery is opt-in and adds no round trips, entries, or manifest bytes to
+   small attached objects.
+5. **GMAC-free-hashing is preserved.** No new leaf construction may force a second
+   pass over ciphertext at write time.
+
+---
+
+### Family A — Integrity substrate
+
+#### P1 — Merkle root signature
+
+**Problem:** the flat concat root signature forces O(N) work to authenticate any
+single segment.
+
+New `rootSignature.alg` value: `MERKLE-HS256`.
+
+Leaves preserve the existing segment hash (so GMAC stays free) and add index binding:
+
+```
+L_i = HMAC-SHA256(DEK, 0x00 || u32be(i) || segment_hash_i)
+```
+
+`segment_hash_i` is exactly the value from
+[`basetdf-int.md §4`](../basetdf/basetdf-int.md) — GMAC tag or HMAC — unchanged.
+Index binding prevents transplanting a valid segment to a different position.
+
+Internal nodes:
+
+```
+N = HMAC-SHA256(DEK, 0x01 || left || right)
+```
+
+All nodes 32 bytes. On an odd level the last node is **promoted** unchanged (not
+duplicated). Promotion is safe only because the leaf count is bound into the root:
+
+```
+root_signature = HMAC-SHA256(DEK, 0x02 || u64be(segmentCount) || tree_root)
+```
+
+Base64-encoded into `rootSignature.sig` as today. Domain separators
+`0x00`/`0x01`/`0x02` prevent leaf/internal/root confusion.
+
+**Inclusion proof:** `ceil(log2(N))` sibling nodes — 20 nodes (640 bytes) for 1 TiB
+at 2 MiB segments.
+
+**Streaming build:** a stack of at most `ceil(log2(N))` partial internal nodes; fold
+each leaf as produced. Root available at finalize with O(log N) resident state.
+
+**Verification** (replaces [`basetdf-int.md §7`](../basetdf/basetdf-int.md) step 2
+when `alg` is `MERKLE-HS256`):
+
+- *Full read:* recompute leaves, rebuild tree, compare. Same cost as today.
+- *Partial read:* fetch the inclusion proof for segment `i`, recompute `L_i` from
+  fetched ciphertext, fold the proof, bind `segmentCount`, compare. Readers MUST
+  reject if proof length disagrees with the length implied by `segmentCount`
+  accounting for promotions.
+
+#### P2 — Uniform layout: implicit segment index
+
+**Problem:** the inline `segments` array is the entire manifest-size problem, and
+under uniform segmentation it is fully derivable.
+
+Add `integrityInformation.layout`: `"explicit"` (default, current behavior) or
+`"uniform"`. When `"uniform"`:
+
+- Segments `0 … N-2` MUST be exactly `segmentSizeDefault` bytes — upgrade the SHOULD
+  at [`basetdf-int.md:340-342`](../basetdf/basetdf-int.md) to MUST for this layout.
+- `segmentCount` and `lastSegmentSize` become REQUIRED.
+- `segments` becomes OPTIONAL and SHOULD be omitted.
+- Segment hashes come from the hash tree (P3).
+
+The manifest becomes **constant size** regardless of payload:
+
+```json
+"integrityInformation": {
+  "rootSignature": { "alg": "MERKLE-HS256", "sig": "<base64>" },
+  "segmentHashAlg": "GMAC",
+  "segmentSizeDefault": 2097152,
+  "encryptedSegmentSizeDefault": 2097180,
+  "layout": "uniform",
+  "segmentCount": 524288,
+  "lastSegmentSize": 1048576,
+  "hashTree": { "nodeSize": 32, "levels": 20, "locator": { "...": "see P9" } }
+}
+```
+
+**Offset arithmetic (normative for `uniform`).** For plaintext offset `B`:
+
+```
+i           = floor(B / segmentSizeDefault)
+intraOffset = B mod segmentSizeDefault
+physOffset  = payloadStart + i * encryptedSegmentSizeDefault
+```
+
+Closed form, O(1). Stating this normatively is what lets a reader skip the segments
+array entirely — the property G3 depends on.
+
+**Writer guidance:** select `explicit` below a configurable threshold (RECOMMENDED
+4,096 segments ≈ 8 GiB), `uniform` above.
+
+#### P3 — Externalized hash tree
+
+**Problem:** the tree must live somewhere range-readable so a partial reader fetches
+~640 bytes instead of the whole structure.
+
+The tree is a distinct artifact addressed by a locator (P9). In the attached
+packaging it is a third ZIP entry, `0.integrity`; in detached packaging it is a
+separate object, or MAY be inlined into the manifest as base64 when small
+(RECOMMENDED threshold: 64 KiB, i.e. ~1,000 segments).
+
+Attached entry order MUST be `0.payload`, `0.integrity`, `0.manifest.json` — payload
+first so streaming readers are unaffected; the tree is written at finalize when the
+leaf set is complete.
+
+**Binary format** (little-endian; nodes are opaque 32-byte values):
+
+```
+offset  size  field
+0       8     magic       "BTDFMT\x01\x00"
+8       4     version     u32 = 1
+12      1     nodeSize    u8 = 32
+13      1     levels      u8 = ceil(log2(leafCount)) + 1
+14      2     reserved    MUST be zero
+16      8     leafCount   u64
+24      8     nodeCount   u64
+32      ...   nodes       level-order: level 0 (leaves), then level 1, ...
+```
+
+Level `l` has `ceil(leafCount / 2^l)` nodes; its byte offset is
+`32 + 32 * Σ_{j<l} ceil(leafCount / 2^j)`. Both closed-form, so a reader computes
+any proof node's byte range arithmetically with no index.
+
+**Sizing.** ~`2N` nodes = 64 bytes/segment stored — comparable to today's 89-byte
+JSON entry — but the reader **fetches** only `O(log N)`:
+
+| Payload | Tree stored | Fetched per random read |
+|---|---|---|
+| 1 GiB | 33 KB | 320 B (10 nodes) |
+| 1 TiB | 34 MB | 640 B (20 nodes) |
+| 1 PiB | 34 GB | 960 B (30 nodes) |
+
+**Trust.** The tree is unauthenticated on its own — fine, because every node
+consumed folds into a computation checked against `rootSignature.sig`, HMAC'd under
+the DEK. A tampered tree yields a root mismatch. Readers MUST bound reads by the
+header's `nodeCount` and MUST validate `nodeCount` against `leafCount` before
+allocating.
+
+**Streaming write.** Buffer leaf hashes (32 B/segment — 16 MB per TiB) and emit the
+tree at finalize. Per G1 this MAY spill to temporary storage; only the O(log N)
+folding stack must be resident.
+
+---
+
+### Family B — Distribution
+
+#### P4 — Partition key derivation
+
+**Problem:** distributed writers each need the whole DEK.
+
+Add OPTIONAL `encryptionInformation.keyDerivation`. Absent → segments encrypted
+directly under the DEK (current behavior). Present:
+
+```json
+"keyDerivation": { "alg": "HKDF-SHA256", "partitionSegments": 512 }
+```
+
+```
+p   = floor(i / partitionSegments)
+K_p = HKDF-Expand(PRK = DEK, info = "BaseTDF-part-v1" || u64be(p), L = 32)
+```
+
+Segment `i` is encrypted with `K_p`. With `segmentHashAlg: GMAC` the hash is the tag
+under `K_p` — still free. With `HS256` the segment HMAC is keyed with `K_p`.
+
+Merkle leaves, internal nodes, and the root signature stay keyed under the **DEK**,
+so integrity remains a whole-object property and no worker can forge a root. A
+worker computes its segments' *hashes* but not their leaves; the reducer, holding
+the DEK, applies `L_i = HMAC-SHA256(DEK, 0x00 || u32be(i) || segment_hash_i)` — one
+HMAC over 20 bytes per segment, ~500k HMACs for 1 TiB, well under a second.
+
+**Security property delivered:** a worker assigned partition `p` receives only
+`K_p`, decrypting exactly `partitionSegments × segmentSizeDefault` bytes — its
+assigned range and nothing more. This is what G2 requires. At 512 × 2 MiB = 1 GiB
+per partition, a 1 TiB job is 1,024 workers each holding a 1 GiB-scoped key.
+
+Not forward-secret; no protection against a worker that separately obtains the DEK.
+It scopes *distribution*, which is the actual operational risk.
+
+#### P5 — Normative deterministic IV
+
+**Problem:** `basetdf-sec.md:622-624` only RECOMMENDS counter IVs, so distributed
+writers cannot rely on stateless IV assignment interoperating, and readers cannot
+detect nonce reuse.
+
+Upgrade to MUST for `layout: "uniform"`, using NIST SP 800-38D §8.2.1:
+
+```
+IV_i = noncePrefix (4 bytes) || u64be(i)
+```
+
+`noncePrefix` is 4 CSPRNG bytes per TDF, recorded in
+`encryptionInformation.method.noncePrefix`. The IV remains prepended to each
+segment, so the wire format is unchanged — but a 5.0 reader MUST verify the
+prepended IV matches the derived value and MUST reject on mismatch. That converts a
+silent catastrophic failure (nonce reuse) into a detected one. Uniqueness holds for
+`i < 2^64`; with P4, `i` is globally unique so uniqueness holds per-`K_p` too.
+
+#### P6 — ZIP streaming-write profile
+
+**Problem:** unspecified ZIP mechanics for unknown-length input.
+
+Normative, in BaseTDF-PKG:
+
+- A writer without advance knowledge of payload length MUST set general-purpose bit
+  3 on the `0.payload` local file header, write zeros for CRC-32 and both sizes, and
+  emit a ZIP64 data descriptor (8-byte sizes) immediately after the entry data.
+- Such a writer MUST use ZIP64 unconditionally — ZIP64 extra field on the local
+  header, ZIP64 EOCD record and locator. It MUST NOT decide based on final size.
+- CRC-32 computed incrementally over encrypted payload bytes.
+- `0.integrity` and `0.manifest.json` have known sizes and MUST NOT use data
+  descriptors.
+- Readers MUST support data descriptors on `0.payload` and MUST prefer central
+  directory values when the two disagree — the central directory is authoritative.
+
+Non-normative: a writer with known length SHOULD use the non-streaming form, which
+is readable by strictly size-prefix-dependent parsers.
+
+---
+
+### Family C — Packaging and detachment
+
+#### P7 — Packaging profiles
+
+Split "what a TDF *is*" from "how it is *stored*", as JWS splits object from
+serialization. New top-level manifest field `packaging`:
+
+| Value | Description |
+|---|---|
+| `"attached"` | Single ZIP: `0.payload` [`0.integrity`] `0.manifest.json`. The 4.x shape. |
+| `"detached"` | Manifest is a standalone JSON document; payload is one independently-addressed object. |
+| `"sharded"` | Detached, with payload split across N independently-addressed parts. |
+
+**Attached** (default; unchanged from 4.4 apart from the optional third entry):
+
+```json
+"packaging": "attached",
+"payload": {
+  "type": "reference", "url": "0.payload", "protocol": "zip",
+  "mimeType": "text/plain", "isEncrypted": true
+}
+```
+
+**Detached:**
+
+```json
+"packaging": "detached",
+"payload": {
+  "type": "detached",
+  "mimeType": "text/plain",
+  "isEncrypted": true,
+  "size": 1099511627776,
+  "locators": [
+    { "uri": "https://vfs.customer.example/objects/9f2a", "priority": 0 },
+    { "uri": "s3://customer-bucket/tdf/9f2a", "priority": 1 }
+  ]
+}
+```
+
+Multiple priority-ordered locators give mirroring and let the customer host the
+payload wherever they choose while a third party serves manifests.
+
+**Sharded** adds `parts`, each covering a segment range:
+
+```json
+"packaging": "sharded",
+"payload": {
+  "type": "detached", "mimeType": "application/octet-stream", "isEncrypted": true,
+  "size": 1099511627776,
+  "parts": [
+    { "index": 0, "segmentRange": [0, 512], "size": 1073756160, "locators": [ ... ] },
+    { "index": 1, "segmentRange": [512, 1024], "size": 1073756160, "locators": [ ... ] }
+  ]
+}
+```
+
+Parts MUST be ordered, contiguous, non-overlapping, and segment-aligned; readers
+MUST reject a `parts` array violating any of these. Part boundaries need not align
+with P4 partition boundaries, but SHOULD, and writers SHOULD emit them equal.
+
+**Payload-side identification.** A bare payload object carries no pointer to its
+manifest — by design, since that pointer would leak the metadata location to the
+payload host. Manifest discovery is an application concern (a catalog, a naming
+convention, an out-of-band reference). This MUST be stated explicitly rather than
+left as an apparent oversight.
+
+**Content binding.** The authoritative manifest→payload binding is always the
+DEK-keyed root signature. An OPTIONAL `payload.contentBinding` (`{alg, hash}`,
+unkeyed SHA-256 over the ciphertext) MAY be included for deduplication and
+content-addressing. It is a **privacy trade-off**: an unkeyed digest is a stable
+public identifier for the ciphertext, letting a manifest host or network observer
+correlate copies across tenants. RECOMMENDED default is to omit it. See §11 Q3.
+
+#### P8 — Manifest signature
+
+**Problem:** §5.7 — detachment makes the manifest independently tamperable, and
+`payload.locators` becomes a redirect primitive that a reader must evaluate
+*before* it has a DEK.
+
+Add a signature over the whole manifest, verifiable without the DEK.
+
+**Reuse the assertion mechanism rather than inventing a parallel one.** BaseTDF-ASN
+already defines JWS bindings, key resolution, and verification
+([`basetdf-asn.md §5`](../basetdf/basetdf-asn.md)). Add `scope: "manifest"` to the
+scope enum (currently `"tdo"` | `"payload"`,
+[`basetdf-asn.md:115`](../basetdf/basetdf-asn.md)) with these constraints:
+
+- A `scope: "manifest"` assertion MUST use an **asymmetric** binding (`ES256`
+  RECOMMENDED, `RS256` permitted). The ASN default of HS256-with-DEK is
+  **PROHIBITED** for this scope — a DEK-keyed signature is unverifiable until after
+  rewrap, which defeats the purpose of validating locators before fetching them.
+- The signed content is the RFC 8785 (JCS) canonicalization of the manifest with the
+  signing assertion itself removed. JCS avoids depending on byte-exact
+  re-serialization while keeping the manifest a self-contained document.
+- Coverage is the entire manifest: `payload`, `encryptionInformation`, `packaging`,
+  and all other assertions.
+
+**Requirement levels:** REQUIRED for `detached` and `sharded`; OPTIONAL for
+`attached` (where the ZIP provides adequate practical binding).
+
+**Cost:** this introduces a publisher-key PKI dependency that BaseTDF does not have
+today — signer key distribution, `kid` resolution, rotation, revocation. That is a
+real operational burden and the main argument against G4. See §11 Q4.
+
+#### P9 — Resource locators and fetch policy
+
+Detachment turns readers into HTTP clients acting on attacker-influenced URLs. This
+needs its own document (BaseTDF-LOC), not a paragraph.
+
+Locator object:
+
+```json
+{ "uri": "https://vfs.customer.example/objects/9f2a", "priority": 0, "size": 1073756160 }
+```
+
+Normative reader requirements:
+
+- Readers MUST NOT dereference a locator unless its origin matches a configured
+  allowlist. Prior art in the SDK: `allowListFromKASRegistry` (`sdk/tdf.go:784`)
+  and the existing `kasAllowList` config — the same pattern, applied to payload
+  origins.
+- Readers MUST reject schemes outside a configured set (default: `https`, plus
+  explicitly enabled object-store schemes).
+- Readers MUST NOT follow redirects to origins outside the allowlist.
+- Readers MUST verify a P8 manifest signature **before** dereferencing any locator.
+- Readers MUST enforce a declared-size bound on fetched bytes and MUST reject a
+  response exceeding it.
+- Implementations MUST document their default posture. Fetching arbitrary URLs from
+  an unauthenticated manifest is an SSRF vulnerability, and the default MUST be
+  deny.
+
+#### P10 — Multi-manifest semantics
+
+G5 falls out of P7 mechanically: once manifests are standalone documents, publishing
+a second one over the same payload requires only a new KAO set wrapping the same DEK.
+
+**The security semantics must be specified, because they are counterintuitive.**
+Every manifest over a given payload wraps the *same DEK*. Therefore:
+
+> The effective access policy for a payload is the **union** of the policies of all
+> manifests that reference it. A second manifest with a laxer policy does not
+> coexist with a stricter first manifest — it supersedes it for any entity that can
+> obtain the second. Publishing an additional manifest is equivalent to widening the
+> policy on the original.
+
+Writers MUST NOT treat multi-manifest publication as a way to enforce differentiated
+access to the same ciphertext. Genuine separation requires distinct DEKs, i.e.
+re-encryption. This belongs in BaseTDF-SEC as a numbered security consideration, not
+a footnote — it is exactly the mistake a reasonable implementer will make.
+
+#### P11 — Consistency proofs and append-only payloads
+
+With P1's Merkle tree, RFC 6962 §2.2 consistency proofs let a reader verify that
+manifest v2's payload is a strict **extension** of manifest v1's. Combined with
+detachment, that makes live-appended payloads tractable: append segments, publish a
+new manifest with a larger `segmentCount`, and prior manifests still verify against
+the prefix.
+
+```json
+"extends": {
+  "segmentCount": 262144,
+  "rootSignature": "<base64 of prior root signature>",
+  "consistencyProof": ["<base64 node>", "..."]
+}
+```
+
+Verification requires the DEK (nodes are DEK-keyed), so this proves extension to a
+key holder, not to the public. Sufficient for the intended use — a reader confirming
+the object it read yesterday was not rewritten.
+
+Lowest-priority proposal; include the manifest field in 5.0 so the shape is
+reserved, and defer full writer support to 5.1 if schedule pressure demands.
+
+---
+
+### 6.10 Security model changes
+
+These are spec-text obligations, not code, and are easy to drop. They are not
+optional.
+
+1. **Rewrite Tenet 1** ([`basetdf-sec.md:118-122`](../basetdf/basetdf-sec.md)).
+   Today it grounds NIST SP 800-207 Tenet 1 in self-containment. Reframe around
+   **self-description**: the manifest remains the complete authoritative record of
+   what is protected and under what conditions; 5.0 changes where those bytes live,
+   not what they assert. A detached TDF still requires no external *policy* catalog.
+2. **Add the multi-manifest union rule** (P10) as a numbered consideration.
+3. **Add the compartmentalization model** — a table of what each party observes
+   under each packaging profile, stating plainly that detachment does not confer
+   metadata confidentiality against the manifest host (G4 scoping note).
+4. **Add a correlation consideration** — detachment means manifest and payload are
+   fetched separately, often near in time. Traffic analysis can relink them. Note
+   `contentBinding` (P7) as an additional deliberate correlation surface.
+5. **Add crypto-shredding as a property** — destroying a detached manifest destroys
+   the KAOs and hence the path to the DEK, giving a revocation primitive 4.x lacks.
+   State its limits: it is not retroactive against a party who already rewrapped.
+6. **Add the SSRF surface** (P9) to the threat model.
+
+### 6.11 Goal coverage
+
+| Goal | Mechanism |
+|---|---|
+| G1 | P2 caps manifest size; P1 gives O(log N) write state; P3 permits spilling; P6 removes the length requirement |
+| G2 | P4 scopes keys per partition; P5 makes IV assignment stateless; P1 trees are per-partition buildable and mergeable |
+| G3 | P2 gives closed-form offsets; P1+P3 give O(log N) authenticated single-segment reads |
+| G4 | P7 defines the profiles; P8 authenticates the manifest; P9 constrains dereferencing; P2 makes manifests small enough to serve |
+| G5 | P7 (standalone manifests) + P10 (semantics) |
+
+**G3 after the change, 1 TiB cold single-byte read:** ~2 KB manifest + 32 B tree
+header + 640 B proof + one 2 MiB segment. Meets the ≤ 64 KiB criterion for
+everything except the segment, which is inherent to segment size.
+
+---
+
+## 7. Suite document plan
+
+**BaseTDF-CORE** — refactored. Retains the abstract manifest schema, `packaging`
+dispatch, and creation/reading flows. ZIP specifics move to PKG. Design Principle 1
+becomes "self-description."
+
+**BaseTDF-PKG (new)** — packaging profiles: attached (ZIP layout, entry order,
+constraints, hardening from current CORE §10.2), detached, sharded; the streaming
+write profile (P6); the `0.integrity` entry.
+
+**BaseTDF-LOC (new)** — locator object, URI schemes, allowlisting, redirect and
+size-bound rules, SSRF threat model (P9).
+
+**BaseTDF-INT** — extended: Merkle construction (P1), `layout` and closed-form
+offsets (P2), hash tree format (P3), partial-verification conformance profile,
+consistency proofs (P11).
+
+**BaseTDF-SEC** — extended per §6.10.
+
+**BaseTDF-ALG** — new registry rows: `MERKLE-HS256` (integrity MAC),
+`HKDF-SHA256` (key derivation, new category), `ES256` for manifest signing.
+
+**BaseTDF-ASN** — `scope: "manifest"` plus the asymmetric-binding constraint (P8).
+
+**BaseTDF-KAO / POL / KAS** — frozen. Republished at 5.0.0 with no normative change.
+
+**BaseTDF-EX** — new worked examples per §8.7.
+
+Update the dependency graph and reading order in
+[`README.md:23-67`](../basetdf/README.md) for the two new documents.
+
+---
+
+## 8. Reference implementation plan (Go SDK)
+
+Target module `sdk/`. All work must satisfy the repo's mandatory checks — see
+[`CLAUDE.md`](../../CLAUDE.md): `golangci-lint run` clean, `go test ./...` passing,
+`gofumpt -w` on changed files, and `go test -run TestREADMECodeBlocks` in `sdk/` if
+README examples change.
+
+### 8.1 New package `sdk/internal/merkle`
+
+```go
+package merkle
+
+// Builder folds leaves in streaming order with O(log N) resident state.
+type Builder struct{ /* stack []node; count uint64; dek []byte */ }
+
+func NewBuilder(dek []byte) *Builder
+func (b *Builder) Add(index uint64, segmentHash []byte) error
+func (b *Builder) Count() uint64
+func (b *Builder) Root() ([]byte, error)
+func (b *Builder) RootSignature() ([]byte, error) // HMAC(dek, 0x02||u64be(count)||root)
+
+type Tree struct{ /* levels [][]byte; leafCount uint64 */ }
+
+func BuildTree(dek []byte, segmentHashes [][]byte) (*Tree, error)
+func (t *Tree) WriteTo(w io.Writer) (int64, error)
+func (t *Tree) Proof(index uint64) ([][]byte, error)
+
+// ProofReader fetches only the sibling path via ranged reads.
+type ProofReader struct{ /* ra io.ReaderAt; leafCount uint64; levels uint8 */ }
+
+func OpenProofReader(ra io.ReaderAt) (*ProofReader, error)
+func (p *ProofReader) Proof(index uint64) ([][]byte, error)
+
+func VerifyInclusion(dek []byte, index, leafCount uint64, segmentHash []byte,
+    proof [][]byte, wantRootSig []byte) error
+
+func Merge(dek []byte, partitions []*Tree) (*Tree, error)         // reducer
+func ConsistencyProof(t *Tree, oldLeafCount uint64) ([][]byte, error) // P11
+```
+
+Node offsets must be closed-form so `ProofReader` issues exactly `levels` ranged
+reads.
+
+### 8.2 `sdk/manifest.go`
+
+Confirmed existing shape: `IntegrityInformation` (`manifest.go:14`),
+`EncryptionInformation` (`manifest.go:54`), `Method` (`manifest.go:39`),
+`Payload` (`manifest.go:45`). Add, all `omitempty` so explicit/attached
+serialization is byte-identical to today:
+
+```go
+type IntegrityInformation struct {
+    // ... existing ...
+    Layout          string       `json:"layout,omitempty"`
+    SegmentCount    int64        `json:"segmentCount,omitempty"`
+    LastSegmentSize int64        `json:"lastSegmentSize,omitempty"`
+    HashTree        *HashTreeRef `json:"hashTree,omitempty"`
+}
+
+type Locator struct {
+    URI      string `json:"uri"`
+    Priority int    `json:"priority,omitempty"`
+    Size     int64  `json:"size,omitempty"`
+}
+
+type PayloadPart struct {
+    Index        int64     `json:"index"`
+    SegmentRange [2]int64  `json:"segmentRange"`
+    Size         int64     `json:"size"`
+    Locators     []Locator `json:"locators"`
+}
+```
+
+Plus `Packaging string` on `Manifest`; `Locators []Locator` and `Parts []PayloadPart`
+on `Payload`; `KeyDerivation *KeyDerivation` on `EncryptionInformation`;
+`NoncePrefix string` on `Method`.
+
+The existing `Segments []Segment` (`manifest.go:19`) has no `omitempty` and must
+gain one. Verify this does not change attached/explicit output — `Segments` is never
+empty on that path — but **assert it in a golden-fixture test** rather than assuming.
+
+Add accessors that normalize the zero value so call sites never branch on `""`:
+`Manifest.Layout()` → `"explicit"`, `Manifest.Packaging()` → `"attached"`.
+
+### 8.3 `sdk/tdf.go` — writer
+
+- `CreateTDFContext` (`tdf.go:164`) keeps its signature and behavior; add layout
+  selection above the threshold.
+- **New** `CreateTDFStream(ctx, w io.Writer, r io.Reader, opts ...TDFOption)` — no
+  seek, always uniform layout, always the P6 ZIP profile. The G1 entry point. Do not
+  overload `CreateTDFContext`; the size-known path has different optimal behavior
+  and conflating them produces a function nobody can reason about.
+- Replace the `strings.Builder` aggregate hash (`tdf.go:233-294`) with
+  `merkle.Builder` under uniform layout; keep the existing path for explicit.
+- Assertion binding (`tdf.go:362`) concatenates the aggregate hash. Under Merkle,
+  substitute the 32-byte tree root. **This changes assertion signatures** — gate on
+  layout and cover with a fixture per profile.
+
+### 8.4 `sdk/tdf.go` — reader
+
+- `Reader.ReadAt` (`tdf.go:994`) — rewrite. Uniform layout: closed-form offsets plus
+  `merkle.ProofReader`, no segments scan. Explicit layout: keep the scan but build a
+  prefix-sum offset table **once** at `LoadTDF` instead of rescanning per call. That
+  fix is independently valuable and lands first (Phase 0).
+- Root validation (`tdf.go:1317-1327`) — under uniform layout there is no segments
+  array to fold; verify lazily per segment via inclusion proof rather than eagerly
+  materializing the tree.
+- Add `Reader.VerifyWhole(ctx) error` for callers wanting today's all-or-nothing
+  guarantee explicitly, since partial reads no longer imply it.
+- Derive `K_p` in `buildKey` (`tdf.go:1249`) when `keyDerivation` is present; cache
+  derived keys in a 16-entry LRU on the `Reader`.
+
+### 8.5 `sdk/internal/zipstream`
+
+- Writer: general-purpose bit 3, ZIP64 data descriptors, incremental CRC-32.
+- Reader: accept and validate data descriptors; prefer central directory values.
+- Third entry `0.integrity` with a ranged `ReadIntegrity(offset, length int64)`
+  accessor mirroring `ReadPayload`.
+- `manifestMaxSize` stays at 10 MB (`tdf3_reader.go:15`). Under uniform layout it is
+  no longer a payload-size ceiling. **Document it** — the current limit is
+  undocumented and surprising.
+
+### 8.6 New packages
+
+**`sdk/packaging`** — the P7 abstraction. `Reader`/`Writer` interfaces over
+attached/detached/sharded so `sdk.Reader` is agnostic:
+
+```go
+type PayloadSource interface {
+    ReadAt(p []byte, off int64) (int, error)
+    Size() int64
+}
+type IntegritySource interface {
+    ReadAt(p []byte, off int64) (int, error)
+}
+func Open(m *Manifest, res Resolver) (PayloadSource, IntegritySource, error)
+```
+
+**`sdk/locator`** — P9. `Resolver` with allowlist enforcement, scheme restriction,
+redirect policy, size bounds. **Default-deny.** Reuse the `allowListFromKASRegistry`
+(`tdf.go:784`) pattern for consistency.
+
+**`sdk/distributed`** — the G2 surface; keep out of the root package until the API
+settles.
+
+```go
+type JobSpec struct {
+    TotalSize, SegmentSize, PartitionSegments int64
+    NoncePrefix [4]byte
+}
+type Partition struct {
+    Index     int64
+    ByteRange [2]int64 // plaintext, segment-aligned
+    Key       []byte   // K_p only — never the DEK
+}
+func Plan(spec JobSpec) ([]Partition, error)
+
+type PartitionResult struct {
+    Index         int64
+    SegmentHashes [][]byte
+    CiphertextLen int64
+}
+func EncryptPartition(p Partition, spec JobSpec, r io.Reader, w io.Writer) (*PartitionResult, error)
+
+type Assembler struct{ /* dek, spec */ }
+func (a *Assembler) Add(res *PartitionResult) error
+func (a *Assembler) Finalize(w io.Writer, payload io.Reader) (*Manifest, error)
+```
+
+`Plan` MUST reject a `TotalSize` producing a non-final interior partition whose byte
+range is not a multiple of `SegmentSize` — fail loudly at plan time, not corrupt at
+reduce time.
+
+**`sdk/manifestsig`** — P8. JCS canonicalization (RFC 8785), ES256 sign/verify,
+`kid` resolution. Reuse `sdk/assertion.go` binding machinery where possible.
+
+### 8.7 Schema and test vectors
+
+Update [`spec/schema/BaseTDF/manifest.schema.json`](../schema/BaseTDF/manifest.schema.json):
+conditionals on `layout` (uniform requires `segmentCount`/`lastSegmentSize`/
+`hashTree`, forbids `segments`) and on `packaging` (detached/sharded require
+`payload.locators` or `payload.parts` and a manifest signature; forbid
+`payload.url`). Use `if`/`then`/`else`, not `oneOf`, so errors name the actual
+missing field.
+
+Vectors in [`basetdf-ex.md`](../basetdf/basetdf-ex.md) with fixtures under
+`sdk/testdata/basetdf-v5/`:
+
+1. Merkle trees, N ∈ {1, 2, 3, 5, 8, 1000}, fixed DEK, all nodes shown. N=3 and N=5
+   exercise promotion.
+2. Inclusion proofs for N=1000 at i ∈ {0, 1, 499, 998, 999}.
+3. **Promotion-attack negative vector** — a forged tree duplicating the last leaf to
+   reach N+1, proving count binding rejects it.
+4. Uniform manifest for a 16 GiB TDF, demonstrating it is under 2 KB.
+5. `0.integrity` fixture, byte-for-byte, with annotated level offsets.
+6. Partition key vectors: DEK → `K_0`, `K_1`, `K_1023` at `partitionSegments: 512`.
+7. Deterministic IV vectors: `noncePrefix` → `IV_0`, `IV_1`, `IV_{2^32}`.
+8. Cross-profile round trip: same plaintext, explicit and uniform, identical output.
+9. Streaming-write ZIP fixture, verified against `unzip`, Go `archive/zip`, and
+   Python `zipfile`.
+10. Detached manifest + separate payload object, with a signature vector.
+11. Sharded manifest with 4 parts, including a negative vector for a non-contiguous
+    `parts` array.
+12. **Locator negative vectors** — off-allowlist origin, non-https scheme,
+    redirect-to-unlisted, oversize response.
+13. Consistency proof: manifest at N=1000 extending N=512.
+
+---
+
+## 9. Sequencing
+
+Each phase is a separately reviewable change with tests. Phases 1 and 2 are
+independent after Phase 0.
+
+**Phase 0 — Non-breaking prerequisites.** No format change; ship against 4.4.
+- Fix the O(N)-per-call scan in `Reader.ReadAt` (`tdf.go:994`) with a prefix-sum
+  table built at `LoadTDF`.
+- Document the `manifestMaxSize` ceiling and its payload-size implication; surface
+  an actionable error.
+- Benchmarks `BenchmarkReadAtCold` / `BenchmarkReadAtRandom` at 1, 10, 100 GiB — the
+  regression baseline for everything below.
+
+**Phase 1 — Merkle core.** `sdk/internal/merkle`, BaseTDF-INT §5.4, ALG rows,
+vectors 1–3. Pure library, no format change.
+
+**Phase 2 — ZIP streaming profile (P6).** BaseTDF-PKG, zipstream changes, vector 9.
+
+**Phase 3 — Uniform layout (P2 + P3).** Manifest fields, `0.integrity`, schema,
+closed-form offsets, partial verification. Depends on 1, 2. Vectors 4, 5, 8.
+**Meets G3.**
+
+**Phase 4 — Streaming writer.** `CreateTDFStream`. Depends on 2, 3. **Meets G1.**
+Acceptance: encrypt from a pipe with no length; assert bounded RSS via
+`runtime.MemStats` across payload sizes spanning three orders of magnitude.
+
+**Phase 5 — Partition keys and IVs (P4 + P5).** Vectors 6, 7.
+
+**Phase 6 — Distributed writer.** `sdk/distributed`. Depends on 3, 5. **Meets G2.**
+Acceptance: plan a job, run partitions in separate goroutines holding only their
+`K_p`, assemble, round-trip — plus a negative test asserting a worker with `K_p`
+cannot decrypt partition `p+1`.
+
+**Phase 7 — Suite refactor.** Split CORE into CORE + PKG; create LOC; update the
+README dependency graph. Spec-only, no code. Can run in parallel with 4–6.
+
+**Phase 8 — Manifest signature (P8).** `sdk/manifestsig`, ASN `scope: "manifest"`,
+vector 10's signature. Depends on 7.
+
+**Phase 9 — Detached and sharded packaging (P7 + P9).** `sdk/packaging`,
+`sdk/locator`, schema conditionals, vectors 10–12. Depends on 3, 8. **Meets G4.**
+
+**Phase 10 — Multi-manifest (P10).** Largely spec text plus a helper to mint an
+additional manifest against an existing payload. **Meets G5.**
+
+**Phase 11 — Consistency proofs (P11).** Vector 13. Deferrable to 5.1.
+
+**Phase 12 — Interop and release.** Cross-implementation vectors, 4.4→5.0 migration
+guide, explicit statement of 4.x reader behavior on a 5.0 object, SEC changes from
+§6.10 landed and reviewed.
+
+---
+
+## 10. Risks
+
+| Risk | Mitigation |
+|---|---|
+| **Scope creep** — a major version invites reopening POL, KAS, PQC | The §3.4 charter is normative for the release. Frozen documents republish unchanged. |
+| **PKI dependency** (P8) — signer key distribution, rotation, revocation | Required only for detached/sharded. Attached users never encounter it. |
+| **SSRF** in detached readers | P9 default-deny plus negative vectors 12. Treat a permissive default as a release blocker. |
+| **Multi-manifest misuse** (P10) — implementers assume differentiated access | Numbered SEC consideration, not a footnote. Consider an SDK-level warning when minting a second manifest. |
+| **Multi-SDK migration** (Go, JS, Java, Python) | Attached+explicit stays byte-identical, so most of the matrix is a version-string change. Gate 5.0 GA on two independent implementations passing the vectors. |
+| **Tenet 1 rewrite** reads as weakening zero trust | Land the SEC rewrite in the same change as the CORE refactor, with the self-description framing argued explicitly. |
+
+---
+
+## 11. Open questions
+
+1. **Merkle arity.** Binary gives 20-node proofs at 1 TiB. Arity 4 gives 10 levels ×
+   3 siblings = 30 nodes — worse in bytes, better in round trips if the tree is not
+   contiguously fetchable. Since levels are contiguous and range-readable, binary
+   looks right. Confirm against real object-store latency before freezing.
+2. **Full tree or leaves only in `0.integrity`?** Full tree is 64 B/segment with
+   O(log N) fetch; leaves only is 32 B/segment but O(N) to reconstruct any internal
+   node. Full tree proposed; revisit if storage cost dominates read latency for a
+   known workload.
+3. **`contentBinding` default (P7).** Unkeyed digest gives dedup and content
+   addressing but is a stable cross-tenant correlation handle. Recommendation: omit
+   by default, OPTIONAL for dedup-oriented deployments. **This is a product decision
+   as much as a security one and needs an explicit owner.**
+4. **Is the P8 PKI dependency acceptable?** It is the largest new operational
+   requirement in 5.0. Alternative: DEK-keyed manifest signature, cheaper but
+   unverifiable before rewrap — which does not solve the locator-validation problem
+   and so does not actually meet G4. If the PKI burden is rejected, G4 should be
+   deferred rather than met with a weaker signature.
+5. **`partitionSegments` as a metadata leak.** It reveals producer job topology.
+   Probably acceptable given the manifest already exposes policy and KAS URLs, but
+   it warrants an explicit SEC note.
+6. **Assertion binding under Merkle.** Substituting the tree root for the aggregate
+   hash is proposed. Confirm no deployed assertion verifier depends on the aggregate
+   hash's length or structure.
+7. **Does the KAS need to know about partitions?** P4 derives client-side from the
+   DEK, so no. A future variant where the KAS releases only partition keys is a KAS
+   protocol change — out of charter, 5.1 at the earliest.
+8. **Manifest discovery for detached payloads.** Deliberately an application
+   concern (P7). Confirm no platform component needs a normative answer, or accept
+   that a catalog service becomes a de facto dependency.
+9. **Interaction with nano TDF.** Out of scope; confirm nothing here forecloses a
+   future shared integrity model.
+
+---
+
+## 12. Appendix: notation
+
+| Symbol | Meaning |
+|---|---|
+| `L` | Plaintext payload length in bytes |
+| `S` | `segmentSizeDefault` |
+| `N` | Segment count = `ceil(L / S)` |
+| `DEK` | Data Encryption Key, 256 bits |
+| `K_p` | Partition key for partition `p` (P4) |
+| `h_i` | Segment hash of segment `i` per [`basetdf-int.md §4`](../basetdf/basetdf-int.md) |
+| `L_i` | Merkle leaf for segment `i` (P1) |
+| `u32be(x)` / `u64be(x)` | Big-endian fixed-width integer encoding |
+| `‖` | Byte concatenation |
+
+---
+
+## 13. References
+
+- [BaseTDF-CORE](../basetdf/basetdf-core.md) — container format, manifest
+- [BaseTDF-INT](../basetdf/basetdf-int.md) — segment model, integrity
+- [BaseTDF-SEC](../basetdf/basetdf-sec.md) — zero trust tenets (§2.2), IV uniqueness (§6.6)
+- [BaseTDF-ALG](../basetdf/basetdf-alg.md) — algorithm registry (§3.3)
+- [BaseTDF-ASN](../basetdf/basetdf-asn.md) — assertion scopes (§2.2), bindings (§5)
+- [BaseTDF-KAO](../basetdf/basetdf-kao.md) — key splitting, policy binding
+- [BaseTDF-KAS](../basetdf/basetdf-kas.md) — bulk rewrap (§8)
+- NIST SP 800-207 — Zero Trust Architecture
+- NIST SP 800-38D §8.2.1 — deterministic IV construction
+- RFC 5869 — HKDF
+- RFC 6962 §2.1, §2.2 — Certificate Transparency: inclusion and consistency proofs
+- RFC 7515 — JWS (serialization-profile precedent)
+- RFC 8785 — JSON Canonicalization Scheme
+- APPNOTE 6.3.10 §4.3.9, §4.4.4 — ZIP data descriptors, general-purpose bit 3


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #3097** (`basetdf/spec-v4.4`). Review that PR first and retarget
> this PR to `main` after #3097 merges.

### Proposed Changes

Defines the BaseTDF **5.0.0** specification suite under `spec/basetdf/v5/` and
retains `spec/goals/scale-improvements.md` as the design rationale. Version 5 is
a breaking wire-format release focused on very large, streamed, distributed,
detached, and randomly accessed payloads. A 5.0 implementation can continue to
read version 4 objects; a 4.x reader is expected to reject version 5 manifests.

The specification now:

* Adds explicit, uniform, and indexed integrity layouts, scalable Merkle proofs,
  append consistency proofs, deterministic segment nonces, and HKDF-derived
  partition keys.
* Separates the logical manifest from physical packaging and defines attached,
  detached, and sharded profiles, including manifest signatures and default-deny
  locator validation.
* Supports distributed writers, constant-overhead random access, multiple
  manifests over one payload, and logical plaintexts of at least **50 TiB**.
* Preserves the BaseTDF 4.4 KAO, policy, and KAS semantics; policy-language,
  KAS-protocol, and new post-quantum changes remain outside the 5.0 charter.

### AES-GCM limits and 50 TiB scaling

The latest changes replace the former independent 1 TiB-per-key rule with the
RFC 9001 multi-user GCM confidentiality budget:

```text
Adv_conf(object) <= 2 * sum(sigma_p^2) / 2^128
sum(sigma_p^2) <= 2^70
```

This retains the approximately `2^-57` object-wide confidentiality target used
by TLS analysis. It implies an absolute limit of `2^35` plaintext blocks, or
512 GiB, under any one content-encryption key. The scalable profile recommends
approximately 1 GiB partitions, which keeps a 50 TiB object below `2^-59`.

The suite includes checked reader/writer validation, exact limit vectors, and a
50 TiB example using 4 MiB segments, 13,107,200 segments, 51,200 partition keys,
and ten ciphertext shards. Sharding accounts for the 28-byte per-segment AEAD
overhead; storage-provider multipart numbers are never used as cryptographic
nonces or segment indexes.

### Checklist

- [ ] I have added or updated unit tests (not applicable: documentation only)
- [ ] I have added or updated integration tests (not applicable: documentation only)
- [x] I have added or updated documentation

### Testing Instructions

Documentation-only change. The GCM inequalities, checked boundary cases, exact
50 TiB segment/partition/shard arithmetic, encrypted sizes, and Merkle-tree sizes
were independently recalculated. Review the normative conformance requirements
in BaseTDF-CORE and the worked vectors in BaseTDF-EX.
