### PR TITLE
feat(core): add trace-log correlation for otel

### DIFF
--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -95,11 +95,12 @@ The logger configuration is used to define how the application logs its output.
 
 Root level key `logger`
 
-| Field    | Description                              | Default  | Environment Variable  |
-| -------- | ---------------------------------------- | -------- | --------------------- |
-| `level`  | The logging level.                       | `info`   | OPENTDF_LOGGER_LEVEL  |
-| `type`   | The format of the log output.            | `json`   | OPENTDF_LOGGER_TYPE   |
-| `output` | Stream output for logs, stderr or stdout | `stdout` | OPENTDF_LOGGER_OUTPUT |
+| Field               | Description                                                | Default  | Environment Variable             |
+| ------------------- | ---------------------------------------------------------- | -------- | -------------------------------- |
+| `level`             | The logging level.                                           | `info`   | OPENTDF_LOGGER_LEVEL             |
+| `type`              | The format of the log output.                                | `json`   | OPENTDF_LOGGER_TYPE              |
+| `output`            | Stream output for logs, stderr or stdout                     | `stdout` | OPENTDF_LOGGER_OUTPUT            |
+| `trace_correlation` | Add the active trace and span IDs to log and audit records   | `true`   | OPENTDF_LOGGER_TRACE_CORRELATION |
 
 Example:
 
@@ -109,6 +110,9 @@ logger:
   type: text
   output: stderr
 ```
+
+`trace_correlation` only has an effect when tracing is enabled; see
+[Tracing Configuration](#tracing-configuration).
 
 ## Server Configuration
 
@@ -318,6 +322,30 @@ server:
         endpoint: "localhost:4317"
         insecure: true
 ```
