### PR TITLE
feat(core): Expose real-time audit logging

### DIFF
--- a/service/logger/audit/clone_test.go
+++ b/service/logger/audit/clone_test.go
@@ -33,10 +33,12 @@ func TestCloneCopiesContextDataAndCreatesIndependentTransaction(t *testing.T) {
 	require.Len(t, parentTx.events, 1)
 	assert.Empty(t, cloneTx.events)
 
-	l.PolicyCRUDFailure(cloned, policyCRUDParams)
+	require.PanicsWithValue(t,
+		"cannot buffer an audit event on a detached transaction; use Logger.LogPolicyCRUD",
+		func() { l.PolicyCRUDFailure(cloned, policyCRUDParams) },
+	)
 	require.Len(t, parentTx.events, 1)
-	require.Len(t, cloneTx.events, 1)
-	assert.NotSame(t, parentTx.events[0].event, cloneTx.events[0].event)
+	assert.Empty(t, cloneTx.events)
 }
 
 func TestLogPolicyCRUDEmitsOnceAndParentCloseDoesNotDuplicate(t *testing.T) {

--- a/service/logger/audit/clone_test.go
+++ b/service/logger/audit/clone_test.go
@@ -1,0 +1,164 @@
+package audit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type cloneContextValueKey struct{}
+
+func TestCloneCopiesContextDataAndCreatesIndependentTransaction(t *testing.T) {
+	l, _ := createTestLogger()
+	parent := context.WithValue(createTestContext(t), cloneContextValueKey{}, "retained")
+	parent, cancel := context.WithCancel(parent)
+
+	l.PolicyCRUDSuccess(parent, policyCRUDParams)
+	cloned := l.Clone(parent)
+	cancel()
+
+	assert.Equal(t, GetAuditDataFromContext(parent), GetAuditDataFromContext(cloned))
+	assert.Equal(t, "retained", cloned.Value(cloneContextValueKey{}))
+	assert.Nil(t, cloned.Done())
+	require.NoError(t, cloned.Err())
+
+	parentTx := requireAuditTransaction(parent, t)
+	cloneTx := requireAuditTransaction(cloned, t)
+	assert.NotSame(t, parentTx, cloneTx)
+	require.Len(t, parentTx.events, 1)
+	assert.Empty(t, cloneTx.events)
+
+	l.PolicyCRUDFailure(cloned, policyCRUDParams)
+	require.Len(t, parentTx.events, 1)
+	require.Len(t, cloneTx.events, 1)
+	assert.NotSame(t, parentTx.events[0].event, cloneTx.events[0].event)
+}
+
+func TestLogPolicyCRUDEmitsOnceAndParentCloseDoesNotDuplicate(t *testing.T) {
+	l, buf := createTestLogger()
+	parent := createTestContext(t)
+	cloned := l.Clone(parent)
+
+	l.LogPolicyCRUD(cloned, true, policyCRUDParams)
+	payloads := decodeAuditPayloads(t, buf)
+	require.Len(t, payloads, 1)
+	assert.Equal(t, "success", requireMap(t, payloads[0]["action"])["result"])
+	assert.Empty(t, requireAuditTransaction(parent, t).events)
+	assert.Empty(t, requireAuditTransaction(cloned, t).events)
+
+	requireAuditTransaction(parent, t).logClose(parent, l, true, nil)
+	require.Len(t, decodeAuditPayloads(t, buf), 1)
+}
+
+func TestLogPolicyCRUDMatchesBufferedSchema(t *testing.T) {
+	tests := []struct {
+		name      string
+		isSuccess bool
+	}{
+		{name: "success", isSuccess: true},
+		{name: "failure", isSuccess: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bufferedLogger, bufferedOutput := createTestLogger()
+			bufferedCtx := createTestContext(t)
+			if test.isSuccess {
+				bufferedLogger.PolicyCRUDSuccess(bufferedCtx, policyCRUDParams)
+			} else {
+				bufferedLogger.PolicyCRUDFailure(bufferedCtx, policyCRUDParams)
+			}
+			requireAuditTransaction(bufferedCtx, t).logClose(bufferedCtx, bufferedLogger, true, nil)
+
+			immediateLogger, immediateOutput := createTestLogger()
+			immediateCtx := immediateLogger.Clone(createTestContext(t))
+			immediateLogger.LogPolicyCRUD(immediateCtx, test.isSuccess, policyCRUDParams)
+
+			bufferedPayloads := decodeAuditPayloads(t, bufferedOutput)
+			immediatePayloads := decodeAuditPayloads(t, immediateOutput)
+			require.Len(t, bufferedPayloads, 1)
+			require.Len(t, immediatePayloads, 1)
+			delete(bufferedPayloads[0], "timestamp")
+			delete(immediatePayloads[0], "timestamp")
+			assert.Equal(t, bufferedPayloads[0], immediatePayloads[0])
+		})
+	}
+}
+
+func TestLogPolicyCRUDUsesJWTEnrichmentFromClonedContext(t *testing.T) {
+	l, buf := createTestLogger()
+	require.NoError(t, l.ApplyConfig(Config{JWTClaimMappings: []JWTClaimMapping{
+		{Claim: "sub", Path: "eventMetaData.requester.sub"},
+		{Claim: "realm_access.roles", Path: "eventMetaData.requester.roles"},
+	}}))
+	token, rawToken := createTestJWTForAudit(t)
+	parent, cancel := context.WithCancel(ctxAuth.ContextWithAuthNInfo(createTestContext(t), nil, token, rawToken))
+	cloned := l.Clone(parent)
+	cancel()
+
+	l.LogPolicyCRUD(cloned, true, policyCRUDParams)
+	payloads := decodeAuditPayloads(t, buf)
+	require.Len(t, payloads, 1)
+	eventMetadata := requireMap(t, payloads[0]["eventMetaData"])
+	requester := requireMap(t, eventMetadata["requester"])
+	assert.Equal(t, "jwt-user", requester["sub"])
+	assert.Equal(t, []any{"admin", "user"}, requester["roles"])
+}
+
+func TestCloneWithoutParentUsesDefaultAttribution(t *testing.T) {
+	l, buf := createTestLogger()
+	cloned := l.Clone(t.Context())
+
+	data := GetAuditDataFromContext(cloned)
+	assert.Equal(t, defaultNone, data.ActorID)
+	assert.Equal(t, defaultNone, data.UserAgent)
+	assert.Equal(t, defaultNone, data.RequestIP)
+	require.NotNil(t, requireAuditTransaction(cloned, t))
+
+	l.LogPolicyCRUD(cloned, true, policyCRUDParams)
+	payloads := decodeAuditPayloads(t, buf)
+	require.Len(t, payloads, 1)
+	assert.Equal(t, "00000000-0000-0000-0000-000000000000", payloads[0]["requestID"])
+}
+
+func TestLogPolicyCRUDWithoutTransactionEmitsImmediately(t *testing.T) {
+	l, buf := createTestLogger()
+
+	l.LogPolicyCRUD(t.Context(), false, policyCRUDParams)
+	payloads := decodeAuditPayloads(t, buf)
+	require.Len(t, payloads, 1)
+	assert.Equal(t, "error", requireMap(t, payloads[0]["action"])["result"])
+}
+
+func decodeAuditPayloads(t *testing.T, logBuffer *bytes.Buffer) []map[string]any {
+	t.Helper()
+
+	decoder := json.NewDecoder(bytes.NewReader(logBuffer.Bytes()))
+	payloads := make([]map[string]any, 0)
+	for decoder.More() {
+		var entry logEntryStructure
+		require.NoError(t, decoder.Decode(&entry))
+		payloads = append(payloads, decodeAuditPayload(t, entry.Audit))
+	}
+	return payloads
+}
+
+func requireAuditTransaction(ctx context.Context, t *testing.T) *auditTransaction {
+	t.Helper()
+	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
+	require.True(t, ok)
+	require.NotNil(t, tx)
+	return tx
+}
+
+func requireMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	mapped, ok := value.(map[string]any)
+	require.True(t, ok)
+	return mapped
+}

