### PR TITLE
docs(spec): add BinaryTDF v1alpha specification suite

### DIFF
--- a/spec/binarytdf/v1alpha/README.md
+++ b/spec/binarytdf/v1alpha/README.md
@@ -63,9 +63,10 @@ BinaryTDF-REC separates recovery topology from protection of one recovery value.
 
 BinaryTDF-STREAM registers both segmented content-encryption suites, identifiers 2 and
 3. Suite 3 matches the BaseTDF 5 partition-key construction: both expand a partition
-key from the content key using HKDF and a big-endian partition index, and both hold one
-content-encryption key to 2^40 plaintext bytes. Labels, encodings, and wire formats
-remain suite-specific.
+key from the content key using HKDF and a big-endian partition index. Both enforce the
+same `sum(sigma_p^2) <= 2^70` object-wide GCM confidentiality budget and recommend
+approximately 1 GiB partitions for 50 TiB plaintexts. Labels, encodings, and wire
+formats remain suite-specific.
 
 BinaryTDF-PAY covers the payload-encryption portion of BaseTDF-INT. BinaryTDF has no
 separate INT module because its baseline integrity is supplied by the selected AEAD

--- a/spec/binarytdf/v1alpha/README.md
+++ b/spec/binarytdf/v1alpha/README.md
@@ -2,64 +2,84 @@
 
 BinaryTDF is a compact, immutable format for protecting one payload. Each object
 contains deterministic CBOR metadata, object-key recovery information, and encrypted
-content. Exact wire bytes are cryptographic inputs and must not be reconstructed after
-parsing.
+content. Exact serialized bytes are cryptographic inputs and must not be reconstructed
+after parsing.
 
-This suite reorganizes BinaryTDF draft 0.2, frame version 2, into parallel components.
-It changes presentation, not wire format, intent, algorithms, validation, or security
-semantics. The source draft's recovery documents, streaming suite, key-epoch extension,
-NATO metadata profile, and Go prototype migration guide are included.
+This suite reorganizes BinaryTDF draft 0.2, frame version 2, into components aligned
+with the BaseTDF 5 architecture. The refactoring changes document ownership, not wire
+format, algorithms, validation, or security semantics.
 
-## Documents
+## Core modules
 
-| Layer | Document | Title | File |
+| Layer | Document | Responsibility | File |
 |---|---|---|---|
-| Foundation | BinaryTDF-SEC | Security Considerations | [binarytdf-sec.md](binarytdf-sec.md) |
-| Foundation | BinaryTDF-ALG | Algorithm and Extension Registries | [binarytdf-alg.md](binarytdf-alg.md) |
-| Model | BinaryTDF-MTD | Protected Metadata | [binarytdf-mtd.md](binarytdf-mtd.md) |
-| Model | BinaryTDF-POL | Canonical Policy | [binarytdf-pol.md](binarytdf-pol.md) |
-| Recovery | BinaryTDF-REC | Object Key Recovery | [binarytdf-rec.md](binarytdf-rec.md) |
-| Recovery | BinaryTDF-KAO | Key Access Object and Wrapping | [binarytdf-kao.md](binarytdf-kao.md) |
-| Payload | BinaryTDF-PAY | Payload Protection | [binarytdf-pay.md](binarytdf-pay.md) |
-| Protocol | BinaryTDF-KAS | KAS Rewrap Protocol | [binarytdf-kas.md](binarytdf-kas.md) |
-| Assembly | BinaryTDF-CORE | Frame and End-to-End Processing | [binarytdf-core.md](binarytdf-core.md) |
-| Schema | BinaryTDF-CDDL | Normative CDDL | [binarytdf-cddl.md](binarytdf-cddl.md) |
-| Examples | BinaryTDF-EX | Worked Example | [binarytdf-ex.md](binarytdf-ex.md) |
-| Extension | BinaryTDF-STREAM | AES-256-GCM-HKDF Streaming Suite | [binarytdf-ext-stream.md](binarytdf-ext-stream.md) |
-| Extension | BinaryTDF-KEY-EPOCH | KEY_EPOCH Recovery | [binarytdf-ext-key-epoch.md](binarytdf-ext-key-epoch.md) |
-| Profile | BinaryTDF-NATO | NATO Metadata Interoperability | [binarytdf-profile-nato.md](binarytdf-profile-nato.md) |
-| Migration | BinaryTDF-MIG | Go Prototype Migration | [binarytdf-migration.md](binarytdf-migration.md) |
+| Foundation | BinaryTDF-SEC | Security considerations and parser limits | [binarytdf-sec.md](binarytdf-sec.md) |
+| Foundation | BinaryTDF-ALG | Algorithm and extension registries | [binarytdf-alg.md](binarytdf-alg.md) |
+| Model | BinaryTDF-MTD | Protected metadata and extension carriage | [binarytdf-mtd.md](binarytdf-mtd.md) |
+| Policy | BinaryTDF-POL | Canonical authorization policy | [binarytdf-pol.md](binarytdf-pol.md) |
+| Operations | BinaryTDF-REC | Object-key recovery topology | [binarytdf-rec.md](binarytdf-rec.md) |
+| Operations | BinaryTDF-KAO | Protection of one recovery value | [binarytdf-kao.md](binarytdf-kao.md) |
+| Operations | BinaryTDF-PAY | Payload-key derivation and encryption | [binarytdf-pay.md](binarytdf-pay.md) |
+| Policy | BinaryTDF-KAS | KAS rewrap protocol | [binarytdf-kas.md](binarytdf-kas.md) |
+| Storage | BinaryTDF-PKG | Physical binary frame | [binarytdf-pkg.md](binarytdf-pkg.md) |
+| Schema | BinaryTDF-SCH | Deterministic CBOR and consolidated CDDL | [binarytdf-sch.md](binarytdf-sch.md) |
+| Assembly | BinaryTDF-CORE | Logical object and end-to-end processing | [binarytdf-core.md](binarytdf-core.md) |
+| Examples | BinaryTDF-EX | Worked example | [binarytdf-ex.md](binarytdf-ex.md) |
+
+## Extensions, profiles, and guides
+
+| Kind | Document | Extends | File |
+|---|---|---|---|
+| Extension | BinaryTDF-STREAM | PAY and PKG | [binarytdf-ext-stream.md](binarytdf-ext-stream.md) |
+| Extension | BinaryTDF-KEY-EPOCH | REC | [binarytdf-ext-key-epoch.md](binarytdf-ext-key-epoch.md) |
+| Profile | BinaryTDF-NATO | MTD and POL | [binarytdf-profile-nato.md](binarytdf-profile-nato.md) |
+| Guide | BinaryTDF-MIG | CORE, PKG, and SCH | [binarytdf-migration.md](binarytdf-migration.md) |
 
 ## Architecture
 
+Arrows point from prerequisites to consumers.
+
 ```text
-SEC ──► ALG ──► MTD, REC, KAO, PAY
- │                 │    │    │
- ├──► POL ─────────┘    │    │
- └──────────────────────► KAS
+SEC ──► ALG, MTD, POL, REC, KAO, PAY, KAS, PKG
+ALG, MTD, POL, KAO ──► REC
+ALG, MTD, REC ───────► PAY
+ALG, MTD, POL, REC, KAO ──► KAS
+ALG, MTD, POL, REC, KAO, KAS ──► SCH ──► PKG
 
-MTD, POL, REC, KAO, PAY, KAS ──► CORE
-All component schemas ──────────► CDDL
-CORE, CDDL ─────────────────────► EX
+SEC, ALG, MTD, POL, REC, KAO, PAY, KAS, SCH, PKG ──► CORE ──► EX
 
-REC ──► KEY-EPOCH
-PAY ──► STREAM
+PAY, PKG ──► STREAM
+REC, SCH ──► KEY-EPOCH
 MTD, POL ──► NATO
-CORE ──► MIG
+CORE, PKG, SCH ──► MIG
 ```
+
+## Alignment with BaseTDF 5
+
+The suites use the same names for shared responsibilities: SEC, ALG, POL, KAO, KAS,
+PKG, CORE, and EX. BinaryTDF-SCH corresponds to the BaseTDF JSON schemas while using
+CDDL for deterministic CBOR. BinaryTDF-MTD makes metadata carriage explicit, and
+BinaryTDF-REC separates recovery topology from protection of one recovery value.
+
+BinaryTDF-PAY covers the payload-encryption portion of BaseTDF-INT. BinaryTDF has no
+separate INT module because its baseline integrity is supplied by the selected AEAD
+suite. It has no ASN module because signed claims are not a core capability, and no LOC
+module because frame version 2 carries its payload inline. These absences are format
+boundaries rather than missing placeholder documents.
 
 ## Conventions
 
 BCP 14 requirement terms are normative only when written in all capitals. Unless
-specified otherwise, unsigned integers in the binary frame are big-endian, `||`
-means byte concatenation, indexes are zero-based, and CBOR uses the Core Deterministic
-Encoding Requirements of RFC 8949 Section 4.2.
+specified otherwise, unsigned integers in BinaryTDF-PKG are big-endian, `||` means byte
+concatenation, indexes are zero-based, and CBOR follows BinaryTDF-SCH.
 
 ## Status and source
 
 The suite is an alpha draft. Its normative source is BinaryTDF draft 0.2, frame
 version 2, in the `pr-2-codex-binary-tdf-draft-0-2` branch of the BinaryTDF
 specification project. Prototype frame version 1 is incompatible with frame version 2.
+The source draft's recovery documents, streaming suite, key-epoch extension, NATO
+metadata profile, and Go prototype migration guide are included.
 
 ## License
 

--- a/spec/binarytdf/v1alpha/README.md
+++ b/spec/binarytdf/v1alpha/README.md
@@ -1,0 +1,66 @@
+# BinaryTDF Specification Suite — Version 1 Alpha
+
+BinaryTDF is a compact, immutable format for protecting one payload. Each object
+contains deterministic CBOR metadata, object-key recovery information, and encrypted
+content. Exact wire bytes are cryptographic inputs and must not be reconstructed after
+parsing.
+
+This suite reorganizes BinaryTDF draft 0.2, frame version 2, into parallel components.
+It changes presentation, not wire format, intent, algorithms, validation, or security
+semantics. The source draft's recovery documents, streaming suite, key-epoch extension,
+NATO metadata profile, and Go prototype migration guide are included.
+
+## Documents
+
+| Layer | Document | Title | File |
+|---|---|---|---|
+| Foundation | BinaryTDF-SEC | Security Considerations | [binarytdf-sec.md](binarytdf-sec.md) |
+| Foundation | BinaryTDF-ALG | Algorithm and Extension Registries | [binarytdf-alg.md](binarytdf-alg.md) |
+| Model | BinaryTDF-MTD | Protected Metadata | [binarytdf-mtd.md](binarytdf-mtd.md) |
+| Model | BinaryTDF-POL | Canonical Policy | [binarytdf-pol.md](binarytdf-pol.md) |
+| Recovery | BinaryTDF-REC | Object Key Recovery | [binarytdf-rec.md](binarytdf-rec.md) |
+| Recovery | BinaryTDF-KAO | Key Access Object and Wrapping | [binarytdf-kao.md](binarytdf-kao.md) |
+| Payload | BinaryTDF-PAY | Payload Protection | [binarytdf-pay.md](binarytdf-pay.md) |
+| Protocol | BinaryTDF-KAS | KAS Rewrap Protocol | [binarytdf-kas.md](binarytdf-kas.md) |
+| Assembly | BinaryTDF-CORE | Frame and End-to-End Processing | [binarytdf-core.md](binarytdf-core.md) |
+| Schema | BinaryTDF-CDDL | Normative CDDL | [binarytdf-cddl.md](binarytdf-cddl.md) |
+| Examples | BinaryTDF-EX | Worked Example | [binarytdf-ex.md](binarytdf-ex.md) |
+| Extension | BinaryTDF-STREAM | AES-256-GCM-HKDF Streaming Suite | [binarytdf-ext-stream.md](binarytdf-ext-stream.md) |
+| Extension | BinaryTDF-KEY-EPOCH | KEY_EPOCH Recovery | [binarytdf-ext-key-epoch.md](binarytdf-ext-key-epoch.md) |
+| Profile | BinaryTDF-NATO | NATO Metadata Interoperability | [binarytdf-profile-nato.md](binarytdf-profile-nato.md) |
+| Migration | BinaryTDF-MIG | Go Prototype Migration | [binarytdf-migration.md](binarytdf-migration.md) |
+
+## Architecture
+
+```text
+SEC ──► ALG ──► MTD, REC, KAO, PAY
+ │                 │    │    │
+ ├──► POL ─────────┘    │    │
+ └──────────────────────► KAS
+
+MTD, POL, REC, KAO, PAY, KAS ──► CORE
+All component schemas ──────────► CDDL
+CORE, CDDL ─────────────────────► EX
+
+REC ──► KEY-EPOCH
+PAY ──► STREAM
+MTD, POL ──► NATO
+CORE ──► MIG
+```
+
+## Conventions
+
+BCP 14 requirement terms are normative only when written in all capitals. Unless
+specified otherwise, unsigned integers in the binary frame are big-endian, `||`
+means byte concatenation, indexes are zero-based, and CBOR uses the Core Deterministic
+Encoding Requirements of RFC 8949 Section 4.2.
+
+## Status and source
+
+The suite is an alpha draft. Its normative source is BinaryTDF draft 0.2, frame
+version 2, in the `pr-2-codex-binary-tdf-draft-0-2` branch of the BinaryTDF
+specification project. Prototype frame version 1 is incompatible with frame version 2.
+
+## License
+
+This specification is licensed under the repository's license terms.

--- a/spec/binarytdf/v1alpha/README.md
+++ b/spec/binarytdf/v1alpha/README.md
@@ -61,6 +61,12 @@ PKG, CORE, and EX. BinaryTDF-SCH corresponds to the BaseTDF JSON schemas while u
 CDDL for deterministic CBOR. BinaryTDF-MTD makes metadata carriage explicit, and
 BinaryTDF-REC separates recovery topology from protection of one recovery value.
 
+BinaryTDF-STREAM registers both segmented content-encryption suites, identifiers 2 and
+3. Suite 3 matches the BaseTDF 5 partition-key construction: both expand a partition
+key from the content key using HKDF and a big-endian partition index, and both hold one
+content-encryption key to 2^40 plaintext bytes. Labels, encodings, and wire formats
+remain suite-specific.
+
 BinaryTDF-PAY covers the payload-encryption portion of BaseTDF-INT. BinaryTDF has no
 separate INT module because its baseline integrity is supplied by the selected AEAD
 suite. It has no ASN module because signed claims are not a core capability, and no LOC

--- a/spec/binarytdf/v1alpha/binarytdf-alg.md
+++ b/spec/binarytdf/v1alpha/binarytdf-alg.md
@@ -17,10 +17,11 @@
 | `UNSPECIFIED` | 0 | `00` | invalid |
 | `AES_256_GCM_HKDF_SHA256` | 1 | `01` | baseline single-message suite |
 | `AES_256_GCM_HKDF_SHA256_STREAM` | 2 | `02` | streaming suite defined by BinaryTDF-STREAM |
+| `AES_256_GCM_HKDF_SHA256_STREAM_PART` | 3 | `03` | partitioned streaming suite defined by BinaryTDF-STREAM |
 
-Suite 1 is mandatory. Suite 2 is optional. A suite defines the complete payload
-construction inside the opaque Ciphertext section. Registering a suite does not change
-the frame or object-key recovery.
+Suite 1 is mandatory. Suites 2 and 3 are optional and independent of each other. A
+suite defines the complete payload construction inside the opaque Ciphertext section.
+Registering a suite does not change the frame or object-key recovery.
 
 ## 2. Recovery schemes
 
@@ -67,6 +68,9 @@ A suite, scheme, or extension specification MUST define, as applicable:
 - its identifier and encoded bytes or registered CBOR tag;
 - algorithms, parameter sets, key sizes, output sizes, and encodings;
 - KDF inputs, domain-separation strings, and associated data;
+- for a content-encryption suite, the maximum plaintext one key protects and the
+  maximum plaintext one AEAD invocation protects, within the bounds of BinaryTDF-SEC
+  Section 3;
 - producer, opener, and authority validation;
 - malformed-input and cryptographic-failure behavior;
 - whether the capability is normally critical; and

--- a/spec/binarytdf/v1alpha/binarytdf-alg.md
+++ b/spec/binarytdf/v1alpha/binarytdf-alg.md
@@ -1,0 +1,99 @@
+# BinaryTDF-ALG: Algorithm and Extension Registries
+
+| | |
+|---|---|
+| Document | BinaryTDF-ALG |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft |
+| Depends on | BinaryTDF-CORE |
+| Referenced by | BinaryTDF-MTD, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-PAY, BinaryTDF-KAS, BinaryTDF-CDDL |
+
+## 1. Content-encryption suites
+
+| Symbol | Integer | Encoded bytes | Definition |
+|---|---:|---|---|
+| `UNSPECIFIED` | 0 | `00` | invalid |
+| `AES_256_GCM_HKDF_SHA256` | 1 | `01` | baseline single-message suite |
+| `AES_256_GCM_HKDF_SHA256_STREAM` | 2 | `02` | streaming suite defined by BinaryTDF-STREAM |
+
+Suite 1 is mandatory. Suite 2 is optional. A suite defines the complete payload
+construction inside the opaque Ciphertext section. Registering a suite does not change
+the frame or object-key recovery.
+
+## 2. Recovery schemes
+
+| Symbol | Integer | Encoded bytes | Definition |
+|---|---:|---|---|
+| `UNSPECIFIED` | 0 | `00` | invalid |
+| `DIRECT` | 1 | `01` | direct object-key release |
+| `XOR_ALL` | 2 | `02` | all required shares XOR to the object key |
+| `KEY_EPOCH` | 3 | `03` | separately defined epoch derivation |
+| `PRIVATE_USE` | 24–255 | `18 18`–`18 ff` | explicit profile |
+
+BinaryTDF-REC defines registry semantics and the recovery-scheme contract.
+
+## 3. KAO wrap suites
+
+| Symbol | Integer | Recipient key | Encapsulation |
+|---|---:|---|---|
+| `UNSPECIFIED` | 0 | — | invalid |
+| `ECDH_P256_HKDF_SHA256_AES_256_GCM` | 1 | NIST P-256 | 33-byte compressed SEC 1 point |
+| `ECDH_P384_HKDF_SHA256_AES_256_GCM` | 2 | NIST P-384 | 49-byte compressed SEC 1 point |
+| `ECDH_P521_HKDF_SHA256_AES_256_GCM` | 3 | NIST P-521 | 67-byte compressed SEC 1 point |
+| `ML_KEM_768_HKDF_SHA256_AES_256_GCM` | 4 | 1184-byte ML-KEM-768 key | 1088-byte ML-KEM ciphertext |
+| `ML_KEM_1024_HKDF_SHA256_AES_256_GCM` | 5 | 1568-byte ML-KEM-1024 key | 1568-byte ML-KEM ciphertext |
+
+Every frame version 2 implementation MUST support suite 1. An implementation claiming
+post-quantum KAO wrapping MUST support suite 4; suite 5 is optional.
+
+Hybrid suites may be registered without a frame change, but each assignment MUST fully
+define component order, encodings, combiner, domain separation, and failure behavior.
+
+## 4. Policy binding
+
+| Symbol | Integer | Encoded bytes |
+|---|---:|---|
+| `UNSPECIFIED` | 0 | `00` |
+| `HMAC_SHA256` | 1 | `01` |
+
+HMAC-SHA256 is the only registered policy-binding algorithm.
+
+## 5. Registry requirements
+
+A suite, scheme, or extension specification MUST define, as applicable:
+
+- its identifier and encoded bytes or registered CBOR tag;
+- algorithms, parameter sets, key sizes, output sizes, and encodings;
+- KDF inputs, domain-separation strings, and associated data;
+- producer, opener, and authority validation;
+- malformed-input and cryptographic-failure behavior;
+- whether the capability is normally critical; and
+- security and downgrade considerations with cross-language vectors.
+
+Recovery schemes additionally MUST define their recovery-data CDDL plug, KAO path
+shape, key-material generation and size, object-key production, group satisfaction,
+reconstruction, policy binding, partial success, and malicious contribution handling.
+Stateful schemes also MUST define identity, lifetime, replay, cache, and resolution
+rules.
+
+Metadata extensions additionally MUST define their CDDL plug and any explicit mapping
+to Canonical Policy. Metadata never becomes authorization policy merely by being
+present. A mapping MUST be deterministic and published as its own specification or
+profile.
+
+For BinaryTDF-owned unsigned-integer registries, identifiers 1 through 23 are reserved
+for compact, broadly deployed assignments. Identifier 0 is permanently invalid. Each
+registry defines its remaining policy and Private Use range. Unassigned identifiers and
+unconfigured Private Use values MUST be rejected.
+
+An identifier or registered tag denotes one stable wire contract. Compatible revisions
+retain it. Incompatible changes to schema, cryptographic behavior, validation, or
+interpretation MUST use a new identifier or tag.
+
+## 6. Capability handling
+
+An object declares capabilities; it does not negotiate them. A receiver MUST reject an
+unsupported suite, scheme, or critical extension as `UNSUPPORTED_CAPABILITY` and MUST
+NOT fall back to another capability.

--- a/spec/binarytdf/v1alpha/binarytdf-alg.md
+++ b/spec/binarytdf/v1alpha/binarytdf-alg.md
@@ -7,8 +7,8 @@
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Draft |
-| Depends on | BinaryTDF-CORE |
-| Referenced by | BinaryTDF-MTD, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-PAY, BinaryTDF-KAS, BinaryTDF-CDDL |
+| Depends on | BinaryTDF-SEC |
+| Referenced by | BinaryTDF-MTD, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-PAY, BinaryTDF-KAS, BinaryTDF-SCH, BinaryTDF-CORE, BinaryTDF extensions |
 
 ## 1. Content-encryption suites
 