+
+While tracing is enabled, every log and audit record emitted during a traced
+request also carries the trace context of the active span, so a backend can
+link a span to the logs it produced:
+
+```json
+{
+  "level": "AUDIT",
+  "msg": "rewrap",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "span_id": "00f067aa0ba902b7",
+  "audit": { "...": "..." }
+}
+```
+
+`trace_id` and `span_id` are lowercase hex, 32 and 16 characters respectively,
+following the OpenTelemetry logging convention. Records emitted outside a
+request (startup, background work) have no active span and carry no trace
+fields. Set `logger.trace_correlation` to `false` to disable this; see
+[Logger Configuration](#logger-configuration).
+
+Backends generally also require the log's service tag to match the span's
+`service.name`, which defaults to `opentdf-platform` and can be overridden with
+`OTEL_SERVICE_NAME` or `OTEL_RESOURCE_ATTRIBUTES`.
 
 ## Database Configuration
 

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -111,7 +111,7 @@ logger:
   output: stderr
 ```
 
-`trace_correlation` only has an effect when tracing is enabled; see
+`trace_correlation` emits fields only when the request carries trace context; see
 [Tracing Configuration](#tracing-configuration).
 
 ## Server Configuration

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -2,6 +2,9 @@ logger:
   level: debug
   type: text
   output: stderr
+  # Adds the active OTel trace_id/span_id to log and audit records. Enabled by
+  # default; only emits anything while server.trace.enabled is true.
+  # trace_correlation: true
 audit:
   # Optional JWT claim mappings for audit enrichment.
   # Paths use dot notation over the emitted audit log shape.

--- a/service/logger/contextHandler.go
+++ b/service/logger/contextHandler.go
@@ -9,38 +9,63 @@ import (
 	"github.com/opentdf/platform/service/logger/audit"
 )
 
-// ContextHandler is a custom slog.Handler that adds context attributes to log records from values set to the
-// context by the RPC interceptor. It is used to enrich log records with request-specific metadata such as
-// request ID, user agent, request IP, and actor ID.
-type ContextHandler struct {
+// contextAttrsFunc derives log attributes from a record's context. It returns
+// nil when the context carries nothing to add.
+type contextAttrsFunc func(context.Context) []slog.Attr
+
+// contextAttrsHandler is a slog.Handler that enriches each record with
+// attributes derived from its context, then delegates to the wrapped handler.
+type contextAttrsHandler struct {
 	handler slog.Handler
+	sources []contextAttrsFunc
 }
 
-// Handle overrides the default Handle method to add context values set by RPC interceptor.
-func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error {
-	contextData := audit.GetAuditDataFromContext(ctx)
+// newContextAttrsHandler wraps handler so each record gains the attributes
+// produced by sources, in order. With no sources, handler is returned as-is.
+func newContextAttrsHandler(handler slog.Handler, sources ...contextAttrsFunc) slog.Handler {
+	if len(sources) == 0 {
+		return handler
+	}
 
-	// Only add context attributes if RequestID is present, indicating this is part of a request
-	if contextData.RequestID != uuid.Nil {
-		r.AddAttrs(
-			slog.String(string(sdkAudit.RequestIDContextKey), contextData.RequestID.String()),
-			slog.String(string(sdkAudit.UserAgentContextKey), contextData.UserAgent),
-			slog.String(string(sdkAudit.RequestIPContextKey), contextData.RequestIP),
-			slog.String(string(sdkAudit.ActorIDContextKey), contextData.ActorID),
-		)
+	return &contextAttrsHandler{handler: handler, sources: sources}
+}
+
+func (h *contextAttrsHandler) Handle(ctx context.Context, r slog.Record) error {
+	for _, source := range h.sources {
+		if attrs := source(ctx); len(attrs) > 0 {
+			r.AddAttrs(attrs...)
+		}
 	}
 
 	return h.handler.Handle(ctx, r)
 }
 
-func (h *ContextHandler) Enabled(ctx context.Context, level slog.Level) bool {
+func (h *contextAttrsHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	return h.handler.Enabled(ctx, level)
 }
 
-func (h *ContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &ContextHandler{handler: h.handler.WithAttrs(attrs)}
+func (h *contextAttrsHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &contextAttrsHandler{handler: h.handler.WithAttrs(attrs), sources: h.sources}
 }
 
-func (h *ContextHandler) WithGroup(name string) slog.Handler {
-	return &ContextHandler{handler: h.handler.WithGroup(name)}
+func (h *contextAttrsHandler) WithGroup(name string) slog.Handler {
+	return &contextAttrsHandler{handler: h.handler.WithGroup(name), sources: h.sources}
+}
+
+// requestContextAttrs returns the request metadata set on the context by the
+// RPC interceptor: request ID, user agent, request IP, and actor ID.
+func requestContextAttrs(ctx context.Context) []slog.Attr {
+	contextData := audit.GetAuditDataFromContext(ctx)
+
+	// Only add context attributes if RequestID is present, indicating this is part of a request
+	if contextData.RequestID == uuid.Nil {
+		return nil
+	}
+
+	return []slog.Attr{
+		slog.String(string(sdkAudit.RequestIDContextKey), contextData.RequestID.String()),
+		slog.String(string(sdkAudit.UserAgentContextKey), contextData.UserAgent),
+		slog.String(string(sdkAudit.RequestIPContextKey), contextData.RequestIP),
+		slog.String(string(sdkAudit.ActorIDContextKey), contextData.ActorID),
+	}
 }

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -81,7 +81,7 @@ func NewLogger(config Config) (*Logger, error) {
 		return nil, fmt.Errorf("invalid logger type: %s", config.Type)
 	}
 
-	sLogger = slog.New(withTraceCorrelation(&ContextHandler{handler}, config))
+	sLogger = slog.New(newContextAttrsHandler(handler, contextAttrSources(config, requestContextAttrs)...))
 
 	// Audit logger will always log at the AUDIT level and be JSON formatted
 	var auditLoggerHandler slog.Handler = slog.NewJSONHandler(w, &slog.HandlerOptions{
@@ -89,9 +89,9 @@ func NewLogger(config Config) (*Logger, error) {
 		ReplaceAttr: audit.ReplaceAttrAuditLevel,
 	})
 
-	// Audit events skip ContextHandler on purpose: the request metadata it adds
-	// is already inside the audit payload. They still need trace correlation.
-	auditLoggerBase := slog.New(withTraceCorrelation(auditLoggerHandler, config))
+	// Audit events skip requestContextAttrs on purpose: the request metadata it
+	// adds is already inside the audit payload. They still need trace correlation.
+	auditLoggerBase := slog.New(newContextAttrsHandler(auditLoggerHandler, contextAttrSources(config)...))
 	auditLogger := audit.CreateAuditLogger(*auditLoggerBase)
 
 	logger.Logger = sLogger
@@ -108,11 +108,14 @@ func (l *Logger) With(key string, value string) *Logger {
 	}
 }
 
-func withTraceCorrelation(handler slog.Handler, config Config) slog.Handler {
+// contextAttrSources returns the attribute sources for a logger, prepending
+// trace correlation when enabled so trace IDs lead the appended attributes.
+func contextAttrSources(config Config, extra ...contextAttrsFunc) []contextAttrsFunc {
 	if !config.traceCorrelationEnabled() {
-		return handler
+		return extra
 	}
-	return NewTraceHandler(handler)
+
+	return append([]contextAttrsFunc{traceContextAttrs}, extra...)
 }
 
 func getWriter(config Config) (io.Writer, error) {

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -38,6 +38,13 @@ type Config struct {
 	Level  string `mapstructure:"level" json:"level" default:"info"`
 	Output string `mapstructure:"output" json:"output" default:"stdout"`
 	Type   string `mapstructure:"type" json:"type" default:"json"`
+	// TraceCorrelation adds the active trace and span IDs to log and audit
+	// records. No-op unless tracing is enabled via `server.trace`. Nil means enabled.
+	TraceCorrelation *bool `mapstructure:"trace_correlation" json:"trace_correlation" default:"true"`
+}
+
+func (c Config) traceCorrelationEnabled() bool {
+	return c.TraceCorrelation == nil || *c.TraceCorrelation
 }
 
 const (
@@ -74,15 +81,17 @@ func NewLogger(config Config) (*Logger, error) {
 		return nil, fmt.Errorf("invalid logger type: %s", config.Type)
 	}
 
-	sLogger = slog.New(&ContextHandler{handler})
+	sLogger = slog.New(withTraceCorrelation(&ContextHandler{handler}, config))
 
 	// Audit logger will always log at the AUDIT level and be JSON formatted
-	auditLoggerHandler := slog.NewJSONHandler(w, &slog.HandlerOptions{
+	var auditLoggerHandler slog.Handler = slog.NewJSONHandler(w, &slog.HandlerOptions{
 		Level:       audit.LevelAudit,
 		ReplaceAttr: audit.ReplaceAttrAuditLevel,
 	})
 
-	auditLoggerBase := slog.New(auditLoggerHandler)
+	// Audit events skip ContextHandler on purpose: the request metadata it adds
+	// is already inside the audit payload. They still need trace correlation.
+	auditLoggerBase := slog.New(withTraceCorrelation(auditLoggerHandler, config))
 	auditLogger := audit.CreateAuditLogger(*auditLoggerBase)
 
 	logger.Logger = sLogger
@@ -97,6 +106,13 @@ func (l *Logger) With(key string, value string) *Logger {
 		Logger: l.Logger.With(key, value),
 		Audit:  l.Audit.With(key, value),
 	}
+}
+
+func withTraceCorrelation(handler slog.Handler, config Config) slog.Handler {
+	if !config.traceCorrelationEnabled() {
+		return handler
+	}
+	return NewTraceHandler(handler)
 }
 
 func getWriter(config Config) (io.Writer, error) {

--- a/service/logger/logger_test.go
+++ b/service/logger/logger_test.go
@@ -1,0 +1,124 @@
+package logger
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/opentdf/platform/service/logger/audit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStdout swaps os.Stdout for a pipe and returns the lines written by fn.
+func captureStdout(t *testing.T, fn func()) []string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	defer func() {
+		os.Stdout = orig
+	}()
+
+	fn()
+	require.NoError(t, w.Close())
+
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		if line := strings.TrimSpace(scanner.Text()); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	require.NoError(t, scanner.Err())
+
+	return lines
+}
+
+func decodeLine(t *testing.T, line string) map[string]any {
+	t.Helper()
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &out))
+	return out
+}
+
+// emitAuditEvent drives an audit event through the interceptor, which owns the
+// transaction lifecycle and flushes pending events on return.
+func emitAuditEvent(ctx context.Context, t *testing.T, lg *Logger) {
+	t.Helper()
+
+	next := audit.ContextServerInterceptor(lg.Audit)(
+		func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+			audit.LogAuditEvent(ctx, audit.VerbRewrap, &audit.EventObject{})
+			return nil, nil //nolint:nilnil // the interceptor ignores the response in this test
+		},
+	)
+
+	_, err := next(ctx, connect.NewRequest(&struct{}{}))
+	require.NoError(t, err)
+}
+
+func Test_NewLogger_CorrelatesMainAndAuditLogs(t *testing.T) {
+	ctx := tracedContext(t)
+
+	lines := captureStdout(t, func() {
+		lg, err := NewLogger(Config{Level: "info", Output: "stdout", Type: "json"})
+		require.NoError(t, err)
+
+		lg.InfoContext(ctx, "handled request")
+		emitAuditEvent(ctx, t, lg)
+	})
+	require.Len(t, lines, 2, "expected one application log and one audit log")
+
+	appLog := decodeLine(t, lines[0])
+	assert.Equal(t, "handled request", appLog["msg"])
+	assert.Equal(t, testTraceIDHex, appLog[TraceIDKey])
+	assert.Equal(t, testSpanIDHex, appLog[SpanIDKey])
+
+	auditLog := decodeLine(t, lines[1])
+	assert.Equal(t, "AUDIT", auditLog["level"])
+	assert.Equal(t, testTraceIDHex, auditLog[TraceIDKey])
+	assert.Equal(t, testSpanIDHex, auditLog[SpanIDKey])
+}
+
+func Test_NewLogger_TraceCorrelationDisabled(t *testing.T) {
+	ctx := tracedContext(t)
+	disabled := false
+
+	lines := captureStdout(t, func() {
+		lg, err := NewLogger(Config{Level: "info", Output: "stdout", Type: "json", TraceCorrelation: &disabled})
+		require.NoError(t, err)
+
+		lg.InfoContext(ctx, "handled request")
+		emitAuditEvent(ctx, t, lg)
+	})
+	require.Len(t, lines, 2)
+
+	for _, line := range lines {
+		entry := decodeLine(t, line)
+		assert.NotContains(t, entry, TraceIDKey)
+		assert.NotContains(t, entry, SpanIDKey)
+	}
+}
+
+func Test_NewLogger_UntracedRequestHasNoTraceFields(t *testing.T) {
+	lines := captureStdout(t, func() {
+		lg, err := NewLogger(Config{Level: "info", Output: "stdout", Type: "json"})
+		require.NoError(t, err)
+
+		lg.InfoContext(context.Background(), "startup")
+	})
+	require.Len(t, lines, 1)
+
+	entry := decodeLine(t, lines[0])
+	assert.NotContains(t, entry, TraceIDKey)
+	assert.NotContains(t, entry, SpanIDKey)
+}

--- a/service/logger/logger_test.go
+++ b/service/logger/logger_test.go
@@ -81,13 +81,13 @@ func Test_NewLogger_CorrelatesMainAndAuditLogs(t *testing.T) {
 
 	appLog := decodeLine(t, lines[0])
 	assert.Equal(t, "handled request", appLog["msg"])
-	assert.Equal(t, testTraceIDHex, appLog[TraceIDKey])
-	assert.Equal(t, testSpanIDHex, appLog[SpanIDKey])
+	assert.Equal(t, testTraceIDHex, appLog[traceIDKey])
+	assert.Equal(t, testSpanIDHex, appLog[spanIDKey])
 
 	auditLog := decodeLine(t, lines[1])
 	assert.Equal(t, "AUDIT", auditLog["level"])
-	assert.Equal(t, testTraceIDHex, auditLog[TraceIDKey])
-	assert.Equal(t, testSpanIDHex, auditLog[SpanIDKey])
+	assert.Equal(t, testTraceIDHex, auditLog[traceIDKey])
+	assert.Equal(t, testSpanIDHex, auditLog[spanIDKey])
 }
 
 func Test_NewLogger_TraceCorrelationDisabled(t *testing.T) {
@@ -105,9 +105,42 @@ func Test_NewLogger_TraceCorrelationDisabled(t *testing.T) {
 
 	for _, line := range lines {
 		entry := decodeLine(t, line)
-		assert.NotContains(t, entry, TraceIDKey)
-		assert.NotContains(t, entry, SpanIDKey)
+		assert.NotContains(t, entry, traceIDKey)
+		assert.NotContains(t, entry, spanIDKey)
 	}
+}
+
+// The main logger carries request metadata alongside the trace IDs; audit
+// records carry only the trace IDs, since the metadata is already in the payload.
+func Test_NewLogger_RequestMetadataOnlyOnMainLogger(t *testing.T) {
+	ctx := tracedContext(t)
+
+	lines := captureStdout(t, func() {
+		lg, err := NewLogger(Config{Level: "info", Output: "stdout", Type: "json"})
+		require.NoError(t, err)
+
+		next := audit.ContextServerInterceptor(lg.Audit)(
+			func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+				lg.InfoContext(ctx, "handled request")
+				audit.LogAuditEvent(ctx, audit.VerbRewrap, &audit.EventObject{})
+				return nil, nil //nolint:nilnil // the interceptor ignores the response in this test
+			},
+		)
+		_, err = next(ctx, connect.NewRequest(&struct{}{}))
+		require.NoError(t, err)
+	})
+	require.Len(t, lines, 2)
+
+	appLog := decodeLine(t, lines[0])
+	assert.Equal(t, testTraceIDHex, appLog[traceIDKey])
+	assert.NotEmpty(t, appLog["request-id"])
+	assert.Contains(t, appLog, "user-agent")
+	assert.Contains(t, appLog, "request-ip")
+	assert.Contains(t, appLog, "actor-id")
+
+	auditLog := decodeLine(t, lines[1])
+	assert.Equal(t, testTraceIDHex, auditLog[traceIDKey])
+	assert.NotContains(t, auditLog, "request-id")
 }
 
 // With tracing disabled the platform installs a noop tracer provider but keeps
@@ -131,8 +164,8 @@ func Test_NewLogger_NoopProviderPreservesInboundTraceContext(t *testing.T) {
 
 		for _, line := range lines {
 			entry := decodeLine(t, line)
-			assert.Equal(t, testTraceIDHex, entry[TraceIDKey])
-			assert.Equal(t, testSpanIDHex, entry[SpanIDKey])
+			assert.Equal(t, testTraceIDHex, entry[traceIDKey])
+			assert.Equal(t, testSpanIDHex, entry[spanIDKey])
 		}
 	})
 
@@ -149,8 +182,8 @@ func Test_NewLogger_NoopProviderPreservesInboundTraceContext(t *testing.T) {
 		require.Len(t, lines, 1)
 
 		entry := decodeLine(t, lines[0])
-		assert.NotContains(t, entry, TraceIDKey)
-		assert.NotContains(t, entry, SpanIDKey)
+		assert.NotContains(t, entry, traceIDKey)
+		assert.NotContains(t, entry, spanIDKey)
 	})
 }
 
@@ -164,6 +197,6 @@ func Test_NewLogger_UntracedRequestHasNoTraceFields(t *testing.T) {
 	require.Len(t, lines, 1)
 
 	entry := decodeLine(t, lines[0])
-	assert.NotContains(t, entry, TraceIDKey)
-	assert.NotContains(t, entry, SpanIDKey)
+	assert.NotContains(t, entry, traceIDKey)
+	assert.NotContains(t, entry, spanIDKey)
 }

--- a/service/logger/logger_test.go
+++ b/service/logger/logger_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opentdf/platform/service/logger/audit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 // captureStdout swaps os.Stdout for a pipe and returns the lines written by fn.
@@ -107,6 +108,50 @@ func Test_NewLogger_TraceCorrelationDisabled(t *testing.T) {
 		assert.NotContains(t, entry, TraceIDKey)
 		assert.NotContains(t, entry, SpanIDKey)
 	}
+}
+
+// With tracing disabled the platform installs a noop tracer provider but keeps
+// the W3C propagator, so an inbound traceparent still reaches the logs while
+// self-started spans do not.
+func Test_NewLogger_NoopProviderPreservesInboundTraceContext(t *testing.T) {
+	tracer := noop.NewTracerProvider().Tracer("test")
+
+	t.Run("inbound trace context is kept", func(t *testing.T) {
+		lines := captureStdout(t, func() {
+			lg, err := NewLogger(Config{Level: "info", Output: "stdout", Type: "json"})
+			require.NoError(t, err)
+
+			ctx, span := tracer.Start(tracedContext(t), "rewrap")
+			defer span.End()
+
+			lg.InfoContext(ctx, "handled request")
+			emitAuditEvent(ctx, t, lg)
+		})
+		require.Len(t, lines, 2)
+
+		for _, line := range lines {
+			entry := decodeLine(t, line)
+			assert.Equal(t, testTraceIDHex, entry[TraceIDKey])
+			assert.Equal(t, testSpanIDHex, entry[SpanIDKey])
+		}
+	})
+
+	t.Run("span without inbound context emits nothing", func(t *testing.T) {
+		lines := captureStdout(t, func() {
+			lg, err := NewLogger(Config{Level: "info", Output: "stdout", Type: "json"})
+			require.NoError(t, err)
+
+			ctx, span := tracer.Start(context.Background(), "rewrap")
+			defer span.End()
+
+			lg.InfoContext(ctx, "handled request")
+		})
+		require.Len(t, lines, 1)
+
+		entry := decodeLine(t, lines[0])
+		assert.NotContains(t, entry, TraceIDKey)
+		assert.NotContains(t, entry, SpanIDKey)
+	})
 }
 
 func Test_NewLogger_UntracedRequestHasNoTraceFields(t *testing.T) {

--- a/service/logger/traceHandler.go
+++ b/service/logger/traceHandler.go
@@ -1,0 +1,53 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// OpenTelemetry-convention log attributes for trace context: 32- and
+// 16-character lowercase hex respectively.
+const (
+	TraceIDKey = "trace_id"
+	SpanIDKey  = "span_id"
+)
+
+// TraceHandler annotates records with the trace and span IDs of the
+// OpenTelemetry span active on the record's context, letting backends link a
+// span to the logs it produced. Records emitted outside a traced request are
+// left untouched.
+type TraceHandler struct {
+	handler slog.Handler
+}
+
+// NewTraceHandler wraps handler so emitted records carry the active span's
+// trace and span IDs.
+func NewTraceHandler(handler slog.Handler) *TraceHandler {
+	return &TraceHandler{handler: handler}
+}
+
+// Handle adds the active span's trace and span IDs to the record, if any.
+func (h *TraceHandler) Handle(ctx context.Context, r slog.Record) error {
+	if spanCtx := trace.SpanContextFromContext(ctx); spanCtx.IsValid() {
+		r.AddAttrs(
+			slog.String(TraceIDKey, spanCtx.TraceID().String()),
+			slog.String(SpanIDKey, spanCtx.SpanID().String()),
+		)
+	}
+
+	return h.handler.Handle(ctx, r)
+}
+
+func (h *TraceHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.handler.Enabled(ctx, level)
+}
+
+func (h *TraceHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &TraceHandler{handler: h.handler.WithAttrs(attrs)}
+}
+
+func (h *TraceHandler) WithGroup(name string) slog.Handler {
+	return &TraceHandler{handler: h.handler.WithGroup(name)}
+}

--- a/service/logger/traceHandler.go
+++ b/service/logger/traceHandler.go
@@ -10,44 +10,21 @@ import (
 // OpenTelemetry-convention log attributes for trace context: 32- and
 // 16-character lowercase hex respectively.
 const (
-	TraceIDKey = "trace_id"
-	SpanIDKey  = "span_id"
+	traceIDKey = "trace_id"
+	spanIDKey  = "span_id"
 )
 
-// TraceHandler annotates records with the trace and span IDs of the
-// OpenTelemetry span active on the record's context, letting backends link a
-// span to the logs it produced. Records emitted outside a traced request are
-// left untouched.
-type TraceHandler struct {
-	handler slog.Handler
-}
-
-// NewTraceHandler wraps handler so emitted records carry the active span's
-// trace and span IDs.
-func NewTraceHandler(handler slog.Handler) *TraceHandler {
-	return &TraceHandler{handler: handler}
-}
-
-// Handle adds the active span's trace and span IDs to the record, if any.
-func (h *TraceHandler) Handle(ctx context.Context, r slog.Record) error {
-	if spanCtx := trace.SpanContextFromContext(ctx); spanCtx.IsValid() {
-		r.AddAttrs(
-			slog.String(TraceIDKey, spanCtx.TraceID().String()),
-			slog.String(SpanIDKey, spanCtx.SpanID().String()),
-		)
+// traceContextAttrs returns the trace and span IDs of the OpenTelemetry span
+// active on the context, letting backends link a span to the logs it produced.
+// Records emitted outside a traced request gain nothing.
+func traceContextAttrs(ctx context.Context) []slog.Attr {
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if !spanCtx.IsValid() {
+		return nil
 	}
 
-	return h.handler.Handle(ctx, r)
-}
-
-func (h *TraceHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	return h.handler.Enabled(ctx, level)
-}
-
-func (h *TraceHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &TraceHandler{handler: h.handler.WithAttrs(attrs)}
-}
-
-func (h *TraceHandler) WithGroup(name string) slog.Handler {
-	return &TraceHandler{handler: h.handler.WithGroup(name)}
+	return []slog.Attr{
+		slog.String(traceIDKey, spanCtx.TraceID().String()),
+		slog.String(spanIDKey, spanCtx.SpanID().String()),
+	}
 }

--- a/service/logger/traceHandler_test.go
+++ b/service/logger/traceHandler_test.go
@@ -1,0 +1,125 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	testTraceIDHex = "4bf92f3577b34da6a3ce929d0e0e4736"
+	testSpanIDHex  = "00f067aa0ba902b7"
+	testLogMsg     = "test message"
+)
+
+// tracedContext returns a context carrying a valid, non-recording span context.
+func tracedContext(t *testing.T) context.Context {
+	t.Helper()
+
+	traceID, err := trace.TraceIDFromHex(testTraceIDHex)
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex(testSpanIDHex)
+	require.NoError(t, err)
+
+	spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	require.True(t, spanCtx.IsValid())
+
+	return trace.ContextWithSpanContext(context.Background(), spanCtx)
+}
+
+// logJSON emits a record through handler and returns the decoded output.
+func logJSON(ctx context.Context, t *testing.T, buf *bytes.Buffer, handler slog.Handler) map[string]any {
+	t.Helper()
+
+	slog.New(handler).InfoContext(ctx, testLogMsg)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+	return out
+}
+
+func Test_TraceHandler_AddsTraceAndSpanID(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewTraceHandler(slog.NewJSONHandler(buf, nil))
+
+	out := logJSON(tracedContext(t), t, buf, handler)
+
+	// 32- and 16-character lowercase hex, per the OpenTelemetry convention.
+	assert.Equal(t, testTraceIDHex, out[TraceIDKey])
+	assert.Equal(t, testSpanIDHex, out[SpanIDKey])
+}
+
+func Test_TraceHandler_NoSpanOnContext(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewTraceHandler(slog.NewJSONHandler(buf, nil))
+
+	out := logJSON(context.Background(), t, buf, handler)
+
+	assert.NotContains(t, out, TraceIDKey)
+	assert.NotContains(t, out, SpanIDKey)
+}
+
+// An invalid (all-zero) span context must not leak placeholder IDs into logs.
+func Test_TraceHandler_InvalidSpanContext(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewTraceHandler(slog.NewJSONHandler(buf, nil))
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{}))
+
+	out := logJSON(ctx, t, buf, handler)
+
+	assert.NotContains(t, out, TraceIDKey)
+	assert.NotContains(t, out, SpanIDKey)
+}
+
+func Test_TraceHandler_PreservesWrappedHandlerAttrs(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewTraceHandler(slog.NewJSONHandler(buf, nil)).
+		WithAttrs([]slog.Attr{slog.String("service", "kas")})
+
+	out := logJSON(tracedContext(t), t, buf, handler)
+
+	assert.Equal(t, "kas", out["service"])
+	assert.Equal(t, testTraceIDHex, out[TraceIDKey])
+	assert.Equal(t, testSpanIDHex, out[SpanIDKey])
+}
+
+func Test_TraceHandler_EnabledDelegates(t *testing.T) {
+	inner := slog.NewJSONHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelWarn})
+	handler := NewTraceHandler(inner)
+
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelInfo))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+}
+
+func Test_Config_TraceCorrelationEnabled(t *testing.T) {
+	enabled := true
+	disabled := false
+
+	assert.True(t, Config{}.traceCorrelationEnabled(), "unset should default to enabled")
+	assert.True(t, Config{TraceCorrelation: &enabled}.traceCorrelationEnabled())
+	assert.False(t, Config{TraceCorrelation: &disabled}.traceCorrelationEnabled())
+}
+
+func Test_WithTraceCorrelation_DisabledIsPassthrough(t *testing.T) {
+	buf := &bytes.Buffer{}
+	inner := slog.NewJSONHandler(buf, nil)
+	disabled := false
+
+	handler := withTraceCorrelation(inner, Config{TraceCorrelation: &disabled})
+	assert.Same(t, inner, handler)
+
+	out := logJSON(tracedContext(t), t, buf, handler)
+	assert.NotContains(t, out, TraceIDKey)
+	assert.NotContains(t, out, SpanIDKey)
+}

--- a/service/logger/traceHandler_test.go
+++ b/service/logger/traceHandler_test.go
@@ -51,55 +51,74 @@ func logJSON(ctx context.Context, t *testing.T, buf *bytes.Buffer, handler slog.
 
 func Test_TraceHandler_AddsTraceAndSpanID(t *testing.T) {
 	buf := &bytes.Buffer{}
-	handler := NewTraceHandler(slog.NewJSONHandler(buf, nil))
+	handler := newContextAttrsHandler(slog.NewJSONHandler(buf, nil), traceContextAttrs)
 
 	out := logJSON(tracedContext(t), t, buf, handler)
 
 	// 32- and 16-character lowercase hex, per the OpenTelemetry convention.
-	assert.Equal(t, testTraceIDHex, out[TraceIDKey])
-	assert.Equal(t, testSpanIDHex, out[SpanIDKey])
+	assert.Equal(t, testTraceIDHex, out[traceIDKey])
+	assert.Equal(t, testSpanIDHex, out[spanIDKey])
 }
 
 func Test_TraceHandler_NoSpanOnContext(t *testing.T) {
 	buf := &bytes.Buffer{}
-	handler := NewTraceHandler(slog.NewJSONHandler(buf, nil))
+	handler := newContextAttrsHandler(slog.NewJSONHandler(buf, nil), traceContextAttrs)
 
 	out := logJSON(context.Background(), t, buf, handler)
 
-	assert.NotContains(t, out, TraceIDKey)
-	assert.NotContains(t, out, SpanIDKey)
+	assert.NotContains(t, out, traceIDKey)
+	assert.NotContains(t, out, spanIDKey)
 }
 
 // An invalid (all-zero) span context must not leak placeholder IDs into logs.
 func Test_TraceHandler_InvalidSpanContext(t *testing.T) {
 	buf := &bytes.Buffer{}
-	handler := NewTraceHandler(slog.NewJSONHandler(buf, nil))
+	handler := newContextAttrsHandler(slog.NewJSONHandler(buf, nil), traceContextAttrs)
 	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{}))
 
 	out := logJSON(ctx, t, buf, handler)
 
-	assert.NotContains(t, out, TraceIDKey)
-	assert.NotContains(t, out, SpanIDKey)
+	assert.NotContains(t, out, traceIDKey)
+	assert.NotContains(t, out, spanIDKey)
 }
 
 func Test_TraceHandler_PreservesWrappedHandlerAttrs(t *testing.T) {
 	buf := &bytes.Buffer{}
-	handler := NewTraceHandler(slog.NewJSONHandler(buf, nil)).
+	handler := newContextAttrsHandler(slog.NewJSONHandler(buf, nil), traceContextAttrs).
 		WithAttrs([]slog.Attr{slog.String("service", "kas")})
 
 	out := logJSON(tracedContext(t), t, buf, handler)
 
 	assert.Equal(t, "kas", out["service"])
-	assert.Equal(t, testTraceIDHex, out[TraceIDKey])
-	assert.Equal(t, testSpanIDHex, out[SpanIDKey])
+	assert.Equal(t, testTraceIDHex, out[traceIDKey])
+	assert.Equal(t, testSpanIDHex, out[spanIDKey])
 }
 
 func Test_TraceHandler_EnabledDelegates(t *testing.T) {
 	inner := slog.NewJSONHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelWarn})
-	handler := NewTraceHandler(inner)
+	handler := newContextAttrsHandler(inner, traceContextAttrs)
 
 	assert.False(t, handler.Enabled(context.Background(), slog.LevelInfo))
 	assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+}
+
+// Sources are applied in order, so a logger with both trace and request
+// correlation emits the trace IDs ahead of the request metadata.
+func Test_ContextAttrsHandler_AppliesSourcesInOrder(t *testing.T) {
+	buf := &bytes.Buffer{}
+	first := func(context.Context) []slog.Attr { return []slog.Attr{slog.Int("order", 1)} }
+	second := func(context.Context) []slog.Attr { return []slog.Attr{slog.Int("order", 2)} }
+
+	handler := newContextAttrsHandler(slog.NewJSONHandler(buf, nil), first, second)
+	logJSON(context.Background(), t, buf, handler)
+
+	assert.Regexp(t, `"order":1.*"order":2`, buf.String())
+}
+
+func Test_ContextAttrsHandler_NoSourcesIsPassthrough(t *testing.T) {
+	inner := slog.NewJSONHandler(&bytes.Buffer{}, nil)
+
+	assert.Same(t, inner, newContextAttrsHandler(inner))
 }
 
 func Test_Config_TraceCorrelationEnabled(t *testing.T) {
@@ -111,15 +130,16 @@ func Test_Config_TraceCorrelationEnabled(t *testing.T) {
 	assert.False(t, Config{TraceCorrelation: &disabled}.traceCorrelationEnabled())
 }
 
-func Test_WithTraceCorrelation_DisabledIsPassthrough(t *testing.T) {
+func Test_ContextAttrSources_TraceCorrelationDisabled(t *testing.T) {
 	buf := &bytes.Buffer{}
 	inner := slog.NewJSONHandler(buf, nil)
 	disabled := false
 
-	handler := withTraceCorrelation(inner, Config{TraceCorrelation: &disabled})
-	assert.Same(t, inner, handler)
+	sources := contextAttrSources(Config{TraceCorrelation: &disabled})
+	assert.Empty(t, sources, "no sources means the wrapped handler is used directly")
 
+	handler := newContextAttrsHandler(inner, sources...)
 	out := logJSON(tracedContext(t), t, buf, handler)
-	assert.NotContains(t, out, TraceIDKey)
-	assert.NotContains(t, out, SpanIDKey)
+	assert.NotContains(t, out, traceIDKey)
+	assert.NotContains(t, out, spanIDKey)
 }

--- a/service/pkg/config/legacy_loader.go
+++ b/service/pkg/config/legacy_loader.go
@@ -38,6 +38,10 @@ func NewLegacyLoader(key, file string) (*LegacyLoader, error) {
 	// Default config values (non-zero)
 	v.SetDefault("server.auth.cache_refresh_interval", "15m")
 
+	// Registered so AutomaticEnv can resolve it without the key also being
+	// present in the config file. Must match the struct tag default.
+	v.SetDefault("logger.trace_correlation", true)
+
 	// Environment variable settings
 	v.SetEnvPrefix(key)
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/service/pkg/config/trace_correlation_test.go
+++ b/service/pkg/config/trace_correlation_test.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeConfig(t *testing.T, yaml string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o600))
+	return path
+}
+
+// loadWithDefaults loads yaml backed by the default-settings loader, matching
+// the loader priority used at startup (first loader wins).
+func loadWithDefaults(t *testing.T, yaml string) *Config {
+	t.Helper()
+
+	fileLoader, err := NewConfigFileLoader(configKey, writeConfig(t, yaml))
+	require.NoError(t, err)
+	defaultsLoader, err := NewDefaultSettingsLoader()
+	require.NoError(t, err)
+
+	cfg, err := Load(t.Context(), fileLoader, defaultsLoader)
+	require.NoError(t, err)
+
+	return cfg
+}
+
+func Test_LoggerTraceCorrelation_DefaultsOn(t *testing.T) {
+	cfg := loadWithDefaults(t, "logger:\n  level: debug\n")
+
+	require.Equal(t, "debug", cfg.Logger.Level, "file value must win over defaults")
+	require.NotNil(t, cfg.Logger.TraceCorrelation)
+	assert.True(t, *cfg.Logger.TraceCorrelation)
+}
+
+func Test_LoggerTraceCorrelation_FileOverride(t *testing.T) {
+	cfg := loadWithDefaults(t, "logger:\n  trace_correlation: false\n")
+
+	require.NotNil(t, cfg.Logger.TraceCorrelation)
+	assert.False(t, *cfg.Logger.TraceCorrelation)
+}
+
+// AutomaticEnv only resolves keys the loader already knows about, so this
+// depends on the legacy loader registering the key.
+func Test_LoggerTraceCorrelation_EnvOverride(t *testing.T) {
+	t.Setenv("TEST_LOGGER_TRACE_CORRELATION", "false")
+
+	legacyLoader, err := NewLegacyLoader(configKey, writeConfig(t, "logger:\n  level: debug\n"))
+	require.NoError(t, err)
+	defaultsLoader, err := NewDefaultSettingsLoader()
+	require.NoError(t, err)
+
+	cfg, err := Load(t.Context(), legacyLoader, defaultsLoader)
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.Logger.TraceCorrelation)
+	assert.False(t, *cfg.Logger.TraceCorrelation)
+}


### PR DESCRIPTION
### Proposed Changes

*

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Log and audit records now include active OpenTelemetry trace and span IDs by default.
  - Trace correlation can be disabled through configuration.
  - Records outside traced requests remain free of trace fields.
  - Configuration supports file and environment-variable overrides.

- **Documentation**
  - Added configuration guidance and tracing details, including correlated fields, formatting, and service-name requirements.
  - Added commented trace-correlation settings to the example configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->