### PR TITLE
feat(cli): enforce required flags from man docs at cobra layer

### DIFF
--- a/otdfctl/cmd/execute.go
+++ b/otdfctl/cmd/execute.go
@@ -49,11 +49,38 @@ func Execute(opts ...ExecuteOptFunc) {
 			os.Exit(cli.ExitCodeError)
 		}
 	} else {
-		err := RootCmd.Execute()
+		// Take over error printing so cobra-level failures (e.g. required or
+		// mutually-exclusive flag validation, which run before the command
+		// handler) still honor --json. Cobra would otherwise print plain text
+		// and usage, producing invalid JSON for automation.
+		RootCmd.SilenceErrors = true
+		RootCmd.SilenceUsage = true
+		cmd, err := RootCmd.ExecuteC()
 		if err != nil {
-			os.Exit(cli.ExitCodeError)
+			handleExecuteError(cmd, err)
 		}
 	}
+}
+
+// handleExecuteError formats an error returned from cobra's Execute. In --json
+// mode it emits the standard JSON error envelope via cli.ExitWithError; otherwise
+// it reproduces cobra's default output (the error followed by usage) on stderr.
+// Either way it exits with a non-zero status.
+func handleExecuteError(cmd *cobra.Command, err error) {
+	if cmd == nil {
+		cmd = RootCmd
+	}
+
+	// --json is a persistent flag on the root command, so it is inherited by the
+	// executed command and parsed by the time Execute returns.
+	if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+		cli.New(cmd, os.Args).ExitWithError(err.Error(), nil)
+		return
+	}
+
+	cmd.PrintErrln("Error:", err.Error())
+	cmd.PrintErrln(cmd.UsageString())
+	os.Exit(cli.ExitCodeError)
 }
 
 func MountRoot(newRoot *cobra.Command, cmd *cobra.Command) error {

--- a/otdfctl/cmd/execute.go
+++ b/otdfctl/cmd/execute.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/opentdf/platform/otdfctl/pkg/cli"
+	"github.com/opentdf/platform/otdfctl/pkg/man"
 	"github.com/spf13/cobra"
 )
 
