### PR TITLE
adr(kas): DPoP and rewrap hardening audit, plus pluggable store ADR

### DIFF
--- a/adr/decisions/2026-08-15-pluggable-dpop-replay-and-nonce-stores.md
+++ b/adr/decisions/2026-08-15-pluggable-dpop-replay-and-nonce-stores.md
@@ -1,0 +1,288 @@
+---
+status: 'proposed'
+date: '2026-08-15'
+tags:
+ - auth
+ - dpop
+ - kas
+ - scalability
+driver: '@dmihalcik-virtru'
+---
+# Pluggable DPoP Replay and Nonce Stores
+
+## Context and Problem Statement
+
+DPoP proof validation keeps two pieces of server-side state, both of which are
+per-process and in-memory today:
+
+- **`jti` replay cache** (`service/internal/auth/dpop_replay.go`): a
+  mutex-guarded `map[string]time.Time`, TTL set to `DPoPSkew` (default `1h`),
+  swept by a scan throttled to once per TTL.
+- **Server nonce** (`dpopNonceManager`, `service/internal/auth/authn.go:141`):
+  a random 16-byte value generated at process start, rotated lazily on read,
+  with the current and previous values accepted.
+
+Neither survives horizontal scaling, which is the deployment style the platform
+is actually run in:
+
+1. **Replay protection does not hold across replicas.** An attacker who captures
+   a DPoP proof replays it against a different replica, whose cache has never
+   seen the `jti`. With `DPoPSkew: 1h` the proof stays usable for an hour. The
+   protection the code advertises (RFC 9449 §11.1) is only real for a
+   single-process deployment.
+2. **`require_nonce: true` is unusable behind a load balancer.** Each replica
+   mints its own nonce, so a client that obtains a nonce from replica A and
+   lands on replica B gets `use_dpop_nonce`, retries, gets B's nonce, and then
+   may land on C. Clients bounce through challenge/retry indefinitely instead of
+   converging. This is why `require_nonce` still defaults to `false`
+   (`service/internal/auth/config.go:49`) despite the machinery being complete.
+
+We need both stores to be replaceable by deployment-appropriate backends
+without forcing a shared-state dependency on every operator, and without adding
+a network round trip to the hot path where it can be avoided.
+
+## Decision Drivers
+
+* Correct replay and nonce semantics across N replicas, with no load-balancer
+  affinity requirement.
+* No new mandatory infrastructure dependency for single-node and dev
+  deployments.
+* Hot-path latency: rewrap already pays asymmetric crypto plus an authorization
+  round trip; DPoP validation must not add a second unavoidable network hop.
+* Extensibility by embedders, matching the pattern already established for
+  role providers (`service/pkg/authz/role_provider.go`,
+  `WithAuthZRoleProviderFactory`).
+* Explicit, configurable behavior when a backing store is unavailable — no
+  silent downgrade of a security control.
+
+## Considered Options
+
+* **A. Shared cache for both stores.** Put `jti` and the nonce in Redis/Valkey.
+  Correct, but makes a shared cache mandatory for anyone enforcing DPoP, and
+  puts a network round trip in front of every authenticated request including
+  the nonce read.
+* **B. Sticky sessions.** Pin clients to replicas at the load balancer. Rejected:
+  pushes a security requirement into infrastructure the platform does not
+  control, breaks on rescale, and does nothing for replay across a rolling
+  deploy.
+* **C. Pluggable interfaces, with a stateless nonce as the default answer for
+  multi-replica.** Define `ReplayGuard` and `NonceSource` interfaces plus a
+  factory registry. Ship an in-memory driver (today's behavior, honest about
+  its scope), an HMAC-derived stateless nonce driver that needs no coordination
+  at all, and let operators plug a shared store for `jti` when they need
+  cross-replica replay protection.
+
+## Decision Outcome
+
+Chosen option: **C**.
+
+The two problems are not symmetric and should not get the same solution:
+
+- **Nonces do not need shared state.** A nonce only has to be recognizable by
+  the issuer as recent and self-issued. Deriving it as
+  `HMAC(K, time_bucket)` makes every replica holding `K` able to issue and
+  validate the same nonce with zero coordination, zero storage, and zero extra
+  latency. This eliminates the load-balancer problem outright rather than
+  distributing the state.
+- **Replay detection genuinely needs a shared decision point** — it is a
+  distributed uniqueness claim. That cost is real, so it is opt-in, it is one
+  atomic round trip, and the acceptance window shrinks so the store stays small.
+
+### Interfaces
+
+New exported package `service/pkg/auth/dpop`, so out-of-tree deployments can
+implement drivers (siblings to `service/pkg/authz`):
+
+```go
+// Package dpop defines the pluggable state stores used by DPoP proof validation.
+package dpop
+
+// ReplayGuard records single-use DPoP proof identifiers (RFC 9449 §11.1).
+type ReplayGuard interface {
+	// Observe atomically records id for ttl and reports whether it had already
+	// been recorded.
+	//
+	// Implementations MUST be atomic with respect to every other caller sharing
+	// the same backend: of N concurrent Observe calls carrying the same id,
+	// exactly one returns seen=false. A read-then-write implementation is not
+	// acceptable; the TOCTOU window is precisely the race an attacker replays into.
+	//
+	// A non-nil error means the guard could not reach a decision. Callers apply
+	// the configured on-error policy; they MUST NOT treat an error as seen=false.
+	Observe(ctx context.Context, id string, ttl time.Duration) (seen bool, err error)
+}
+
+// NonceSource issues and validates server nonces (RFC 9449 §8, §9).
+type NonceSource interface {
+	// Issue returns the nonce to advertise in a DPoP-Nonce response header.
+	Issue(ctx context.Context) (string, error)
+	// Validate reports whether nonce is currently acceptable. It returns nil when
+	// the nonce is good, ErrNonceStale when the client should retry with a fresh
+	// one, and ErrNonceMalformed when the proof is simply invalid.
+	Validate(ctx context.Context, nonce string) error
+}
+
+var (
+	// ErrNonceStale is retryable: the caller answers with a use_dpop_nonce
+	// challenge and a fresh DPoP-Nonce header.
+	ErrNonceStale = errors.New("dpop nonce expired or unrecognized")
+	// ErrNonceMalformed is not retryable: the caller answers with
+	// invalid_dpop_proof.
+	ErrNonceMalformed = errors.New("dpop nonce malformed")
+)
+
+// Factories construct drivers at startup.
+type (
+	ReplayGuardFactory func(ctx context.Context, cfg ProviderConfig, log *logger.Logger) (ReplayGuard, error)
+	NonceSourceFactory func(ctx context.Context, cfg ProviderConfig, log *logger.Logger) (NonceSource, error)
+)
+
+// ProviderConfig carries driver-specific settings plus the window the
+// authenticator enforces, so drivers can size themselves without duplicating
+// configuration.
+type ProviderConfig struct {
+	Config map[string]any
+	Window time.Duration
+}
+```
+
+`Validate` returning a typed error rather than `bool` is deliberate: it maps
+directly onto the existing retryable/non-retryable split
+(`DPoPNonceError` vs `DPoPNonceMalformedError`, `authn.go:364-380`), which the
+current `validateNonce() bool` collapses and then reconstructs at the call site.
+
+### Built-in drivers
+
+**`ReplayGuard`**
+
+| Driver | Semantics | When to use |
+|---|---|---|
+| `memory` (default) | Time-bucketed sharded maps; O(1) eviction by dropping whole buckets instead of the current throttled full scan. | Single replica, dev, and deployments that accept per-replica scope. |
+| `none` | Always returns `seen=false`. | Explicit, audited opt-out — better than a store that looks like it works and does not. |
+| *registered* | Supplied by the embedder via factory. | Redis/Valkey, DynamoDB, any store with a conditional insert. |
+
+A shared driver's `Observe` is one atomic conditional insert, e.g. Redis
+`SET dpop:jti:<id> 1 NX PX <ttl>` where a nil reply means "already present".
+Note that `service/pkg/cache.Cache` is deliberately **not** used for this: its
+`Get`/`Set` pair (`service/pkg/cache/cache.go:95-131`) is not atomic, so a
+guard built on it would have exactly the race `Observe` forbids.
+
+Any remote guard is wrapped in a **tiered guard**: consult the local
+time-bucketed map first and reject immediately on a local hit, otherwise fall
+through to the remote store and record locally. Detected replays then cost zero
+network; only first-sight proofs pay the round trip.
+
+**`NonceSource`**
+
+| Driver | Semantics | When to use |
+|---|---|---|
+| `memory` (default) | Today's per-process random nonce, current + previous accepted. | Single replica, dev. Startup warns when combined with `require: true`. |
+| `hmac` | Stateless, derived below. | Any multi-replica deployment. |
+| *registered* | Supplied by the embedder. | Shared-store or HSM-backed variants. |
+
+Stateless nonce construction:
+
+```
+bucket = floor(unix_seconds / expiration_seconds)
+tag    = HMAC-SHA256(K_kid, "opentdf-dpop-nonce/v1" || uint32_be(bucket))
+nonce  = base64url( uint32_be(bucket) || kid || tag[0:15] )
+```
+
+20 bytes, 27 base64url characters. Validation decodes the bucket and key id,
+recomputes the tag, compares in constant time, and accepts
+`bucket ∈ {current, current-1}` so a client is never rejected for straddling a
+boundary. Key rotation is a newest-first list of secrets keyed by `kid`, so `K`
+can be rolled with an overlap window. `K` is required configuration when
+`nonce.driver: hmac`; startup fails rather than silently generating a
+per-process secret, which would reintroduce the bug this driver exists to fix.
+
+Beyond fixing the load-balancer problem, this delivers the property RFC 9449
+§11.1 calls out — "a server managed timestamp via the nonce claim" — so proof
+freshness stops depending on client clock accuracy, which is what forces the
+`DPoPSkew` window to be generous today.
+
+### Configuration
+
+```yaml
+server:
+  auth:
+    dpop:
+      enforce: true
+      strict_htu: true
+      skew: 1m                 # proof acceptance window; also the replay TTL
+      replay:
+        driver: memory         # memory | none | <registered name>
+        on_error: deny         # deny | allow | local
+        config: {}
+      nonce:
+        require: false
+        driver: memory         # memory | hmac | <registered name>
+        expiration: 5m
+        config:
+          secrets:             # hmac driver
+            - kid: "1"
+              secret_ref: env:DPOP_NONCE_SECRET
+```
+
+`on_error` governs a guard that returns an error, and is a genuine
+availability/security trade rather than something to pick a default for
+silently:
+
+- `deny` (default) — fail closed. A store outage stops rewraps.
+- `local` — degrade to the in-memory guard, emit an audit event and a metric.
+  Recommended for deployments that cannot trade availability for this control.
+- `allow` — skip the check, emit an audit event and a metric.
+
+Factories are injected exactly like role providers: `mapstructure:"-"` fields on
+`auth.Config`, populated from new `WithDPoPReplayGuardFactory(name, factory)` and
+`WithDPoPNonceSourceFactory(name, factory)` start options
+(`service/pkg/server/options.go:162` is the model), and resolved in
+`NewAuthenticator` by `resolveReplayGuard`/`resolveNonceSource` mirroring
+`resolveRoleProvider` (`service/internal/auth/authn.go:323`).
+
+### Validation ordering
+
+`validateDPoP` keeps checking `jti` **last**, after signature verification
+(`service/internal/auth/authn.go:1304-1317`). It is tempting to start the
+`Observe` round trip early and join later to hide its latency behind signature
+verification, but that would let unauthenticated garbage proofs write into a
+shared store — a cheap remote-fill DoS. Signature verification is well under a
+millisecond; the ordering property is worth more than the overlap.
+
+### Observability
+
+Every driver reports through the existing OTel pipeline:
+
+- `dpop.replay.observe.duration` (histogram, tagged by driver and outcome)
+- `dpop.replay.rejected` (counter)
+- `dpop.replay.store_error` (counter, tagged by applied `on_error` policy)
+- `dpop.nonce.challenge_issued` / `dpop.nonce.rejected` (counters)
+
+`dpop.replay.store_error` with `on_error: local|allow` is the signal that a
+security control is silently degraded, and should be alerted on.
+
+## Consequences
+
+* Good: `require_nonce: true` becomes deployable at scale with no shared state
+  and no extra latency.
+* Good: cross-replica replay protection becomes available to operators who want
+  it, without imposing a dependency on those who do not.
+* Good: the default configuration's actual guarantee (per-replica) becomes
+  explicit at startup instead of implied by code comments.
+* Good: replaces a throttled full-map scan with O(1) bucket eviction.
+* Bad: three more configuration knobs, and a security control whose strength now
+  varies by deployment — mitigated by startup warnings and the metrics above.
+* Bad: a shared replay driver adds one round trip to first-sight proofs, and its
+  outage becomes a rewrap-availability event under the default `deny` policy.
+
+## Migration
+
+1. Land interfaces, drivers, and config with `memory` defaults — no behavior
+   change.
+2. Warn at startup when `enforce: true` and `replay.driver: memory`, stating
+   that replay protection is per-replica.
+3. Shrink `skew` from `1h` to `1m` (tracked separately; see
+   `docs/dpop-rewrap-hardening.md`), which shrinks replay state proportionally
+   and makes a shared store cheap.
+4. Document `nonce.driver: hmac` as the required setting for multi-replica
+   deployments that enable `require: true`.