--- a/spec/binarytdf/v1alpha/binarytdf-cddl.md
+++ b/spec/binarytdf/v1alpha/binarytdf-cddl.md
@@ -1,0 +1,131 @@
+# BinaryTDF-CDDL: Normative Schema
+
+| | |
+|---|---|
+| Document | BinaryTDF-CDDL |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft |
+| Depends on | BinaryTDF-CORE, BinaryTDF-ALG, BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-KAS |
+
+Semantic, suite-specific, scheme-specific, and extension-specific requirements apply
+in addition to this shape.
+
+```cddl
+content-encryption-suite = &(
+  unspecified: 0,
+  aes-256-gcm-hkdf-sha256: 1,
+  aes-256-gcm-hkdf-sha256-stream-64k: 2
+)
+
+recovery-scheme = &(
+  unspecified: 0,
+  direct: 1,
+  xor-all: 2,
+  key-epoch: 3
+)
+
+wrap-suite = &(
+  unspecified: 0,
+  ecdh-p256-hkdf-sha256-aes-256-gcm: 1,
+  ecdh-p384-hkdf-sha256-aes-256-gcm: 2,
+  ecdh-p521-hkdf-sha256-aes-256-gcm: 3,
+  ml-kem-768-hkdf-sha256-aes-256-gcm: 4,
+  ml-kem-1024-hkdf-sha256-aes-256-gcm: 5
+)
+
+binding-algorithm = &(
+  unspecified: 0,
+  hmac-sha256: 1
+)
+
+metadata-extension =
+  $binary-tdf-metadata-extension /
+  unknown-metadata-extension
+
+unknown-metadata-extension = #6(any)
+
+protected-metadata = {
+  1 => content-encryption-suite,
+  ? 2 => tstr,
+  ? 3 => bstr,
+  ? 4 => [* metadata-extension],
+  ? 5 => [* uint]
+}
+
+policy-entry = [
+  namespace: policy-namespace,
+  attribute: tstr,
+  values: [+ tstr]
+]
+
+policy-namespace = tstr
+
+canonical-policy = [+ policy-entry]
+
+authority-id = tstr
+
+policy-binding = {
+  1 => binding-algorithm,
+  2 => bstr
+}
+
+key-access-object = {
+  1 => authority-id,
+  ? 2 => bstr,
+  3 => wrap-suite,
+  4 => bstr,
+  5 => bstr,
+  6 => policy-binding
+}
+
+recovery-scheme-data = $binary-tdf-recovery-scheme-data
+
+object-key-recovery = {
+  1 => recovery-scheme,
+  ? 2 => canonical-policy,
+  3 => recovery-scheme-data
+}
+
+kao-path = [1* uint]
+
+kao-context = {
+  1 => authority-id,
+  ? 2 => bstr,
+  3 => wrap-suite,
+  4 => uint,
+  5 => bstr .size 32,
+  6 => bstr .size 32,
+  7 => bstr .size 32,
+  8 => recovery-scheme,
+  9 => kao-path
+}
+
+session-context = {
+  1 => uint,
+  2 => bstr .size 32,
+  3 => bstr .size 32,
+  4 => kao-path,
+  5 => wrap-suite,
+  6 => bstr .size 32
+}
+
+direct-kao-set = [key-access-object]
+
+xor-all-share-group = [1* key-access-object]
+
+xor-all-kao-groups = [2* xor-all-share-group]
+
+direct-recovery-data = direct-kao-set
+
+xor-all-recovery-data = xor-all-kao-groups
+
+$binary-tdf-recovery-scheme-data /= direct-recovery-data
+$binary-tdf-recovery-scheme-data /= xor-all-recovery-data
+```
+
+Extension specifications augment the two `$binary-tdf-*` sockets with `/=`. The
+metadata wildcard permits only unknown non-critical tags; recognized tags use their
+registered sub-schema. The selected recovery identifier determines the valid closed
+recovery plug.

--- a/spec/binarytdf/v1alpha/binarytdf-core.md
+++ b/spec/binarytdf/v1alpha/binarytdf-core.md
@@ -138,6 +138,7 @@ At minimum, interoperability tests SHOULD cover:
 - one-byte changes to version, metadata, recovery, encapsulation, wrapped material,
   and ciphertext;
 - wrong-suite keys, lengths, and encodings;
+- content-encryption per-invocation and volume limits at and just above the boundary;
 - ML-KEM failure without distinguishable error leakage;
 - DIRECT and XOR_ALL paths, alternatives, missing groups, and reconstruction;
 - non-canonical, duplicate, and substituted policies; and