@@ -36,6 +37,11 @@ func Execute(opts ...ExecuteOptFunc) {
 	for _, opt := range opts {
 		c = opt(c)
 	}
+
+	// Enforce `required: true` doc metadata at the cobra layer now that the whole
+	// command tree is assembled. Done here (rather than in init) so commands added
+	// after otdfctl's own init, including a consumer's, are covered.
+	man.Docs.MarkRequiredFlags()
 
 	if c.mountTo != nil {
 		err := MountRoot(c.mountTo, c.renameCmd)

--- a/otdfctl/e2e/actions.bats
+++ b/otdfctl/e2e/actions.bats
@@ -69,7 +69,7 @@ teardown_file() {
   # missing flag
     run_otdfctl_action create --namespace "$ACTION_NAMESPACE"
         assert_failure
-        assert_output --partial "Flag '--name' is required"
+        assert_output --partial 'required flag(s) "name" not set'
 
     # TODO: re-enable when namespace is required
     # run_otdfctl_action create --name no_namespace

--- a/otdfctl/e2e/attributes.bats
+++ b/otdfctl/e2e/attributes.bats
@@ -468,11 +468,11 @@ teardown_file() {
   # Test with missing required flags
   run_otdfctl_attr key assign --attribute "$ATTR_ID"
   assert_failure
-  assert_output --partial "Flag '--key-id' is required"
+  assert_output --partial 'required flag(s) "key-id" not set'
 
   run_otdfctl_attr key assign --key-id "$KAS_KEY_SYSTEM_ID"
   assert_failure
-  assert_output --partial "Flag '--attribute' is required"
+  assert_output --partial 'required flag(s) "attribute" not set'
 }
 
 @test "KAS key assignment error handling - attribute value" {
@@ -484,11 +484,11 @@ teardown_file() {
   # Test with missing required flags
   run_otdfctl_attr values key assign --key-id "$KAS_KEY_SYSTEM_ID"
   assert_failure
-  assert_output --partial "Flag '--value' is required"
+  assert_output --partial 'required flag(s) "value" not set'
 
   run_otdfctl_attr values key assign --value "00000000-0000-0000-0000-000000000000"
   assert_failure
-  assert_output --partial "Flag '--key-id' is required"
+  assert_output --partial 'required flag(s) "key-id" not set'
 }
 
 @test "List attribute values - Good" {
@@ -557,7 +557,7 @@ teardown_file() {
   # Test with missing required flag
   run_otdfctl_attr values list
   assert_failure
-  assert_output --partial "Flag '--attribute-id' is required"
+  assert_output --partial 'required flag(s) "attribute-id" not set'
 
   # Test with invalid attribute ID format
   run_otdfctl_attr values list --attribute-id "invalid-id"

--- a/otdfctl/e2e/dynamic-value-mapping.bats
+++ b/otdfctl/e2e/dynamic-value-mapping.bats
@@ -93,17 +93,17 @@ teardown_file() {
     # operator is required
     run_otdfctl_dvm create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --action "$ACTION_READ_NAME"
         assert_failure
-        assert_output --partial "resolver operator [--operator] is required"
+        assert_output --partial 'required flag(s) "operator" not set'
 
     # an attribute definition reference is required
     run_otdfctl_dvm create --selector "$SELECTOR" --operator IN --action "$ACTION_READ_NAME"
         assert_failure
-        assert_output --partial "Attribute Definition reference [--attribute] is required"
+        assert_output --partial 'required flag(s) "attribute" not set'
 
     # an action is required
     run_otdfctl_dvm create --attribute "$DVM_ATTR_ID" --selector "$SELECTOR" --operator IN
         assert_failure
-        assert_output --partial "At least one Action [--action] is required"
+        assert_output --partial 'required flag(s) "action" not set'
 }
 
 @test "Create dynamic value mapping rejects a HIERARCHY definition" {

--- a/otdfctl/e2e/kas-keys-mappings.bats
+++ b/otdfctl/e2e/kas-keys-mappings.bats
@@ -232,11 +232,13 @@ assert_key_mapping_details() {
 @test "kas-keys-mappings: list key mappings - required together are missing" {
   run_otdfctl_key list-mappings --key-id "nonexistent-key" --json
   assert_failure
-  assert_output --partial "--kas"
+  assert_equal "$(echo "$output" | jq -r .status)" "ERROR"
+  assert_equal "$(echo "$output" | jq -r .message)" "if any flags in the group [key-id kas] are set they must all be set; missing [kas]"
 
   run_otdfctl_key list-mappings --kas "${KAS_NAME}" --json
   assert_failure
-  assert_output --partial "--kas"
+  assert_equal "$(echo "$output" | jq -r .status)" "ERROR"
+  assert_equal "$(echo "$output" | jq -r .message)" "if any flags in the group [key-id kas] are set they must all be set; missing [key-id]"
 }
 
 @test "kas-keys-mappings: list key mappings - mutually exclusive flags" {

--- a/otdfctl/e2e/kas-keys-mappings.bats
+++ b/otdfctl/e2e/kas-keys-mappings.bats
@@ -242,5 +242,6 @@ assert_key_mapping_details() {
 @test "kas-keys-mappings: list key mappings - mutually exclusive flags" {
   run_otdfctl_key list-mappings --kas "${KAS_NAME}" --key-id "nonexistent-key" --id "${KEY_ID_1}" --json
   assert_failure
-  assert_output --partial "Error: if any flags in the group [kas id] are set none of the others can be; [id kas] were all set"
+  assert_equal "$(echo "$output" | jq -r .status)" "ERROR"
+  assert_equal "$(echo "$output" | jq -r .message)" "if any flags in the group [kas id] are set none of the others can be; [id kas] were all set"
 }

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -612,7 +612,8 @@ format_kas_name_as_uri() {
 @test "kas-keys: get key (failure: only kas, missing key-id or system id)" {
   run_otdfctl_key get --kas "${KAS_REGISTRY_ID}" --json
   assert_failure
-  assert_output --partial 'required flag(s) "key" not set'
+  assert_equal "$(echo "$output" | jq -r .status)" "ERROR"
+  assert_equal "$(echo "$output" | jq -r .message)" 'required flag(s) "key" not set'
 }
 
 @test "kas-keys: get key (not found by system ID)" {
@@ -692,9 +693,10 @@ format_kas_name_as_uri() {
 @test "kas-keys: update key (missing id)" {
   run_otdfctl_key update --json
   assert_failure
-  # Cobra rejects the missing required flag before the handler runs, so the error
-  # is plain text on stderr rather than the handler's JSON envelope.
-  assert_output --partial 'required flag(s) "id" not set'
+  # Cobra rejects the missing required flag before the handler runs; the error is
+  # formatted as the standard JSON envelope because --json is set.
+  assert_equal "$(echo "$output" | jq -r .status)" "ERROR"
+  assert_equal "$(echo "$output" | jq -r .message)" 'required flag(s) "id" not set'
 }
 
 @test "kas-keys: unsafe update key mode remote to public_key" {

--- a/otdfctl/e2e/kas-keys.bats
+++ b/otdfctl/e2e/kas-keys.bats
@@ -312,21 +312,21 @@ format_kas_name_as_uri() {
 @test "kas-keys: create key (missing key-id)" {
   run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --algorithm "rsa:2048" --mode "local" --wrapping-key-id "wrapping-key-1" --wrapping-key "${WRAPPING_KEY}"
   assert_failure
-  assert_output --partial "Flag '--key-id' is required"
+  assert_output --partial 'required flag(s) "key-id" not set'
 }
 
 @test "kas-keys: create key (missing algorithm)" {
   KEY_ID=$(generate_key_id)
   run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${KEY_ID}" --mode "local" --wrapping-key-id "wrapping-key-1" --wrapping-key "${WRAPPING_KEY}"
   assert_failure
-  assert_output --partial "Flag '--algorithm' is required"
+  assert_output --partial 'required flag(s) "algorithm" not set'
 }
 
 @test "kas-keys: create key (missing mode)" {
   KEY_ID=$(generate_key_id)
   run_otdfctl_key create --kas "${KAS_REGISTRY_ID}" --key-id "${KEY_ID}" --algorithm "rsa:2048" --wrapping-key-id "wrapping-key-1" --wrapping-key "${WRAPPING_KEY}"
   assert_failure
-  assert_output --partial "Flag '--mode' is required"
+  assert_output --partial 'required flag(s) "mode" not set'
 }
 
 @test "kas-keys: create key (local mode, missing wrapping-key-id)" {
@@ -421,7 +421,7 @@ format_kas_name_as_uri() {
   KEY_ID=$(generate_key_id)
   run_otdfctl_key create --key-id "${KEY_ID}" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64}"
   assert_failure
-  assert_output --partial "Flag '--kas' is required"
+  assert_output --partial 'required flag(s) "kas" not set'
 }
 
 @test "kas-keys: create key (using kasName)" {
@@ -612,7 +612,7 @@ format_kas_name_as_uri() {
 @test "kas-keys: get key (failure: only kas, missing key-id or system id)" {
   run_otdfctl_key get --kas "${KAS_REGISTRY_ID}" --json
   assert_failure
-  assert_output --partial "Flag '--key' is required"
+  assert_output --partial 'required flag(s) "key" not set'
 }
 
 @test "kas-keys: get key (not found by system ID)" {
@@ -692,8 +692,9 @@ format_kas_name_as_uri() {
 @test "kas-keys: update key (missing id)" {
   run_otdfctl_key update --json
   assert_failure
-  assert_equal "$(echo "$output" | jq -r .status)" "ERROR"
-  assert_equal "$(echo "$output" | jq -r .message)" "Flag '--id' is required"
+  # Cobra rejects the missing required flag before the handler runs, so the error
+  # is plain text on stderr rather than the handler's JSON envelope.
+  assert_output --partial 'required flag(s) "id" not set'
 }
 
 @test "kas-keys: unsafe update key mode remote to public_key" {
@@ -800,7 +801,7 @@ format_kas_name_as_uri() {
 @test "kas-keys: unsafe update key failure - (missing id)" {
   run_otdfctl_key unsafe update --mode public_key --force
   assert_failure
-  assert_output --partial "Flag '--id' is required"
+  assert_output --partial 'required flag(s) "id" not set'
 }
 
 @test "kas-keys: unsafe update key failure - (missing provider configuration)" {
@@ -1281,25 +1282,25 @@ format_kas_name_as_uri() {
 @test "kas-keys: rotate key (missing key)" {
   run_otdfctl_key rotate --key-id "new-key-id" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64}"
   assert_failure
-  assert_output --partial "Flag '--key' is required"
+  assert_output --partial 'required flag(s) "key" not set'
 }
 
 @test "kas-keys: rotate key (missing key-id)" {
   run_otdfctl_key rotate --key "old-key-id" --algorithm "rsa:2048" --mode "public_key" --public-key-pem "${PEM_B64}"
   assert_failure
-  assert_output --partial "Flag '--key-id' is required"
+  assert_output --partial 'required flag(s) "key-id" not set'
 }
 
 @test "kas-keys: rotate key (missing algorithm)" {
   run_otdfctl_key rotate --key "old-key-id" --key-id "new-key-id" --mode "public_key" --public-key-pem "${PEM_B64}"
   assert_failure
-  assert_output --partial "Flag '--algorithm' is required"
+  assert_output --partial 'required flag(s) "algorithm" not set'
 }
 
 @test "kas-keys: rotate key (missing mode)" {
   run_otdfctl_key rotate --key "old-key-id" --key-id "new-key-id" --algorithm "rsa:2048" --public-key-pem "${PEM_B64}"
   assert_failure
-  assert_output --partial "Flag '--mode' is required"
+  assert_output --partial 'required flag(s) "mode" not set'
 }
 
 @test "kas-keys: rotate key (local mode, missing wrapping-key-id)" {
@@ -1462,7 +1463,7 @@ format_kas_name_as_uri() {
     --public-key-pem "${PEM_B64}"
   
   assert_failure
-  assert_output --partial "'--private-key-pem' is required"
+  assert_output --partial 'required flag(s) "private-key-pem" not set'
 }
 
 @test "kas-keys: import key failure - invalid wrapping key" {
@@ -1536,7 +1537,7 @@ format_kas_name_as_uri() {
     --private-key-pem "${PEM_B64}"
   
   assert_failure
-  assert_output --partial "'--wrapping-key-id' is required"
+  assert_output --partial 'required flag(s) "wrapping-key-id" not set'
 }
 
 @test "kas-keys: import key failure - missing wrapping key" {
@@ -1550,7 +1551,7 @@ format_kas_name_as_uri() {
     --private-key-pem "${PEM_B64}"
   
   assert_failure
-  assert_output --partial "'--wrapping-key' is required"
+  assert_output --partial 'required flag(s) "wrapping-key" not set'
 }
 
 @test "kas-keys: delete key" {
@@ -1571,17 +1572,17 @@ format_kas_name_as_uri() {
 @test "kas-keys: delete key failure - (missing id)" {
   run_otdfctl_key unsafe delete --kas-uri "a-uri" --key-id "key" --force
   assert_failure
-  assert_output --partial "Flag '--id' is required"
+  assert_output --partial 'required flag(s) "id" not set'
 }
 
 @test "kas-keys: delete key failure - (missing key-id)" {
   run_otdfctl_key unsafe delete --id "ded32e6d-9fec-4a4c-a391-13158c52e5f2" --kas-uri "a-uri" --force
   assert_failure
-  assert_output --partial "Flag '--key-id' is required"
+  assert_output --partial 'required flag(s) "key-id" not set'
 }
 
 @test "kas-keys: delete key failure - (missing kas-uri)" {
   run_otdfctl_key unsafe delete --id "ded32e6d-9fec-4a4c-a391-13158c52e5f2" --key-id "kid" --force
   assert_failure
-  assert_output --partial "Flag '--kas-uri' is required"
+  assert_output --partial 'required flag(s) "kas-uri" not set'
 }

--- a/otdfctl/e2e/key-base.bats
+++ b/otdfctl/e2e/key-base.bats
@@ -151,7 +151,7 @@ teardown_file() {
 @test "base-key: set (missing key identifier: id or keyId)" {
   run_otdfctl_base_key set --kas "${KAS_REGISTRY_ID_BASE_KEY_TEST}"
   assert_failure
-  assert_output --partial "Flag '--key' is required"
+  assert_output --partial 'required flag(s) "key" not set'
 }
 
 @test "base-key: set (using non-existent keyId)" {

--- a/otdfctl/e2e/namespaces.bats
+++ b/otdfctl/e2e/namespaces.bats
@@ -73,7 +73,7 @@ teardown_file() {
   # missing flag
   run_otdfctl_ns create
   assert_failure
-  assert_output --partial "Flag '--name' is required"
+  assert_output --partial 'required flag(s) "name" not set'
 
   # conflict
   run_otdfctl_ns create -n "$NS_NAME"
@@ -96,7 +96,7 @@ teardown_file() {
 @test "Get a namespace - Bad" {
   run_otdfctl_ns get
   assert_failure
-  assert_output --partial "Flag '--id' is required"
+  assert_output --partial 'required flag(s) "id" not set'
 
   run_otdfctl_ns get --id 'example.com'
   assert_failure
@@ -280,11 +280,11 @@ teardown_file() {
   # Test with missing required flags
   run_otdfctl_ns key assign --namespace "$NS_ID"
   assert_failure
-  assert_output --partial "Flag '--key-id' is required"
+  assert_output --partial 'required flag(s) "key-id" not set'
 
   run_otdfctl_ns key assign --key-id "$KAS_KEY_SYSTEM_ID"
   assert_failure
-  assert_output --partial "Flag '--namespace' is required"
+  assert_output --partial 'required flag(s) "namespace" not set'
 }
 
 @test "Deactivate namespace" {

--- a/otdfctl/e2e/obligations.bats
+++ b/otdfctl/e2e/obligations.bats
@@ -346,7 +346,7 @@ teardown_file() {
   # missing flag
   run_otdfctl_obl create
     assert_failure
-    assert_output --partial "Flag '--name' is required"
+    assert_output --partial 'required flag(s) "name", "namespace" not set'
   
   # conflict
   run_otdfctl_obl create --name test_create_obl_conflict --namespace "$NS_ID" --json
@@ -586,10 +586,10 @@ teardown_file() {
   # missing flag
   run_otdfctl_obl_values create
     assert_failure
-    assert_output --partial "Flag '--obligation' is required"
+    assert_output --partial 'required flag(s) "obligation", "value" not set'
   run_otdfctl_obl_values create --obligation "$OBL_ID"
     assert_failure
-    assert_output --partial "Flag '--value' is required"
+    assert_output --partial 'required flag(s) "value" not set'
 
   # non-existent obligation fqn
   run_otdfctl_obl_values create --obligation invalid_fqn --value test_create_obl_val
@@ -1021,15 +1021,15 @@ EOF
   # missing flags
   run_otdfctl_obl_triggers create --attribute-value "http://example.com/attr/attr_name/value/attr_value" --action "read" 
   assert_failure 
-  assert_output --partial "Flag '--obligation-value' is required"
+  assert_output --partial 'required flag(s) "obligation-value" not set'
   
   run_otdfctl_obl_triggers create --obligation-value "http://example.com/attr/attr_name/value/attr_value" --action "read"
   assert_failure
-  assert_output --partial "Flag '--attribute-value' is required"
+  assert_output --partial 'required flag(s) "attribute-value" not set'
 
   run_otdfctl_obl_triggers create --obligation-value "http://example.com/attr/attr_name/value/attr_value" --attribute-value "http://example.com/attr/attr_name/value/attr_value"
   assert_failure
-  assert_output --partial "Flag '--action' is required"
+  assert_output --partial 'required flag(s) "action" not set'
 }
 
 @test "Delete an obligation trigger - Good" {

--- a/otdfctl/e2e/provider-config.bats
+++ b/otdfctl/e2e/provider-config.bats
@@ -35,13 +35,13 @@ delete_pc_by_id() {
 @test "fail to create provider configuration without config" {
     run_otdfctl_key_pc create --name test-value --manager "$TEST_MANAGER"
     assert_failure
-    assert_output --partial "Flag '--config' is required"
+    assert_output --partial 'required flag(s) "config" not set'
 }
 
 @test "fail to create provider configuration without name" {
     run_otdfctl_key_pc create --manager "$TEST_MANAGER" --config '{}'
     assert_failure
-    assert_output --partial "Flag '--name' is required"
+    assert_output --partial 'required flag(s) "name" not set'
 }
 
 @test "fail to create provider configuration with invalid config" {
@@ -156,7 +156,7 @@ delete_pc_by_id() {
 @test "fail to update provider configuration - missing id" {
     run_otdfctl_key_pc update --name test-config
     assert_failure
-    assert_output --partial "Flag '--id' is required"
+    assert_output --partial 'required flag(s) "id" not set'
 }
 
 @test "fail to update provider configuration - no optional flags" {
@@ -191,7 +191,7 @@ delete_pc_by_id() {
 @test "delete provider configuration fail -- no id" {
   run_otdfctl_key_pc delete
   assert_failure
-  assert_output --partial "Flag '--id' is required"
+  assert_output --partial 'required flag(s) "id" not set'
 }
 
 @test "delete provider configuration fail -- no force" {

--- a/otdfctl/e2e/registered-resources.bats
+++ b/otdfctl/e2e/registered-resources.bats
@@ -103,7 +103,7 @@ teardown_file() {
   # missing flags
   run_otdfctl_reg_res create
     assert_failure
-    assert_output --partial "Flag '--name' is required"
+    assert_output --partial 'required flag(s) "name" not set'
 
   # conflict
   run_otdfctl_reg_res create --name test_create_rr_conflict --namespace "$NS_ID"
@@ -292,7 +292,7 @@ teardown_file() {
   # no id
   run_otdfctl_reg_res delete
     assert_failure
-    assert_output --partial "Flag '--id' is required"
+    assert_output --partial 'required flag(s) "id" not set'
 
   # invalid id
   run_otdfctl_reg_res delete --id 'not_a_uuid'
@@ -367,10 +367,10 @@ teardown_file() {
   # missing flag
   run_otdfctl_reg_res_values create
     assert_failure
-    assert_output --partial "Flag '--resource' is required"
+    assert_output --partial 'required flag(s) "resource", "value" not set'
   run_otdfctl_reg_res_values create --resource "$RR_ID"
     assert_failure
-    assert_output --partial "Flag '--value' is required"
+    assert_output --partial 'required flag(s) "value" not set'
 
   # bad action attribute value arg separator (not a semicolon)
   run_otdfctl_reg_res_values create --resource "$RR_ID" --value test_create_rr_val_bad_aav --action-attribute-value "\"$READ_ACTION_ID:$ATTR_VAL_1_ID\""
@@ -545,7 +545,7 @@ teardown_file() {
   # no id
   run_otdfctl_reg_res_values delete
     assert_failure
-    assert_output --partial "Flag '--id' is required"
+    assert_output --partial 'required flag(s) "id" not set'
 
   # invalid id
   run_otdfctl_reg_res_values delete --id 'not_a_uuid'

--- a/otdfctl/e2e/resource-mapping-groups.bats
+++ b/otdfctl/e2e/resource-mapping-groups.bats
@@ -65,7 +65,7 @@ teardown_file() {
     # name is required
     run_otdfctl_rmg create --namespace-id "$NS_ID"
     assert_failure
-    assert_output --partial "Flag '--name' is required"
+    assert_output --partial 'required flag(s) "name" not set'
 }
 
 @test "Get resource mapping group" {
@@ -87,7 +87,7 @@ teardown_file() {
     # id required
     run_otdfctl_rmg get
         assert_failure
-        assert_output --partial "is required"
+        assert_output --partial 'required flag(s) "id" not set'
     run_otdfctl_rmg get --id "test"
         assert_failure
         assert_output --partial "must be a valid UUID"

--- a/otdfctl/e2e/resource-mapping.bats
+++ b/otdfctl/e2e/resource-mapping.bats
@@ -94,7 +94,7 @@ teardown_file() {
     # id required
     run_otdfctl_rm get
         assert_failure
-        assert_output --partial "is required"
+        assert_output --partial 'required flag(s) "id" not set'
     run_otdfctl_rm get --id "test"
         assert_failure
         assert_output --partial "must be a valid UUID"

--- a/otdfctl/e2e/resource-mapping.bats
+++ b/otdfctl/e2e/resource-mapping.bats
@@ -57,7 +57,7 @@ teardown_file() {
     # terms are required
     run_otdfctl_rm create --attribute-value-id $RM_VAL2_ID
     assert_failure
-    assert_output --partial "must have at least 1 non-empty values"
+    assert_output --partial 'required flag(s) "terms" not set'
 }
 
 @test "Create resource mapping in a group" {

--- a/otdfctl/e2e/subject-mapping.bats
+++ b/otdfctl/e2e/subject-mapping.bats
@@ -59,7 +59,7 @@ teardown_file() {
     # action is required
     run_otdfctl_sm create -a "$SM_VAL1_ID" --subject-condition-set-new "$SCS_2"
     assert_failure
-    assert_output --partial "At least one Action [--action] is required"
+    assert_output --partial 'required flag(s) "action" not set'
 }
 
 @test "Match subject mapping" {

--- a/otdfctl/pkg/man/docflags.go
+++ b/otdfctl/pkg/man/docflags.go
@@ -59,3 +59,26 @@ func (d *Doc) MarkSensitiveFlags() {
 		}
 	}
 }
+
+// MarkRequiredFlags marks every flag the doc metadata declares `required: true`
+// as required on the command, so cobra rejects an invocation that omits it and
+// generated tooling (e.g. the MCP server) can advertise the flag as required.
+//
+// Unlike MarkSensitiveFlags, flags declared required in the doc but not
+// registered on this command are skipped rather than panicking: the registry
+// sweep visits every doc, including parent/index docs and commands that were
+// never built into the active tree, and flags may be registered on a subcommand
+// or via a shared injector. Call after all flags have been registered.
+func (d *Doc) MarkRequiredFlags() {
+	for _, df := range d.DocFlags {
+		if !df.Required {
+			continue
+		}
+		if d.Flags().Lookup(df.Name) == nil {
+			continue
+		}
+		if err := d.MarkFlagRequired(df.Name); err != nil {
+			panic(fmt.Sprintf("failed to mark flag %q as required for command %q: %v", df.Name, d.Use, err))
+		}
+	}
+}

--- a/otdfctl/pkg/man/docflags_test.go
+++ b/otdfctl/pkg/man/docflags_test.go
@@ -136,3 +136,96 @@ Body.
 	require.NotNil(t, idFlag)
 	assert.Nil(t, idFlag.Annotations[cobra.BashCompOneRequiredFlag])
 }
+
+func TestMarkRequiredFlags(t *testing.T) {
+	doc, err := ProcessDoc(`---
+title: Test Command
+command:
+  name: test
+  flags:
+    - name: id
+      required: true
+      description: Required
+    - name: label
+      description: Optional
+---
+
+Body.
+`)
+	require.NoError(t, err)
+
+	doc.Flags().String("id", "", "Required")
+	doc.Flags().String("label", "", "Optional")
+
+	doc.MarkRequiredFlags()
+
+	idFlag := doc.Flags().Lookup("id")
+	require.NotNil(t, idFlag)
+	assert.Equal(t, []string{"true"}, idFlag.Annotations[cobra.BashCompOneRequiredFlag])
+
+	labelFlag := doc.Flags().Lookup("label")
+	require.NotNil(t, labelFlag)
+	assert.Nil(t, labelFlag.Annotations[cobra.BashCompOneRequiredFlag])
+}
+
+// Unlike MarkSensitiveFlags, a required flag declared in the doc but not
+// registered on the command is skipped rather than panicking, so the registry
+// sweep can safely visit parent/index docs and unbuilt commands.
+func TestMarkRequiredFlagsSkipsUnregistered(t *testing.T) {
+	doc := &Doc{
+		Command: cobra.Command{Use: "test"},
+		DocFlags: []DocFlag{
+			{Name: "missing-flag", Required: true},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		doc.MarkRequiredFlags()
+	})
+}
+
+func TestManualMarkRequiredFlags(t *testing.T) {
+	withReq, err := ProcessDoc(`---
+title: With Required
+command:
+  name: with-required
+  flags:
+    - name: id
+      required: true
+      description: Required
+---
+
+Body.
+`)
+	require.NoError(t, err)
+	withReq.Flags().String("id", "", "Required")
+
+	withoutReq, err := ProcessDoc(`---
+title: Without Required
+command:
+  name: without-required
+  flags:
+    - name: label
+      description: Optional
+---
+
+Body.
+`)
+	require.NoError(t, err)
+	withoutReq.Flags().String("label", "", "Optional")
+
+	m := Manual{En: map[string]*Doc{
+		"with-required":    withReq,
+		"without-required": withoutReq,
+	}}
+
+	m.MarkRequiredFlags()
+
+	idFlag := withReq.Flags().Lookup("id")
+	require.NotNil(t, idFlag)
+	assert.Equal(t, []string{"true"}, idFlag.Annotations[cobra.BashCompOneRequiredFlag])
+
+	labelFlag := withoutReq.Flags().Lookup("label")
+	require.NotNil(t, labelFlag)
+	assert.Nil(t, labelFlag.Annotations[cobra.BashCompOneRequiredFlag])
+}

--- a/otdfctl/pkg/man/man.go
+++ b/otdfctl/pkg/man/man.go
@@ -106,6 +106,18 @@ func (m Manual) GetDoc(cmd string) *Doc {
 	return m.En[cmd]
 }
 
+// MarkRequiredFlags enforces `required: true` doc metadata across every command
+// in the registry by marking each such flag required on its cobra command. It is
+// the single entry point callers invoke (once, at Execute time, after the command
+// tree is fully assembled) so that any command, current or added later, is
+// enforced without per-command wiring. Consumers that embed this registry (e.g.
+// tructl) call it the same way before executing their own root command.
+func (m Manual) MarkRequiredFlags() {
+	for _, doc := range m.En {
+		doc.MarkRequiredFlags()
+	}
+}
+
 func (m Manual) GetCommand(cmd string, opts ...CommandOpts) *Doc {
 	d := m.GetDoc(cmd)
 


### PR DESCRIPTION
## Summary

PR #3840 landed `DocFlag.Required` metadata and reconciled `required: true` across the policy man
docs, but deliberately left it as inert metadata. This wires it into the cobra command tree so a
missing required flag is rejected up front, and gives generated tooling (e.g. the tructl MCP server)
a single source of truth for requiredness.

- Add `(*Doc).MarkRequiredFlags()` (`pkg/man/docflags.go`): marks each `required: true` doc flag on
  the cobra command. Mirrors `MarkSensitiveFlags`, but skips flags not registered on the command
  instead of panicking, since the sweep visits every doc (including parent/index docs).
- Add `(Manual).MarkRequiredFlags()` (`pkg/man/man.go`): a registry sweep over all commands. Single
  reusable entry point.
- Call the sweep in `Execute()` (`cmd/execute.go`) before `RootCmd.Execute()`.

## Automatic For New Commands And Consumers

Enforcement runs as a registry sweep at `Execute()` time rather than per-command wiring, so **any
command added later (top-level or nested) is enforced automatically**. Because the sweep is exposed
as `man.Docs.MarkRequiredFlags()`, consumers that reuse this registry (e.g. tructl, which reuses
`otdfctl.RootCmd`) enforce the same way with a single call before executing their own root command.

## Behavior Change

A missing required flag now produces cobra's native error and fails before the handler/connection:

```
Error: required flag(s) "name", "namespace", "rule" not set
```

Previously the handler produced `Flag '--name' is required` (or command-specific text). Global scope
adds exactly one flag beyond the policy tree, `auth login --client-id`, which was already enforced by
the handler.

## Testing

- Added `TestMarkRequiredFlags`, `TestMarkRequiredFlagsSkipsUnregistered`, `TestManualMarkRequiredFlags`
  in `pkg/man/docflags_test.go`.
- Updated the affected `e2e/*.bats` assertions to cobra's `required flag(s) "X" not set`. Each
  expected message was taken from the actual binary for the exact flags each test passes (single vs.
  multi-flag). The `kas-keys` `update --json` case was rewritten because cobra emits plain-text before
  the handler's JSON envelope. Remaining `is required` assertions are mode-dependent / trigger-JSON /
  value-validation checks that cobra does not preempt.
- `go build ./...`, `go vet`, `gofmt`, `golangci-lint` (changed packages), and `go test ./...` for the
  otdfctl module all pass. The `otdfctl-test` job exercises the happy-path e2e against a live platform.

## Follow-up (DSP, separate PR)

Add `man.Docs.MarkRequiredFlags()` to tructl's `Execute()` to enforce required flags across all tructl
commands (including `collaborate`) via the shared registry, and bump the otdfctl pin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI commands now consistently enforce required options.
  * Missing required options display standardized validation messages.
  * JSON mode returns structured error responses for command failures.

* **Bug Fixes**
  * Improved command validation and error handling for missing inputs.

* **Tests**
  * Updated end-to-end coverage for standardized required-option errors.
  * Added coverage for required-option enforcement, including optional and unregistered options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->