--- a/docs/dpop-rewrap-hardening.md
+++ b/docs/dpop-rewrap-hardening.md
@@ -1,0 +1,246 @@
+# DPoP and Rewrap Hardening
+
+Findings and proposed fixes from an audit of how DPoP interacts with the rewrap
+protocol, covering both the implementation (`service/internal/auth`,
+`service/kas/access`, `sdk/`) and the BaseTDF specification suite
+(`spec/basetdf/`, v4.4 and v5).
+
+Pluggable replay/nonce stores are designed separately in
+[ADR: Pluggable DPoP Replay and Nonce Stores](../adr/decisions/2026-08-15-pluggable-dpop-replay-and-nonce-stores.md);
+this document covers everything else.
+
+## Background: the three-signature stack
+
+A rewrap request carries three signed artifacts, two of them signed by the same
+client key:
+
+| # | Artifact | Signer | Claims | Verified at |
+|---|---|---|---|---|
+| 1 | Access token | IdP | `cnf.jkt` = SHA-256 thumbprint of the client DPoP key | `service/internal/auth/token_verifier.go` |
+| 2 | DPoP proof (`DPoP:` header) | Client DPoP key | `typ`, `jwk`, `jti`, `htm`, `htu`, `iat`, `ath`, `nonce?` | `service/internal/auth/authn.go:1163` |
+| 3 | SRT (`signedRequestToken`) | Same DPoP key | `requestBody`, `iat`, `exp` | `service/kas/access/rewrap.go:373` |
+
+The two layers are joined only through request context: the authenticator stores
+the verified DPoP JWK (`authn.go:1159`) and the KAS retrieves it to verify the
+SRT (`rewrap.go:381`, `:403`).
+
+Artifact 2 already provides everything RFC 9449 promises. Artifact 3 contributes
+exactly one non-redundant property: integrity of the request body, which
+RFC 9449 §11.7 explicitly declines to cover. Everything else about the SRT is a
+duplicate signature, a duplicate temporal window with its own skew setting, and
+a second serialization of the request body.
+
+## Implementation fixes
+
+### P0-1 — The SRT is unverified in the default configuration
+
+`DPoP.Enforce` defaults to `false` (`service/internal/auth/config.go:48`). When
+the access token has no `cnf` claim, `checkToken` returns before `validateDPoP`
+(`authn.go:1140`), so no JWK reaches the context, so `requireVerification` is
+false and `verifySRTSignature` never runs (`rewrap.go:384-406`). In the default
+posture the SRT is parsed and trusted, providing no integrity at all.
+
+**Fix:** default `server.auth.dpop.enforce` to `true`. For deployments that must
+run without DPoP, keep the request working but record the fact — see P1-4.
+
+### P0-2 — Proof acceptance window is one hour
+
+`DPoPSkew` defaults to `1h` (`config.go:34`) and gates the `iat` freshness check
+(`authn.go:1242`). It also sets the replay cache TTL (`authn.go:205-208`), so a
+captured proof is usable for an hour and the cache retains an hour of `jti`
+values. The future-dated direction is fine: `jwt.Parse` validates by default and
+a `+2h` `iat` is rejected (`authn_test.go:1062`).
+
+**Fix:** default to `1m`, matching `TokenSkew` and
+`config.DefaultUnsafeClockSkew`. With the `hmac` nonce driver from the ADR,
+freshness no longer depends on client clocks, so a tight window is safe.
+
+### P0-3 — The client rewrap key is not ephemeral
+
+Both specs argue that rewrap replay is harmless because the response is
+encrypted to a per-request ephemeral key (`basetdf-kas.md` §11.5,
+`basetdf-sec.md:344`). The Go SDK generates **one** RSA-2048 `kasSessionKey` per
+SDK instance and reuses it for the process lifetime (`sdk/sdk.go:140-145`,
+`sdk/options.go:50`). A replayed rewrap is therefore decryptable by anyone
+holding that long-lived key, and there is no forward secrecy across requests.
+
+**Fix:** generate the rewrap recipient key per request (or per decrypt
+operation), and default it to EC P-256 rather than RSA-2048 — smaller, faster,
+and the algorithm path the spec recommends. Verify the Java and JS SDKs for the
+same pattern before relying on the spec claim.
+
+### P1-1 — DPoP-bound tokens are accepted under the `Bearer` scheme
+
+RFC 9449 §7.1 requires a `cnf`-bearing token to be presented as
+`Authorization: DPoP`. The code detects the violation and only warns
+(`authn.go:1133-1139`).
+
+**Fix:** promote to a hard rejection behind a config flag, default it on one
+release later. The warning has been in place long enough to identify
+non-compliant SDKs; check xtest results for java/js before flipping.
+
+### P1-2 — The SRT is not audience-bound
+
+The SRT carries only `requestBody`, `iat`, and `exp`
+(`sdk/kas_client.go:347-355`) — no `aud`, `htu`, `jti`, or `ath`. With DPoP
+enforced, the proof's `htu` prevents cross-KAS replay. With DPoP off, nothing
+does: in a split-key TDF, a malicious KAS-A can forward the client's bearer
+token and SRT verbatim to KAS-B. The forwarded request yields a key wrapped to
+the original client's public key, so KAS-A learns nothing, but it is an
+unattributed access against KAS-B's policy and audit log.
+
+**Fix:** add `aud` (the KAS URL) to the SRT and require the KAS to check it.
+Superseded by P2-1 if that lands first.
+
+### P1-3 — No rate limiting on rewrap
+
+`basetdf-kas.md` §7 says the KAS SHOULD rate limit per entity; there is no rate
+limiting anywhere in `service/kas`. Replay protection and rate limiting solve
+different halves of the same abuse problem — a valid credential can still probe
+the KAS as a chosen-policy oracle with fresh, non-replayed proofs.
+
+**Fix:** per-entity (`sub` + `cnf.jkt`) token bucket on `/kas.AccessService/Rewrap`,
+returning 429 with `Retry-After`. Shares the same pluggable-store problem as the
+replay guard, so it should reuse that driver registry.
+
+### P1-4 — Audit records do not identify the proving key or the binding mode
+
+`RewrapAuditEventParams` (`service/logger/audit/rewrap.go:22-29`) records policy,
+algorithm, key id, and policy binding, but not the DPoP key thumbprint and not
+whether the request was DPoP-bound at all. Neither does the spec's required
+field list (`basetdf-kas.md` §6.2). Without the thumbprint there is no way to
+correlate abuse to a key, and no way to tell a bound request from an unbound one
+after the fact.
+
+**Fix:** add `dpopJkt` (thumbprint, already computable — see
+`jwkThumbprintAttr`, `rewrap.go:143`) and `dpopBound` (bool) to the event
+metadata, and to the spec's minimum field list.
+
+### P2-1 — Fold the body binding into the DPoP proof and retire the SRT
+
+RFC 9449 §4.2 permits additional claims, and §11.7 explicitly endorses this use:
+*"additional information to be signed can be added into DPoP proofs."* Two
+variants, in increasing order of coverage:
+
+- **`cpk_jkt`** — thumbprint of the client's ephemeral rewrap key. Fixed size,
+  no canonicalization concerns, and it states the actual invariant: the holder
+  of the auth key is also the intended recipient of the DEK. A MITM can still
+  substitute KAOs (denial, audit noise) but cannot redirect key material.
+- **`rbh`** — base64url(SHA-256(request body)), covering the whole body. Stronger,
+  but requires hashing the exact bytes received, because protobuf serialization
+  is not canonical across language implementations. Practical approach: keep the
+  body as an opaque JSON string field (which is what the `requestBody` claim
+  already is) and hash that string, sidestepping canonicalization entirely.
+
+Either way the request loses a signature, a duplicate temporal window, and a
+~1.4× re-encoding of the body. Do not put the body itself in the proof — it is
+an HTTP header and bulk rewrap would exceed the usual 8–16 KB limits.
+
+The standards-track spelling of this is `Content-Digest` (RFC 9530) with
+RFC 9421 HTTP Message Signatures; neither is vendored in the local reference
+library, so confirm the details against the RFCs before writing spec text.
+
+### P2-2 — Do not reuse the DPoP key as the rewrap recipient key
+
+Recorded because it is the obvious-looking simplification and it is wrong: RSA
+signing keys must not double as RSA-OAEP keys; browser WebCrypto DPoP keys are
+created with `key_ops: ["sign"]` and cannot perform ECDH; and DPoP keys are
+session-lifetime, which would destroy the per-request property P0-3 restores.
+Bind the ephemeral key to the DPoP key (P2-1), do not merge them.
+
+### P2-3 — Minor cleanups
+
+- `verifySRTSignature` reads `alg` from the SRT header and only checks it against
+  an allowlist (`rewrap.go:277-299`). A mismatch against the DPoP key type fails
+  verification, so this is not exploitable, but constraining `alg` to the key's
+  family is cheap defense in depth.
+- The `X-Virtrupubkey` legacy header is logged and otherwise unused
+  (`rewrap.go:376-378`). Remove it or document why it is retained.
+- `getCurrentNonce()` mutates state on a read path (`authn.go:178-193`). Resolved
+  by the `hmac` driver in the ADR.
+- The replay cache sweep is a throttled full scan (`dpop_replay.go:45-55`).
+  Resolved by time-bucketed eviction in the ADR.
+
+## Specification changes
+
+Applies to `spec/basetdf/basetdf-kas.md` and `basetdf-sec.md`; the v4.4 and v5
+authentication sections are currently byte-identical, so both need the edit.
+
+### S-1 — §4 understates what the implementation does
+
+`basetdf-kas.md` §4.2 lists three verification steps (extract DPoP key, verify
+SRT signature, validate SRT temporal claims). It says nothing about `jti` replay
+rejection, the proof acceptance window, `htm`/`htu` binding, `ath`, or server
+nonces — all of which the platform implements. An independent implementation
+following the spec literally would be materially weaker.
+
+**Fix:** add a subsection enumerating proof checks by reference to RFC 9449 §4.3,
+marking `jti` replay detection RECOMMENDED and nonce support OPTIONAL, and
+stating the acceptance window as a bounded, configurable value.
+
+### S-2 — §11.5 and `basetdf-sec.md:344` rest on a property no SDK provides
+
+Both make the replay argument from a per-request ephemeral client key. See P0-3.
+
+**Fix:** state the ephemerality requirement normatively — the client MUST
+generate a fresh key pair per rewrap request — or weaken the replay claim to
+match reality. The first is preferable; the second is dishonest about the
+residual risk.
+
+### S-3 — §4.3 should say plainly that non-DPoP mode has no body integrity
+
+The current text ("the KAS MUST still verify the SRT structure and extract the
+request body") reads as though something is verified. Without a DPoP key there
+is nothing to verify the signature against.
+
+**Fix:** state that in non-DPoP deployments the SRT signature is unverifiable and
+the request body has only TLS-level integrity, and that the deployment therefore
+does not satisfy SI-4.
+
+### S-4 — SI-4 should require audience binding
+
+Add to `basetdf-sec.md` SI-4: the SRT (or its successor claim) MUST be bound to
+the specific KAS, so a request captured by one KAS cannot be presented to
+another. See P1-2.
+
+### S-5 — Add a deployment-considerations section
+
+Neither document acknowledges that replay and nonce state are per-instance in a
+scaled deployment. Add to `basetdf-kas.md` §11: implementations that detect
+replay MUST either share that state across instances or derive it statelessly,
+and MUST document which guarantee they provide.
+
+### S-6 — §6.2 audit fields
+
+Add the DPoP key thumbprint and a DPoP-bound indicator to the minimum audit
+field list. See P1-4.
+
+### S-7 — Pin hash agility
+
+`jkt` and `ath` are SHA-256 throughout. RFC 9449 §11.10 raises hash agility as a
+future concern. Pin SHA-256 explicitly in the spec rather than leaving it
+implied, so a future change is a versioned decision rather than a silent
+divergence.
+
+### S-8 — Document the v5 direction for the SRT
+
+If P2-1 is accepted, `spec/basetdf/v5/basetdf-kas.md` §3.2 and §4 should describe
+the DPoP-proof claim as the primary mechanism with the SRT retained for
+backward compatibility, and the terminology table entry for SRT marked
+deprecated.
+
+## Cross-SDK validation
+
+Every item touching the wire format needs xtest coverage before it ships,
+because the java and js SDKs build their own proofs and SRTs:
+
+- P0-1 (`enforce: true` by default) — confirm all three SDKs send proofs on the
+  rewrap path, not just the token endpoint.
+- P0-3 (ephemeral recipient key) — verify per-SDK; the property is claimed
+  normatively but implemented per-SDK.
+- P1-1 (`Bearer` rejection) — this is the item most likely to break a client.
+- P2-1 (new proof claim) — needs a negotiated rollout: KAS accepts either form
+  until all SDKs emit the new claim.
+
+Run with the branch under test wired into each `*-ref` input, and confirm
+`test_dpop.py` actually ran rather than being skipped (see `AGENTS.md`).


### PR DESCRIPTION
### Proposed Changes

Docs only — parking an audit of how DPoP interacts with the rewrap protocol so the work can be picked up later. **No code changes, nothing implemented yet.**

* `docs/dpop-rewrap-hardening.md` — findings from auditing `service/internal/auth`, `service/kas/access`, `sdk/`, and the BaseTDF suite (v4.4 and v5).
* `adr/decisions/2026-08-15-pluggable-dpop-replay-and-nonce-stores.md` — ADR, status `proposed`.

#### The framing result

A rewrap request carries three signed artifacts: the access token (IdP-signed, `cnf.jkt`), the DPoP proof, and the `signedRequestToken`. The latter two are signed by the *same* client key. The SRT contributes exactly one property the DPoP proof does not — request-body integrity, which RFC 9449 §11.7 explicitly declines to cover. Everything else it does is a duplicate signature over a second serialization of the body, with its own independent skew setting.

#### Selected findings

* **P0-1 — the SRT is unverified in the default configuration.** `DPoP.Enforce` defaults to `false`, so when the access token has no `cnf` claim `checkToken` returns before `validateDPoP`, no JWK reaches the request context, `requireVerification` is false, and `verifySRTSignature` never runs. The SRT is parsed and trusted.
* **P0-2 — one-hour proof acceptance window.** `DPoPSkew` defaults to `1h` and also sets the replay cache TTL.
* **P0-3 — the client rewrap key is not ephemeral.** Both specs argue replay is harmless because the response is encrypted to a per-request ephemeral key, but the Go SDK generates one RSA-2048 `kasSessionKey` per SDK instance and reuses it for the process lifetime. Java and JS need checking for the same pattern.

#### The ADR

Proposes `ReplayGuard` and `NonceSource` interfaces in a new exported `service/pkg/auth/dpop` package, injected by factory the same way `authz` role providers already are.

The decision splits the two stores rather than putting both behind a shared cache, because the problems are not symmetric:

* **Nonces need no shared state.** A nonce only has to be recognizable by its issuer as recent and self-issued, so deriving it as `HMAC(K, time_bucket)` lets every replica issue and validate the same nonce with zero coordination. This eliminates the load-balancer problem outright rather than distributing the state — which is what currently keeps `require_nonce` at `false` despite the machinery being complete.
* **Replay detection is a genuine distributed uniqueness claim.** That cost is real, so a shared driver stays opt-in, is one atomic conditional insert, and carries an explicit `on_error` policy (`deny` / `local` / `allow`) instead of silently degrading a security control.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation

### Testing Instructions

Nothing to test — documentation only. Review is of the analysis and the proposed design.

Open questions worth arguing about before any implementation lands:

1. Is the SRT worth keeping at all once DPoP is enforced, or should request-body integrity move into the DPoP proof (e.g. a body-hash claim)?
2. Is `deny` the right default for `on_error`, given it turns a replay-store outage into a rewrap-availability event?
3. Does dropping `DPoPSkew` from `1h` to `1m` break any real deployment that is not already broken?
