### PR TITLE
fix(core): establish verified audit principal

### DIFF
--- a/sdk/audit/context_keys.go
+++ b/sdk/audit/context_keys.go
@@ -15,7 +15,10 @@ const (
 	UserAgentHeaderKey RequestHeader = "user-agent"
 	RequestIDHeaderKey RequestHeader = "x-request-id"
 	RequestIPHeaderKey RequestHeader = "x-forwarded-request-ip"
-	ActorIDHeaderKey   RequestHeader = "x-forwarded-actor-id"
+	// ActorIDHeaderKey is retained for source compatibility. OpenTDF no longer
+	// forwards or trusts this unauthenticated header for actor attribution.
+	// Deprecated: actor identity is derived from the verified access token.
+	ActorIDHeaderKey RequestHeader = "x-forwarded-actor-id"
 )
 
 func (r RequestHeader) String() string {

--- a/sdk/audit/context_keys.go
+++ b/sdk/audit/context_keys.go
@@ -17,6 +17,7 @@ const (
 	RequestIPHeaderKey RequestHeader = "x-forwarded-request-ip"
 	// ActorIDHeaderKey is retained for source compatibility. OpenTDF no longer
 	// forwards or trusts this unauthenticated header for actor attribution.
+	//
 	// Deprecated: actor identity is derived from the verified access token.
 	ActorIDHeaderKey RequestHeader = "x-forwarded-actor-id"
 )

--- a/sdk/audit/metadata_adding_interceptor.go
+++ b/sdk/audit/metadata_adding_interceptor.go
@@ -27,11 +27,6 @@ func MetadataAddingConnectInterceptor() connect.UnaryInterceptorFunc {
 				req.Header().Set(string(RequestIPHeaderKey), requestIP)
 			}
 
-			// Add the actor ID from the request so it is preserved if we need it
-			if actorID, okAct := ctx.Value(ActorIDContextKey).(string); okAct {
-				req.Header().Set(string(ActorIDHeaderKey), actorID)
-			}
-
 			return next(ctx, req)
 		}
 	})

