### PR TITLE
feat(kas): Move key_management to stable

### DIFF
--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -390,7 +390,6 @@ Root level key `kas`
 Environment Variables:
 
 ```shell
-OPENTDF_SERVICES_KAS_KEY_MANAGEMENT=true
 OPENTDF_SERVICES_KAS_KEYRING='[{"kid":"k1","alg":"rsa:2048"},{"kid":"k2","alg":"ec:secp256r1"}]'
 ```
 

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -387,16 +387,24 @@ Root level key `services`
 
 Root level key `kas`
 
-Environment Variable: `OPENTDF_SERVICES_KAS_KEYRING='[{"kid":"k1","alg":"rsa:2048"},{"kid":"k2","alg":"ec:secp256r1"}]'`
+Environment Variables:
+
+```shell
+OPENTDF_SERVICES_KAS_KEY_MANAGEMENT=true
+OPENTDF_SERVICES_KAS_KEYRING='[{"kid":"k1","alg":"rsa:2048"},{"kid":"k2","alg":"ec:secp256r1"}]'
+```
 
 | Field                    | Description                                                                     | Default  |
 | ------------------------ | ------------------------------------------------------------------------------- | -------- |
-| `keyring.*.kid`          | Which key id this is binding                                                    |          |
+| `key_management`         | Whether stable, policy-backed key management is enabled.                        | `false`  |
+| `keyring.*.kid`          | Which static key id this is binding.                                            |          |
 | `keyring.*.alg`          | (Optional) Associated algorithm. (Allows reusing KID with different algorithms) |          |
 | `keyring.*.legacy`       | Indicates this may be used for TDFs with no key ID; default if all unspecified. | inferred |
 | `preview.ec_tdf_enabled` | Whether tdf based ecc support is enabled.                                       | `false`  |
-| `preview.key_management` | Whether new key management features are enabled.                                | `false`  |
-| `root_key`               | Key needed when new key_management functionality is enabled.                    |          |
+| `preview.key_management` | Deprecated alias for `key_management`.                                          |          |
+| `root_key`               | Key needed when key management uses the built-in basic key manager.             |          |
+
+The deprecated `preview.key_management: true` setting remains supported and logs a warning directing users to `key_management`. A deprecated setting of `false` is ignored without a warning. Setting `preview.key_management: true` will start kas with key_management even if the top-level `key_management` field is `false`.
 
 Example:
 
@@ -408,6 +416,7 @@ security:
 
 services:
   kas:
+    key_management: false
     keyring:
       - kid: e2
         alg: ec:secp256r1

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -404,7 +404,7 @@ OPENTDF_SERVICES_KAS_KEYRING='[{"kid":"k1","alg":"rsa:2048"},{"kid":"k2","alg":"
 | `preview.key_management` | Deprecated alias for `key_management`.                                          |          |
 | `root_key`               | Key needed when key management uses the built-in basic key manager.             |          |
 
-The deprecated `preview.key_management: true` setting remains supported and logs a warning directing users to `key_management`. A deprecated setting of `false` is ignored without a warning. Setting `preview.key_management: true` will start kas with key_management even if the top-level `key_management` field is `false`.
+The deprecated `preview.key_management` setting remains supported and logs a warning whenever it is configured. A value of `true` enables key management even if the top-level `key_management` field is `false`; a value of `false` does not override the top-level setting.
 
 Example:
 

--- a/opentdf-dev.yaml
+++ b/opentdf-dev.yaml
@@ -29,10 +29,10 @@ audit:
 services:
   kas:
     registered_kas_uri: http://localhost:8080 # Should match what you have registered for *this* KAS in the policy db.
+    key_management: false
     preview:
       ec_tdf_enabled: false
       hybrid_tdf_enabled: false
-      key_management: false
     root_key: a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1 # For local development testing only
     keyring:
       - kid: e1

--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -29,6 +29,7 @@ db:
 # mode: all
 services:
   kas:
+    key_management: false
     eccertid: e1
     rsacertid: r1
   entityresolution:

--- a/opentdf-kas-mode.yaml
+++ b/opentdf-kas-mode.yaml
@@ -26,9 +26,9 @@ security:
 services:
   kas:
     registered_kas_uri: http://localhost:8080 # Should match what you have registered for *this* KAS in the policy db.