--- a/service/logger/audit/clone_test.go
+++ b/service/logger/audit/clone_test.go
@@ -126,13 +126,14 @@ func TestCloneWithoutParentUsesDefaultAttribution(t *testing.T) {
 	assert.Equal(t, "00000000-0000-0000-0000-000000000000", payloads[0]["requestID"])
 }
 
-func TestLogPolicyCRUDWithoutTransactionEmitsImmediately(t *testing.T) {
+func TestLogPolicyCRUDWithoutDetachedContextDoesNotEmit(t *testing.T) {
 	l, buf := createTestLogger()
 
 	l.LogPolicyCRUD(t.Context(), false, policyCRUDParams)
-	payloads := decodeAuditPayloads(t, buf)
-	require.Len(t, payloads, 1)
-	assert.Equal(t, "error", requireMap(t, payloads[0]["action"])["result"])
+	assert.Empty(t, decodeAuditPayloads(t, buf))
+
+	l.LogPolicyCRUD(createTestContext(t), false, policyCRUDParams)
+	assert.Empty(t, decodeAuditPayloads(t, buf))
 }
 
 func decodeAuditPayloads(t *testing.T, logBuffer *bytes.Buffer) []map[string]any {

--- a/service/logger/audit/context.go
+++ b/service/logger/audit/context.go
@@ -36,9 +36,11 @@ func ContextWithActorID(ctx context.Context, actorID string) context.Context {
 	return ctx
 }
 
-// Detach returns a context with an independent copy of the current request's
-// audit attribution. It does not copy pending audit events or alter the parent
-// context's cancellation behavior.
+// Detach returns a non-canceling context with an independent copy of the current
+// request's audit attribution. It does not copy pending audit events. Consumers
+// can add cancellation appropriate to the detached work's lifecycle. Detached
+// audit transactions must log policy events with LogPolicyCRUD; buffered audit
+// methods are only valid for interceptor-owned transactions.
 func (a *Logger) Detach(ctx context.Context) context.Context {
 	tx := &auditTransaction{
 		ContextData: GetAuditDataFromContext(ctx),
@@ -46,5 +48,5 @@ func (a *Logger) Detach(ctx context.Context) context.Context {
 		detached:    true,
 	}
 
-	return context.WithValue(ctx, contextKey{}, tx)
+	return context.WithValue(context.WithoutCancel(ctx), contextKey{}, tx)
 }

--- a/service/logger/audit/context.go
+++ b/service/logger/audit/context.go
@@ -34,3 +34,15 @@ func ContextWithActorID(ctx context.Context, actorID string) context.Context {
 	tx.ActorID = actorID
 	return ctx
 }
+
+// Clone returns a non-canceling context with an independent copy of the current
+// request's audit attribution. It does not copy pending audit events.
+// Should be used by services that require auditting outside of the RPC lifecycle (Ex: asynch job worker)
+func (a *Logger) Clone(ctx context.Context) context.Context {
+	tx := &auditTransaction{
+		ContextData: GetAuditDataFromContext(ctx),
+		events:      make([]pendingEvent, 0),
+	}
+
+	return context.WithValue(context.WithoutCancel(ctx), contextKey{}, tx)
+}

--- a/service/logger/audit/context.go
+++ b/service/logger/audit/context.go
@@ -13,8 +13,9 @@ type contextKey struct{}
 // auditTransaction holds pending audit events to be logged on completion
 type auditTransaction struct {
 	ContextData
-	events []pendingEvent
-	mu     sync.Mutex
+	events   []pendingEvent
+	mu       sync.Mutex
+	detached bool // true only when created by Clone; required by LogPolicyCRUD
 }
 
 func ContextWithActorID(ctx context.Context, actorID string) context.Context {
@@ -37,11 +38,12 @@ func ContextWithActorID(ctx context.Context, actorID string) context.Context {
 
 // Clone returns a non-canceling context with an independent copy of the current
 // request's audit attribution. It does not copy pending audit events.
-// Should be used by services that require auditting outside of the RPC lifecycle (Ex: asynch job worker)
+// Should be used by services that require auditing outside of the RPC lifecycle (Ex: asynch job worker)
 func (a *Logger) Clone(ctx context.Context) context.Context {
 	tx := &auditTransaction{
 		ContextData: GetAuditDataFromContext(ctx),
 		events:      make([]pendingEvent, 0),
+		detached:    true,
 	}
 
 	return context.WithValue(context.WithoutCancel(ctx), contextKey{}, tx)

--- a/service/logger/audit/context.go
+++ b/service/logger/audit/context.go
@@ -15,7 +15,7 @@ type auditTransaction struct {
 	ContextData
 	events   []pendingEvent
 	mu       sync.Mutex
-	detached bool // true only when created by Clone; required by LogPolicyCRUD
+	detached bool // true only when created by Detach; required by LogPolicyCRUD
 }
 
 func ContextWithActorID(ctx context.Context, actorID string) context.Context {
@@ -36,15 +36,15 @@ func ContextWithActorID(ctx context.Context, actorID string) context.Context {
 	return ctx
 }
 
-// Clone returns a non-canceling context with an independent copy of the current
-// request's audit attribution. It does not copy pending audit events.
-// Should be used by services that require auditing outside of the RPC lifecycle (Ex: asynch job worker)
-func (a *Logger) Clone(ctx context.Context) context.Context {
+// Detach returns a context with an independent copy of the current request's
+// audit attribution. It does not copy pending audit events or alter the parent
+// context's cancellation behavior.
+func (a *Logger) Detach(ctx context.Context) context.Context {
 	tx := &auditTransaction{
 		ContextData: GetAuditDataFromContext(ctx),
 		events:      make([]pendingEvent, 0),
 		detached:    true,
 	}
 
-	return context.WithValue(context.WithoutCancel(ctx), contextKey{}, tx)
+	return context.WithValue(ctx, contextKey{}, tx)
 }

--- a/service/logger/audit/detach_test.go
+++ b/service/logger/audit/detach_test.go
@@ -13,19 +13,18 @@ import (
 
 type cloneContextValueKey struct{}
 
-func TestCloneCopiesContextDataAndCreatesIndependentTransaction(t *testing.T) {
+func TestDetachCopiesContextDataAndCreatesIndependentTransaction(t *testing.T) {
 	l, _ := createTestLogger()
 	parent := context.WithValue(createTestContext(t), cloneContextValueKey{}, "retained")
 	parent, cancel := context.WithCancel(parent)
 
 	l.PolicyCRUDSuccess(parent, policyCRUDParams)
-	cloned := l.Clone(parent)
+	cloned := l.Detach(parent)
 	cancel()
 
 	assert.Equal(t, GetAuditDataFromContext(parent), GetAuditDataFromContext(cloned))
 	assert.Equal(t, "retained", cloned.Value(cloneContextValueKey{}))
-	assert.Nil(t, cloned.Done())
-	require.NoError(t, cloned.Err())
+	require.ErrorIs(t, cloned.Err(), context.Canceled)
 
 	parentTx := requireAuditTransaction(parent, t)
 	cloneTx := requireAuditTransaction(cloned, t)
@@ -44,7 +43,7 @@ func TestCloneCopiesContextDataAndCreatesIndependentTransaction(t *testing.T) {
 func TestLogPolicyCRUDEmitsOnceAndParentCloseDoesNotDuplicate(t *testing.T) {
 	l, buf := createTestLogger()
 	parent := createTestContext(t)
-	cloned := l.Clone(parent)
+	cloned := l.Detach(parent)
 
 	l.LogPolicyCRUD(cloned, true, policyCRUDParams)
 	payloads := decodeAuditPayloads(t, buf)
@@ -78,7 +77,7 @@ func TestLogPolicyCRUDMatchesBufferedSchema(t *testing.T) {
 			requireAuditTransaction(bufferedCtx, t).logClose(bufferedCtx, bufferedLogger, true, nil)
 
 			immediateLogger, immediateOutput := createTestLogger()
-			immediateCtx := immediateLogger.Clone(createTestContext(t))
+			immediateCtx := immediateLogger.Detach(createTestContext(t))
 			immediateLogger.LogPolicyCRUD(immediateCtx, test.isSuccess, policyCRUDParams)
 
 			bufferedPayloads := decodeAuditPayloads(t, bufferedOutput)
@@ -100,7 +99,7 @@ func TestLogPolicyCRUDUsesJWTEnrichmentFromClonedContext(t *testing.T) {
 	}}))
 	token, rawToken := createTestJWTForAudit(t)
 	parent, cancel := context.WithCancel(ctxAuth.ContextWithAuthNInfo(createTestContext(t), nil, token, rawToken))
-	cloned := l.Clone(parent)
+	cloned := l.Detach(context.WithoutCancel(parent))
 	cancel()
 
 	l.LogPolicyCRUD(cloned, true, policyCRUDParams)
@@ -112,9 +111,9 @@ func TestLogPolicyCRUDUsesJWTEnrichmentFromClonedContext(t *testing.T) {
 	assert.Equal(t, []any{"admin", "user"}, requester["roles"])
 }
 
-func TestCloneWithoutParentUsesDefaultAttribution(t *testing.T) {
+func TestDetachWithoutParentUsesDefaultAttribution(t *testing.T) {
 	l, buf := createTestLogger()
-	cloned := l.Clone(t.Context())
+	cloned := l.Detach(t.Context())
 
 	data := GetAuditDataFromContext(cloned)
 	assert.Equal(t, defaultNone, data.ActorID)

--- a/service/logger/audit/detach_test.go
+++ b/service/logger/audit/detach_test.go
@@ -24,7 +24,8 @@ func TestDetachCopiesContextDataAndCreatesIndependentTransaction(t *testing.T) {
 
 	assert.Equal(t, GetAuditDataFromContext(parent), GetAuditDataFromContext(cloned))
 	assert.Equal(t, "retained", cloned.Value(cloneContextValueKey{}))
-	require.ErrorIs(t, cloned.Err(), context.Canceled)
+	assert.Nil(t, cloned.Done())
+	require.NoError(t, cloned.Err())
 
 	parentTx := requireAuditTransaction(parent, t)
 	cloneTx := requireAuditTransaction(cloned, t)
@@ -99,7 +100,7 @@ func TestLogPolicyCRUDUsesJWTEnrichmentFromClonedContext(t *testing.T) {
 	}}))
 	token, rawToken := createTestJWTForAudit(t)
 	parent, cancel := context.WithCancel(ctxAuth.ContextWithAuthNInfo(createTestContext(t), nil, token, rawToken))
-	cloned := l.Detach(context.WithoutCancel(parent))
+	cloned := l.Detach(parent)
 	cancel()
 
 	l.LogPolicyCRUD(cloned, true, policyCRUDParams)

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -144,7 +144,7 @@ func (a *Logger) PolicyCRUDFailure(ctx context.Context, eventParams PolicyEventP
 func (a *Logger) LogPolicyCRUD(ctx context.Context, isSuccess bool, eventParams PolicyEventParams) {
 	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
 	if !ok || tx == nil || !tx.detached {
-		a.logger.ErrorContext(ctx, "immediate policy CRUD audit logging requires a detached audit context; use Logger.Clone first")
+		a.logger.ErrorContext(ctx, "immediate policy CRUD audit logging requires a detached audit context; use Logger.Detach first")
 		return
 	}
 

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -178,8 +178,11 @@ func (a *Logger) GetDecisionV2(ctx context.Context, eventParams GetDecisionV2Eve
 
 func LogAuditEvent(ctx context.Context, verb Verb, event *EventObject) {
 	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
-	if !ok {
+	if !ok || tx == nil {
 		panic("audit transaction missing from context")
+	}
+	if tx.detached {
+		panic("cannot buffer an audit event on a detached transaction; use Logger.LogPolicyCRUD")
 	}
 	if event == nil {
 		panic("nil audit event provided")

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -137,6 +137,21 @@ func (a *Logger) PolicyCRUDFailure(ctx context.Context, eventParams PolicyEventP
 	a.policyCrudBase(ctx, false, eventParams)
 }
 
+// LogPolicyCRUD creates and immediately emits a policy CRUD audit event. It is
+// intended for work whose lifetime is not owned by an RPC audit transaction.
+// If you are within a synchronous policy operation you should use: PolicyCRUDSuccess/Failure.
+// ! Use this carefully to avoid duplication of audit events from being recorded.
+func (a *Logger) LogPolicyCRUD(ctx context.Context, isSuccess bool, eventParams PolicyEventParams) {
+	auditEvent, err := CreatePolicyEvent(ctx, isSuccess, eventParams)
+	if err != nil {
+		a.logger.ErrorContext(ctx, "error creating policy attribute audit event", slog.Any("error", err))
+		return
+	}
+
+	//nolint:sloglint // audit message is always just the verb
+	a.logger.Log(ctx, LevelAudit, string(VerbPolicyCRUD), slog.Any("audit", a.buildLogEntry(ctx, auditEvent)))
+}
+
 func (a *Logger) GetDecision(ctx context.Context, eventParams GetDecisionEventParams) {
 	auditEvent, err := CreateGetDecisionEvent(ctx, eventParams)
 	if err != nil {

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -144,7 +144,7 @@ func (a *Logger) PolicyCRUDFailure(ctx context.Context, eventParams PolicyEventP
 func (a *Logger) LogPolicyCRUD(ctx context.Context, isSuccess bool, eventParams PolicyEventParams) {
 	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
 	if !ok || tx == nil || !tx.detached {
-		a.logger.ErrorContext(ctx, "LogPolicyCRUD requires a detached audit context; use Logger.Clone first")
+		a.logger.ErrorContext(ctx, "immediate policy CRUD audit logging requires a detached audit context; use Logger.Clone first")
 		return
 	}
 

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -142,6 +142,12 @@ func (a *Logger) PolicyCRUDFailure(ctx context.Context, eventParams PolicyEventP
 // If you are within a synchronous policy operation you should use: PolicyCRUDSuccess/Failure.
 // ! Use this carefully to avoid duplication of audit events from being recorded.
 func (a *Logger) LogPolicyCRUD(ctx context.Context, isSuccess bool, eventParams PolicyEventParams) {
+	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
+	if !ok || tx == nil || !tx.detached {
+		a.logger.ErrorContext(ctx, "LogPolicyCRUD requires a detached audit context; use Logger.Clone first")
+		return
+	}
+
 	auditEvent, err := CreatePolicyEvent(ctx, isSuccess, eventParams)
 	if err != nil {
 		a.logger.ErrorContext(ctx, "error creating policy attribute audit event", slog.Any("error", err))


### PR DESCRIPTION
## Summary

  Expose audit logging support for asynchronous work that outlives the originating RPC.

  ## Changes

  - Added `Audit.Detach(ctx)` to:
    - Preserve request audit attribution and other context values.
    - Detach cancellation from the originating RPC.
    - Create an independent audit transaction without copying pending events.
   

  - Added `Audit.LogPolicyCRUD(...)` to:
    - Emit policy CRUD audit events immediately.
    - Support background jobs outside the RPC interceptor lifecycle.
    - Log event-construction errors internally.
    - Guard against misuse with the detached flag

  - Existing synchronous `LogAuditEvent` guards against detached auditTransactions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for immediately recording policy create, update, and delete audit events outside an RPC transaction.
  * Added context cloning that preserves audit attribution while isolating pending events.
* **Bug Fixes**
  * Improved consistency between buffered and immediate audit event records.
  * Preserved JWT claim details and default attribution across cloned contexts.
  * Prevented duplicate or unintended audit event emission.
* **Tests**
  * Expanded coverage for transaction independence, event emission, attribution, and audit payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->