@@ -151,6 +152,10 @@ KAO and session context bytes, payload AAD, derived-key inputs, and expected fai
 - [BCP 14](https://www.rfc-editor.org/info/bcp14)
 - [RFC 5869: HKDF](https://www.rfc-editor.org/rfc/rfc5869)
 - [RFC 8126: Protocol Registries](https://www.rfc-editor.org/rfc/rfc8126)
+- [RFC 8446: TLS 1.3](https://www.rfc-editor.org/rfc/rfc8446)
 - [RFC 8610: CDDL](https://www.rfc-editor.org/rfc/rfc8610)
 - [RFC 8949: CBOR](https://www.rfc-editor.org/rfc/rfc8949)
 - [FIPS 203: ML-KEM](https://csrc.nist.gov/pubs/fips/203/final)
+- [NIST SP 800-38D: GCM and GMAC](https://doi.org/10.6028/NIST.SP.800-38D)
+- [Luykx and Paterson: Limits on Authenticated Encryption Use in TLS](https://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf)
+- [Iwata, Ohashi, and Minematsu: Breaking and Repairing GCM Security Proofs](https://eprint.iacr.org/2012/438)

--- a/spec/binarytdf/v1alpha/binarytdf-core.md
+++ b/spec/binarytdf/v1alpha/binarytdf-core.md
@@ -4,7 +4,7 @@
 |---|---|
 | Document | BinaryTDF-CORE |
 | Version | 1 Alpha |
-| Source draft | 0.2 |
+| Source draft | 0.3 |
 | Frame version | 2 |
 | Status | Draft |
 | Depends on | BinaryTDF-SEC, BinaryTDF-ALG, BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-PAY, BinaryTDF-KAS, BinaryTDF-SCH, BinaryTDF-PKG |
@@ -138,7 +138,8 @@ At minimum, interoperability tests SHOULD cover:
 - one-byte changes to version, metadata, recovery, encapsulation, wrapped material,
   and ciphertext;
 - wrong-suite keys, lengths, and encodings;
-- content-encryption per-invocation and volume limits at and just above the boundary;
+- content-encryption per-invocation and object-wide confidentiality budgets at and
+  just above the boundary;
 - ML-KEM failure without distinguishable error leakage;
 - DIRECT and XOR_ALL paths, alternatives, missing groups, and reconstruction;
 - non-canonical, duplicate, and substituted policies; and
@@ -153,9 +154,12 @@ KAO and session context bytes, payload AAD, derived-key inputs, and expected fai
 - [RFC 5869: HKDF](https://www.rfc-editor.org/rfc/rfc5869)
 - [RFC 8126: Protocol Registries](https://www.rfc-editor.org/rfc/rfc8126)
 - [RFC 8446: TLS 1.3](https://www.rfc-editor.org/rfc/rfc8446)
+- [RFC 9001: Using TLS to Secure QUIC](https://www.rfc-editor.org/rfc/rfc9001)
 - [RFC 8610: CDDL](https://www.rfc-editor.org/rfc/rfc8610)
 - [RFC 8949: CBOR](https://www.rfc-editor.org/rfc/rfc8949)
 - [FIPS 203: ML-KEM](https://csrc.nist.gov/pubs/fips/203/final)
 - [NIST SP 800-38D: GCM and GMAC](https://doi.org/10.6028/NIST.SP.800-38D)
 - [Luykx and Paterson: Limits on Authenticated Encryption Use in TLS](https://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf)
 - [Iwata, Ohashi, and Minematsu: Breaking and Repairing GCM Security Proofs](https://eprint.iacr.org/2012/438)
+- [Hoang, Tessaro, and Thiruvengadam: The Multi-user Security of GCM, Revisited](https://eprint.iacr.org/2018/993)
+- [Amazon S3 multipart upload limits](https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html)

--- a/spec/binarytdf/v1alpha/binarytdf-core.md
+++ b/spec/binarytdf/v1alpha/binarytdf-core.md
@@ -1,4 +1,4 @@
-# BinaryTDF-CORE: Frame and End-to-End Processing
+# BinaryTDF-CORE: Object and End-to-End Processing
 
 | | |
 |---|---|
@@ -7,15 +7,16 @@
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Draft |
-| Depends on | BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-PAY, BinaryTDF-KAS, BinaryTDF-SEC |
-| Referenced by | BinaryTDF-CDDL, BinaryTDF-EX, BinaryTDF-MIG |
+| Depends on | BinaryTDF-SEC, BinaryTDF-ALG, BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-PAY, BinaryTDF-KAS, BinaryTDF-SCH, BinaryTDF-PKG |
+| Referenced by | BinaryTDF-EX, BinaryTDF extensions and profiles |
 
 ## 1. Scope
 
-BinaryTDF is a compact, self-contained format for protecting one payload. Each object
-contains deterministic CBOR metadata, information needed to recover its object key,
-and encrypted content. Every byte is fixed at creation, and exact wire bytes are used
-directly by the cryptographic protocol.
+BinaryTDF is a compact, self-contained format for protecting one payload. Each logical
+object contains Protected Metadata, Object Key Recovery, and encrypted content. The
+physical frame is defined by BinaryTDF-PKG and the deterministic encoding and schemas
+are defined by BinaryTDF-SCH. Every byte is fixed at creation, and exact serialized
+bytes are used directly by the cryptographic protocol.
 
 Frame version 2 defines:
 
@@ -109,75 +110,24 @@ This subsection is non-normative; the referenced component requirements are norm
 4. Derive every KAO context, wrap its value, and compute its policy binding.
 5. Derive the payload key and encrypt using the exact metadata and recovery bytes as
    AAD.
-6. Emit the frame in the order defined below.
+6. Serialize the object using BinaryTDF-SCH and BinaryTDF-PKG.
 
 Steps 2 and 3 finish before steps 4 and 5 because their exact bytes are inputs to KAO
 wrapping and payload encryption.
 
-## 3. Binary frame
-
-All integer lengths are unsigned and big-endian.
-
-```text
-+----------------------------+----------------------------------+
-| Field                      | Size                             |
-+----------------------------+----------------------------------+
-| Magic                      | 3 bytes: ASCII "L2L"            |
-| Version                    | 1 byte: 0x02                    |
-| Metadata Length            | 4 bytes                         |
-| Protected Metadata CBOR    | Metadata Length bytes           |
-| Object Key Recovery Length | 4 bytes                         |
-| Object Key Recovery CBOR   | Recovery Length bytes           |
-| Ciphertext Length          | 8 bytes                         |
-| Ciphertext                 | Ciphertext Length bytes         |
-+----------------------------+----------------------------------+
-```
-
-Ciphertext Length includes all suite-specific header, nonce, ciphertext, and tag bytes.
-There MUST be no bytes after the declared Ciphertext section.
-
-The 64-bit ciphertext length permits payloads larger than 4 GiB. It is a framing bound,
-not an allocation instruction. A decoder MUST reject an object before CBOR processing
-when:
-
-- magic or version is unsupported;
-- a length field is truncated;
-- a declared section exceeds remaining input;
-- offset or capacity arithmetic overflows; or
-- the Ciphertext section does not consume remaining input exactly.
-
-Changing frame layout, a cryptographic input construction, or the meaning of an
-existing security-bearing field requires a new frame version.
-
-## 4. CBOR encoding
-
-All CBOR MUST use RFC 8949 Core Deterministic Encoding Requirements. Encoders MUST use
-preferred serialization, deterministic map-key ordering, and definite-length items.
-Optional fields with absent, empty, or zero values are omitted unless specified
-otherwise.
-
-Decoders MUST reject duplicate map keys, indefinite-length items, non-deterministic
-encodings, invalid types, unregistered core keys, and resource-limit violations.
-Implementations MUST impose finite limits on nesting, collection sizes, and section
-lengths.
-
-Core maps use unsigned integer keys. Registry identifiers are unsigned integers without
-a CBOR tag. `encode_deterministic_cbor(value)` denotes this specification operation;
-it is not a separate wire format.
-
-## 5. Opening procedure
+## 3. Opening procedure
 
 A conforming opener performs:
 
-1. frame and exact-length validation;
-2. deterministic CBOR and registered-core-field validation;
+1. BinaryTDF-PKG frame and exact-length validation;
+2. BinaryTDF-SCH deterministic CBOR and registered-core-field validation;
 3. suite, scheme, and critical-extension validation;
 4. local unwrap or KAS rewrap and policy-binding verification for required KAOs;
 5. object-key reconstruction or derivation; and
 6. payload authentication before returning plaintext, subject to a registered
    content-encryption suite's explicit incremental release rules.
 
-## 6. Conformance
+## 4. Conformance
 
 At minimum, interoperability tests SHOULD cover:
 
@@ -196,7 +146,7 @@ At minimum, interoperability tests SHOULD cover:
 Cross-language vectors SHOULD include the complete object, raw sections, policy bytes,
 KAO and session context bytes, payload AAD, derived-key inputs, and expected failure.
 
-## 7. References
+## 5. References
 
 - [BCP 14](https://www.rfc-editor.org/info/bcp14)
 - [RFC 5869: HKDF](https://www.rfc-editor.org/rfc/rfc5869)

--- a/spec/binarytdf/v1alpha/binarytdf-core.md
+++ b/spec/binarytdf/v1alpha/binarytdf-core.md
@@ -1,0 +1,206 @@
+# BinaryTDF-CORE: Frame and End-to-End Processing
+
+| | |
+|---|---|
+| Document | BinaryTDF-CORE |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft |
+| Depends on | BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-PAY, BinaryTDF-KAS, BinaryTDF-SEC |
+| Referenced by | BinaryTDF-CDDL, BinaryTDF-EX, BinaryTDF-MIG |
+
+## 1. Scope
+
+BinaryTDF is a compact, self-contained format for protecting one payload. Each object
+contains deterministic CBOR metadata, information needed to recover its object key,
+and encrypted content. Every byte is fixed at creation, and exact wire bytes are used
+directly by the cryptographic protocol.
+
+Frame version 2 defines:
+
+- one compact-object frame containing one payload;
+- direct and all-shares XOR object-key recovery;
+- a baseline AES-256-GCM content-encryption suite;
+- classical ECDH and non-hybrid ML-KEM-768 and ML-KEM-1024 KAO wrap suites;
+- deterministic policy and object binding;
+- an algorithm-neutral KAS rewrap exchange; and
+- extension sockets for metadata, recovery schemes, and content-encryption suites.
+
+The core does not define additional payload constructions, signature formats, signed
+claims, classification labels, or domain metadata schemas. Those capabilities use
+separately versioned specifications and the registries defined by BinaryTDF-ALG.
+
+The key words MUST, MUST NOT, REQUIRED, SHOULD, SHOULD NOT, and MAY are interpreted as
+described by BCP 14 when written in all capitals.
+
+### 1.1 Terminology
+
+- A producer creates a BinaryTDF. An opener decrypts one.
+- An authority controls a KAO recipient key and decides whether to release the value
+  it protects. A Key Access Service, or KAS, deploys that role.
+- AEAD encrypts data and detects changes to the ciphertext and associated data.
+- Associated data, or AAD, is authenticated but not encrypted.
+- A nonce is a per-encryption value that must not repeat under one AES-GCM key.
+- HKDF derives domain-separated keys from secret material and context.
+- A key-encryption key, or KEK, is used only to encrypt another key.
+- Wrapping encrypts a key or share for an authority. Rewrap encrypts the recovered
+  value to an opener session key.
+- Encapsulation is the public material sent by a key-establishment scheme: an
+  ephemeral ECDH public key or an ML-KEM ciphertext.
+
+## 2. Object model
+
+A BinaryTDF is immutable. Three sections define what is protected, how the object key
+is recovered, and the encrypted content:
+
+```text
++-----------------------+
+| Protected Metadata    |
++-----------------------+
+| Object Key Recovery   |
++-----------------------+
+| Encrypted Payload     |
++-----------------------+
+```
+
+All three are cryptographic inputs. Protected Metadata and Object Key Recovery are
+payload AAD, and every KAO is bound to its exact context. Changing any byte invalidates
+key recovery or payload authentication.
+
+External systems MAY identify an object by a cryptographic hash of its complete bytes.
+Detached attestations, audit records, and transfer manifests can use that hash without
+cooperation from the format.
+
+Signed claims are not a core mechanism. Unsigned claims belong in application data or
+a registered metadata extension. Signed claims use an extension with its own signature
+and validation rules or a detached attestation over the complete object hash.
+
+### 2.1 Key hierarchy
+
+- The object key is a unique 32-byte root key generated or derived for one object.
+- A key share is a 32-byte value used by a split recovery scheme.
+- The payload key is derived from the object key by the content-encryption suite.
+
+A KAO protects an object key, a key share, or another 32-byte value defined by a
+registered recovery scheme. The authority releases that value; reconstruction and
+payload-key derivation occur locally at the opener.
+
+### 2.2 Capability selection
+
+| Field | Selection |
+|---|---|
+| `content_encryption_suite` | Payload-key derivation and payload encryption |
+| `recovery_scheme` | Object-key recovery procedure |
+| `wrap_suite` | Protection of one KAO value |
+| Metadata extension tag | Application-specific metadata schema |
+
+The object declares these choices and does not negotiate them. Capability discovery
+occurs before creation. A receiver MUST NOT replace an unsupported capability with a
+weaker one.
+
+### 2.3 Producer lifecycle
+
+This subsection is non-normative; the referenced component requirements are normative.
+
+1. Create the object key and any shares required by BinaryTDF-REC.
+2. Encode Protected Metadata as deterministic CBOR.
+3. Encode Canonical Policy and Object Key Recovery as deterministic CBOR.
+4. Derive every KAO context, wrap its value, and compute its policy binding.
+5. Derive the payload key and encrypt using the exact metadata and recovery bytes as
+   AAD.
+6. Emit the frame in the order defined below.
+
+Steps 2 and 3 finish before steps 4 and 5 because their exact bytes are inputs to KAO
+wrapping and payload encryption.
+
+## 3. Binary frame
+
+All integer lengths are unsigned and big-endian.
+
+```text
++----------------------------+----------------------------------+
+| Field                      | Size                             |
++----------------------------+----------------------------------+
+| Magic                      | 3 bytes: ASCII "L2L"            |
+| Version                    | 1 byte: 0x02                    |
+| Metadata Length            | 4 bytes                         |
+| Protected Metadata CBOR    | Metadata Length bytes           |
+| Object Key Recovery Length | 4 bytes                         |
+| Object Key Recovery CBOR   | Recovery Length bytes           |
+| Ciphertext Length          | 8 bytes                         |
+| Ciphertext                 | Ciphertext Length bytes         |
++----------------------------+----------------------------------+
+```
+
+Ciphertext Length includes all suite-specific header, nonce, ciphertext, and tag bytes.
+There MUST be no bytes after the declared Ciphertext section.
+
+The 64-bit ciphertext length permits payloads larger than 4 GiB. It is a framing bound,
+not an allocation instruction. A decoder MUST reject an object before CBOR processing
+when:
+
+- magic or version is unsupported;
+- a length field is truncated;
+- a declared section exceeds remaining input;
+- offset or capacity arithmetic overflows; or
+- the Ciphertext section does not consume remaining input exactly.
+
+Changing frame layout, a cryptographic input construction, or the meaning of an
+existing security-bearing field requires a new frame version.
+
+## 4. CBOR encoding
+
+All CBOR MUST use RFC 8949 Core Deterministic Encoding Requirements. Encoders MUST use
+preferred serialization, deterministic map-key ordering, and definite-length items.
+Optional fields with absent, empty, or zero values are omitted unless specified
+otherwise.
+
+Decoders MUST reject duplicate map keys, indefinite-length items, non-deterministic
+encodings, invalid types, unregistered core keys, and resource-limit violations.
+Implementations MUST impose finite limits on nesting, collection sizes, and section
+lengths.
+
+Core maps use unsigned integer keys. Registry identifiers are unsigned integers without
+a CBOR tag. `encode_deterministic_cbor(value)` denotes this specification operation;
+it is not a separate wire format.
+
+## 5. Opening procedure
+
+A conforming opener performs:
+
+1. frame and exact-length validation;
+2. deterministic CBOR and registered-core-field validation;
+3. suite, scheme, and critical-extension validation;
+4. local unwrap or KAS rewrap and policy-binding verification for required KAOs;
+5. object-key reconstruction or derivation; and
+6. payload authentication before returning plaintext, subject to a registered
+   content-encryption suite's explicit incremental release rules.
+
+## 6. Conformance
+
+At minimum, interoperability tests SHOULD cover:
+
+- byte-identical deterministic encoding across SDKs;
+- malformed lengths and trailing data;
+- duplicate, indefinite-length, non-deterministic, and unknown core fields;
+- unknown non-critical and critical extensions;
+- one-byte changes to version, metadata, recovery, encapsulation, wrapped material,
+  and ciphertext;
+- wrong-suite keys, lengths, and encodings;
+- ML-KEM failure without distinguishable error leakage;
+- DIRECT and XOR_ALL paths, alternatives, missing groups, and reconstruction;
+- non-canonical, duplicate, and substituted policies; and
+- permit, deny, malformed, unsupported-capability, and partial-success rewrap.
+
+Cross-language vectors SHOULD include the complete object, raw sections, policy bytes,
+KAO and session context bytes, payload AAD, derived-key inputs, and expected failure.
+
+## 7. References
+
+- [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [RFC 5869: HKDF](https://www.rfc-editor.org/rfc/rfc5869)
+- [RFC 8126: Protocol Registries](https://www.rfc-editor.org/rfc/rfc8126)
+- [RFC 8610: CDDL](https://www.rfc-editor.org/rfc/rfc8610)
+- [RFC 8949: CBOR](https://www.rfc-editor.org/rfc/rfc8949)
+- [FIPS 203: ML-KEM](https://csrc.nist.gov/pubs/fips/203/final)

--- a/spec/binarytdf/v1alpha/binarytdf-ex.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ex.md
@@ -4,7 +4,7 @@
 |---|---|
 | Document | BinaryTDF-EX |
 | Version | 1 Alpha |
-| Source draft | 0.2 |
+| Source draft | 0.3 |
 | Frame version | 2 |
 | Status | Informational |
 | Depends on | BinaryTDF-CORE, BinaryTDF-PKG, BinaryTDF-SCH |
@@ -143,10 +143,11 @@ before decryption, on frame and header values alone.
    68719476704 plaintext bytes with a 12-byte nonce and a 16-byte tag, exactly the
    BinaryTDF-PAY Section 4 limit, and MUST open. A Ciphertext Length of `68719476733`
    carries one byte more and MUST be rejected.
-2. Suite 2 at the volume ceiling. With `segment_size` 1048576, a Ciphertext Length of
-   `1099528405308` spans 1048593 segments and 1099511627776 plaintext bytes, exactly
-   the BinaryTDF-STREAM Section 8.1 ceiling, and MUST open. A Ciphertext Length of
-   `1099528405309` carries one plaintext byte more and MUST be rejected.
+2. Suite 2 at the block ceiling. With `segment_size` 1048576, a Ciphertext Length of
+   `549764202672` spans 524297 segments and 549755813876 plaintext bytes. Its segment
+   invocations contain exactly `2^35` plaintext blocks, so it MUST open. A Ciphertext
+   Length of `549764202673` makes the final invocation cross into one additional block
+   and MUST be rejected by BinaryTDF-STREAM Section 8.1.
 3. Suite 3 at a partition boundary. With `segment_size` 1048576 and
    `partition_segments` 4, segment 3 decrypts under `K_0` and segment 4 under `K_1`,
    where `K_1` is `HKDF-Expand(payload_key,
@@ -154,7 +155,15 @@ before decryption, on frame and header values alone.
    index and the nonce indexes are hexadecimal. Their nonces keep the absolute index:
    `nonce_prefix || 00000003 || 00` and `nonce_prefix || 00000004 || 00`. Swapping the
    two ciphertext segments MUST fail authentication.
-4. Suite 3 parameter rejection. With `segment_size` 1048576, `partition_segments`
-   1048592 is the largest conforming value, because `1048592 * 1048560` is
-   1099511627520. The value 1048593 gives 1099512676080 and MUST be rejected by
-   BinaryTDF-STREAM Section 9.4.
+4. Suite 3 confidentiality-budget boundary. With `segment_size` 1048576,
+   `partition_segments` 524297, and Ciphertext Length `549764202688`, all 524297
+   segments are in partition 0 and contain exactly `sigma_0 = 2^35` plaintext blocks.
+   Thus `sigma_0^2 = 2^70` and the object MUST open. A Ciphertext Length of
+   `549764202689` adds one block to the final invocation, exceeds the budget, and MUST
+   be rejected by BinaryTDF-STREAM Section 9.4.
+5. Suite 3 at 50 TiB. With `segment_size` 1048576 and `partition_segments` 1024,
+   54975581388800 plaintext bytes produce Ciphertext Length `54976420262464`,
+   52429601 segments, and 51201 partitions. The exact block-square sum is
+   `230580012879620085778`, below `2^70`; the object MUST open. Implementations MUST
+   obtain the same value using checked integer arithmetic without iterating over all
+   segments.

--- a/spec/binarytdf/v1alpha/binarytdf-ex.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ex.md
@@ -131,3 +131,30 @@ binding     = HMAC-SHA256(binding_key, policy_bytes)
 ```
 
 The approximate fixed overhead is 250 bytes.
+
+## 5. Limit vectors
+
+These items extend the BinaryTDF-CORE Section 4 coverage with the content-encryption
+limits of BinaryTDF-SEC Section 3. Lengths are exact; payload bytes are omitted because
+only the declared lengths and header fields decide each case. Every rejection happens
+before decryption, on frame and header values alone.
+
+1. Suite 1 at the per-invocation limit. A Ciphertext Length of `68719476732` carries
+   68719476704 plaintext bytes with a 12-byte nonce and a 16-byte tag, exactly the
+   BinaryTDF-PAY Section 4 limit, and MUST open. A Ciphertext Length of `68719476733`
+   carries one byte more and MUST be rejected.
+2. Suite 2 at the volume ceiling. With `segment_size` 1048576, a Ciphertext Length of
+   `1099528405308` spans 1048593 segments and 1099511627776 plaintext bytes, exactly
+   the BinaryTDF-STREAM Section 8.1 ceiling, and MUST open. A Ciphertext Length of
+   `1099528405309` carries one plaintext byte more and MUST be rejected.
+3. Suite 3 at a partition boundary. With `segment_size` 1048576 and
+   `partition_segments` 4, segment 3 decrypts under `K_0` and segment 4 under `K_1`,
+   where `K_1` is `HKDF-Expand(payload_key,
+   UTF8("binary-tdf:v2:stream-partition") || 0000000000000001, 32)`. The partition
+   index and the nonce indexes are hexadecimal. Their nonces keep the absolute index:
+   `nonce_prefix || 00000003 || 00` and `nonce_prefix || 00000004 || 00`. Swapping the
+   two ciphertext segments MUST fail authentication.
+4. Suite 3 parameter rejection. With `segment_size` 1048576, `partition_segments`
+   1048592 is the largest conforming value, because `1048592 * 1048560` is
+   1099511627520. The value 1048593 gives 1099512676080 and MUST be rejected by
+   BinaryTDF-STREAM Section 9.4.

--- a/spec/binarytdf/v1alpha/binarytdf-ex.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ex.md
@@ -1,0 +1,133 @@
+# BinaryTDF-EX: Worked Example
+
+| | |
+|---|---|
+| Document | BinaryTDF-EX |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Informational |
+| Depends on | BinaryTDF-CORE, BinaryTDF-CDDL |
+
+This example builds a minimal DIRECT object with one authority, one policy attribute,
+and a five-byte payload. CBOR structures and lengths are exact. Cryptographic outputs
+shown as `h'…'` are placeholders, not interoperability vectors.
+
+## 1. Protected Metadata
+
+```text
+{
+  1: 1,
+  2: "text/plain"
+}
+```
+
+Deterministic encoding, 15 bytes:
+
+```text
+a2
+   01 01
+   02 6a 74 65 78 74 2f 70 6c 61 69 6e
+```
+
+## 2. Object Key Recovery
+
+```text
+{
+  1: 1,
+  2: [
+    ["example.com", "classification", ["confidential"]]
+  ],
+  3: [
+    {
+      1: "urn:example:authority:1",
+      3: 1,
+      4: h'02…',
+      5: h'…',
+      6: { 1: 1, 2: h'…' }
+    }
+  ]
+}
+```
+
+The wrapped material is exactly 60 bytes:
+
+```text
+12-byte nonce || 32-byte encrypted object key || 16-byte tag
+```
+
+Encoded size is 215 bytes:
+
+| Item | Bytes |
+|---|---:|
+| map header | 1 |
+| `1: 1` | 2 |
+| `2:` and policy | 1 + 43 |
+| `3:` and array header | 1 + 1 |
+| KAO map header | 1 |
+| `authority_id` | 1 + 24 |
+| `3: 1` | 2 |
+| 33-byte encapsulation | 1 + 35 |
+| 60-byte wrapped material | 1 + 62 |
+| policy-binding map | 1 + 38 |
+
+The policy bytes are:
+
+```text
+81
+   83
+      6b 65 78 61 6d 70 6c 65 2e 63 6f 6d
+      6e 63 6c 61 73 73 69 66 69 63 61 74 69 6f 6e
+      81 6c 63 6f 6e 66 69 64 65 6e 74 69 61 6c
+```
+
+## 3. Frame layout
+
+For five plaintext bytes, Ciphertext is `12 + 5 + 16 = 33` bytes. The complete object
+is 283 bytes:
+
+| Offset | Field | Bytes |
+|---:|---|---:|
+| `0x000` | Magic `4c 32 4c` | 3 |
+| `0x003` | Version `02` | 1 |
+| `0x004` | Metadata Length `00 00 00 0f` | 4 |
+| `0x008` | Protected Metadata | 15 |
+| `0x017` | Recovery Length `00 00 00 d7` | 4 |
+| `0x01b` | Object Key Recovery | 215 |
+| `0x0f2` | Ciphertext Length `00 00 00 00 00 00 00 21` | 8 |
+| `0x0fa` | nonce, ciphertext, tag | 33 |
+
+## 4. Derived values
+
+Payload AAD is 239 bytes and uses original frame bytes:
+
+```text
+payload_aad = 02
+           || 00 00 00 0f || <15 metadata bytes>
+           || 00 00 00 d7 || <215 recovery bytes>
+```
+
+The KAO context uses DIRECT path `[0]`:
+
+```text
+{
+  1: "urn:example:authority:1",
+  3: 1,
+  4: 2,
+  5: h'SHA-256 of metadata bytes',
+  6: h'SHA-256 of encapsulation',
+  7: h'SHA-256 of policy bytes',
+  8: 1,
+  9: [0]
+}
+```
+
+```text
+object_key  = 32 random bytes
+payload_key = HKDF(object_key,  info = "binary-tdf:v2:payload-key")
+wrap_kek    = HKDF(ecdh_secret, info = "binary-tdf:v2:kao-kek" || context)
+binding_key = HKDF(object_key,  info = "binary-tdf:v2:policy-binding")
+binding     = HMAC-SHA256(binding_key, policy_bytes)
+```
+
+The approximate fixed overhead is 250 bytes.

--- a/spec/binarytdf/v1alpha/binarytdf-ex.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ex.md
@@ -7,7 +7,7 @@
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Informational |
-| Depends on | BinaryTDF-CORE, BinaryTDF-CDDL |
+| Depends on | BinaryTDF-CORE, BinaryTDF-PKG, BinaryTDF-SCH |
 
 This example builds a minimal DIRECT object with one authority, one policy attribute,
 and a five-byte payload. CBOR structures and lengths are exact. Cryptographic outputs
@@ -81,7 +81,7 @@ The policy bytes are:
       81 6c 63 6f 6e 66 69 64 65 6e 74 69 61 6c
 ```
 
-## 3. Frame layout
+## 3. BinaryTDF-PKG frame layout
 
 For five plaintext bytes, Ciphertext is `12 + 5 + 16 = 33` bytes. The complete object
 is 283 bytes:

--- a/spec/binarytdf/v1alpha/binarytdf-ext-key-epoch.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ext-key-epoch.md
@@ -1,0 +1,237 @@
+# BinaryTDF-KEY-EPOCH: KEY_EPOCH Recovery Extension
+
+| | |
+|---|---|
+| Document | BinaryTDF-KEY-EPOCH |
+| Extension version | 0.1 |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Registry identifier | `KEY_EPOCH = 3` |
+| Status | Draft, optional |
+| Depends on | BinaryTDF-CORE, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-KAS, BinaryTDF-PAY |
+
+KEY_EPOCH amortizes authority contact across a bounded cryptographic generation while
+retaining a unique object key per BinaryTDF. It is intended for independently framed
+objects in a dataset or stream sharing policy and recipients for a limited generation.
+
+## 1. Core relationship
+
+Identifier 3 is reserved for this recovery extension. A compatible revision retains
+it; incompatible schema, cryptographic, validation, or interpretation changes require
+a new identifier.
+
+Support is optional. An implementation MAY claim core conformance without implementing
+this extension. A receiver that does not implement KEY_EPOCH MUST reject scheme 3 as
+`UNSUPPORTED_CAPABILITY` and MUST NOT substitute another scheme. The extension uses
+core KAOs, wrapping, policy binding, rewrap, and DIRECT/XOR_ALL topologies without
+modification.
+
+```cddl
+$binary-tdf-recovery-scheme-data /= key-epoch-recovery-data
+```
+
+## 2. Scope
+
+An epoch is a bounded logical generation, not wall-clock time. It has one anchor whose
+KAOs protect a fresh 32-byte epoch secret. Other objects are references identifying the
+anchor and contain no KAO. After one authorized anchor recovery, an opener derives a
+different object key for every object in that epoch.
+
+Releasing the epoch secret authorizes the complete epoch. This extension MUST NOT be
+used when each object requires an independent authority decision.
+
+An epoch share is a 32-byte value used to reconstruct an epoch secret. The extension
+defines identity and recovery but not transport, delivery order, packaging, buffering,
+or anchor lookup protocol.
+
+```text
+anchor KAO release ─► epoch secret ─┬─ context A + HKDF ─► object key A
+                                    ├─ context B + HKDF ─► object key B
+                                    └─ context C + HKDF ─► object key C
+```
+
+The anchor is a payload-bearing object and consumes one unique dataset/epoch/stream/
+sequence tuple. It need not be first, though producers SHOULD use sequence zero when
+the stream model permits it.
+
+## 3. Wire schema
+
+`recovery_data` is one of two closed maps selected by `role`:
+
+| Key | Field | Anchor | Reference | Type |
+|---:|---|---|---|---|
+| 1 | `role` | `0`, required | `1`, required | `uint` |
+| 2 | `dataset_id` | required | required | 16-byte `bstr` |
+| 3 | `epoch` | required | required | `uint64` |
+| 4 | `stream_id` | required | required | `uint32` |
+| 5 | `sequence` | required | required | `uint64` |
+| 6 | `anchor_id` | required | required | 16-byte `bstr` |
+| 7 | `epoch_limits` | required | forbidden | map |
+| 8 | `epoch_secret_recovery` | required | forbidden | array |
+
+`dataset_id` and `anchor_id` MUST be independently generated with a cryptographically
+secure random source. They are identifiers, not locations. The deployment-defined
+resolver is untrusted. An opener MUST verify exact anchor, dataset, and epoch equality.
+Unknown roles, extra role-specific fields, and mismatched identifiers are malformed.
+
+```cddl
+key-epoch-role = &(anchor: 0, reference: 1)
+
+epoch-uint64 = 0..18446744073709551615
+epoch-uint32 = 0..4294967295
+
+epoch-limits = {
+  1 => max_streams: 1..4294967295,
+  2 => max_sequence: epoch-uint64,
+  ? 3 => max_total_plaintext_bytes: 1..18446744073709551615,
+  ? 4 => producer_not_after: 1..18446744073709551615
+}
+
+epoch-secret-recovery = [
+  base-scheme: (1 / 2),
+  base-data: (direct-kao-set / xor-all-kao-groups)
+]
+
+key-epoch-anchor-data = {
+  1 => 0,
+  2 => bstr .size 16,
+  3 => epoch-uint64,
+  4 => epoch-uint32,
+  5 => epoch-uint64,
+  6 => bstr .size 16,
+  7 => epoch-limits,
+  8 => epoch-secret-recovery
+}
+
+key-epoch-reference-data = {
+  1 => 1,
+  2 => bstr .size 16,
+  3 => epoch-uint64,
+  4 => epoch-uint32,
+  5 => epoch-uint64,
+  6 => bstr .size 16
+}
+
+key-epoch-recovery-data =
+  key-epoch-anchor-data /
+  key-epoch-reference-data
+```
+
+`stream_id` MUST be less than `max_streams`; `sequence` MUST be at most
+`max_sequence`. `producer_not_after` is an unsigned Unix creation deadline in seconds
+and does not make existing objects undecryptable. A producer MUST count complete epoch
+plaintext when the byte limit is present. Epoch values MUST increase within a dataset
+and MUST NOT be reused.
+
+## 4. Epoch-secret recovery
+
+The anchor selects one base topology:
+
+- DIRECT contains exactly one KAO wrapping the epoch secret.
+- XOR_ALL contains two or more required groups whose shares XOR to the epoch secret.
+
+| Topology | KAO path |
+|---|---|
+| DIRECT | `[1, 0]` |
+| XOR_ALL | `[2, group_index, alternative_index]` |
+
+The top-level KAO context identifies KEY_EPOCH. Each KAO wraps the epoch secret or a
+share and binds policy using that `kao_value`. The authority returns the value; the
+opener XORs when needed.
+
+A reference has no path and MUST NOT be sent directly for rewrap. The opener resolves
+the anchor and submits exact anchor sections and anchor paths.
+
+## 5. Object-key derivation
+
+```text
+epoch_object_context = encode_deterministic_cbor([
+  "binary-tdf:v2:key-epoch",
+  frame_version,
+  KEY_EPOCH,
+  role,
+  content_encryption_suite,
+  dataset_id,
+  epoch,
+  stream_id,
+  sequence,
+  anchor_id
+])
+
+object_key = HKDF-SHA256(
+  ikm  = epoch_secret,
+  salt = UTF8("binary-tdf:v2:hkdf-salt"),
+  info = epoch_object_context,
+  len  = 32
+)
+```
+
+Context fields MUST NOT be concatenated outside deterministic CBOR. The object key is
+given to the selected content-encryption suite and never serialized. Producers MUST
+NOT repeat a dataset/epoch/stream/sequence tuple. Role, suite, and identity changes
+change the object key. Payload encryption still uses required fresh randomness.
+
+## 6. Policy and lifecycle
+
+The anchor policy governs the epoch. References MUST omit top-level policy. For a
+KEY_EPOCH reference, absence means inheritance from the verified anchor rather than
+public access. A reference carrying policy is malformed. Other recovery schemes retain
+the core public-policy default.
+
+Changing policy, recipient, KAO topology, wrap suite, or epoch limit requires a fresh
+epoch secret, new epoch value, and new anchor ID.
+
+Every epoch is bounded by streams and sequence. Producers MAY add lower byte or
+creation-time limits and MUST rotate at the first declared limit. Lost sequence state,
+rollback, or inability to prove tuple uniqueness requires a new epoch. If a greater
+unused epoch cannot be proved, the producer MUST create a new dataset ID.
+
+An opener MAY cache the epoch secret under verified anchor ID. The cache MUST be
+bounded and scoped to the matching dataset and epoch, MUST be excluded from logs, and
+MUST be cleared when no longer needed. Persistent clear epoch-secret storage is
+forbidden.
+
+## 7. Opening and replay
+
+To open a reference:
+
+1. strictly parse it;
+2. resolve anchor ID using a configured resolver;
+3. strictly parse and verify the anchor role, limits, and identifiers;
+4. validate anchor policy and critical extensions;
+5. recover or retrieve the cached epoch secret;
+6. derive the object key from exact reference context; and
+7. authenticate payload before returning plaintext.
+
+Resolution MUST have finite request, recursion, response-size, and cache limits. An
+anchor may be retransmitted or stored, but a reference MUST never mean “use the
+previous key.” Failure to resolve the exact anchor fails closed.
+
+A generic opener MAY reopen stored objects. A live-processing profile MUST maintain a
+replay window per dataset/epoch/stream, reject accepted sequences, bound out-of-order
+acceptance, and reject values past declared limits.
+
+## 8. Security
+
+- An epoch-secret holder can decrypt and construct AEAD-valid objects for the epoch.
+  AEAD does not identify the producer.
+- Source-sensitive records MUST carry a producer-signed metadata claim or detached
+  attestation from a trusted signer.
+- Rotation limits exposure but does not provide forward secrecy or post-compromise
+  security within an epoch.
+- Revocation cannot retract a released epoch secret; changes apply to new objects at
+  the next epoch.
+- XOR limits what one authority can reconstruct before release, not what an opener can
+  do after reconstructing and caching the epoch secret.
+- ML-KEM protects KAO and session transport but not symmetric exposure after release.
+- References depend on bounded, exact, fail-closed anchor resolution and availability.
+  Deployments MUST define retransmission or trusted lookup when references can outlive
+  their delivery session.
+
+## 9. Conformance
+
+Vectors MUST include byte-exact anchor and reference data; DIRECT and XOR_ALL recovery;
+deterministic contexts and keys; mutations of role, suite, and identity; duplicate
+tuples, rollback, and limits; missing, mismatched, malformed, and recursive anchors;
+references carrying policy or KAO material; live replay behavior; and indistinguishable
+policy, unwrap, derivation, and payload failures.

--- a/spec/binarytdf/v1alpha/binarytdf-ext-key-epoch.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ext-key-epoch.md
@@ -123,6 +123,19 @@ and does not make existing objects undecryptable. A producer MUST count complete
 plaintext when the byte limit is present. Epoch values MUST increase within a dataset
 and MUST NOT be reused.
 
+Every epoch limit, including `max_total_plaintext_bytes`, is an authorization
+blast-radius and rotation control on a long-lived producer key. It bounds how much data
+one released epoch secret exposes and when the producer must rotate, and it is counted
+across every object in the epoch. It is not an AEAD usage bound. The AEAD bound is
+separate: it applies per content-encryption key per object and is stated by
+BinaryTDF-SEC Section 3.1 and BinaryTDF-PAY Section 5. Every object in an epoch has its
+own object key by the Section 5 derivation below, so an epoch may carry far more
+plaintext than the AEAD bound without any key approaching it. Neither limit relieves
+the other: an epoch byte
+limit of any size leaves a suite 2 object with its own ceiling, and an object that
+respects every partition ceiling still counts its complete plaintext against the epoch
+limit.
+
 ## 4. Epoch-secret recovery
 
 The anchor selects one base topology:

--- a/spec/binarytdf/v1alpha/binarytdf-ext-key-epoch.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ext-key-epoch.md
@@ -8,7 +8,7 @@
 | Frame version | 2 |
 | Registry identifier | `KEY_EPOCH = 3` |
 | Status | Draft, optional |
-| Depends on | BinaryTDF-CORE, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-KAS, BinaryTDF-PAY |
+| Depends on | BinaryTDF-SEC, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-KAS, BinaryTDF-PAY, BinaryTDF-SCH |
 
 KEY_EPOCH amortizes authority contact across a bounded cryptographic generation while
 retaining a unique object key per BinaryTDF. It is intended for independently framed

--- a/spec/binarytdf/v1alpha/binarytdf-ext-key-epoch.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ext-key-epoch.md
@@ -4,7 +4,7 @@
 |---|---|
 | Document | BinaryTDF-KEY-EPOCH |
 | Extension version | 0.1 |
-| Source draft | 0.2 |
+| Source draft | 0.3 |
 | Frame version | 2 |
 | Registry identifier | `KEY_EPOCH = 3` |
 | Status | Draft, optional |
@@ -127,14 +127,13 @@ Every epoch limit, including `max_total_plaintext_bytes`, is an authorization
 blast-radius and rotation control on a long-lived producer key. It bounds how much data
 one released epoch secret exposes and when the producer must rotate, and it is counted
 across every object in the epoch. It is not an AEAD usage bound. The AEAD bound is
-separate: it applies per content-encryption key per object and is stated by
+separate: it is an object-wide budget over content-encryption keys and is stated by
 BinaryTDF-SEC Section 3.1 and BinaryTDF-PAY Section 5. Every object in an epoch has its
 own object key by the Section 5 derivation below, so an epoch may carry far more
-plaintext than the AEAD bound without any key approaching it. Neither limit relieves
-the other: an epoch byte
-limit of any size leaves a suite 2 object with its own ceiling, and an object that
-respects every partition ceiling still counts its complete plaintext against the epoch
-limit.
+plaintext than one object's AEAD budget. Neither limit relieves the other: an epoch
+byte limit of any size leaves a suite 2 object with its own ceiling, and an object that
+respects the suite 3 block-square budget still counts its complete plaintext against
+the epoch limit.
 
 ## 4. Epoch-secret recovery
 

--- a/spec/binarytdf/v1alpha/binarytdf-ext-stream.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ext-stream.md
@@ -8,7 +8,7 @@
 | Frame version | 2 |
 | Registry identifier | `AES_256_GCM_HKDF_SHA256_STREAM = 2` |
 | Status | Draft, optional |
-| Depends on | BinaryTDF-CORE, BinaryTDF-PAY |
+| Depends on | BinaryTDF-SEC, BinaryTDF-PAY, BinaryTDF-SCH, BinaryTDF-PKG |
 
 This suite protects one large payload as independently authenticated segments inside
 the ordinary Ciphertext section. Its key schedule, nonce construction, and segment
@@ -17,7 +17,7 @@ encryption derive from the
 A BinaryTDF header declares ciphertext segment size.
 
 It supports bounded-memory processing and optional random access without changing the
-frame, recovery, KAO wrapping, policy binding, or KAS protocol.
+BinaryTDF-PKG frame, recovery, KAO wrapping, policy binding, or KAS protocol.
 
 ## 1. Core relationship
 
@@ -128,8 +128,8 @@ segment_nonce(i) = nonce_prefix
 
 `final_byte` is `0x01` for the final segment and `0x00` otherwise. Index and final
 marker detect reordering, duplication, truncation, and extension. Segment AES-GCM AAD
-is empty; core `payload_aad` and segment size are bound into the payload key as Tink
-specifies.
+is empty; BinaryTDF-PAY `payload_aad` and segment size are bound into the payload key
+as Tink specifies.
 
 ## 6. Encryption
 
@@ -159,7 +159,8 @@ order.
   completeness still requires authenticating the final segment. Omission-sensitive
   applications MUST NOT act on the payload as complete before then.
 
-Strict frame, CBOR, policy-binding, and key-recovery validation precedes segment work.
+Strict BinaryTDF-PKG frame, BinaryTDF-SCH CBOR, policy-binding, and key-recovery
+validation precedes segment work.
 
 ## 8. Limits
 

--- a/spec/binarytdf/v1alpha/binarytdf-ext-stream.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ext-stream.md
@@ -1,36 +1,40 @@
-# BinaryTDF-STREAM: AES-256-GCM-HKDF Streaming Suite
+# BinaryTDF-STREAM: AES-256-GCM-HKDF Streaming Suites
 
 | | |
 |---|---|
 | Document | BinaryTDF-STREAM |
-| Extension version | 0.1 |
+| Extension version | 0.2 |
 | Source draft | 0.2 |
 | Frame version | 2 |
-| Registry identifier | `AES_256_GCM_HKDF_SHA256_STREAM = 2` |
+| Registry identifiers | `AES_256_GCM_HKDF_SHA256_STREAM = 2`, `AES_256_GCM_HKDF_SHA256_STREAM_PART = 3` |
 | Status | Draft, optional |
 | Depends on | BinaryTDF-SEC, BinaryTDF-PAY, BinaryTDF-SCH, BinaryTDF-PKG |
 
-This suite protects one large payload as independently authenticated segments inside
-the ordinary Ciphertext section. Its key schedule, nonce construction, and segment
-encryption derive from the
+This document registers two suites that protect one large payload as independently
+authenticated segments inside the ordinary Ciphertext section. Sections 1 through 8
+define suite 2, whose key schedule, nonce construction, and segment encryption derive
+from the
 [Tink AES-GCM-HKDF Streaming AEAD encryption function](https://developers.google.com/tink/streaming-aead/aes_gcm_hkdf_streaming).
-A BinaryTDF header declares ciphertext segment size.
+Section 9 defines suite 3, which adds partition-key derivation to that construction so
+that one object may exceed the volume a single AES-GCM key may protect. A BinaryTDF
+header declares ciphertext segment size.
 
-It supports bounded-memory processing and optional random access without changing the
+Both support bounded-memory processing and optional random access without changing the
 BinaryTDF-PKG frame, recovery, KAO wrapping, policy binding, or KAS protocol.
 
 ## 1. Core relationship
 
-Identifier 2 is reserved for this suite. A compatible revision retains it; an
-incompatible parameter, encoding, derivation, nonce, release, or interpretation change
-requires a new identifier.
+Identifier 2 is reserved for suite 2 and identifier 3 for suite 3. A compatible
+revision retains an identifier; an incompatible parameter, encoding, derivation, nonce,
+release, or interpretation change requires a new identifier.
 
-Support is optional. An implementation MAY claim core conformance without implementing
-this suite. A receiver that does not implement it MUST reject suite 2 as
-`UNSUPPORTED_CAPABILITY` and MUST NOT fall back to another suite. The suite consumes
-the 32-byte object key from any recovery scheme. KEY_EPOCH includes the
-content-encryption identifier in object-key derivation, so selecting this suite
-produces a different object key than suite 1 for the same epoch identity.
+Support is optional and the two suites are independent: an implementation MAY claim
+core conformance without implementing either, and MAY implement one without the other.
+A receiver that does not implement a suite MUST reject it as `UNSUPPORTED_CAPABILITY`
+and MUST NOT fall back to another suite. Each suite consumes the 32-byte object key
+from any recovery scheme. KEY_EPOCH includes the content-encryption identifier in
+object-key derivation, so selecting a suite here produces a different object key than
+suite 1 for the same epoch identity.
 
 This adopts Tink's cryptographic construction, not Tink keysets, Protocol Buffers, or
 byte-exact header. BinaryTDF's object key is Tink `KeyValue`; `segment_size` is
@@ -39,14 +43,25 @@ plus encoded segment size is Tink `AssociatedData`.
 
 ## 2. Applicability
 
-Suite 1 is a single AES-GCM message and is limited to about 64 GiB of plaintext; its
-release rule also requires buffering or double-reading large data. This suite removes
-those limits with independently authenticated segments.
+Suite 1 is a single AES-GCM message, so it cannot carry more than 68719476704
+plaintext bytes: the NIST SP 800-38D Section 5.2.1.1 per-invocation limit, stated
+normatively in BinaryTDF-PAY Section 4. Its release rule also requires buffering or
+double-reading large data. Independently authenticated segments remove both
+constraints, because each segment is a separate bounded invocation that is verified
+and may be released on its own.
 
-It protects one logical payload. It is not a collection container. The frame still
-places Ciphertext Length before bytes, so the producer MUST know final encoded length
-or use seekable output and backpatch it. Open-ended live streams require multiple
-bounded objects or a separate transport/container specification.
+Segmentation removes a per-invocation framing limit; it does not remove the cumulative
+volume bound. The AES-GCM confidentiality bound counts total plaintext blocks under one
+key however those blocks are divided into messages, so splitting a payload into more
+segments does not let one key protect more of it. Segmenting is not rekeying.
+Section 8.1 therefore caps a suite 2 object at 2^40 plaintext bytes, and Section 9
+defines suite 3, which rekeys at partition boundaries to carry larger objects.
+BinaryTDF-SEC Section 3 gives the analysis behind both.
+
+Each suite protects one logical payload; neither is a collection container. The frame
+still places Ciphertext Length before bytes, so the producer MUST know final encoded
+length or use seekable output and backpatch it. Open-ended live streams require
+multiple bounded objects or a separate transport/container specification.
 
 ## 3. Parameters and derivation
 
@@ -170,14 +185,203 @@ validation precedes segment work.
 | Segment 0 plaintext | `segment_size - 60` maximum |
 | Later plaintext segment | `segment_size - 16` maximum |
 | Segment count | at most 2^32 |
+| Total plaintext | at most 1099511627776 bytes, that is 2^40 |
 | Fixed overhead | 44-byte header and 16-byte tag per segment |
 | Working memory | one segment |
 
-Maximum plaintext is constrained by segment count, size, and outer Ciphertext Length.
-Implementations MUST enforce configured total-byte, size, and count limits before
-allocation or cryptographic processing. Profiles MAY set lower limits.
+Maximum plaintext is constrained by segment count, size, outer Ciphertext Length, and
+the volume ceiling below. Implementations MUST enforce configured total-byte, size, and
+count limits before allocation or cryptographic processing. Profiles MAY set lower
+limits.
 
-## 9. Security
+### 8.1 Volume ceiling
+
+One payload key protects every segment of a suite 2 object, so the object as a whole is
+one content-encryption key's worth of plaintext. A suite 2 object MUST NOT protect more
+than 2^40 plaintext bytes, that is 1099511627776 bytes. BinaryTDF-SEC Section 3.1
+states the limit and gives its analysis.
+
+The complete plaintext length follows from the frame before any decryption:
+
+```text
+segment_count   = ceil(Ciphertext Length / segment_size)
+total_plaintext = Ciphertext Length - 44 - 16 * segment_count
+```
+
+A producer MUST NOT emit a suite 2 object whose `total_plaintext` exceeds the ceiling,
+and a decoder MUST reject such an object before allocating a segment buffer or
+authenticating any segment. Choosing a smaller `segment_size` does not raise the
+ceiling, because the bound counts plaintext blocks and not messages.
+
+Suite 2 therefore tops out at 1 TiB of plaintext per object. That is its scale ceiling:
+a larger payload MUST use suite 3, which rekeys per partition, or be divided into
+several objects with independent object keys.
+
+## 9. Partitioned suite 3
+
+Identifier 3, `AES_256_GCM_HKDF_SHA256_STREAM_PART`, is suite 2's segment construction
+with one addition: the payload key encrypts nothing, and every segment is encrypted
+under a partition key expanded from it. Rekeying at partition boundaries keeps each
+content-encryption key inside the BinaryTDF-SEC Section 3.1 volume ceiling while the
+object grows to storage scale.
+
+Sections 3 through 7 apply to suite 3 as written except where this section replaces
+them, and Section 1 governs identifier 3 unchanged. Suite 3 adds no CBOR field: its
+only appearance in CBOR is `content_encryption_suite = 3` in Protected Metadata,
+registered by BinaryTDF-SCH as `aes-256-gcm-hkdf-sha256-stream-part`. Its parameter
+travels in the ciphertext header like every other suite 2 parameter.
+
+### 9.1 Header and partition parameter
+
+`partition_segments` is an unsigned 32-bit count of segments per partition. It is
+appended to the Section 4 header, which grows from 44 to 48 bytes:
+
+```text
+header = 0x30 || uint32_be(segment_size) || stream_salt
+      || nonce_prefix || uint32_be(partition_segments)
+
+0x30                1 byte    declared header length, 48 bytes
+segment_size        4 bytes
+stream_salt        32 bytes
+nonce_prefix        7 bytes
+partition_segments  4 bytes
+```
+
+The parameter is appended rather than inserted, so every field shared with suite 2
+keeps its offset and meaning and the first byte still declares total header length. A
+decoder MUST reject a declared header length other than `0x30`, which also prevents a
+suite 2 reader from consuming a suite 3 header or the reverse.
+
+Capacities and offsets change only by the four added bytes:
+
+```text
+segment 0 plaintext capacity = segment_size - 64
+later plaintext capacity     = segment_size - 16
+
+segment_0_encrypted_offset   = 48
+segment_i_encrypted_offset   = i * segment_size, for i > 0
+```
+
+`segment_size` MUST be greater than 64 and MUST NOT exceed 2147483647. The Ciphertext
+section MUST be at least 64 bytes: the header and one tag for an empty final segment.
+The Section 4 rules on maximum-length non-final segments, the non-empty final segment,
+and rejection of truncated or malformed segments apply unchanged.
+
+### 9.2 Derivation
+
+The payload key is derived as in Section 3 with `partition_segments` appended to the
+info string:
+
+```text
+payload_key = HKDF-SHA256(
+  ikm  = object_key,
+  salt = stream_salt,
+  info = payload_aad || uint32_be(segment_size) || uint32_be(partition_segments),
+  len  = 32
+)
+```
+
+The additional fixed-width suffix binds the partition parameter and separates the two
+suites: one object key, salt, AAD, and segment size yield unrelated payload keys under
+suite 2 and suite 3. In the Section 3 mapping, Tink `AssociatedData` is
+`payload_aad || uint32_be(segment_size) || uint32_be(partition_segments)`; every other
+parameter is unchanged.
+
+`partition_segments` MUST be at least 1. Partition `p` covers segment indexes
+`p * partition_segments` through `p * partition_segments + partition_segments - 1`, so
+segment `i` is encrypted under:
+
+```text
+p   = floor(i / partition_segments)
+
+K_p = HKDF-Expand(
+  prk  = payload_key,
+  info = UTF8("binary-tdf:v2:stream-partition") || uint64_be(p),
+  len  = 32
+)
+```
+
+This is RFC 5869 Expand with the payload key directly as the pseudorandom key and no
+Extract step, because the payload key is already a uniform HKDF output. The partition
+index is encoded in eight bytes even though a 32-bit segment index cannot produce a
+partition index above 2^32 - 1; the label and width match BaseTDF 5 partition
+derivation.
+
+The Section 6 producer step 4 emits
+`AES-256-GCM(K_p, segment_nonce(i), empty_aad, segment_plaintext)`. The payload key
+performs no AES-GCM operation. A producer that distributes segment work MUST hand a
+worker only the partition keys it needs and MUST NOT hand it the payload key.
+
+### 9.3 Nonce
+
+Nonce construction is unchanged from Section 5:
+
+```text
+segment_nonce(i) = nonce_prefix || uint32_be(i) || final_byte
+```
+
+The index is the absolute segment index; it does not restart at a partition boundary.
+Restarting would also be sound, because each partition has its own key, but the
+absolute index is strictly safer: it keeps every key and nonce pair distinct even if a
+partition key were repeated, whether through a repeated payload key or an
+implementation error in Section 9.2. It also keeps random access simple, because the
+nonce of segment `i` depends only on `i`. Segment AES-GCM AAD remains empty.
+
+### 9.4 Volume ceiling
+
+No partition key may protect more than 2^40 plaintext bytes. The header alone bounds
+that quantity, because no segment carries more than `segment_size - 16` plaintext
+bytes:
+
+```text
+partition_segments * (segment_size - 16) <= 1099511627776
+```
+
+A producer MUST select parameters satisfying this inequality, and a decoder MUST reject
+a header that violates it before allocating a segment buffer or authenticating any
+segment. The bound is conservative: segment 0 carries 48 fewer bytes and the final
+segment may be short, so a conforming partition holds at most, and usually less than,
+the ceiling.
+
+At the maximum `segment_size` of 2147483647, `partition_segments` MUST NOT exceed 512,
+because `512 * 2147483631` is 1099511619072 and `513 * 2147483631` is 1101659102703.
+
+### 9.5 Limits and object size
+
+| Quantity | Limit |
+|---|---|
+| Ciphertext segment | 65 through 2147483647 bytes |
+| Segment 0 plaintext | `segment_size - 64` maximum |
+| Later plaintext segment | `segment_size - 16` maximum |
+| Segment count | at most 2^32 |
+| `partition_segments` | 1 through 4294967295, further bounded by Section 9.4 |
+| Partition plaintext | at most 1099511627776 bytes, that is 2^40 |
+| Total plaintext | bounded by segment count and segment size, not by the volume ceiling |
+| Fixed overhead | 48-byte header and 16-byte tag per segment |
+| Working memory | one segment |
+
+Object size is bounded by the segment fields rather than by the volume ceiling:
+
+```text
+max object plaintext = (segment_size - 64) + (2^32 - 1) * (segment_size - 16)
+                     = 9223371963840331728 bytes at segment_size 2147483647
+```
+
+That is 8 EiB, within rounding of 2^63, and its Ciphertext Length of
+9223372032559808512 bytes fits the 8-byte frame field. The partition arithmetic gives
+the same figure: at that segment size a partition holds at most
+`512 * 2147483631 = 1099511619072` bytes, just under 2^40, and `2^32 / 512` is 2^23
+partitions, so partition size times partition count is at most
+`2^23 * 2^40 = 2^63` bytes and exactly `2^23 * 1099511619072 = 9223371963840331776`
+bytes, which is the formula above plus the 48 header bytes segment 0 gives up.
+
+The Amazon S3 single-object maximum of 5 TiB, or 5497558138880 bytes, is about 1.7
+million times smaller than that. Ordinary parameters reach it comfortably: at
+`segment_size` 1048576 and `partition_segments` 1048576, each partition protects at
+most 1099494850560 bytes, 16 MiB inside the ceiling, and a 5 TiB payload occupies
+5242961 segments in six partitions.
+
+## 10. Security
 
 - Prefix authenticity is not completeness. Pipelines need a failure path that retracts
   or abandons partial output.
@@ -188,8 +392,16 @@ allocation or cryptographic processing. Profiles MAY set lower limits.
 - Segments do not transplant across objects or positions because payload derivation,
   index, and final marker differ.
 - Random access may reveal access patterns to storage or transport.
+- Suite 2 has no rekeying mechanism, so the Section 8.1 ceiling is its only protection
+  against AES-GCM volume degradation. Producers of large data SHOULD prefer suite 3
+  rather than approaching that ceiling.
+- `partition_segments` is attacker-controlled until authentication in the same way
+  segment size is. Validate it against Section 9.4 before allocation; its derivation
+  binding detects later change.
+- A disclosed partition key exposes only the segments of its partition. It does not
+  yield the payload key, another partition key, or any other object.
 
-## 10. Conformance
+## 11. Conformance
 
 Vectors MUST include at least three segment sizes including 65536; empty payloads and
 payloads around every boundary; exact headers, keys, offsets, nonces, ciphertext, and
@@ -197,3 +409,11 @@ tags; truncation and removal of final segments; reorder, duplication, and traili
 bytes; invalid sizes and bit corruption in every header and segment component;
 cross-object transplant; late sequential failure after partial release; and interior
 random access with and without final completion.
+
+Vectors MUST additionally include, for the limits of Sections 8.1 and 9.4, a suite 2
+object at exactly the volume ceiling and the next larger object; a suite 3 object whose
+segment indexes cross at least two partition boundaries, with exact `K_p` values and
+absolute-index nonces on both sides of each boundary; a suite 3 header whose
+`partition_segments` and `segment_size` product exceeds the ceiling; and a suite 3
+header presented to a suite 2 reader and the reverse. BinaryTDF-EX Section 5 gives
+worked values for the boundary cases.

--- a/spec/binarytdf/v1alpha/binarytdf-ext-stream.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ext-stream.md
@@ -1,0 +1,198 @@
+# BinaryTDF-STREAM: AES-256-GCM-HKDF Streaming Suite
+
+| | |
+|---|---|
+| Document | BinaryTDF-STREAM |
+| Extension version | 0.1 |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Registry identifier | `AES_256_GCM_HKDF_SHA256_STREAM = 2` |
+| Status | Draft, optional |
+| Depends on | BinaryTDF-CORE, BinaryTDF-PAY |
+
+This suite protects one large payload as independently authenticated segments inside
+the ordinary Ciphertext section. Its key schedule, nonce construction, and segment
+encryption derive from the
+[Tink AES-GCM-HKDF Streaming AEAD encryption function](https://developers.google.com/tink/streaming-aead/aes_gcm_hkdf_streaming).
+A BinaryTDF header declares ciphertext segment size.
+
+It supports bounded-memory processing and optional random access without changing the
+frame, recovery, KAO wrapping, policy binding, or KAS protocol.
+
+## 1. Core relationship
+
+Identifier 2 is reserved for this suite. A compatible revision retains it; an
+incompatible parameter, encoding, derivation, nonce, release, or interpretation change
+requires a new identifier.
+
+Support is optional. An implementation MAY claim core conformance without implementing
+this suite. A receiver that does not implement it MUST reject suite 2 as
+`UNSUPPORTED_CAPABILITY` and MUST NOT fall back to another suite. The suite consumes
+the 32-byte object key from any recovery scheme. KEY_EPOCH includes the
+content-encryption identifier in object-key derivation, so selecting this suite
+produces a different object key than suite 1 for the same epoch identity.
+
+This adopts Tink's cryptographic construction, not Tink keysets, Protocol Buffers, or
+byte-exact header. BinaryTDF's object key is Tink `KeyValue`; `segment_size` is
+`CiphertextSegmentSize`; `DerivedKeySize` is 32; hash is SHA-256; and BinaryTDF AAD
+plus encoded segment size is Tink `AssociatedData`.
+
+## 2. Applicability
+
+Suite 1 is a single AES-GCM message and is limited to about 64 GiB of plaintext; its
+release rule also requires buffering or double-reading large data. This suite removes
+those limits with independently authenticated segments.
+
+It protects one logical payload. It is not a collection container. The frame still
+places Ciphertext Length before bytes, so the producer MUST know final encoded length
+or use seekable output and backpatch it. Open-ended live streams require multiple
+bounded objects or a separate transport/container specification.
+
+## 3. Parameters and derivation
+
+| Tink parameter | Value |
+|---|---|
+| `KeyValue` | 32-byte object key |
+| `CiphertextSegmentSize` | stream-header `segment_size` |
+| `DerivedKeySize` | 32 bytes |
+| `HkdfHashType` | SHA-256 |
+| `AssociatedData` | `payload_aad || uint32_be(segment_size)` |
+
+`segment_size` is an unsigned 32-bit byte count. It MUST be greater than 60 and MUST
+NOT exceed 2147483647. An implementation MUST validate it and apply configured
+resource limits before allocating a segment buffer. A deployment MAY reject otherwise
+valid objects whose segment size exceeds its limit.
+
+The producer generates a fresh random 32-byte `stream_salt` and derives:
+
+```text
+payload_key = HKDF-SHA256(
+  ikm  = object_key,
+  salt = stream_salt,
+  info = payload_aad || uint32_be(segment_size),
+  len  = 32
+)
+```
+
+The fixed-width suffix binds segment boundaries. The suite identifier is already in
+Protected Metadata covered by `payload_aad`.
+
+## 4. Ciphertext layout
+
+```text
+header || encrypted_segment[0] || ... || encrypted_segment[n-1]
+
+header = 0x2c || uint32_be(segment_size) || stream_salt || nonce_prefix
+         1 byte  4 bytes                    32 bytes       7 bytes
+```
+
+- `0x2c` declares the 44-byte header.
+- `segment_size` is the maximum wire-segment size, including header in segment 0 and
+  the tag in every segment.
+- `stream_salt` is used by Section 3.
+- `nonce_prefix` is fresh and uniformly random.
+- Every encrypted segment ends with a 16-byte AES-GCM tag.
+
+```text
+segment 0: [44-byte header | ciphertext | 16-byte tag]
+segment i: [ciphertext                 | 16-byte tag]
+
+segment 0 plaintext capacity = segment_size - 60
+later plaintext capacity     = segment_size - 16
+```
+
+When multiple segments exist, segment 0 and every non-final segment MUST have maximum
+length. The final segment MAY be shorter but MUST NOT be empty unless the complete
+payload is empty.
+
+The Ciphertext section MUST be at least 60 bytes: the header and one tag for an empty
+final segment.
+
+```text
+segment_count = ceil(Ciphertext Length / segment_size)
+segment_0_encrypted_offset = 44
+segment_i_encrypted_offset = i * segment_size, for i > 0
+```
+
+A decoder MUST reject header length other than `0x2c`, invalid segment size, truncated
+header or tag, non-final short segment, or empty final segment in a multi-segment
+object.
+
+## 5. Nonce and associated data
+
+```text
+segment_nonce(i) = nonce_prefix
+                 || uint32_be(i)
+                 || final_byte
+```
+
+`final_byte` is `0x01` for the final segment and `0x00` otherwise. Index and final
+marker detect reordering, duplication, truncation, and extension. Segment AES-GCM AAD
+is empty; core `payload_aad` and segment size are bound into the payload key as Tink
+specifies.
+
+## 6. Encryption
+
+After metadata and recovery are complete, the producer:
+
+1. selects valid `segment_size` and generates `stream_salt` and `nonce_prefix`;
+2. derives `payload_key`;
+3. splits plaintext using Section 4; and
+4. emits `AES-256-GCM(payload_key, segment_nonce(i), empty_aad, segment_plaintext)`.
+
+Indexes MUST strictly increase from zero. Exactly one segment, the last, MUST use the
+final byte. Producers MAY encrypt segments in parallel; emitted order remains index
+order.
+
+## 7. Decryption and release
+
+- A sequential opener MUST verify in order and MAY release a segment after it authenticates.
+  Released data is authentic prefix data. The stream is complete only when the final
+  segment authenticates at the position implied by section length and consumes the
+  section exactly.
+- Any authentication failure or absence of a valid final segment MUST fail the stream.
+  An application consuming prefix data MUST be able to discard or abandon partial
+  output and MUST NOT treat prefix data as the complete payload.
+- A streaming API MUST expose final completion or failure separately from prefix
+  delivery. An API returning one complete object MUST stage output until completion.
+- A random-access opener MAY verify and release a segment independently. Whole-payload
+  completeness still requires authenticating the final segment. Omission-sensitive
+  applications MUST NOT act on the payload as complete before then.
+
+Strict frame, CBOR, policy-binding, and key-recovery validation precedes segment work.
+
+## 8. Limits
+
+| Quantity | Limit |
+|---|---|
+| Ciphertext segment | 61 through 2147483647 bytes |
+| Segment 0 plaintext | `segment_size - 60` maximum |
+| Later plaintext segment | `segment_size - 16` maximum |
+| Segment count | at most 2^32 |
+| Fixed overhead | 44-byte header and 16-byte tag per segment |
+| Working memory | one segment |
+
+Maximum plaintext is constrained by segment count, size, and outer Ciphertext Length.
+Implementations MUST enforce configured total-byte, size, and count limits before
+allocation or cryptographic processing. Profiles MAY set lower limits.
+
+## 9. Security
+
+- Prefix authenticity is not completeness. Pipelines need a failure path that retracts
+  or abandons partial output.
+- Header randomness MUST be fresh. Reusing object key and salt may repeat the payload
+  key; reusing the complete header may repeat AES-GCM key/nonce pairs.
+- Segment size is attacker-controlled until authentication. Validate and bound it
+  before allocation. Its derivation binding detects changes.
+- Segments do not transplant across objects or positions because payload derivation,
+  index, and final marker differ.
+- Random access may reveal access patterns to storage or transport.
+
+## 10. Conformance
+
+Vectors MUST include at least three segment sizes including 65536; empty payloads and
+payloads around every boundary; exact headers, keys, offsets, nonces, ciphertext, and
+tags; truncation and removal of final segments; reorder, duplication, and trailing
+bytes; invalid sizes and bit corruption in every header and segment component;
+cross-object transplant; late sequential failure after partial release; and interior
+random access with and without final completion.

--- a/spec/binarytdf/v1alpha/binarytdf-ext-stream.md
+++ b/spec/binarytdf/v1alpha/binarytdf-ext-stream.md
@@ -3,8 +3,8 @@
 | | |
 |---|---|
 | Document | BinaryTDF-STREAM |
-| Extension version | 0.2 |
-| Source draft | 0.2 |
+| Extension version | 0.3 |
+| Source draft | 0.3 |
 | Frame version | 2 |
 | Registry identifiers | `AES_256_GCM_HKDF_SHA256_STREAM = 2`, `AES_256_GCM_HKDF_SHA256_STREAM_PART = 3` |
 | Status | Draft, optional |
@@ -54,9 +54,10 @@ Segmentation removes a per-invocation framing limit; it does not remove the cumu
 volume bound. The AES-GCM confidentiality bound counts total plaintext blocks under one
 key however those blocks are divided into messages, so splitting a payload into more
 segments does not let one key protect more of it. Segmenting is not rekeying.
-Section 8.1 therefore caps a suite 2 object at 2^40 plaintext bytes, and Section 9
-defines suite 3, which rekeys at partition boundaries to carry larger objects.
-BinaryTDF-SEC Section 3 gives the analysis behind both.
+Section 8.1 therefore caps a suite 2 object at `2^35` plaintext blocks, at most
+512 GiB, and Section 9 defines suite 3, which rekeys at partition boundaries and
+applies one object-wide block-square budget to carry larger objects. BinaryTDF-SEC
+Section 3 gives the analysis behind both.
 
 Each suite protects one logical payload; neither is a collection container. The frame
 still places Ciphertext Length before bytes, so the producer MUST know final encoded
@@ -185,21 +186,29 @@ validation precedes segment work.
 | Segment 0 plaintext | `segment_size - 60` maximum |
 | Later plaintext segment | `segment_size - 16` maximum |
 | Segment count | at most 2^32 |
-| Total plaintext | at most 1099511627776 bytes, that is 2^40 |
+| Plaintext blocks | at most 34359738368, that is 2^35 |
+| Total plaintext | at most 549755813888 bytes, that is 512 GiB |
 | Fixed overhead | 44-byte header and 16-byte tag per segment |
 | Working memory | one segment |
 
 Maximum plaintext is constrained by segment count, size, outer Ciphertext Length, and
-the volume ceiling below. Implementations MUST enforce configured total-byte, size, and
-count limits before allocation or cryptographic processing. Profiles MAY set lower
-limits.
+the confidentiality budget below. Implementations MUST enforce configured total-byte,
+size, and count limits before allocation or cryptographic processing. Profiles MAY set
+lower limits.
 
 ### 8.1 Volume ceiling
 
-One payload key protects every segment of a suite 2 object, so the object as a whole is
-one content-encryption key's worth of plaintext. A suite 2 object MUST NOT protect more
-than 2^40 plaintext bytes, that is 1099511627776 bytes. BinaryTDF-SEC Section 3.1
-states the limit and gives its analysis.
+One payload key protects every segment of a suite 2 object. For an invocation carrying
+`x` plaintext bytes, define `block_count(x) = ceil(x / 16)`. Let `sigma` be the sum of
+`block_count` over every segment. A suite 2 object MUST satisfy:
+
+```text
+sigma <= 2^35
+```
+
+This is the single-key form of the BinaryTDF-SEC Section 3 object-wide
+confidentiality budget. It permits at most 549755813888 plaintext bytes (512 GiB),
+and per-segment partial-block rounding may make the exact permitted byte count lower.
 
 The complete plaintext length follows from the frame before any decryption:
 
@@ -208,22 +217,24 @@ segment_count   = ceil(Ciphertext Length / segment_size)
 total_plaintext = Ciphertext Length - 44 - 16 * segment_count
 ```
 
-A producer MUST NOT emit a suite 2 object whose `total_plaintext` exceeds the ceiling,
-and a decoder MUST reject such an object before allocating a segment buffer or
-authenticating any segment. Choosing a smaller `segment_size` does not raise the
-ceiling, because the bound counts plaintext blocks and not messages.
+A producer computes each segment plaintext length from Section 4 and MUST NOT emit an
+object whose `sigma` exceeds the ceiling. A decoder can make the same computation from
+the declared Ciphertext Length, `segment_size`, and fixed layout, and MUST reject an
+over-budget object before allocating a segment buffer or authenticating any segment.
+All arithmetic MUST be checked for overflow. Choosing a smaller `segment_size` does
+not raise the ceiling, because the bound counts plaintext blocks and not messages.
 
-Suite 2 therefore tops out at 1 TiB of plaintext per object. That is its scale ceiling:
-a larger payload MUST use suite 3, which rekeys per partition, or be divided into
-several objects with independent object keys.
+Suite 2 therefore tops out at 512 GiB of plaintext per object. A larger payload MUST
+use suite 3, which rekeys per partition, or be divided into several objects with
+independent object keys.
 
 ## 9. Partitioned suite 3
 
 Identifier 3, `AES_256_GCM_HKDF_SHA256_STREAM_PART`, is suite 2's segment construction
 with one addition: the payload key encrypts nothing, and every segment is encrypted
-under a partition key expanded from it. Rekeying at partition boundaries keeps each
-content-encryption key inside the BinaryTDF-SEC Section 3.1 volume ceiling while the
-object grows to storage scale.
+under a partition key expanded from it. Rekeying at partition boundaries distributes
+the BinaryTDF-SEC Section 3.1 confidentiality budget across independently derived keys
+while the object grows to storage scale.
 
 Sections 3 through 7 apply to suite 3 as written except where this section replaces
 them, and Section 1 governs identifier 3 unchanged. Suite 3 adds no CBOR field: its
@@ -327,24 +338,49 @@ partition key were repeated, whether through a repeated payload key or an
 implementation error in Section 9.2. It also keeps random access simple, because the
 nonce of segment `i` depends only on `i`. Segment AES-GCM AAD remains empty.
 
-### 9.4 Volume ceiling
+### 9.4 Object-wide confidentiality budget
 
-No partition key may protect more than 2^40 plaintext bytes. The header alone bounds
-that quantity, because no segment carries more than `segment_size - 16` plaintext
-bytes:
+For an invocation carrying `x` plaintext bytes, define
+`block_count(x) = ceil(x / 16)`. For each partition `p`, let:
 
 ```text
-partition_segments * (segment_size - 16) <= 1099511627776
+sigma_p = sum(block_count(segment_plaintext_length(i))
+              for every segment i in partition p)
 ```
 
-A producer MUST select parameters satisfying this inequality, and a decoder MUST reject
-a header that violates it before allocating a segment buffer or authenticating any
-segment. The bound is conservative: segment 0 carries 48 fewer bytes and the final
-segment may be short, so a conforming partition holds at most, and usually less than,
-the ceiling.
+A suite 3 object MUST satisfy:
 
-At the maximum `segment_size` of 2147483647, `partition_segments` MUST NOT exceed 512,
-because `512 * 2147483631` is 1099511619072 and `513 * 2147483631` is 1101659102703.
+```text
+sum(sigma_p^2 for every partition p) <= 2^70
+```
+
+This is the BinaryTDF-SEC Section 3 object-wide confidentiality budget. It implies
+that no individual partition can exceed `2^35` blocks (512 GiB), but independent
+per-partition ceilings are not sufficient: every partition contributes to the sum.
+
+The producer MUST compute the sum with checked integer arithmetic before emitting the
+object. The decoder derives the exact segment plaintext lengths and partition ranges
+from the declared Ciphertext Length, `segment_size`, and `partition_segments`; it MUST
+reject an over-budget object before allocating a segment buffer or authenticating any
+segment. Arithmetic MUST be checked with sufficient width; unsigned 128-bit
+intermediates are sufficient for the registered field ranges, and overflow MUST be
+treated as over budget. An implementation MAY compute runs of equal full partitions
+algebraically rather than iterating over every segment.
+
+For advance parameter selection, the conservative per-segment value
+`c = ceil((segment_size - 16) / 16)` gives an upper bound. With `n` segments and
+`m = partition_segments`, a producer may validate:
+
+```text
+f = floor(n / m)
+r = n mod m
+f * (m * c)^2 + (r * c)^2 <= 2^70
+```
+
+where the final term is zero when `r` is zero. Exact accounting can admit slightly
+more data because segment 0 and the final segment may be short. At a 1048576-byte wire
+segment, `partition_segments = 1024` is RECOMMENDED: an ordinary full partition
+protects `1024 * 65535 = 67107840` blocks, just under 1 GiB of plaintext.
 
 ### 9.5 Limits and object size
 
@@ -355,31 +391,50 @@ because `512 * 2147483631` is 1099511619072 and `513 * 2147483631` is 1101659102
 | Later plaintext segment | `segment_size - 16` maximum |
 | Segment count | at most 2^32 |
 | `partition_segments` | 1 through 4294967295, further bounded by Section 9.4 |
-| Partition plaintext | at most 1099511627776 bytes, that is 2^40 |
-| Total plaintext | bounded by segment count and segment size, not by the volume ceiling |
+| Blocks under one partition key | at most 2^35 and normally much less |
+| Object confidentiality | `sum(sigma_p^2) <= 2^70` |
+| Total plaintext | intersection of the structural fields and Section 9.4 budget |
 | Fixed overhead | 48-byte header and 16-byte tag per segment |
 | Working memory | one segment |
 
-Object size is bounded by the segment fields rather than by the volume ceiling:
+The structural fields alone would permit:
 
 ```text
 max object plaintext = (segment_size - 64) + (2^32 - 1) * (segment_size - 16)
                      = 9223371963840331728 bytes at segment_size 2147483647
 ```
 
-That is 8 EiB, within rounding of 2^63, and its Ciphertext Length of
-9223372032559808512 bytes fits the 8-byte frame field. The partition arithmetic gives
-the same figure: at that segment size a partition holds at most
-`512 * 2147483631 = 1099511619072` bytes, just under 2^40, and `2^32 / 512` is 2^23
-partitions, so partition size times partition count is at most
-`2^23 * 2^40 = 2^63` bytes and exactly `2^23 * 1099511619072 = 9223371963840331776`
-bytes, which is the formula above plus the 48 header bytes segment 0 gives up.
+That is about 8 EiB, and its Ciphertext Length of 9223372032559808512 bytes fits the
+8-byte frame field. Section 9.4 is an additional, normally tighter cryptographic
+constraint; the structural maximum is not a conforming suite 3 object.
 
-The Amazon S3 single-object maximum of 5 TiB, or 5497558138880 bytes, is about 1.7
-million times smaller than that. Ordinary parameters reach it comfortably: at
-`segment_size` 1048576 and `partition_segments` 1048576, each partition protects at
-most 1099494850560 bytes, 16 MiB inside the ceiling, and a 5 TiB payload occupies
-5242961 segments in six partitions.
+A 50 TiB plaintext is conforming with `segment_size = 1048576` and
+`partition_segments = 1024`. Exact values are:
+
+| Quantity | Value |
+|---|---:|
+| Plaintext bytes | 54975581388800 |
+| Segment count | 52429601 |
+| Partition count | 51201 |
+| Ciphertext Length | 54976420262464 |
+| GCM header/tag overhead | 838873664 bytes |
+| `sum(sigma_p^2)` | 230580012879620085778 |
+
+The block-square sum is less than `2^70 = 1180591620717411303424`; the resulting
+dominant confidentiality advantage is approximately `2^-59.36`.
+
+The encrypted representation is larger than its plaintext. Amazon S3 specifies an
+exact single-object maximum of 50,000 GiB (approximately 48.83 TiB), and multipart
+upload does not change that final-object limit. With the parameters above, an object
+of exactly that physical size carries at most 53686271999952 plaintext bytes. A
+50 TiB logical plaintext therefore requires either a byte-addressable storage mapping
+that concatenates several physical blobs or multiple independent BinaryTDF objects
+with fresh object keys. A virtual concatenation preserves one cryptographic object and
+its Section 9.4 budget. A logical-file profile using multiple cryptographic objects
+MUST apply `sum(sigma_p^2) <= 2^70` across the union of their independently keyed
+partitions to retain the same whole-file target. That storage mapping and logical-file
+catalog are outside the BinaryTDF frame; S3 multipart part numbers MUST NOT replace
+the cryptographic segment index or partition index.
 
 ## 10. Security
 
@@ -392,12 +447,12 @@ most 1099494850560 bytes, 16 MiB inside the ceiling, and a 5 TiB payload occupie
 - Segments do not transplant across objects or positions because payload derivation,
   index, and final marker differ.
 - Random access may reveal access patterns to storage or transport.
-- Suite 2 has no rekeying mechanism, so the Section 8.1 ceiling is its only protection
-  against AES-GCM volume degradation. Producers of large data SHOULD prefer suite 3
-  rather than approaching that ceiling.
+- Suite 2 has no rekeying mechanism, so the Section 8.1 block ceiling is its only
+  protection against AES-GCM volume degradation. Producers of large data SHOULD
+  prefer suite 3 rather than approaching that ceiling.
 - `partition_segments` is attacker-controlled until authentication in the same way
-  segment size is. Validate it against Section 9.4 before allocation; its derivation
-  binding detects later change.
+  segment size is. Validate it and the complete Section 9.4 budget before allocation;
+  its derivation binding detects later change.
 - A disclosed partition key exposes only the segments of its partition. It does not
   yield the payload key, another partition key, or any other object.
 
@@ -411,9 +466,9 @@ cross-object transplant; late sequential failure after partial release; and inte
 random access with and without final completion.
 
 Vectors MUST additionally include, for the limits of Sections 8.1 and 9.4, a suite 2
-object at exactly the volume ceiling and the next larger object; a suite 3 object whose
+object at exactly the block ceiling and the next larger object; a suite 3 object whose
 segment indexes cross at least two partition boundaries, with exact `K_p` values and
 absolute-index nonces on both sides of each boundary; a suite 3 header whose
-`partition_segments` and `segment_size` product exceeds the ceiling; and a suite 3
-header presented to a suite 2 reader and the reverse. BinaryTDF-EX Section 5 gives
-worked values for the boundary cases.
+block-square sum is exactly `2^70` and one whose sum exceeds it; the 50 TiB case from
+Section 9.5; and a suite 3 header presented to a suite 2 reader and the reverse.
+BinaryTDF-EX Section 5 gives worked values for the boundary cases.

--- a/spec/binarytdf/v1alpha/binarytdf-kao.md
+++ b/spec/binarytdf/v1alpha/binarytdf-kao.md
@@ -1,0 +1,166 @@
+# BinaryTDF-KAO: Key Access Object and Wrapping
+
+| | |
+|---|---|
+| Document | BinaryTDF-KAO |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft |
+| Depends on | BinaryTDF-CORE, BinaryTDF-ALG, BinaryTDF-POL, BinaryTDF-REC |
+| Referenced by | BinaryTDF-KAS, BinaryTDF-CDDL, BinaryTDF-EX |
+
+## 1. Structure
+
+| Key | Field | Type | Required |
+|---:|---|---|---|
+| 1 | `authority_id` | `tstr` | yes |
+| 2 | `kid` | `bstr` | no |
+| 3 | `wrap_suite` | `uint` | yes |
+| 4 | `encapsulation` | `bstr` | yes |
+| 5 | `wrapped_key_material` | `bstr` | yes |
+| 6 | `policy_binding` | `policy-binding` | yes |
+
+`wrapped_key_material` encrypts the object key for DIRECT, a group share for XOR_ALL,
+or the 32-byte value defined by another registered scheme.
+
+`encapsulation` is suite-specific public material. For ECDH it is the producer's
+ephemeral public key; for ML-KEM it is the KEM ciphertext. A new suite may change its
+encoding and length but not this core meaning.
+
+There is no generic parameter byte string. Every parameter, encoding, and required
+length belongs to `wrap_suite`.
+
+## 2. Authority identity
+
+`authority_id` is a globally unique, stable absolute URI identifying the authority.
+It is not a network location and MUST NOT be dereferenced. A consumer resolves it
+through trusted local configuration. Producers SHOULD use an organization-controlled
+identity URI or `urn:uuid`.
+
+Trusted configuration maps authority identity to service endpoints and key metadata;
+`kid` selects a key within the authority. That mapping may change without rewriting
+the object.
+
+Identifiers are compared as exact UTF-8 strings. Consumers MUST NOT apply URI
+normalization. URI ownership provides uniqueness, not authorization or trust.
+
+## 3. KAO context
+
+The context is derived and not serialized separately:
+
+| Key | Value |
+|---:|---|
+| 1 | exact `authority_id` |
+| 2 | `kid`, if present |
+| 3 | `wrap_suite` |
+| 4 | outer frame version |
+| 5 | SHA-256 of exact Protected Metadata bytes |
+| 6 | SHA-256 of `encapsulation` |
+| 7 | SHA-256 of deterministic policy bytes, or SHA-256 of empty bytes when absent |
+| 8 | `recovery_scheme` |
+| 9 | zero-based KAO path |
+
+```text
+kao_context_bytes = encode_deterministic_cbor(kao_context)
+```
+
+The recovery scheme defines path shape. The path prevents movement to another group or
+alternative position. Context bytes are KDF input and AAD for wrapped key material.
+Payload encryption separately authenticates the complete serialized recovery section.
+
+Every field closes a substitution path: authority or key redirection, suite downgrade,
+cross-version replay, metadata or policy substitution, encapsulation splicing,
+recovery-scheme reinterpretation, and KAO relocation all cause unwrap failure.
+
+## 4. Common wrapping
+
+The producer obtains `shared_secret` using the selected suite:
+
+- ECDH generates a fresh ephemeral key pair, performs ECDH with the recipient public
+  key, and stores the compressed ephemeral public key in `encapsulation`.
+- ML-KEM runs `ML-KEM.Encaps` with the recipient encapsulation key and stores the KEM
+  ciphertext in `encapsulation`.
+
+It derives:
+
+```text
+wrap_kek = HKDF-SHA256(
+  ikm  = shared_secret,
+  salt = UTF8("binary-tdf:v2:hkdf-salt"),
+  info = UTF8("binary-tdf:v2:kao-kek") || kao_context_bytes,
+  len  = 32
+)
+```
+
+`kao_value` is the 32-byte object key, share, or registered scheme value. Encrypt it
+with AES-256-GCM, a fresh 12-byte nonce, and `kao_context_bytes` as AAD:
+
+```text
+wrapped_key_material = nonce || encrypted_kao_value || tag
+```
+
+Recipient keys are distributed out of band and selected by `authority_id` and `kid`.
+Implementations MUST validate suite, recipient key, encapsulation encoding, and exact
+lengths before deriving or releasing material. ECDH implementations MUST validate
+public points and reject an all-zero shared secret.
+
+ML-KEM suites MUST use FIPS 203 `ML-KEM.Encaps` and `ML-KEM.Decaps`, including implicit
+rejection. An invalid correct-length ciphertext produces the specified pseudorandom
+shared secret and later fails wrapped-key authentication. Only `KEY_RECOVERY_FAILED`
+may be returned; implicit-rejection state MUST NOT appear in errors, outputs, or logs.
+
+## 5. Policy binding
+
+```text
+policy_bytes = encode_deterministic_cbor(effective_canonical_policy)
+               or empty bytes for public policy
+
+binding_key = HKDF-SHA256(
+  ikm  = kao_value,
+  salt = UTF8("binary-tdf:v2:hkdf-salt"),
+  info = UTF8("binary-tdf:v2:policy-binding"),
+  len  = 32
+)
+
+binding = HMAC-SHA256(binding_key, policy_bytes)
+```
+
+The authority MUST verify binding after unwrap and before authorization or release.
+Every alternative KAO in one XOR_ALL group wraps the same share and has the same
+binding. The check ensures that the plaintext policy being authorized is the one bound
+to the recovered value.
+
+## 6. CDDL
+
+```cddl
+authority-id = tstr
+
+policy-binding = {
+  1 => binding-algorithm,
+  2 => bstr
+}
+
+key-access-object = {
+  1 => authority-id,
+  ? 2 => bstr,
+  3 => wrap-suite,
+  4 => bstr,
+  5 => bstr,
+  6 => policy-binding
+}
+
+kao-path = [1* uint]
+
+kao-context = {
+  1 => authority-id,
+  ? 2 => bstr,
+  3 => wrap-suite,
+  4 => uint,
+  5 => bstr .size 32,
+  6 => bstr .size 32,
+  7 => bstr .size 32,
+  8 => recovery-scheme,
+  9 => kao-path
+}
+```

--- a/spec/binarytdf/v1alpha/binarytdf-kao.md
+++ b/spec/binarytdf/v1alpha/binarytdf-kao.md
@@ -7,8 +7,8 @@
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Draft |
-| Depends on | BinaryTDF-CORE, BinaryTDF-ALG, BinaryTDF-POL, BinaryTDF-REC |
-| Referenced by | BinaryTDF-KAS, BinaryTDF-CDDL, BinaryTDF-EX |
+| Depends on | BinaryTDF-SEC, BinaryTDF-ALG, BinaryTDF-MTD, BinaryTDF-POL |
+| Referenced by | BinaryTDF-REC, BinaryTDF-KAS, BinaryTDF-SCH, BinaryTDF-CORE, BinaryTDF-EX |
 
 ## 1. Structure
 

--- a/spec/binarytdf/v1alpha/binarytdf-kas.md
+++ b/spec/binarytdf/v1alpha/binarytdf-kas.md
@@ -7,8 +7,8 @@
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Draft |
-| Depends on | BinaryTDF-CORE, BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-ALG, BinaryTDF-SEC |
-| Referenced by | BinaryTDF-CDDL, BinaryTDF-KEY-EPOCH |
+| Depends on | BinaryTDF-SEC, BinaryTDF-ALG, BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-REC, BinaryTDF-KAO |
+| Referenced by | BinaryTDF-SCH, BinaryTDF-CORE, BinaryTDF-KEY-EPOCH |
 
 ## 1. Request
 

--- a/spec/binarytdf/v1alpha/binarytdf-kas.md
+++ b/spec/binarytdf/v1alpha/binarytdf-kas.md
@@ -1,0 +1,115 @@
+# BinaryTDF-KAS: Key Access Service Rewrap Protocol
+
+| | |
+|---|---|
+| Document | BinaryTDF-KAS |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft |
+| Depends on | BinaryTDF-CORE, BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-ALG, BinaryTDF-SEC |
+| Referenced by | BinaryTDF-CDDL, BinaryTDF-KEY-EPOCH |
+
+## 1. Request
+
+A request carries:
+
+- `session_suite`, a supported wrap-suite identifier used only for the response;
+- `session_recipient_key`, encoded for that suite;
+- exact Protected Metadata and Object Key Recovery CBOR bytes;
+- the outer frame version; and
+- correlation IDs and zero-based KAO paths.
+
+For ECDH, the session recipient key is the opener's ephemeral public key. For ML-KEM,
+it is the opener's ML-KEM-768 or ML-KEM-1024 encapsulation key with suite-fixed size.
+
+## 2. Authority processing
+
+For each distinct KAO path, the authority MUST:
+
+1. strictly parse deterministic metadata and recovery bytes;
+2. resolve `authority_id` through trusted configuration and reject KAOs not assigned
+   to it;
+3. reject invalid paths, structures, extensions, suites, keys, and encodings;
+4. derive KAO context, recover `kao_value`, and verify policy binding;
+5. authorize the authenticated caller against Canonical Policy; and
+6. establish a session shared secret and wrap `kao_value` to the opener.
+
+Key material MUST NOT be returned before authorization. Per-item failures MUST NOT
+prevent independent items from receiving results.
+
+## 3. Response
+
+The response carries `session_suite`, suite-specific `encapsulation`, and
+`wrapped_key_material`.
+
+- For ECDH, encapsulation is the authority's ephemeral public key.
+- For ML-KEM, encapsulation is the ciphertext produced for the opener: 1088 bytes for
+  ML-KEM-768 or 1568 bytes for ML-KEM-1024.
+
+The session context is:
+
+```text
+session_context = encode_deterministic_cbor({
+  1: frame_version,
+  2: SHA-256(metadata_bytes),
+  3: SHA-256(object_key_recovery_bytes),
+  4: kao_path,
+  5: session_suite,
+  6: SHA-256(response_encapsulation)
+})
+```
+
+The authority derives `session_kek` with HKDF-SHA256 using the session shared secret,
+the salt `binary-tdf:v2:hkdf-salt`, and:
+
+```text
+UTF8("binary-tdf:v2:rewrap-kek") || session_context
+```
+
+It encrypts `kao_value` with AES-256-GCM, a fresh 12-byte nonce, and
+`session_context` as AAD.
+
+## 4. Opener processing
+
+The opener validates every response against its requested path.
+
+- DIRECT returns the object key.
+- XOR_ALL accepts at most one authenticated share per group, requires every group,
+  and XORs shares locally. The authority does not reconstruct the object key.
+- A registered recovery extension defines its returned values and reconstruction.
+
+ML-KEM session suites use FIPS 203 implicit rejection and indistinguishable failure.
+Invalid response encapsulation fails wrapped-key authentication and is reported as
+generic key-recovery failure.
+
+## 5. Failure classes
+
+| Error | Meaning |
+|---|---|
+| `UNSUPPORTED_FORMAT` | unsupported frame version |
+| `UNSUPPORTED_CAPABILITY` | unsupported suite, scheme, or critical extension |
+| `MALFORMED_CBOR` | invalid deterministic CBOR, path, recovery structure, or encoding |
+| `UNSUPPORTED_FIELD` | unregistered core key |
+| `KEY_RECOVERY_FAILED` | ECDH, decapsulation, authentication, context, or policy-binding failure |
+| `ENTITLEMENT_DENIED` | authorization denied release |
+
+ECDH, ML-KEM, authentication, context, and policy-binding failures MUST be
+indistinguishable through this single error class. Payload authentication failure is
+local to the opener after rewrap.
+
+## 6. CDDL
+
+The rewrap protocol's transport schema is implementation-specific, but session context
+is byte-exact:
+
+```cddl
+session-context = {
+  1 => uint,
+  2 => bstr .size 32,
+  3 => bstr .size 32,
+  4 => kao-path,
+  5 => wrap-suite,
+  6 => bstr .size 32
+}
+```

--- a/spec/binarytdf/v1alpha/binarytdf-migration.md
+++ b/spec/binarytdf/v1alpha/binarytdf-migration.md
@@ -1,0 +1,48 @@
+# BinaryTDF-MIG: Go Prototype Migration
+
+| | |
+|---|---|
+| Document | BinaryTDF-MIG |
+| Guide version | 0.1 |
+| Source draft | 0.2 |
+| Target frame version | 2 |
+| Status | Non-normative |
+| Depends on | BinaryTDF-CORE |
+
+This guide applies to the original Go SDK frame version 1 prototype. It does not define
+interoperability or change normative requirements.
+
+## 1. Migration boundary
+
+Frame versions 1 and 2 are intentionally incompatible. The Go SDK was the only known
+frame version 1 implementation and prototype use was internal. Frame version 2 therefore
+establishes a long-term model rather than preserving prototype wire compatibility.
+
+A version 1 object cannot be converted in place. Decrypt and write a new version 2
+object, or retain a separate read-only version 1 decoder.
+
+## 2. Changes
+
+| Prototype version 1 | Frame version 2 | Reason |
+|---|---|---|
+| loose AEAD and KDF `crypto_suite` | complete `content_encryption_suite` | prevents invalid combinations |
+| `wrap_algorithm` | `wrap_suite` | suites fix KEM/ECDH, KDF, AEAD, sizes, encodings |
+| `ephemeral_public_key` | `encapsulation` | supports ECDH keys and ML-KEM ciphertexts |
+| opaque `wrap_params` | removed | parameters belong to registered suites |
+| `split_id` and reserved SPLIT | XOR_ALL with explicit groups | defines AND/OR reconstruction structurally |
+| unknown metadata core keys accepted | closed core and tagged extensions | separates compatibility from ambiguous semantics |
+| empty and absent public policies | absent policy only | one deterministic encoding |
+| KAS URL as locator | stable `authority_id` resolved by configuration | separates identity from routing |
+| empty AAD for key and session wrap | context CBOR as AAD | binds object, path, and session |
+| ECDH-specific rewrap | suite-neutral recipient and encapsulation | supports ML-KEM and future suites |
+| core private assertion identifiers | claims use metadata extensions | claim formats own validation |
+
+## 3. Options
+
+1. Re-encrypt: open with the prototype decoder and create a new frame version 2 object
+   from plaintext and current policy.
+2. Retain a read-only version 1 decoder with explicit isolated dispatch until objects
+   migrate or expire.
+
+Do not interpret version 1 bytes with version 2 schemas, silently upgrade during parse,
+or emit new version 1 objects.

--- a/spec/binarytdf/v1alpha/binarytdf-migration.md
+++ b/spec/binarytdf/v1alpha/binarytdf-migration.md
@@ -7,7 +7,7 @@
 | Source draft | 0.2 |
 | Target frame version | 2 |
 | Status | Non-normative |
-| Depends on | BinaryTDF-CORE |
+| Depends on | BinaryTDF-CORE, BinaryTDF-PKG, BinaryTDF-SCH |
 
 This guide applies to the original Go SDK frame version 1 prototype. It does not define
 interoperability or change normative requirements.

--- a/spec/binarytdf/v1alpha/binarytdf-mtd.md
+++ b/spec/binarytdf/v1alpha/binarytdf-mtd.md
@@ -7,8 +7,8 @@
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Draft |
-| Depends on | BinaryTDF-CORE, BinaryTDF-ALG |
-| Referenced by | BinaryTDF-KAO, BinaryTDF-PAY, BinaryTDF-KAS, BinaryTDF-CDDL, BinaryTDF-NATO |
+| Depends on | BinaryTDF-SEC, BinaryTDF-ALG |
+| Referenced by | BinaryTDF-KAO, BinaryTDF-PAY, BinaryTDF-KAS, BinaryTDF-SCH, BinaryTDF-CORE, BinaryTDF-NATO |
 
 ## 1. Structure
 

--- a/spec/binarytdf/v1alpha/binarytdf-mtd.md
+++ b/spec/binarytdf/v1alpha/binarytdf-mtd.md
@@ -1,0 +1,95 @@
+# BinaryTDF-MTD: Protected Metadata
+
+| | |
+|---|---|
+| Document | BinaryTDF-MTD |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft |
+| Depends on | BinaryTDF-CORE, BinaryTDF-ALG |
+| Referenced by | BinaryTDF-KAO, BinaryTDF-PAY, BinaryTDF-KAS, BinaryTDF-CDDL, BinaryTDF-NATO |
+
+## 1. Structure
+
+| Key | Field | Type | Required |
+|---:|---|---|---|
+| 1 | `content_encryption_suite` | `uint` | yes |
+| 2 | `mime_type` | `tstr` | no |
+| 3 | `application_data` | `bstr` | no |
+| 4 | `metadata_extensions` | `[* metadata-extension]` | no |
+| 5 | `critical_extensions` | `[* uint]` | no |
+
+Protected Metadata provides two application-facing carriers:
+
+- `application_data` contains opaque bytes that the core and authority do not
+  interpret.
+- `metadata_extensions` contains structured data governed by registered extension
+  specifications.
+
+Both are authenticated: their exact bytes are payload AAD and are hashed into every
+KAO context. Neither becomes authorization policy merely by being present.
+
+## 2. Metadata extensions
+
+Each metadata extension is a CBOR-tagged data item. The globally registered CBOR tag
+identifies a separately published, independently versioned extension specification;
+the tagged value carries its data. An extension augments the CDDL socket:
+
+```cddl
+$binary-tdf-metadata-extension /= #6.12345(example-metadata)
+```
+
+A tag MUST appear at most once. Repeated values belong in an array within the tagged
+value. For each item, a receiver MUST:
+
+1. read its tag number;
+2. validate a recognized tag against its exact schema and semantics;
+3. reject an unrecognized tag listed in `critical_extensions` before requesting
+   rewrap; and
+4. preserve or ignore an unrecognized non-critical tag without treating it as policy.
+
+The CDDL permits an unknown tagged value for forward-compatible transport. That
+alternative MUST NOT accept a malformed value for a recognized tag.
+
+`critical_extensions` is sorted and duplicate-free. Every listed tag MUST be present
+in `metadata_extensions`. Criticality applies to processing the containing object.
+
+An extension MUST NOT redefine framing, core keys, cryptographic inputs, capability
+registries, recovery schemes, or failure behavior. Such changes require a core
+mechanism or new frame version. BinaryTDF-ALG defines extension registration rules.
+
+## 3. Signed and detached claims
+
+AEAD proves that carried metadata belongs to the object as produced. It does not prove
+that a claim is true or that a signer is trusted.
+
+A signature inside Protected Metadata cannot sign the complete object containing it,
+because ciphertext depends on the metadata bytes through payload AAD. Such a signature
+binds only the content defined by its extension. An attestation over the complete
+object MUST be detached and reference a hash of the exact object bytes.
+
+A detached attestation can be removed without detection. An application requiring one
+MUST identify the expected claim and trusted signer and reject the object if the
+attestation is absent or invalid.
+
+## 4. CDDL
+
+```cddl
+metadata-extension =
+  $binary-tdf-metadata-extension /
+  unknown-metadata-extension
+
+unknown-metadata-extension = #6(any)
+
+protected-metadata = {
+  1 => content-encryption-suite,
+  ? 2 => tstr,
+  ? 3 => bstr,
+  ? 4 => [* metadata-extension],
+  ? 5 => [* uint]
+}
+```
+
+`#6(any)` is any CBOR tag applied to any value. It exists only to transport an
+unknown, non-critical tag. A recognized tag is governed by its registered schema.

--- a/spec/binarytdf/v1alpha/binarytdf-pay.md
+++ b/spec/binarytdf/v1alpha/binarytdf-pay.md
@@ -7,8 +7,8 @@
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Draft |
-| Depends on | BinaryTDF-CORE, BinaryTDF-MTD, BinaryTDF-REC, BinaryTDF-ALG |
-| Referenced by | BinaryTDF-CDDL, BinaryTDF-EX, BinaryTDF-STREAM, BinaryTDF-KEY-EPOCH |
+| Depends on | BinaryTDF-SEC, BinaryTDF-ALG, BinaryTDF-MTD, BinaryTDF-REC |
+| Referenced by | BinaryTDF-CORE, BinaryTDF-EX, BinaryTDF-STREAM, BinaryTDF-KEY-EPOCH |
 
 ## 1. Suites
 

--- a/spec/binarytdf/v1alpha/binarytdf-pay.md
+++ b/spec/binarytdf/v1alpha/binarytdf-pay.md
@@ -1,0 +1,67 @@
+# BinaryTDF-PAY: Payload Protection
+
+| | |
+|---|---|
+| Document | BinaryTDF-PAY |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft |
+| Depends on | BinaryTDF-CORE, BinaryTDF-MTD, BinaryTDF-REC, BinaryTDF-ALG |
+| Referenced by | BinaryTDF-CDDL, BinaryTDF-EX, BinaryTDF-STREAM, BinaryTDF-KEY-EPOCH |
+
+## 1. Suites
+
+| Symbol | Integer | Definition |
+|---|---:|---|
+| `AES_256_GCM_HKDF_SHA256` | 1 | 32-byte object key, HKDF-SHA256, AES-256-GCM, 12-byte nonce, 16-byte tag |
+| `AES_256_GCM_HKDF_SHA256_STREAM` | 2 | Optional segmented construction defined by BinaryTDF-STREAM |
+
+Every frame version 2 implementation MUST support suite 1. Unsupported suites are
+rejected as `UNSUPPORTED_CAPABILITY`; there is no fallback.
+
+Each object has a unique 32-byte object key. DIRECT and XOR_ALL generate it uniformly
+at random. A derivation scheme defines byte-exact inputs producing a distinct key for
+each object. Object keys MUST NOT be reused or serialized directly.
+
+## 2. Baseline key derivation
+
+For suite 1:
+
+```text
+payload_key = HKDF-SHA256(
+  ikm  = object_key,
+  salt = UTF8("binary-tdf:v2:hkdf-salt"),
+  info = UTF8("binary-tdf:v2:payload-key"),
+  len  = 32
+)
+```
+
+## 3. Associated data
+
+```text
+payload_aad =
+  version_byte ||
+  uint32_be(len(metadata_bytes)) || metadata_bytes ||
+  uint32_be(len(object_key_recovery_bytes)) || object_key_recovery_bytes
+```
+
+Implementations MUST use original section bytes. Parsed structures MUST NOT be
+re-encoded to create AAD.
+
+## 4. Baseline encryption
+
+Suite 1 encrypts the payload with AES-256-GCM and a fresh random 12-byte nonce:
+
+```text
+payload_nonce || encrypted_payload || authentication_tag
+```
+
+No plaintext may be released until authentication succeeds. The streaming suite may
+refine this rule only as defined by its registered specification.
+
+## 5. Security requirements
+
+AES-GCM nonce reuse under one key is catastrophic. Producers MUST use a cryptographically
+secure random source for object keys, shares, identifiers, and random nonces. Derived
+schemes MUST guarantee distinct object-key inputs.

--- a/spec/binarytdf/v1alpha/binarytdf-pay.md
+++ b/spec/binarytdf/v1alpha/binarytdf-pay.md
@@ -16,13 +16,19 @@
 |---|---:|---|
 | `AES_256_GCM_HKDF_SHA256` | 1 | 32-byte object key, HKDF-SHA256, AES-256-GCM, 12-byte nonce, 16-byte tag |
 | `AES_256_GCM_HKDF_SHA256_STREAM` | 2 | Optional segmented construction defined by BinaryTDF-STREAM |
+| `AES_256_GCM_HKDF_SHA256_STREAM_PART` | 3 | Optional partitioned segmented construction defined by BinaryTDF-STREAM |
 
 Every frame version 2 implementation MUST support suite 1. Unsupported suites are
 rejected as `UNSUPPORTED_CAPABILITY`; there is no fallback.
 
 Each object has a unique 32-byte object key. DIRECT and XOR_ALL generate it uniformly
 at random. A derivation scheme defines byte-exact inputs producing a distinct key for
-each object. Object keys MUST NOT be reused or serialized directly.
+each object. Object keys MUST NOT be reused or serialized directly. The suite 1 payload
+key is a deterministic function of the object key, so reuse places two objects under
+one content-encryption key: protected volume accumulates against the Section 5 limit
+and a 12-byte nonce may repeat under one key. Suites 2 and 3 mix in a fresh stream
+salt, which separates their payload keys but does not relax this requirement.
+BinaryTDF-SEC Section 3.5 quantifies both cases.
 
 ## 2. Baseline key derivation
 
@@ -57,10 +63,40 @@ Suite 1 encrypts the payload with AES-256-GCM and a fresh random 12-byte nonce:
 payload_nonce || encrypted_payload || authentication_tag
 ```
 
-No plaintext may be released until authentication succeeds. The streaming suite may
-refine this rule only as defined by its registered specification.
+No plaintext may be released until authentication succeeds. The streaming suites may
+refine this rule only as defined by their registered specification.
 
-## 5. Security requirements
+The complete payload is one AES-GCM invocation, so it is bounded by the NIST SP
+800-38D Section 5.2.1.1 per-invocation limit. A suite 1 payload MUST NOT exceed
+68719476704 plaintext bytes, that is 2^36 - 32 bytes, or 64 GiB - 32 bytes. With the
+12-byte nonce and 16-byte tag, the corresponding Ciphertext Length is at most
+68719476732 bytes. A producer MUST NOT emit a larger suite 1 object, and an opener
+MUST reject one on the declared Ciphertext Length before decryption. The 8-byte
+Ciphertext Length field of BinaryTDF-PKG frames far more than AES-GCM can protect in
+one invocation; this requirement, not the frame, is the binding limit.
+
+A payload larger than that limit MUST use a segmented suite or several objects with
+independent object keys.
+
+## 5. Volume limits
+
+A single content-encryption key MUST NOT protect more than 2^40 plaintext bytes, that
+is 1099511627776 bytes. BinaryTDF-SEC Section 3 gives the analysis; this section gives
+the per-suite consequence.
+
+| Suite | Content-encryption key | Bound on one object |
+|---:|---|---|
+| 1 | payload key | 68719476704 bytes, from Section 4 |
+| 2 | payload key | 1099511627776 bytes, from BinaryTDF-STREAM Section 8.1 |
+| 3 | partition key `K_p` | 1099511627776 bytes per partition; object bounded by segment count |
+
+Suite 1 cannot reach the volume limit, because its per-invocation limit is smaller by
+a factor of about 16. Suite 2 protects a complete object under one payload key, so the
+volume limit is its object ceiling. Suite 3 derives one key per partition and bounds
+each partition instead, so it is the only suite whose object size is unconstrained by
+this limit.
+
+## 6. Security requirements
 
 AES-GCM nonce reuse under one key is catastrophic. Producers MUST use a cryptographically
 secure random source for object keys, shares, identifiers, and random nonces. Derived

--- a/spec/binarytdf/v1alpha/binarytdf-pay.md
+++ b/spec/binarytdf/v1alpha/binarytdf-pay.md
@@ -4,7 +4,7 @@
 |---|---|
 | Document | BinaryTDF-PAY |
 | Version | 1 Alpha |
-| Source draft | 0.2 |
+| Source draft | 0.3 |
 | Frame version | 2 |
 | Status | Draft |
 | Depends on | BinaryTDF-SEC, BinaryTDF-ALG, BinaryTDF-MTD, BinaryTDF-REC |
@@ -78,23 +78,24 @@ one invocation; this requirement, not the frame, is the binding limit.
 A payload larger than that limit MUST use a segmented suite or several objects with
 independent object keys.
 
-## 5. Volume limits
+## 5. Confidentiality budget
 
-A single content-encryption key MUST NOT protect more than 2^40 plaintext bytes, that
-is 1099511627776 bytes. BinaryTDF-SEC Section 3 gives the analysis; this section gives
-the per-suite consequence.
+BinaryTDF-SEC Section 3 limits one object's GCM confidentiality advantage by requiring
+`sum(sigma_p^2) <= 2^70`, where `sigma_p` is the number of 16-byte plaintext blocks
+encrypted under content-encryption key `K_p`. Each AES-GCM invocation contributes
+`ceil(plaintext_length / 16)` blocks. The per-suite consequences are:
 
 | Suite | Content-encryption key | Bound on one object |
 |---:|---|---|
-| 1 | payload key | 68719476704 bytes, from Section 4 |
-| 2 | payload key | 1099511627776 bytes, from BinaryTDF-STREAM Section 8.1 |
-| 3 | partition key `K_p` | 1099511627776 bytes per partition; object bounded by segment count |
+| 1 | payload key | 68719476704 bytes, from the stricter Section 4 invocation limit |
+| 2 | payload key | at most 2^35 plaintext blocks, from BinaryTDF-STREAM Section 8.1 |
+| 3 | partition key `K_p` | sum of squared partition block counts at most 2^70 |
 
-Suite 1 cannot reach the volume limit, because its per-invocation limit is smaller by
-a factor of about 16. Suite 2 protects a complete object under one payload key, so the
-volume limit is its object ceiling. Suite 3 derives one key per partition and bounds
-each partition instead, so it is the only suite whose object size is unconstrained by
-this limit.
+Suite 1 cannot spend the complete confidentiality budget because its single-invocation
+limit binds first. Suite 2 protects the complete object under one payload key, so the
+block budget is its object ceiling. Suite 3 derives one key per partition and applies
+the budget across all partitions, allowing 50 TiB plaintexts with approximately
+1 GiB partitions while retaining the object-wide target.
 
 ## 6. Security requirements
 

--- a/spec/binarytdf/v1alpha/binarytdf-pkg.md
+++ b/spec/binarytdf/v1alpha/binarytdf-pkg.md
@@ -1,0 +1,68 @@
+# BinaryTDF-PKG: Binary Packaging Profile
+
+| | |
+|---|---|
+| Document | BinaryTDF-PKG |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft |
+| Depends on | BinaryTDF-SEC, BinaryTDF-SCH |
+| Referenced by | BinaryTDF-CORE, BinaryTDF-EX, BinaryTDF-STREAM, BinaryTDF-MIG |
+
+## 1. Scope
+
+This document defines the physical serialization of one BinaryTDF object. It owns the
+frame magic, version byte, section ordering, length fields, and outer parsing rules.
+The logical meaning and schema of each section are defined by the component documents
+and BinaryTDF-SCH. The internal construction of the Ciphertext section is selected by
+BinaryTDF-PAY.
+
+Every serialized byte is fixed at creation. Exact Protected Metadata and Object Key
+Recovery bytes are cryptographic inputs and are preserved rather than reconstructed
+after parsing. BinaryTDF-PAY defines the normative use of those original bytes.
+
+## 2. Binary frame
+
+All integer lengths are unsigned and big-endian.
+
+```text
++----------------------------+----------------------------------+
+| Field                      | Size                             |
++----------------------------+----------------------------------+
+| Magic                      | 3 bytes: ASCII "L2L"            |
+| Version                    | 1 byte: 0x02                    |
+| Metadata Length            | 4 bytes                         |
+| Protected Metadata CBOR    | Metadata Length bytes           |
+| Object Key Recovery Length | 4 bytes                         |
+| Object Key Recovery CBOR   | Recovery Length bytes           |
+| Ciphertext Length          | 8 bytes                         |
+| Ciphertext                 | Ciphertext Length bytes         |
++----------------------------+----------------------------------+
+```
+
+Ciphertext Length includes all suite-specific header, nonce, ciphertext, and tag bytes.
+There MUST be no bytes after the declared Ciphertext section.
+
+The 64-bit ciphertext length permits payloads larger than 4 GiB. It is a framing bound,
+not an allocation instruction.
+
+## 3. Parsing
+
+A decoder MUST reject an object before CBOR processing when:
+
+- magic or version is unsupported;
+- a length field is truncated;
+- a declared section exceeds remaining input;
+- offset or capacity arithmetic overflows; or
+- the Ciphertext section does not consume remaining input exactly.
+
+Parser limits from BinaryTDF-SEC apply before allocation, hashing, or authority contact.
+A decoder retains the exact Protected Metadata and Object Key Recovery section bytes
+required by the cryptographic components.
+
+## 4. Versioning and conformance
+
+Changing frame layout, section ordering, length encoding, a cryptographic input
+construction, or the meaning of an existing security-bearing field requires a new
+frame version. BinaryTDF-CORE defines suite-wide conformance coverage.

--- a/spec/binarytdf/v1alpha/binarytdf-pol.md
+++ b/spec/binarytdf/v1alpha/binarytdf-pol.md
@@ -1,0 +1,77 @@
+# BinaryTDF-POL: Canonical Policy
+
+| | |
+|---|---|
+| Document | BinaryTDF-POL |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft |
+| Depends on | BinaryTDF-CORE |
+| Referenced by | BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-KAS, BinaryTDF-CDDL, BinaryTDF-NATO |
+
+## 1. Data model
+
+Policy is a sorted array. Each entry contains one namespace, one attribute, and one or
+more values:
+
+```text
+[
+  ["example.com", "classification", ["confidential"]],
+  ["example.com", "region", ["us", "uk"]]
+]
+```
+
+A namespace is the lowercase ASCII DNS name controlled by the organization defining
+its attributes. It is an identifier, not a URL, and MUST NOT include a scheme, port,
+path, query, fragment, or trailing dot.
+
+For OpenTDF interoperability:
+
+```text
+["example.com", "classification", ["confidential"]]
+```
+
+represents:
+
+```text
+https://example.com/attr/classification/value/confidential
+```
+
+The `https` scheme and fixed path segments are not serialized.
+
+## 2. Canonicalization
+
+Namespace, attribute, and value strings MUST be non-empty. Each namespace/attribute
+pair MUST appear exactly once, and every value in an entry MUST be unique. Entries are
+sorted by namespace and attribute; values are sorted within each entry. Comparisons
+use lexicographic UTF-8 bytes. No Unicode normalization is performed.
+
+Producers create canonical form before encoding. Receivers MUST reject empty entries,
+duplicates, and incorrect ordering; they MUST NOT silently merge or normalize policy.
+
+An absent policy means public access. Producers MUST omit `policy` for public objects;
+an explicit empty policy is not another public-policy encoding. A registered recovery
+scheme may define different absence semantics for its own objects but MUST NOT create a
+second encoding for an existing meaning.
+
+## 3. Metadata mapping
+
+Metadata does not become policy by being carried. A mapping from an external label or
+metadata schema to Canonical Policy MUST be explicit, deterministic, and defined by a
+separate specification or profile. The producer applies that mapping at creation; KAS
+authorizes against Canonical Policy.
+
+## 4. CDDL
+
+```cddl
+policy-entry = [
+  namespace: policy-namespace,
+  attribute: tstr,
+  values: [+ tstr]
+]
+
+policy-namespace = tstr
+
+canonical-policy = [+ policy-entry]
+```

--- a/spec/binarytdf/v1alpha/binarytdf-pol.md
+++ b/spec/binarytdf/v1alpha/binarytdf-pol.md
@@ -7,8 +7,8 @@
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Draft |
-| Depends on | BinaryTDF-CORE |
-| Referenced by | BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-KAS, BinaryTDF-CDDL, BinaryTDF-NATO |
+| Depends on | BinaryTDF-SEC |
+| Referenced by | BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-KAS, BinaryTDF-SCH, BinaryTDF-CORE, BinaryTDF-NATO |
 
 ## 1. Data model
 

--- a/spec/binarytdf/v1alpha/binarytdf-profile-nato.md
+++ b/spec/binarytdf/v1alpha/binarytdf-profile-nato.md
@@ -1,0 +1,141 @@
+# BinaryTDF-NATO: NATO Metadata Interoperability Profile
+
+| | |
+|---|---|
+| Document | BinaryTDF-NATO |
+| Profile version | 0.1 |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft, optional |
+| Depends on | BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-CORE |
+
+This profile carries NATO confidentiality labels and metadata bindings without changing
+core framing, validation, or cryptography.
+
+## 1. Purpose
+
+BinaryTDF transports registered tagged metadata and authenticates exact bytes but
+defines no label, claim, or signature format. NATO standards already define them:
+
+- ADatP-4774 defines confidentiality labels; ADatP-4774.8 defines CBOR label and
+  clearance encodings.
+- ADatP-4778 defines metadata binding; ADatP-4778.8 defines the CBOR Binding Data
+  Object, optionally protected by COSE signatures or MACs.
+- ADatP-5636 defines NATO Core Metadata elements that a binding may carry.
+
+This profile defines socket integration, embedded and detached binding limits, and an
+explicit mapping to Canonical Policy. COSE choice, label semantics, signer trust, and
+revocation remain governed by NATO standards and deployment profiles.
+
+The referenced SRDs were informative drafts in the source specification.
+
+## 2. Confidentiality labels
+
+A producer embeds the tagged ADatP-4774.8 structure directly in
+`metadata_extensions`:
+
+```cddl
+$binary-tdf-metadata-extension /= tagged-ncms-extension
+$binary-tdf-metadata-extension /= tagged-confidentiality-label
+```
+
+Illustrative diagnostic notation using a provisional tag:
+
+```text
+42602({
+  1: {-1: [43], 1: [1234, 1], 2: 0,
+      3: [[2, [26, 1, 4, 2], [1, 2]], [2, [26, 1, 4, 3], [76]]],
+      4: 1620210689, 10: 1685631296}
+})
+```
+
+Carriage rules:
+
+- Core payload AAD and KAO context authenticate label bytes. Alteration, replacement,
+  or injection invalidates decryption.
+- Core deterministic CBOR rules apply to carried bytes. Semantic validation remains
+  governed by ADatP-4774.
+- A label required before processing MUST be listed in `critical_extensions`; an
+  unsupported receiver then fails before rewrap.
+- A label describes data and grants no access by itself.
+
+## 3. Metadata bindings
+
+### 3.1 Embedded binding
+
+A producer MAY embed a complete BDO:
+
+```cddl
+$binary-tdf-metadata-extension /= tagged-bdo
+```
+
+An embedded BDO may carry a label and ADatP-4778 signature for downstream provenance.
+It cannot bind ciphertext or complete object bytes because ciphertext depends on the
+metadata through payload AAD. Its `data-reference` therefore either:
+
+- hashes plaintext before encryption; or
+- is omitted, leaving the binding to cover metadata while core AEAD binds carriage.
+
+A plaintext hash may enable confirmation attacks for low-entropy payloads. Deployments
+SHOULD omit it or use a salted-digest profile when that matters.
+
+### 3.2 Detached binding
+
+Attestations created after the object exists MUST NOT require rebuilding it. They travel
+as detached BDOs:
+
+- the BDO data-reference URI identifies the object in deployment terms; and
+- its hash covers complete immutable BinaryTDF bytes from magic through ciphertext.
+
+The hash SHOULD use a COSE-registered algorithm; SHA-256, COSE `-16`, is recommended.
+
+Detached BDOs allow guards to validate required attestations, add their own, and
+forward both without modifying the object. A workflow requiring one MUST identify the
+claim and trusted signer and MUST fail closed if it is absent or invalid.
+
+## 4. Mapping labels to policy
+
+Labels describe data; Canonical Policy authorizes release. A deployment using labels
+for release MUST publish a total deterministic mapping keyed by the governing
+`security-policy-identifier`.
+
+| Label element | Illustrative policy entry |
+|---|---|
+| classification `2` under OID `1.3.26.1.4` | `["example.com", "classification", ["confidential"]]` |
+| releasability category `[2, [26,1,4,3], [76]]` | `["example.com", "rel-to", ["bra"]]` |
+
+Deployments replace `example.com` with a controlled namespace.
+
+- The producer applies mapping at creation and writes ordinary Canonical Policy. KAS
+  authorizes only against that policy and does not parse labels.
+- Mapping MUST be total for emitted labels; an unmapped value is a creation error.
+- The label remains the authoritative marking and policy is its enforcement projection.
+  A mismatch is a validation failure.
+
+## 5. Tag assignments
+
+Source drafts used provisional tags 42601 for BDO, 42602 for NCMS security metadata,
+and 47740 for clearance. This profile does not fix them:
+
+- implementations MUST use final assignments from the
+  [IANA CBOR Tags registry](https://www.iana.org/assignments/cbor-tags/) for promulgated
+  documents;
+- provisional draft tags MUST be treated as Private Use behind deployment
+  configuration and MUST NOT be emitted for interchange; and
+- `critical_extensions` names the tag actually emitted.
+
+A future compatible profile revision may pin final registrations.
+
+## 6. Security
+
+- Carriage is not clearance. AEAD does not prove label correctness, signer trust, or
+  agreement between content and marking.
+- Labels do not authorize. Only Canonical Policy and KAS authorization control release.
+- Embedded bindings cannot prove a signature covers the exact BinaryTDF; workflows
+  requiring that property MUST use detached bindings over the complete object bytes.
+- Plaintext hashes are stable payload identifiers and should be treated as sensitive
+  metadata.
+- A receiver without this profile MUST reject an object whose required label tag is
+  listed in `critical_extensions`; making a required label non-critical defeats
+  fail-closed marking.
+- Detached attestations are removable and MUST be required by relying applications.

--- a/spec/binarytdf/v1alpha/binarytdf-profile-nato.md
+++ b/spec/binarytdf/v1alpha/binarytdf-profile-nato.md
@@ -7,10 +7,10 @@
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Draft, optional |
-| Depends on | BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-CORE |
+| Depends on | BinaryTDF-SEC, BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-PAY, BinaryTDF-SCH, BinaryTDF-PKG |
 
 This profile carries NATO confidentiality labels and metadata bindings without changing
-core framing, validation, or cryptography.
+BinaryTDF-PKG framing, BinaryTDF-SCH validation, or cryptography.
 
 ## 1. Purpose
 
@@ -51,10 +51,10 @@ Illustrative diagnostic notation using a provisional tag:
 
 Carriage rules:
 
-- Core payload AAD and KAO context authenticate label bytes. Alteration, replacement,
-  or injection invalidates decryption.
-- Core deterministic CBOR rules apply to carried bytes. Semantic validation remains
-  governed by ADatP-4774.
+- BinaryTDF-PAY payload AAD and KAO context authenticate label bytes. Alteration,
+  replacement, or injection invalidates decryption.
+- BinaryTDF-SCH deterministic CBOR rules apply to carried bytes. Semantic validation
+  remains governed by ADatP-4774.
 - A label required before processing MUST be listed in `critical_extensions`; an
   unsupported receiver then fails before rewrap.
 - A label describes data and grants no access by itself.
@@ -74,7 +74,7 @@ It cannot bind ciphertext or complete object bytes because ciphertext depends on
 metadata through payload AAD. Its `data-reference` therefore either:
 
 - hashes plaintext before encryption; or
-- is omitted, leaving the binding to cover metadata while core AEAD binds carriage.
+- is omitted, leaving the binding to cover metadata while payload AEAD binds carriage.
 
 A plaintext hash may enable confirmation attacks for low-entropy payloads. Deployments
 SHOULD omit it or use a salted-digest profile when that matters.

--- a/spec/binarytdf/v1alpha/binarytdf-rec.md
+++ b/spec/binarytdf/v1alpha/binarytdf-rec.md
@@ -1,0 +1,148 @@
+# BinaryTDF-REC: Object Key Recovery
+
+| | |
+|---|---|
+| Document | BinaryTDF-REC |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft |
+| Depends on | BinaryTDF-CORE, BinaryTDF-POL, BinaryTDF-KAO, BinaryTDF-ALG |
+| Referenced by | BinaryTDF-KAS, BinaryTDF-CDDL, BinaryTDF-KEY-EPOCH |
+
+## 1. Recovery object
+
+Object Key Recovery identifies effective authorization policy and contains the
+scheme-specific data used to obtain the object key. It never contains the payload key.
+
+| Key | Field | Type | Required |
+|---:|---|---|---|
+| 1 | `recovery_scheme` | `uint` | yes |
+| 2 | `policy` | `canonical-policy` | no |
+| 3 | `recovery_data` | `recovery-scheme-data` | yes |
+
+The exact recovery bytes are payload AAD. Each KAO is additionally bound to metadata,
+policy, recovery scheme, and position through its KAO context.
+
+`recovery_data` is scheme-specific:
+
+- DIRECT stores exactly one KAO as `[KAO]`.
+- XOR_ALL stores alternatives in required share groups as `[[KAO, ...], ...]`.
+- KEY_EPOCH anchors store KAOs inside `epoch_secret_recovery`; references store none.
+
+A decoder MUST select and validate the complete recovery schema before attempting
+recovery.
+
+## 2. Scheme registry
+
+| Symbol | Integer | Encoded bytes | Result |
+|---|---:|---|---|
+| `UNSPECIFIED` | 0 | `00` | invalid |
+| `DIRECT` | 1 | `01` | one KAO releases the object key |
+| `XOR_ALL` | 2 | `02` | required shares reconstruct the object key |
+| `KEY_EPOCH` | 3 | `03` | separately defined epoch-secret derivation |
+| `PRIVATE_USE` | 24–255 | `18 18`–`18 ff` | explicit interoperability profile |
+
+Identifiers 4 through 23 and 256 or greater are unassigned. Unassigned identifiers
+MUST be rejected as `UNSUPPORTED_CAPABILITY`. Private assignments are not globally
+unique and MUST be enabled by an explicit profile; otherwise they are rejected.
+
+Every frame version 2 implementation MUST support DIRECT and XOR_ALL. KEY_EPOCH is
+optional and defined by [BinaryTDF-KEY-EPOCH](binarytdf-ext-key-epoch.md). A receiver
+MUST NOT substitute another scheme for an unsupported one.
+
+## 3. Common recovery result
+
+DIRECT and XOR_ALL produce one fresh uniformly random 32-byte object key for one
+BinaryTDF. A KAO protects that key or a share. The object key MUST NOT be serialized
+directly or reused.
+
+```text
+DIRECT:   KAO ──authorized release──► object key
+
+XOR_ALL:  group 0 ─► share 0 ┐
+          group 1 ─► share 1 ├─ XOR ─► object key
+          group n ─► share n ┘
+```
+
+### 3.1 DIRECT
+
+DIRECT recovery data is an array containing exactly one KAO. The KAO wraps the
+32-byte object key. The opener's authenticated `kao_value` is the object key. Any
+additional or missing KAO, invalid path, or value of another length is malformed.
+
+### 3.2 XOR_ALL
+
+XOR_ALL recovery data contains two or more non-empty share groups. KAOs within one
+group are alternatives protecting the same 32-byte share:
+
+- OR applies within one group.
+- AND applies across groups.
+
+For `G` groups, the producer MUST generate `G - 1` independent, uniformly random
+32-byte shares and compute the final share such that:
+
+```text
+share[0] XOR share[1] XOR ... XOR share[G-1] = object_key
+```
+
+Shares MUST NOT be reused across objects or groups. An opener accepts at most one
+authenticated share per group, rejects duplicate or inconsistent contributions,
+requires every group, and XORs locally. An authority never reconstructs the object
+key. Incorrect shares may cause denial of service; plaintext MUST NOT be returned
+unless payload authentication succeeds.
+
+## 4. KAO paths
+
+| Scheme | Path |
+|---|---|
+| DIRECT | `[0]` |
+| XOR_ALL | `[group_index, alternative_index]` |
+
+Paths are zero-based and not serialized inside KAOs. They participate in KAO and
+rewrap contexts, so reordering changes cryptographic context.
+
+## 5. Extension contract
+
+A recovery-scheme specification MUST define:
+
+- its identifier and deterministic recovery-data CDDL plug;
+- an interoperability profile for Private Use assignments;
+- whether the object key is generated, reconstructed, or derived;
+- every protected value, KAO path, and policy-binding input;
+- producer, opener, and authority validation;
+- partial-success and indistinguishable-failure behavior;
+- resource, lifetime, and replay limits for stateful schemes;
+- any scheme-specific meaning of absent policy;
+- security and authorization granularity; and
+- cross-language positive and negative vectors.
+
+Threshold recovery other than all-shares XOR requires a registered extension.
+Every new scheme, including a threshold construction, MUST satisfy this contract before
+receiving a registry identifier. A Private Use scheme MUST satisfy the same contract.
+
+## 6. CDDL plug
+
+```cddl
+direct-kao-set = [key-access-object]
+
+xor-all-share-group = [1* key-access-object]
+
+xor-all-kao-groups = [2* xor-all-share-group]
+
+direct-recovery-data = direct-kao-set
+
+xor-all-recovery-data = xor-all-kao-groups
+
+$binary-tdf-recovery-scheme-data /= direct-recovery-data
+$binary-tdf-recovery-scheme-data /= xor-all-recovery-data
+```
+
+The selected `recovery_scheme` determines which otherwise array-shaped plug is valid.
+
+## 7. Conformance
+
+Vectors MUST cover DIRECT cardinality and path validation; XOR_ALL alternatives,
+missing groups, duplicates, and reconstruction; KAO reordering; non-32-byte shares;
+authenticated incorrect shares ending in payload failure; and generic failure handling
+for policy binding, unwrap, and rewrap.

--- a/spec/binarytdf/v1alpha/binarytdf-rec.md
+++ b/spec/binarytdf/v1alpha/binarytdf-rec.md
@@ -7,8 +7,8 @@
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Draft |
-| Depends on | BinaryTDF-CORE, BinaryTDF-POL, BinaryTDF-KAO, BinaryTDF-ALG |
-| Referenced by | BinaryTDF-KAS, BinaryTDF-CDDL, BinaryTDF-KEY-EPOCH |
+| Depends on | BinaryTDF-SEC, BinaryTDF-ALG, BinaryTDF-POL, BinaryTDF-KAO |
+| Referenced by | BinaryTDF-PAY, BinaryTDF-KAS, BinaryTDF-SCH, BinaryTDF-CORE, BinaryTDF-KEY-EPOCH |
 
 ## 1. Recovery object
 

--- a/spec/binarytdf/v1alpha/binarytdf-sch.md
+++ b/spec/binarytdf/v1alpha/binarytdf-sch.md
@@ -1,16 +1,36 @@
-# BinaryTDF-CDDL: Normative Schema
+# BinaryTDF-SCH: Deterministic CBOR Schema
 
 | | |
 |---|---|
-| Document | BinaryTDF-CDDL |
+| Document | BinaryTDF-SCH |
 | Version | 1 Alpha |
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Draft |
-| Depends on | BinaryTDF-CORE, BinaryTDF-ALG, BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-KAS |
+| Depends on | BinaryTDF-ALG, BinaryTDF-MTD, BinaryTDF-POL, BinaryTDF-REC, BinaryTDF-KAO, BinaryTDF-KAS |
+| Referenced by | BinaryTDF-PKG, BinaryTDF-CORE, BinaryTDF-EX, BinaryTDF extensions |
+
+## 1. Deterministic CBOR
+
+All CBOR MUST use RFC 8949 Core Deterministic Encoding Requirements. Encoders MUST use
+preferred serialization, deterministic map-key ordering, and definite-length items.
+Optional fields with absent, empty, or zero values are omitted unless specified
+otherwise.
+
+Decoders MUST reject duplicate map keys, indefinite-length items, non-deterministic
+encodings, invalid types, unregistered core keys, and resource-limit violations.
+Implementations MUST impose finite limits on nesting, collection sizes, and section
+lengths.
+
+Core maps use unsigned integer keys. Registry identifiers are unsigned integers without
+a CBOR tag. `encode_deterministic_cbor(value)` denotes this specification operation; it
+is not a separate wire format.
+
+## 2. Consolidated CDDL
 
 Semantic, suite-specific, scheme-specific, and extension-specific requirements apply
-in addition to this shape.
+in addition to this shape. Component documents repeat relevant fragments near their
+semantic requirements; this section is the consolidated schema.
 
 ```cddl
 content-encryption-suite = &(
@@ -124,6 +144,8 @@ xor-all-recovery-data = xor-all-kao-groups
 $binary-tdf-recovery-scheme-data /= direct-recovery-data
 $binary-tdf-recovery-scheme-data /= xor-all-recovery-data
 ```
+
+## 3. Extension sockets
 
 Extension specifications augment the two `$binary-tdf-*` sockets with `/=`. The
 metadata wildcard permits only unknown non-critical tags; recognized tags use their

--- a/spec/binarytdf/v1alpha/binarytdf-sch.md
+++ b/spec/binarytdf/v1alpha/binarytdf-sch.md
@@ -36,7 +36,8 @@ semantic requirements; this section is the consolidated schema.
 content-encryption-suite = &(
   unspecified: 0,
   aes-256-gcm-hkdf-sha256: 1,
-  aes-256-gcm-hkdf-sha256-stream-64k: 2
+  aes-256-gcm-hkdf-sha256-stream-64k: 2,
+  aes-256-gcm-hkdf-sha256-stream-part: 3
 )
 
 recovery-scheme = &(

--- a/spec/binarytdf/v1alpha/binarytdf-sec.md
+++ b/spec/binarytdf/v1alpha/binarytdf-sec.md
@@ -1,0 +1,76 @@
+# BinaryTDF-SEC: Security Considerations
+
+| | |
+|---|---|
+| Document | BinaryTDF-SEC |
+| Version | 1 Alpha |
+| Source draft | 0.2 |
+| Frame version | 2 |
+| Status | Draft |
+| Depends on | BinaryTDF-CORE |
+| Referenced by | All BinaryTDF components |
+
+## 1. Parser limits
+
+Every parser MUST enforce limits before allocation, hashing, or authority contact. The
+following are frame version 2 baselines; profiles MAY set lower limits.
+
+| Input | Required handling |
+|---|---|
+| Frame section length | Check overflow and remaining bytes before conversion or allocation; enforce a finite maximum |
+| Ciphertext | Streaming is permitted; never allocate directly from the untrusted `uint64` length |
+| CBOR nesting | Reject depth greater than 32 |
+| CBOR array | Reject more than 4096 elements |
+| CBOR map | Reject more than 4096 pairs |
+
+## 2. Cryptographic boundaries
+
+- AES-GCM nonce reuse under one key is catastrophic. Producers MUST use a secure random
+  source for random object keys, shares, identifiers, and nonces. Derivation schemes
+  MUST guarantee distinct object-key inputs.
+- Exact wire bytes are cryptographic inputs. Re-encoding is forbidden wherever the
+  suite requires original bytes.
+- Authorities MUST reject unknown suites, schemes, core fields, and critical
+  extensions before authorization or release.
+- Capability selection is not in-object negotiation. Silent fallback is forbidden.
+- ECDH, ML-KEM, wrapped-key authentication, context, and policy-binding failures MUST
+  return the same `KEY_RECOVERY_FAILED` class. ML-KEM implicit-rejection state MUST NOT
+  be exposed.
+- An XOR_ALL share is sensitive. Fewer than all shares do not reconstruct the object
+  key, but malicious shares may cause denial of service. Every recovered share is
+  authenticated; payload authentication failure fails the complete open.
+- Plaintext, object keys, and unwrapped shares MUST NOT be logged or returned on
+  failure. Implementations SHOULD clear transient key material when practical.
+
+## 3. Trust boundaries
+
+`authority_id` is not a trusted endpoint. It MUST be resolved through trusted local
+configuration and MUST NOT be dereferenced as an arbitrary URL. URI ownership gives
+uniqueness, not trust.
+
+The authority recipient key is distributed outside the object. The deployment remains
+responsible for authenticating that key and its mapping to authority identity and
+`kid`.
+
+## 4. Metadata and signatures
+
+Carriage is not endorsement. AEAD proves that metadata belongs to the object as
+produced, not that claims are true or signers trusted. Trust anchors, certificate
+processing, and revocation belong to extension and deployment specifications.
+
+A signature inside Protected Metadata cannot sign the object that contains it because
+ciphertext depends on the metadata through payload AAD. Such a signature binds only
+what its extension defines. Complete-object attestations are detached and reference a
+hash of exact object bytes.
+
+A detached attestation may be removed. Applications requiring one identify the claim
+and signer and reject its absence or invalidity.
+
+External labels and handling metadata are not access policy. Mapping to Canonical
+Policy must be explicit and deterministic.
+
+## 5. Failure and release
+
+The opener MUST authenticate the payload under the selected suite before treating it
+as complete. A registered streaming suite may release authenticated prefix or selected
+segment plaintext only under explicit completion and failure semantics.

--- a/spec/binarytdf/v1alpha/binarytdf-sec.md
+++ b/spec/binarytdf/v1alpha/binarytdf-sec.md
@@ -4,7 +4,7 @@
 |---|---|
 | Document | BinaryTDF-SEC |
 | Version | 1 Alpha |
-| Source draft | 0.2 |
+| Source draft | 0.3 |
 | Frame version | 2 |
 | Status | Draft |
 | Depends on | None |
@@ -45,17 +45,32 @@ following are frame version 2 baselines; profiles MAY set lower limits.
 
 ## 3. AEAD usage bounds
 
-AES-256-GCM security degrades with the volume of data protected under one key. Two
-bounds apply, from the analysis of Iwata, Ohashi, and Minematsu as applied to TLS by
-Luykx and Paterson. RFC 8446 Section 5.5 derives its record limits from the same
-analysis. BinaryTDF-CORE Section 5 lists all three works.
+AES-256-GCM security degrades with the volume of data protected under each key and
+with the number and size of forgery attempts. RFC 8446 Section 5.5 adopted an
+approximately `2^-57` overall AE target using the analysis of Luykx and Paterson.
+BinaryTDF adopts `2^-57` as its maximum object-wide confidentiality advantage and
+accounts for integrity separately. BinaryTDF-CORE Section 5 lists the references.
 
-For `sigma` total 16-byte plaintext blocks and `q` encryption invocations under one
-key, confidentiality is bounded by:
+RFC 9001 Appendix B.1 applies the tighter multi-user GCM analysis of Hoang, Tessaro,
+and Thiruvengadam. For a single user with unique nonces, its dominant confidentiality
+term is `2 * (q * l)^2 / 2^128`. Writing `sigma_p` for the total number of 16-byte
+plaintext blocks protected under content-encryption key `K_p`, and applying a
+conservative hybrid argument across independently derived partition keys, BinaryTDF
+uses:
 
 ```text
-Adv_IND-CPA <= (sigma + q + 1)^2 / 2^129
+Adv_conf(object) <= 2 * sum(sigma_p^2 for every p) / 2^128
 ```
+
+Therefore an object meets the `2^-57` target when:
+
+```text
+sum(sigma_p^2 for every p) <= 2^70
+```
+
+This mode-level bound assumes AES is a secure pseudorandom permutation, HKDF-SHA256
+produces pseudorandom partition keys, and every nonce is unique under its key. The
+corresponding primitive and KDF advantages are additional negligible terms.
 
 For `v` forgery attempts against messages of at most `l` blocks with a `tau`-bit tag,
 integrity is bounded by:
@@ -64,44 +79,41 @@ integrity is bounded by:
 Adv_INT-CTXT <= 2 * v * (l + 1) / 2^tau
 ```
 
-### 3.1 Volume limit
+### 3.1 Object-wide confidentiality budget
 
-`sigma` dominates `q` at every segment size BinaryTDF permits, so the confidentiality
-bound is a function of total plaintext bytes under one key:
+For one content-encryption key, the block-square budget implies an absolute ceiling of
+`2^35` plaintext blocks, or at most `2^39` bytes (512 GiB). Reaching that ceiling
+spends the entire object-wide target on that key, so a multi-partition object needs
+substantially smaller partitions. The limit is cumulative over the life of every key
+and is independent of how plaintext is divided into segments.
 
-| Total plaintext under one key | IND-CPA advantage |
-|---|---:|
-| 2^38 bytes (256 GiB) | 2^-61 |
-| 2^40 bytes (1 TiB) | 2^-57 |
-| 2^42 bytes (4 TiB) | 2^-53 |
-| 2^43 bytes (8 TiB) | 2^-51 |
-| 2^45 bytes (32 TiB) | 2^-47 |
-| 2^63 bytes (8 EiB) | 2^-11 |
+For an object containing `B` plaintext bytes divided into equal `b`-byte partitions,
+the dominant term simplifies to approximately:
 
-RFC 8446 Section 5.5 targets approximately 2^-57 for AES-GCM. Its record limit of
-2^24.5 records of 2^14 bytes is 2^38.5 bytes, about 389 GB, which attains 2^-60.
-BinaryTDF adopts that margin at the round volume reaching it exactly.
+```text
+Adv_conf(object) <= B * b / 2^135
+```
 
-A single content-encryption key MUST NOT protect more than 2^40 bytes
-(1099511627776) of plaintext. The limit is cumulative over the life of the key and is
-independent of how the plaintext is divided.
+At 50 TiB this permits partitions no larger than approximately 5.12 GiB. BinaryTDF
+RECOMMENDS partitions of approximately 1 GiB, which yield an object-wide advantage
+below `2^-59`. BinaryTDF-STREAM Sections 8.1 and 9.4 define the normative checks in
+terms of actual per-invocation block counts.
 
 | Suite | Key bounded by this limit | Effect |
 |---:|---|---|
 | 1 | payload key | unreachable; Section 3.6 binds first at 68719476704 bytes |
-| 2 | payload key | complete object at most 2^40 bytes, BinaryTDF-STREAM Section 8.1 |
-| 3 | partition key `K_p` | each partition at most 2^40 bytes, no ceiling on the object |
+| 2 | payload key | complete object at most 2^35 blocks, BinaryTDF-STREAM Section 8.1 |
+| 3 | partition key `K_p` | sum of squared partition block counts at most 2^70 |
 
 A suite 3 payload key performs no AES-GCM encryption. It is only the pseudorandom key
 from which each `K_p` is expanded, so this bound does not apply to it.
 
 ### 3.2 Segmentation is not rekeying
 
-`sigma` counts plaintext blocks however they are divided into segments, and `q` is
-negligible beside it. At 2^40 bytes under one key with 1 MiB segments, `sigma` is 2^36
-blocks and `q` is about 2^20 invocations, which moves the bound by less than a
-thousandth of a bit. Halving the segment size doubles `q` and leaves `sigma`
-unchanged.
+`sigma_p` counts plaintext blocks however they are divided into segments. Halving the
+segment size while retaining the same partition bytes leaves `sigma_p` essentially
+unchanged; the only difference is conservative rounding of partial final blocks in
+individual invocations.
 
 Smaller segments therefore do not extend the volume one key may protect, and a
 segmented suite does not escape the volume bound that constrains a single-message
@@ -111,13 +123,25 @@ volume bound, and in BinaryTDF that mechanism is suite 3 partition-key derivatio
 
 ### 3.3 Scale example
 
-The Amazon S3 single-object maximum is 5 TiB, or 5497558138880 bytes. Protected under
-one key it gives `sigma = 5 * 2^36` blocks and an advantage of about 2^-52.4, past the
-target margin. Suite 2 therefore tops out at 2^40 bytes, a fifth of such an object.
-Suite 3 places at most 2^40 bytes under each partition key, so the same object needs
-no more than six partition keys and no key exceeds the limit. BinaryTDF-STREAM Section
-9 gives the parameters and the resulting maximum object size, which is about 1.7
-million times the S3 maximum.
+Amazon S3 multipart limits advertise a 50 TB object and specify an exact maximum of
+50,000 GiB, approximately 48.83 TiB. BinaryTDF's scalable range includes a 50 TiB
+logical plaintext so that it also covers that storage limit when encrypted bytes are
+mapped across enough physical storage.
+
+A 50 TiB plaintext encrypted under one key has `sigma = 50 * 2^36` blocks and a
+confidentiality advantage of approximately `2^-43.7`, well past the target. Merely
+using fifty 1 TiB keys would satisfy the former per-key rule but would still give a
+conservative object-wide advantage of approximately `2^-49.4`.
+
+At approximately 1 GiB per partition, the same object uses about 51,200 partition
+keys. Each protects approximately `2^26` blocks, and:
+
+```text
+Adv_conf(object) <= 2 * 51,200 * (2^26)^2 / 2^128 < 2^-59
+```
+
+BinaryTDF-STREAM Section 9.5 gives exact wire parameters and block counts. Partition
+keys are derived on demand from one payload key and do not add KAOs or CBOR metadata.
 
 ### 3.4 Integrity bound
 
@@ -134,8 +158,8 @@ Every object key protects exactly one object. BinaryTDF-PAY Section 1 states tha
 requirement; the AEAD bounds are its reason.
 
 Suite 1 draws a fresh 12-byte nonce for its single message, so one object key means
-one AES-GCM message under one payload key. That is why suite 1 needs no volume rule
-beyond the per-invocation limit.
+one AES-GCM message under one payload key. Its per-invocation limit is safely inside
+the object-wide confidentiality budget.
 
 Suites 2 and 3 derive the payload key from the object key and a fresh 32-byte
 `stream_salt`, and their nonce prefix is only 56 bits. A repeated object key alone

--- a/spec/binarytdf/v1alpha/binarytdf-sec.md
+++ b/spec/binarytdf/v1alpha/binarytdf-sec.md
@@ -19,6 +19,7 @@ following are frame version 2 baselines; profiles MAY set lower limits.
 |---|---|
 | Frame section length | Check overflow and remaining bytes before conversion or allocation; enforce a finite maximum |
 | Ciphertext | Streaming is permitted; never allocate directly from the untrusted `uint64` length |
+| Content volume | Reject a frame whose declared plaintext exceeds the suite limits of Section 3 before decryption |
 | CBOR nesting | Reject depth greater than 32 |
 | CBOR array | Reject more than 4096 elements |
 | CBOR map | Reject more than 4096 pairs |
@@ -42,7 +43,127 @@ following are frame version 2 baselines; profiles MAY set lower limits.
 - Plaintext, object keys, and unwrapped shares MUST NOT be logged or returned on
   failure. Implementations SHOULD clear transient key material when practical.
 
-## 3. Trust boundaries
+## 3. AEAD usage bounds
+
+AES-256-GCM security degrades with the volume of data protected under one key. Two
+bounds apply, from the analysis of Iwata, Ohashi, and Minematsu as applied to TLS by
+Luykx and Paterson. RFC 8446 Section 5.5 derives its record limits from the same
+analysis. BinaryTDF-CORE Section 5 lists all three works.
+
+For `sigma` total 16-byte plaintext blocks and `q` encryption invocations under one
+key, confidentiality is bounded by:
+
+```text
+Adv_IND-CPA <= (sigma + q + 1)^2 / 2^129
+```
+
+For `v` forgery attempts against messages of at most `l` blocks with a `tau`-bit tag,
+integrity is bounded by:
+
+```text
+Adv_INT-CTXT <= 2 * v * (l + 1) / 2^tau
+```
+
+### 3.1 Volume limit
+
+`sigma` dominates `q` at every segment size BinaryTDF permits, so the confidentiality
+bound is a function of total plaintext bytes under one key:
+
+| Total plaintext under one key | IND-CPA advantage |
+|---|---:|
+| 2^38 bytes (256 GiB) | 2^-61 |
+| 2^40 bytes (1 TiB) | 2^-57 |
+| 2^42 bytes (4 TiB) | 2^-53 |
+| 2^43 bytes (8 TiB) | 2^-51 |
+| 2^45 bytes (32 TiB) | 2^-47 |
+| 2^63 bytes (8 EiB) | 2^-11 |
+
+RFC 8446 Section 5.5 targets approximately 2^-57 for AES-GCM. Its record limit of
+2^24.5 records of 2^14 bytes is 2^38.5 bytes, about 389 GB, which attains 2^-60.
+BinaryTDF adopts that margin at the round volume reaching it exactly.
+
+A single content-encryption key MUST NOT protect more than 2^40 bytes
+(1099511627776) of plaintext. The limit is cumulative over the life of the key and is
+independent of how the plaintext is divided.
+
+| Suite | Key bounded by this limit | Effect |
+|---:|---|---|
+| 1 | payload key | unreachable; Section 3.6 binds first at 68719476704 bytes |
+| 2 | payload key | complete object at most 2^40 bytes, BinaryTDF-STREAM Section 8.1 |
+| 3 | partition key `K_p` | each partition at most 2^40 bytes, no ceiling on the object |
+
+A suite 3 payload key performs no AES-GCM encryption. It is only the pseudorandom key
+from which each `K_p` is expanded, so this bound does not apply to it.
+
+### 3.2 Segmentation is not rekeying
+
+`sigma` counts plaintext blocks however they are divided into segments, and `q` is
+negligible beside it. At 2^40 bytes under one key with 1 MiB segments, `sigma` is 2^36
+blocks and `q` is about 2^20 invocations, which moves the bound by less than a
+thousandth of a bit. Halving the segment size doubles `q` and leaves `sigma`
+unchanged.
+
+Smaller segments therefore do not extend the volume one key may protect, and a
+segmented suite does not escape the volume bound that constrains a single-message
+suite. A segmented suite escapes only the per-invocation limit of Section 3.6, which
+is a framing limit on one GCM call. Rekeying is the only mechanism that extends the
+volume bound, and in BinaryTDF that mechanism is suite 3 partition-key derivation.
+
+### 3.3 Scale example
+
+The Amazon S3 single-object maximum is 5 TiB, or 5497558138880 bytes. Protected under
+one key it gives `sigma = 5 * 2^36` blocks and an advantage of about 2^-52.4, past the
+target margin. Suite 2 therefore tops out at 2^40 bytes, a fifth of such an object.
+Suite 3 places at most 2^40 bytes under each partition key, so the same object needs
+no more than six partition keys and no key exceeds the limit. BinaryTDF-STREAM Section
+9 gives the parameters and the resulting maximum object size, which is about 1.7
+million times the S3 maximum.
+
+### 3.4 Integrity bound
+
+BinaryTDF uses 16-byte tags in every suite, so integrity is not a constraint. The
+largest message any suite permits is one 2147483647-byte segment, which is
+`l = 2^27` blocks, or 134217728 after rounding up. Against 2^32 forgery attempts the
+bound is `2 * 2^32 * (2^27 + 1) / 2^128`, about 2^-68. At a 1 MiB segment, `l = 2^16`,
+the same expression is about 2^-79. Integrity imposes no rekeying requirement at any
+registered parameter.
+
+### 3.5 Object-key freshness
+
+Every object key protects exactly one object. BinaryTDF-PAY Section 1 states that
+requirement; the AEAD bounds are its reason.
+
+Suite 1 draws a fresh 12-byte nonce for its single message, so one object key means
+one AES-GCM message under one payload key. That is why suite 1 needs no volume rule
+beyond the per-invocation limit.
+
+Suites 2 and 3 derive the payload key from the object key and a fresh 32-byte
+`stream_salt`, and their nonce prefix is only 56 bits. A repeated object key alone
+does not repeat a payload key, but a repeated object key and salt together do, and
+`N` streams under one payload key collide on the nonce prefix with probability about
+`N^2 / 2^57`: about 2^-17 at 2^20 streams and even odds at 2^28. A repeated prefix
+repeats the exact key and nonce at every common segment index, which is the
+catastrophic failure Section 2 forbids. Partition derivation does not reduce this
+risk, because `K_p` is a deterministic function of the payload key alone.
+
+### 3.6 Per-invocation limit
+
+NIST SP 800-38D Section 5.2.1.1 caps one GCM invocation at 2^39 - 256 bits, that is
+68719476704 bytes, or 64 GiB - 32 bytes. No suite may exceed it in one AES-GCM call.
+Suite 1 encrypts the complete payload in one call, so this is its hard object ceiling;
+the 64-bit Ciphertext Length of BinaryTDF-PKG frames far more than GCM can protect,
+and only the normative requirement in BinaryTDF-PAY Section 4 closes that gap. Suites
+2 and 3 encrypt one segment per call, and their 2147483647-byte maximum segment is far
+below the cap.
+
+Suites 2 and 3 construct nonces deterministically in the sense of SP 800-38D Section
+8.2.1, with `nonce_prefix` as the fixed field and `uint32_be(i) || final_byte` as the
+invocation field. The 2^32-invocation cap of SP 800-38D Section 8.3 applies to
+RBG-based construction and therefore does not apply to them; their 2^32 segment
+ceiling comes from the width of the index field. Suite 1 does use an RBG-based nonce,
+and its one invocation per key is far inside that cap.
+
+## 4. Trust boundaries
 
 `authority_id` is not a trusted endpoint. It MUST be resolved through trusted local
 configuration and MUST NOT be dereferenced as an arbitrary URL. URI ownership gives
@@ -52,7 +173,7 @@ The authority recipient key is distributed outside the object. The deployment re
 responsible for authenticating that key and its mapping to authority identity and
 `kid`.
 
-## 4. Metadata and signatures
+## 5. Metadata and signatures
 
 Carriage is not endorsement. AEAD proves that metadata belongs to the object as
 produced, not that claims are true or signers trusted. Trust anchors, certificate
@@ -69,7 +190,7 @@ and signer and reject its absence or invalidity.
 External labels and handling metadata are not access policy. Mapping to Canonical
 Policy must be explicit and deterministic.
 
-## 5. Failure and release
+## 6. Failure and release
 
 The opener MUST authenticate the payload under the selected suite before treating it
 as complete. A registered streaming suite may release authenticated prefix or selected

--- a/spec/binarytdf/v1alpha/binarytdf-sec.md
+++ b/spec/binarytdf/v1alpha/binarytdf-sec.md
@@ -7,7 +7,7 @@
 | Source draft | 0.2 |
 | Frame version | 2 |
 | Status | Draft |
-| Depends on | BinaryTDF-CORE |
+| Depends on | None |
 | Referenced by | All BinaryTDF components |
 
 ## 1. Parser limits


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #3097** (`basetdf/spec-v4.4`).

### Proposed Changes

Defines the BinaryTDF v1 alpha specification suite under
`spec/binarytdf/v1alpha/`, reorganizing draft 0.2 and frame version 2 into
BaseTDF-style components while preserving the core wire format.

The suite includes:

* Deterministic CBOR/CDDL, strict parser and failure rules, DIRECT and XOR_ALL
  recovery, payload protection, KAS rewrap, packaging, and worked examples.
* Registered AES-256-GCM-HKDF STREAM suites 2 and 3, the KEY_EPOCH extension,
  NATO metadata profile, and the frame-version-1 migration guide.
* Clear separation between recovery topology, protection of one recovery value,
  payload encryption, schema, packaging, and end-to-end processing.
* Alignment with the BaseTDF 5 security model where the formats share a
  responsibility, while retaining BinaryTDF-specific labels and wire encodings.

### AES-GCM limits and 50 TiB STREAM support

The latest changes replace independent 1 TiB-per-key limits with the same
object-wide GCM confidentiality budget used by BaseTDF 5:

```text
Adv_conf(object) <= 2 * sum(sigma_p^2) / 2^128
sum(sigma_p^2) <= 2^70
```

Consequences for BinaryTDF-STREAM are:

* Suite 2, which uses one payload key, is limited to `2^35` plaintext blocks—at
  most **512 GiB**, with exact per-invocation partial-block accounting.
* Suite 3 derives a key per partition and validates the squared block-count sum
  across the complete object. Independent per-partition ceilings are not enough.
* The recommended 50 TiB profile uses 1,048,576-byte wire segments and 1,024
  segments per partition: 52,429,601 segments, 51,201 partitions, and an exact
  dominant confidentiality advantage of approximately `2^-59.36`.
* Readers and writers must use checked arithmetic; unsigned 128-bit
  intermediates cover all registered field ranges. Boundary vectors hit `2^70`
  exactly and reject the next byte.

The encrypted 50 TiB representation includes approximately 800 MiB of header
and tag overhead. Amazon S3's exact final-object maximum is 50,000 GiB
(approximately 48.83 TiB), and multipart upload does not increase it. The spec
therefore documents virtual concatenation over multiple physical blobs or
multiple independently keyed BinaryTDF objects with the same aggregate
whole-file budget. S3 part numbers must not replace cryptographic segment or
partition indexes.

### Checklist

- [ ] I have added or updated unit tests (not applicable: documentation only)
- [ ] I have added or updated integration tests (not applicable: documentation only)
- [x] I have added or updated documentation

### Testing Instructions

Documentation-only change. Markdown structure and cross-module references were
reviewed, and the suite 2 boundary, suite 3 `2^70` boundary, exact 50 TiB
segment/partition counts, ciphertext length, overhead, and S3-size calculations
were independently recalculated.