+    key_management: false
     preview:
       ec_tdf_enabled: false
-      key_management: false
     # root_key: # create key `openssl rand 32 -hex`
     keyring:
       - kid: e1

--- a/service/kas/access/provider.go
+++ b/service/kas/access/provider.go
@@ -36,6 +36,9 @@ type Provider struct {
 }
 
 type KASConfig struct {
+	// KeyManagement enables stable, policy-backed KAS key management.
+	KeyManagement bool `mapstructure:"key_management" json:"key_management"`
+
 	// Which keys are currently the default.
 	Keyring []CurrentKeyFor `mapstructure:"keyring" json:"keyring"`
 	// Deprecated
@@ -72,7 +75,9 @@ type Preview struct {
 	// and (currently) also enables responding with ML-KEM encrypted responses.
 	// This feature is experimental and may be removed or changed in future releases.
 	MLKEMTDFEnabled bool `mapstructure:"mlkem_tdf_enabled" json:"mlkem_tdf_enabled"`
-	KeyManagement   bool `mapstructure:"key_management" json:"key_management"`
+	// Deprecated: retained for backward compatibility with preview configurations.
+	// Use KASConfig.KeyManagement instead.
+	KeyManagement bool `mapstructure:"key_management" json:"key_management"`
 }
 
 // Specifies the preferred/default key for a given algorithm type.
@@ -159,7 +164,8 @@ func (kasCfg KASConfig) String() string {
 	}
 
 	return fmt.Sprintf(
-		"KASConfig{Keyring:%v, ECCertID:%q, RSACertID:%q, RootKey:%s, KeyCacheExpiration:%s,  Preview:%+v, RegisteredKASURI:%q}",
+		"KASConfig{KeyManagement:%t, Keyring:%v, ECCertID:%q, RSACertID:%q, RootKey:%s, KeyCacheExpiration:%s, Preview:%+v, RegisteredKASURI:%q}",
+		kasCfg.KeyManagement,
 		kasCfg.Keyring,
 		kasCfg.ECCertID,
 		kasCfg.RSACertID,
@@ -177,6 +183,7 @@ func (kasCfg KASConfig) LogValue() slog.Value {
 	}
 
 	return slog.GroupValue(
+		slog.Bool("key_management", kasCfg.KeyManagement),
 		slog.Any("keyring", kasCfg.Keyring),
 		slog.String("eccertid", kasCfg.ECCertID),
 		slog.String("rsacertid", kasCfg.RSACertID),

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -23,8 +23,8 @@ import (
 
 func OnConfigUpdate(p *access.Provider) serviceregistry.OnConfigUpdateHook {
 	return func(ctx context.Context, cfg config.ServiceConfig) error {
-		var kasCfg access.KASConfig
-		if err := mapstructure.Decode(cfg, &kasCfg); err != nil {
+		kasCfg, err := decodeKASConfig(cfg, p.Logger)
+		if err != nil {
 			return fmt.Errorf("invalid kas cfg [%v] %w", cfg, err)
 		}
 
@@ -46,8 +46,8 @@ func NewRegistration() *serviceregistry.Service[kasconnect.AccessServiceHandler]
 			ConnectRPCFunc: kasconnect.NewAccessServiceHandler,
 			OnConfigUpdate: onConfigUpdate,
 			RegisterFunc: func(srp serviceregistry.RegistrationParams) (kasconnect.AccessServiceHandler, serviceregistry.HandlerServer) {
-				var kasCfg access.KASConfig
-				if err := mapstructure.Decode(srp.Config, &kasCfg); err != nil {
+				kasCfg, err := decodeKASConfig(srp.Config, srp.Logger)
+				if err != nil {
 					panic(fmt.Errorf("invalid kas cfg [%v] %w", srp.Config, err))
 				}
 
@@ -64,8 +64,8 @@ func NewRegistration() *serviceregistry.Service[kasconnect.AccessServiceHandler]
 
 				var kmgrs []string
 
-				if kasCfg.Preview.KeyManagement {
-					srp.Logger.Info("preview feature: key management is enabled")
+				if kasCfg.KeyManagement {
+					srp.Logger.Info("key management is enabled")
 
 					kasURL, err := determineKASURL(srp, kasCfg)
 					if err != nil {
@@ -126,6 +126,24 @@ func NewRegistration() *serviceregistry.Service[kasconnect.AccessServiceHandler]
 			},
 		},
 	}
+}
+
+func decodeKASConfig(cfg config.ServiceConfig, log *logger.Logger) (access.KASConfig, error) {
+	var kasCfg access.KASConfig
+	if err := mapstructure.Decode(cfg, &kasCfg); err != nil {
+		return kasCfg, err
+	}
+
+	if kasCfg.Preview.KeyManagement { //nolint:staticcheck // Deprecated field is read for backward compatibility.
+		kasCfg.KeyManagement = true
+		log.Warn(
+			"deprecated KAS preview key management setting is configured",
+			slog.String("deprecated_config", "services.kas.preview.key_management"),
+			slog.String("replacement_config", "services.kas.key_management"),
+		)
+	}
+
+	return kasCfg, nil
 }
 
 func determineKASURL(srp serviceregistry.RegistrationParams, kasCfg access.KASConfig) (*url.URL, error) {

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -136,6 +136,10 @@ func decodeKASConfig(cfg config.ServiceConfig, log *logger.Logger) (access.KASCo
 
 	if kasCfg.Preview.KeyManagement { //nolint:staticcheck // Deprecated field is read for backward compatibility.
 		kasCfg.KeyManagement = true
+	}
+
+	previewCfg, _ := cfg["preview"].(map[string]any)
+	if _, configured := previewCfg["key_management"]; configured {
 		log.Warn(
 			"services.kas.preview.key_management is deprecated; use services.kas.key_management instead",
 			slog.String("deprecated_config", "services.kas.preview.key_management"),

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -137,7 +137,7 @@ func decodeKASConfig(cfg config.ServiceConfig, log *logger.Logger) (access.KASCo
 	if kasCfg.Preview.KeyManagement { //nolint:staticcheck // Deprecated field is read for backward compatibility.
 		kasCfg.KeyManagement = true
 		log.Warn(
-			"deprecated KAS preview key management setting is configured",
+			"services.kas.preview.key_management is deprecated; use services.kas.key_management instead",
 			slog.String("deprecated_config", "services.kas.preview.key_management"),
 			slog.String("replacement_config", "services.kas.key_management"),
 		)

--- a/service/kas/kas_test.go
+++ b/service/kas/kas_test.go
@@ -196,9 +196,10 @@ func TestDecodeKASConfigKeyManagement(t *testing.T) {
 			wantWarning: "services.kas.preview.key_management is deprecated; use services.kas.key_management instead",
 		},
 		{
-			name:        "preview false is ignored",
+			name:        "preview false remains disabled and warns",
 			config:      map[string]any{"preview": map[string]any{"key_management": false}},
 			wantEnabled: false,
+			wantWarning: "services.kas.preview.key_management is deprecated; use services.kas.key_management instead",
 		},
 		{
 			name: "preview true enables key management and warns",
@@ -210,12 +211,13 @@ func TestDecodeKASConfigKeyManagement(t *testing.T) {
 			wantWarning: "services.kas.preview.key_management is deprecated; use services.kas.key_management instead",
 		},
 		{
-			name: "stable true with preview false does not warn",
+			name: "stable true with preview false warns",
 			config: map[string]any{
 				"key_management": true,
 				"preview":        map[string]any{"key_management": false},
 			},
 			wantEnabled: true,
+			wantWarning: "services.kas.preview.key_management is deprecated; use services.kas.key_management instead",
 		},
 	}
 

--- a/service/kas/kas_test.go
+++ b/service/kas/kas_test.go
@@ -167,6 +167,74 @@ func newBufferLogger() (*logger.Logger, *bytes.Buffer) {
 	}, buf
 }
 
+func TestDecodeKASConfigKeyManagement(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      map[string]any
+		wantEnabled bool
+		wantWarning string
+	}{
+		{
+			name:        "key management remains disabled when not configured",
+			config:      map[string]any{},
+			wantEnabled: false,
+		},
+		{
+			name:        "stable setting enables key management",
+			config:      map[string]any{"key_management": true},
+			wantEnabled: true,
+		},
+		{
+			name:        "stable setting disables key management",
+			config:      map[string]any{"key_management": false},
+			wantEnabled: false,
+		},
+		{
+			name:        "preview setting remains supported",
+			config:      map[string]any{"preview": map[string]any{"key_management": true}},
+			wantEnabled: true,
+			wantWarning: "deprecated KAS preview key management setting is configured",
+		},
+		{
+			name:        "preview false is ignored",
+			config:      map[string]any{"preview": map[string]any{"key_management": false}},
+			wantEnabled: false,
+		},
+		{
+			name: "preview true enables key management and warns",
+			config: map[string]any{
+				"key_management": false,
+				"preview":        map[string]any{"key_management": true},
+			},
+			wantEnabled: true,
+			wantWarning: "deprecated KAS preview key management setting is configured",
+		},
+		{
+			name: "stable true with preview false does not warn",
+			config: map[string]any{
+				"key_management": true,
+				"preview":        map[string]any{"key_management": false},
+			},
+			wantEnabled: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			log, buf := newBufferLogger()
+			got, err := decodeKASConfig(tc.config, log)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantEnabled, got.KeyManagement)
+			if tc.wantWarning == "" {
+				assert.Empty(t, buf.String())
+			} else {
+				assert.Contains(t, buf.String(), tc.wantWarning)
+				assert.Contains(t, buf.String(), `"level":"WARN"`)
+			}
+		})
+	}
+}
+
 func TestLogSupportedMechanisms_EmitsInfoLine(t *testing.T) {
 	l, buf := newBufferLogger()
 

--- a/service/kas/kas_test.go
+++ b/service/kas/kas_test.go
@@ -193,7 +193,7 @@ func TestDecodeKASConfigKeyManagement(t *testing.T) {
 			name:        "preview setting remains supported",
 			config:      map[string]any{"preview": map[string]any{"key_management": true}},
 			wantEnabled: true,
-			wantWarning: "deprecated KAS preview key management setting is configured",
+			wantWarning: "services.kas.preview.key_management is deprecated; use services.kas.key_management instead",
 		},
 		{
 			name:        "preview false is ignored",
@@ -207,7 +207,7 @@ func TestDecodeKASConfigKeyManagement(t *testing.T) {
 				"preview":        map[string]any{"key_management": true},
 			},
 			wantEnabled: true,
-			wantWarning: "deprecated KAS preview key management setting is configured",
+			wantWarning: "services.kas.preview.key_management is deprecated; use services.kas.key_management instead",
 		},
 		{
 			name: "stable true with preview false does not warn",

--- a/service/pkg/server/testdata/all-no-config.yaml
+++ b/service/pkg/server/testdata/all-no-config.yaml
@@ -5,6 +5,7 @@ logger:
   output: stderr
 services:
   kas:
+    key_management: false
     keyring:
       - kid: e1
         alg: ec:secp256r1

--- a/test/start-additional-kas/action.yaml
+++ b/test/start-additional-kas/action.yaml
@@ -192,6 +192,7 @@ runs:
                 | .server.cryptoProvider.standard.keys += [{"kid":"x1","alg":"hpqt:xwing","private":"kas-xwing-private.pem","cert":"kas-xwing-public.pem"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768","private":"kas-p256mlkem768-private.pem","cert":"kas-p256mlkem768-public.pem"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024","private":"kas-p384mlkem1024-private.pem","cert":"kas-p384mlkem1024-public.pem"}]
               )
             | (.services.kas.key_management = (env(KEY_MANAGEMENT) == "true"))
+            | (.services.kas.preview.key_management = (env(KEY_MANAGEMENT) == "true"))
             | (.services.kas.registered_kas_uri = "http://localhost:" + env(KAS_PORT))
             | del(.services.kas.root_key)
             | (.logger.level = env(LOG_LEVEL))

--- a/test/start-additional-kas/action.yaml
+++ b/test/start-additional-kas/action.yaml
@@ -191,7 +191,7 @@ runs:
                 .services.kas.keyring += [{"kid":"x1","alg":"hpqt:xwing"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024"}]
                 | .server.cryptoProvider.standard.keys += [{"kid":"x1","alg":"hpqt:xwing","private":"kas-xwing-private.pem","cert":"kas-xwing-public.pem"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768","private":"kas-p256mlkem768-private.pem","cert":"kas-p256mlkem768-public.pem"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024","private":"kas-p384mlkem1024-private.pem","cert":"kas-p384mlkem1024-public.pem"}]
               )
-            | (.services.kas.preview.key_management = (env(KEY_MANAGEMENT) == "true"))
+            | (.services.kas.key_management = (env(KEY_MANAGEMENT) == "true"))
             | (.services.kas.registered_kas_uri = "http://localhost:" + env(KAS_PORT))
             | del(.services.kas.root_key)
             | (.logger.level = env(LOG_LEVEL))

--- a/test/tdf-roundtrips.bats
+++ b/test/tdf-roundtrips.bats
@@ -293,10 +293,10 @@ logger:
 services:
   kas:
     enabled: true
+    key_management: false
     preview:
       ec_tdf_enabled: true
       hybrid_tdf_enabled: true
-      key_management: false
     keyring:
       - kid: ${ec_current_key}
         alg: ec:secp256r1

--- a/tests-bdd/cukes/resources/platform.authz_v2.template
+++ b/tests-bdd/cukes/resources/platform.authz_v2.template
@@ -14,9 +14,9 @@ db:
 services:
   kas:
     registered_kas_uri: http://{{ .hostname }}:{{ .platformPort }}
+    key_management: false
     preview:
       ec_tdf_enabled: false
-      key_management: false
     root_key: a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1
     keyring:
       - kid: e1

--- a/tests-bdd/cukes/resources/platform.direct_entitlements.template
+++ b/tests-bdd/cukes/resources/platform.direct_entitlements.template
@@ -20,9 +20,9 @@ services:
     allow_direct_entitlements: true
   kas:
     registered_kas_uri: http://{{ .hostname }}:{{ .platformPort }}
+    key_management: false
     preview:
       ec_tdf_enabled: false
-      key_management: false
     root_key: a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1 # For local development testing only
     keyring:
       - kid: e1

--- a/tests-bdd/cukes/resources/platform.dynamic_value_mappings.template
+++ b/tests-bdd/cukes/resources/platform.dynamic_value_mappings.template
@@ -18,9 +18,9 @@ services:
     allow_dynamic_value_mappings: true
   kas:
     registered_kas_uri: http://{{ .hostname }}:{{ .platformPort }}
+    key_management: false
     preview:
       ec_tdf_enabled: false
-      key_management: false
     root_key: a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1 # For local development testing only
     keyring:
       - kid: e1

--- a/tests-bdd/cukes/resources/platform.namespaced_policy.template
+++ b/tests-bdd/cukes/resources/platform.namespaced_policy.template
@@ -20,9 +20,9 @@ services:
     enforce_namespaced_entitlements: true
   kas:
     registered_kas_uri: http://{{ .hostname }}:{{ .platformPort }} # Should match what you have registered for *this* KAS in the policy db.
+    key_management: false
     preview:
       ec_tdf_enabled: false
-      key_management: false
     root_key: a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1 # For local development testing only
     keyring:
       - kid: e1

--- a/tests-bdd/cukes/resources/platform.template
+++ b/tests-bdd/cukes/resources/platform.template
@@ -19,9 +19,9 @@ db:
 services:
   kas:
     registered_kas_uri: http://{{ .hostname }}:{{ .platformPort }} # Should match what you have registered for *this* KAS in the policy db.
+    key_management: false # Static development keys are configured below.
     preview:
       ec_tdf_enabled: false
-      key_management: false
     root_key: a8c4824daafcfa38ed0d13002e92b08720e6c4fcee67d52e954c1a6e045907d1 # For local development testing only
     keyring:
       - kid: e1


### PR DESCRIPTION
1.) `services.kas.preview.key_management` emits a deprecation warning with a note to use the new `services.kas.key_management` flag
2.) Maintains backwards compatibility if the old key_management preview flag is still used
3.) Continues to default `key_management` to false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * KAS key management is now configured directly under the KAS service settings.
  * Updated examples and templates reflect the new `key_management` location.
  * Key management remains disabled by default in included configurations.

* **Documentation**
  * Added guidance for the new setting and environment variable.
  * Clarified keyring and root-key behavior.

* **Compatibility**
  * Existing `preview.key_management` configurations continue to work with a deprecation warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->