--- a/sdk/audit/metadata_adding_interceptor_test.go
+++ b/sdk/audit/metadata_adding_interceptor_test.go
@@ -45,16 +45,15 @@ func TestAddingAuditMetadataToOutgoingRequest(t *testing.T) {
 	defer stopC()
 
 	contextRequestID := uuid.New()
-	contextActorID := "actorID"
 	ctx := t.Context()
 	ctx = context.WithValue(ctx, RequestIDContextKey, contextRequestID)
-	ctx = context.WithValue(ctx, ActorIDContextKey, contextActorID)
+	ctx = context.WithValue(ctx, ActorIDContextKey, "untrusted-actor")
 
 	_, err := clientConnect.PublicKey(ctx, connect.NewRequest(&kas.PublicKeyRequest{}))
 	require.NoError(t, err)
 
 	assert.Equal(t, contextRequestID, serverConnect.requestID, "request ID did not match")
-	assert.Equal(t, contextActorID, serverConnect.actorID, "actor ID did not match")
+	assert.Empty(t, serverConnect.actorID, "actor ID header must not be forwarded")
 }
 
 func TestIsOKWithNoContextValues(t *testing.T) {

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -31,7 +31,6 @@ import (
 	internalauthz "github.com/opentdf/platform/service/internal/auth/authz"
 	_ "github.com/opentdf/platform/service/internal/auth/authz/casbin" // Register casbin authorizer
 	"github.com/opentdf/platform/service/logger"
-	"github.com/opentdf/platform/service/logger/audit"
 	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
 	"github.com/opentdf/platform/service/pkg/authz"
 	"google.golang.org/grpc/metadata"
@@ -1120,14 +1119,6 @@ func (a *Authentication) checkToken(ctx context.Context, authHeader []string, dp
 	accessToken, err := a.tokenVerifier.VerifyAccessToken(ctx, tokenRaw)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	// Get actor ID (sub) from unverified token for audit and add to context
-	// Only set the actor ID if it is not already defined
-	existingActorID := audit.GetAuditDataFromContext(ctx).ActorID
-	if existingActorID == "" {
-		actorID := accessToken.Subject()
-		ctx = audit.ContextWithActorID(ctx, actorID)
 	}
 
 	_, tokenHasCNF := accessToken.Get("cnf")

--- a/service/logger/audit/context.go
+++ b/service/logger/audit/context.go
@@ -3,12 +3,13 @@ package audit
 import (
 	"context"
 	"sync"
-
-	"github.com/google/uuid"
 )
 
 // Context key type for audit context
-type contextKey struct{}
+type (
+	contextKey      struct{}
+	actorContextKey struct{}
+)
 
 // auditTransaction holds pending audit events to be logged on completion
 type auditTransaction struct {
@@ -19,21 +20,7 @@ type auditTransaction struct {
 }
 
 func ContextWithActorID(ctx context.Context, actorID string) context.Context {
-	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
-	if !ok || tx == nil {
-		tx = &auditTransaction{
-			ContextData: ContextData{
-				RequestID: uuid.Nil,
-				UserAgent: defaultNone,
-				RequestIP: defaultNone,
-			},
-			events: make([]pendingEvent, 0),
-		}
-		ctx = context.WithValue(ctx, contextKey{}, tx)
-	}
-
-	tx.ActorID = actorID
-	return ctx
+	return context.WithValue(ctx, actorContextKey{}, actorID)
 }
 
 // Detach returns a non-canceling context with an independent copy of the current

--- a/service/logger/audit/context.go
+++ b/service/logger/audit/context.go
@@ -3,6 +3,8 @@ package audit
 import (
 	"context"
 	"sync"
+
+	"github.com/google/uuid"
 )
 
 // Context key type for audit context
@@ -20,6 +22,20 @@ type auditTransaction struct {
 }
 
 func ContextWithActorID(ctx context.Context, actorID string) context.Context {
+	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
+	if !ok || tx == nil {
+		tx = &auditTransaction{
+			ContextData: ContextData{
+				RequestID: uuid.Nil,
+				UserAgent: defaultNone,
+				RequestIP: defaultNone,
+				ActorID:   actorID,
+			},
+			events: make([]pendingEvent, 0),
+		}
+		ctx = context.WithValue(ctx, contextKey{}, tx)
+	}
+
 	return context.WithValue(ctx, actorContextKey{}, actorID)
 }
 

--- a/service/logger/audit/contextServerInterceptor.go
+++ b/service/logger/audit/contextServerInterceptor.go
@@ -17,6 +17,7 @@ func ContextServerInterceptor(logger *Logger) connect.UnaryInterceptorFunc {
 		return connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			// Get metadata from the context
 			headers := req.Header()
+			auditData := GetAuditDataFromContext(ctx)
 
 			// Add request ID from existing header or create a new one
 			var requestID uuid.UUID
@@ -36,7 +37,7 @@ func ContextServerInterceptor(logger *Logger) connect.UnaryInterceptorFunc {
 					RequestID: requestID,
 					UserAgent: "",
 					RequestIP: "",
-					ActorID:   "",
+					ActorID:   auditData.ActorID,
 				},
 				events: make([]pendingEvent, 0),
 			}
@@ -50,10 +51,6 @@ func ContextServerInterceptor(logger *Logger) connect.UnaryInterceptorFunc {
 				if ip.String() != "" && ip.String() != "<nil>" {
 					tx.RequestIP = ip.String()
 				}
-			}
-			actorIDFromMetadata := headers[http.CanonicalHeaderKey(sdkAudit.ActorIDHeaderKey.String())]
-			if len(actorIDFromMetadata) > 0 {
-				tx.ActorID = actorIDFromMetadata[0]
 			}
 			userAgent := headers[http.CanonicalHeaderKey(sdkAudit.UserAgentHeaderKey.String())]
 			if len(userAgent) > 0 {

--- a/service/logger/audit/context_server_interceptor_test.go
+++ b/service/logger/audit/context_server_interceptor_test.go
@@ -17,7 +17,7 @@ func TestContextServerInterceptorIgnoresForwardedActorHeader(t *testing.T) {
 	require.NoError(t, err)
 	ctx := ctxAuth.ContextWithAuthNInfo(t.Context(), nil, token, "raw-token")
 	req := connect.NewRequest(&struct{}{})
-	req.Header().Set(sdkAudit.ActorIDHeaderKey.String(), "spoofed-subject")
+	req.Header().Set(sdkAudit.ActorIDHeaderKey.String(), "spoofed-subject") //nolint:staticcheck // regression test for the deprecated spoofable header
 
 	var captured ContextData
 	next := ContextServerInterceptor(createDiscardLogger())(
@@ -34,7 +34,7 @@ func TestContextServerInterceptorIgnoresForwardedActorHeader(t *testing.T) {
 
 func TestContextServerInterceptorDoesNotTreatHeaderAsPrincipal(t *testing.T) {
 	req := connect.NewRequest(&struct{}{})
-	req.Header().Set(sdkAudit.ActorIDHeaderKey.String(), "spoofed-subject")
+	req.Header().Set(sdkAudit.ActorIDHeaderKey.String(), "spoofed-subject") //nolint:staticcheck // regression test for the deprecated spoofable header
 
 	var captured ContextData
 	next := ContextServerInterceptor(createDiscardLogger())(

--- a/service/logger/audit/context_server_interceptor_test.go
+++ b/service/logger/audit/context_server_interceptor_test.go
@@ -1,0 +1,55 @@
+package audit
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	sdkAudit "github.com/opentdf/platform/sdk/audit"
+	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextServerInterceptorIgnoresForwardedActorHeader(t *testing.T) {
+	token, err := jwt.NewBuilder().Subject("verified-subject").Build()
+	require.NoError(t, err)
+	ctx := ctxAuth.ContextWithAuthNInfo(t.Context(), nil, token, "raw-token")
+	req := connect.NewRequest(&struct{}{})
+	req.Header().Set(sdkAudit.ActorIDHeaderKey.String(), "spoofed-subject")
+
+	var captured ContextData
+	next := ContextServerInterceptor(createDiscardLogger())(
+		func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+			captured = GetAuditDataFromContext(ctx)
+			return nil, nil //nolint:nilnil // response is irrelevant to context propagation
+		},
+	)
+
+	_, err = next(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, "verified-subject", captured.ActorID)
+}
+
+func TestContextServerInterceptorDoesNotTreatHeaderAsPrincipal(t *testing.T) {
+	req := connect.NewRequest(&struct{}{})
+	req.Header().Set(sdkAudit.ActorIDHeaderKey.String(), "spoofed-subject")
+
+	var captured ContextData
+	next := ContextServerInterceptor(createDiscardLogger())(
+		func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+			captured = GetAuditDataFromContext(ctx)
+			return nil, nil //nolint:nilnil // response is irrelevant to context propagation
+		},
+	)
+
+	_, err := next(t.Context(), req)
+	require.NoError(t, err)
+	assert.Empty(t, captured.ActorID)
+}
+
+func createDiscardLogger() *Logger {
+	logger, _ := createTestLogger()
+	return logger
+}

--- a/service/logger/audit/context_test.go
+++ b/service/logger/audit/context_test.go
@@ -1,0 +1,34 @@
+package audit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextWithActorIDSupportsBufferedAuditEvents(t *testing.T) {
+	ctx := ContextWithActorID(t.Context(), "test-actor-id")
+
+	require.NotPanics(t, func() {
+		LogAuditEvent(ctx, VerbDecision, &EventObject{})
+	})
+
+	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
+	require.True(t, ok)
+	require.Equal(t, "test-actor-id", tx.ActorID)
+	require.Len(t, tx.events, 1)
+}
+
+func TestContextWithActorIDDoesNotMutateExistingTransaction(t *testing.T) {
+	tx := &auditTransaction{
+		ContextData: ContextData{ActorID: "existing-actor-id"},
+		events:      make([]pendingEvent, 0),
+	}
+	ctx := context.WithValue(t.Context(), contextKey{}, tx)
+
+	ctx = ContextWithActorID(ctx, "new-actor-id")
+
+	require.Equal(t, "existing-actor-id", tx.ActorID)
+	require.Equal(t, "new-actor-id", GetAuditDataFromContext(ctx).ActorID)
+}

--- a/service/logger/audit/detach_test.go
+++ b/service/logger/audit/detach_test.go
@@ -117,7 +117,7 @@ func TestDetachWithoutParentUsesDefaultAttribution(t *testing.T) {
 	cloned := l.Detach(t.Context())
 
 	data := GetAuditDataFromContext(cloned)
-	assert.Equal(t, defaultNone, data.ActorID)
+	assert.Empty(t, data.ActorID)
 	assert.Equal(t, defaultNone, data.UserAgent)
 	assert.Equal(t, defaultNone, data.RequestIP)
 	require.NotNil(t, requireAuditTransaction(cloned, t))

--- a/service/logger/audit/utils.go
+++ b/service/logger/audit/utils.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/google/uuid"
+	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
 )
 
 // Common Strings
@@ -125,14 +126,23 @@ func (c ContextData) LogValue() slog.Value {
 
 // GetAuditDataFromContext gets relevant audit data from the context object
 func GetAuditDataFromContext(ctx context.Context) ContextData {
+	actorID, _ := ctx.Value(actorContextKey{}).(string)
+	if principal, ok := ctxAuth.PrincipalFromContext(ctx); ok {
+		actorID = principal.Subject
+	}
+
 	tx, ok := ctx.Value(contextKey{}).(*auditTransaction)
-	if ok {
-		return tx.ContextData
+	if ok && tx != nil {
+		data := tx.ContextData
+		if actorID != "" {
+			data.ActorID = actorID
+		}
+		return data
 	}
 	return ContextData{
 		RequestID: uuid.Nil,
 		UserAgent: defaultNone,
 		RequestIP: defaultNone,
-		ActorID:   defaultNone,
+		ActorID:   actorID,
 	}
 }

--- a/service/logger/audit/utils_test.go
+++ b/service/logger/audit/utils_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetAuditDataFromContextHappyPath(t *testing.T) {
@@ -39,7 +42,7 @@ func TestGetAuditDataFromContextDefaultsPath(t *testing.T) {
 	assert.Equal(t, uuid.Nil, auditData.RequestID)
 	assert.Equal(t, defaultNone, auditData.UserAgent)
 	assert.Equal(t, defaultNone, auditData.RequestIP)
-	assert.Equal(t, defaultNone, auditData.ActorID)
+	assert.Empty(t, auditData.ActorID)
 }
 
 func TestGetAuditDataFromContextWithNoKeys(t *testing.T) {
@@ -48,7 +51,7 @@ func TestGetAuditDataFromContextWithNoKeys(t *testing.T) {
 	assert.Equal(t, uuid.Nil, auditData.RequestID)
 	assert.Equal(t, defaultNone, auditData.UserAgent)
 	assert.Equal(t, defaultNone, auditData.RequestIP)
-	assert.Equal(t, defaultNone, auditData.ActorID)
+	assert.Empty(t, auditData.ActorID)
 }
 
 func TestGetAuditDataFromContextWithPartialKeys(t *testing.T) {
@@ -69,4 +72,14 @@ func TestGetAuditDataFromContextWithPartialKeys(t *testing.T) {
 	assert.Equal(t, "partial-user-agent", auditData.UserAgent)
 	assert.Equal(t, "None", auditData.RequestIP)
 	assert.Equal(t, "partial-actor-id", auditData.ActorID)
+}
+
+func TestGetAuditDataFromContextPrefersVerifiedPrincipal(t *testing.T) {
+	token, err := jwt.NewBuilder().Subject("verified-subject").Build()
+	require.NoError(t, err)
+	ctx := ctxAuth.ContextWithAuthNInfo(ContextWithActorID(t.Context(), "context-actor"), nil, token, "raw-token")
+
+	auditData := GetAuditDataFromContext(ctx)
+
+	assert.Equal(t, "verified-subject", auditData.ActorID)
 }

--- a/service/pkg/auth/context_auth.go
+++ b/service/pkg/auth/context_auth.go
@@ -30,6 +30,15 @@ type authContext struct {
 	key         jwk.Key
 	accessToken jwt.Token
 	rawToken    string
+	principal   Principal
+}
+
+// Principal identifies the authenticated requester established by token
+// verification. It is intentionally separate from audit event subjects, which
+// may describe an entity being evaluated rather than the requester.
+type Principal struct {
+	Subject string
+	Issuer  string
 }
 
 // optionalErrorLogger keeps pkg/auth decoupled from the concrete logger package
@@ -39,11 +48,27 @@ type optionalErrorLogger interface {
 }
 
 func ContextWithAuthNInfo(ctx context.Context, key jwk.Key, accessToken jwt.Token, raw string) context.Context {
+	principal := Principal{}
+	if accessToken != nil {
+		principal.Subject = accessToken.Subject()
+		principal.Issuer = accessToken.Issuer()
+	}
 	return context.WithValue(ctx, authnContextKey, &authContext{
-		key,
-		accessToken,
-		raw,
+		key:         key,
+		accessToken: accessToken,
+		rawToken:    raw,
+		principal:   principal,
 	})
+}
+
+// PrincipalFromContext returns the verified requester identity installed by
+// authentication. Header metadata is never considered a principal source.
+func PrincipalFromContext(ctx context.Context) (Principal, bool) {
+	details := getContextDetails(ctx, nil)
+	if details == nil || details.principal.Subject == "" {
+		return Principal{}, false
+	}
+	return details.principal, true
 }
 
 func getContextDetails(ctx context.Context, l optionalErrorLogger) *authContext {

--- a/service/pkg/auth/context_auth_test.go
+++ b/service/pkg/auth/context_auth_test.go
@@ -31,6 +31,27 @@ func TestContextWithAuthNInfo(t *testing.T) {
 	assert.Equal(t, rawToken, testAuthContext.rawToken, "Raw token should match")
 }
 
+func TestPrincipalFromContext(t *testing.T) {
+	token, err := jwt.NewBuilder().Subject("verified-subject").Issuer("https://issuer.example").Build()
+	require.NoError(t, err)
+
+	ctx := ContextWithAuthNInfo(t.Context(), nil, token, "raw-token")
+	principal, ok := PrincipalFromContext(ctx)
+
+	require.True(t, ok)
+	assert.Equal(t, "verified-subject", principal.Subject)
+	assert.Equal(t, "https://issuer.example", principal.Issuer)
+}
+
+func TestPrincipalFromContextRequiresSubject(t *testing.T) {
+	ctx := ContextWithAuthNInfo(t.Context(), nil, jwt.New(), "raw-token")
+
+	principal, ok := PrincipalFromContext(ctx)
+
+	assert.False(t, ok)
+	assert.Empty(t, principal)
+}
+
 func TestGetJWKFromContext(t *testing.T) {
 	// Create mock context with JWK
 	mockJWK, _ := jwk.FromRaw([]byte("mockKey"))


### PR DESCRIPTION
### Proposed Changes

- Establish an immutable, auth-owned Principal only after access-token verification.
- Attribute audit actors from that verified principal and ignore the spoofable x-forwarded-actor-id ingress header.
- Stop SDK clients from forwarding actor identity through that header while retaining deprecated constants for source compatibility.
- Add regression coverage for verified subject attribution, interceptor order, and header spoofing.

This is PR 1 of 4 in stack #3903. PR 2: https://github.com/opentdf/platform/pull/3901

### Security proof: failing against `main`

#### Live curl reproduction

The unchanged PR base commit (`0ef046e9fcf3729b957c39e077e4ec926b286d30`) was started against the local development Keycloak and database. The access token was valid and decoded to:

```json
{"sub":"3fc3d4e5-7409-4531-b51f-cacf3fc335c8","preferred_username":"service-account-opentdf","azp":"opentdf"}
```

An authenticated client then supplied a different actor ID:

```console
$ access_token=$(curl -fsS -X POST \
    http://localhost:8888/auth/realms/opentdf/protocol/openid-connect/token \
    -H 'Content-Type: application/x-www-form-urlencoded' \
    --data-urlencode grant_type=client_credentials \
    --data-urlencode client_id=opentdf \
    --data-urlencode client_secret=secret | jq -r .access_token)

$ curl -fsS -X POST \
    http://localhost:8080/policy.namespaces.NamespaceService/CreateNamespace \
    -H "Authorization: Bearer ${access_token}" \
    -H 'Content-Type: application/json' \
    -H 'Connect-Protocol-Version: 1' \
    -H 'X-Forwarded-Actor-Id: spoofed-after-rebase' \
    --data '{"name":"actor-spoof-after-rebase-20260825.example"}'
{"namespace":{"id":"de3b8b5a-0920-494d-a492-00edbf469403","name":"actor-spoof-after-rebase-20260825.example"}}
```

The request succeeded, and the running base emitted this audit attribution:

```json
{
  "level": "AUDIT",
  "msg": "policy crud",
  "audit": {
    "action": {"result": "success", "type": "create"},
    "actor": {"attributes": [], "id": "spoofed-after-rebase"},
    "original": {
      "id": "de3b8b5a-0920-494d-a492-00edbf469403",
      "name": "actor-spoof-after-rebase-20260825.example"
    },
    "requestID": "cd6274e6-4cb1-4505-8508-321f11eb2eba"
  }
}
```

The authenticated subject (`3fc3d4e5-7409-4531-b51f-cacf3fc335c8`) and recorded actor (`spoofed-after-rebase`) differ solely because of the client-supplied header.

#### Automated regression

The regression test creates an authenticated context whose verified JWT subject is `verified-subject`, then sends the client-controlled header `x-forwarded-actor-id: spoofed-subject` through the audit server interceptor.

To isolate the vulnerable behavior, the test file from this PR was applied to a clean export of the PR base commit (`0ef046e9fcf3729b957c39e077e4ec926b286d30`) without applying any production-code changes. Running:

```console
$ go test ./service/logger/audit -run '^TestContextServerInterceptorIgnoresForwardedActorHeader$' -count=1 -v
=== RUN   TestContextServerInterceptorIgnoresForwardedActorHeader
    Error:       Not equal:
                 expected: "verified-subject"
                 actual  : "spoofed-subject"
--- FAIL: TestContextServerInterceptorIgnoresForwardedActorHeader (0.00s)
FAIL
```

The base implementation copies `x-forwarded-actor-id` directly into the audit transaction. That value is subsequently emitted as `audit.actor.id`. This proves Platform accepts unauthenticated request metadata as actor attribution even when a verified token subject is available. Whether a particular deployment strips this header at an upstream gateway is a separate deployment control and is not enforced by Platform.

The same test passes on this PR:

```console
$ go test ./service/logger/audit -run '^TestContextServerInterceptorIgnoresForwardedActorHeader$' -count=1 -v
=== RUN   TestContextServerInterceptorIgnoresForwardedActorHeader
--- PASS: TestContextServerInterceptorIgnoresForwardedActorHeader (0.00s)
PASS
```

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (not required for this context-only change)
- [ ] I have added or updated documentation (covered by PR #3901)

### Testing Instructions

- make fmt
- go test -race ./service/pkg/auth ./service/logger/audit ./service/internal/auth ./sdk/audit
- changed-code golangci-lint for service and sdk: 0 issues
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Actor identity is now derived from the verified access token rather than forwarded request headers.
  * Unauthenticated actor headers are ignored and no longer trusted or propagated.
  * Verified principal subject and issuer information are available for audit attribution.

* **Audit Logging**
  * Audit records now use authenticated identity when available.
  * Missing actor identities remain empty instead of using a default placeholder.
  * Request IDs and IP metadata continue to be preserved.

* **Bug Fixes**
  * Improved audit context handling for buffered events and detached contexts.
  * Prevented audit transaction data from being unintentionally mutated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->