### PR TITLE
feat(core): add canonical audit recorder

### DIFF
--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -100,6 +100,7 @@ Root level key `logger`
 | `level`             | The logging level.                                           | `info`   | OPENTDF_LOGGER_LEVEL             |
 | `type`              | The format of the log output.                                | `json`   | OPENTDF_LOGGER_TYPE              |
 | `output`            | Stream output for logs, stderr or stdout                     | `stdout` | OPENTDF_LOGGER_OUTPUT            |
+| `audit_timeout` | Audit processing budget; non-positive values use the default | `5s` | OPENTDF_LOGGER_AUDIT_TIMEOUT |
 | `trace_correlation` | Add the active trace and span IDs to log and audit records   | `true`   | OPENTDF_LOGGER_TRACE_CORRELATION |
 
 Example:
@@ -109,6 +110,7 @@ logger:
   level: debug
   type: text
   output: stderr
+  audit_timeout: 5s
 ```
 
 `trace_correlation` emits fields only when the request carries trace context; see

--- a/service/logger/audit/README.md
+++ b/service/logger/audit/README.md
@@ -12,47 +12,43 @@ err := params.Logger.Audit.Record(ctx, audit.Event{
 })
 ```
 
-`Record` snapshots caller-owned data, stamps request attribution, and hands the
-event to the configured sink before returning. Encoding and sink handoff use a
-bounded context detached from request cancellation. Callers therefore do not
-need to detach contexts or create audit transactions.
+`Record` snapshots caller-owned data, stamps request attribution, validates the
+generic event fields, and hands the event to the configured processor before
+returning. Processing uses a bounded context detached from request cancellation.
+Callers therefore do not need to detach contexts or create audit transactions.
 
-For operations that require evidence before a side effect, record an
-`attempted` event first and a separate `completed` event afterward with the
-same event ID. If the attempted record is rejected, security-sensitive callers
+For operations that require evidence before a side effect, generate an event ID
+and record an `attempted` event first, then a separate `completed` event with
+that same ID. If the attempted record is rejected, security-sensitive callers
 should fail closed rather than perform the side effect.
 
-## Encoding and delivery
+## Processing and delivery
 
-Embedding applications may install one instance-scoped encoder and sink:
+Embedding applications may install one instance-scoped processor:
 
 ```go
 server.Start(
-	server.WithAuditEncoder(audit.EncoderFunc(
-		func(ctx context.Context, event audit.Event) ([]audit.Emission, error) {
-			return []audit.Emission{{
-				Level: audit.LevelAudit,
-				Message: string(event.Verb),
-				Attrs: []slog.Attr{slog.String("message", encode(event))},
-			}}, nil
+	server.WithAuditProcessor(audit.ProcessorFunc(
+		func(ctx context.Context, event audit.Event) error {
+			return processAuditEvent(ctx, event)
 		},
 	)),
-	server.WithAuditSink(mySink),
 )
 ```
 
-An encoder may produce one or many ordered emissions. Zero emissions are
-invalid: errors, panics, or empty results fall back to the unchanged OpenTDF
-wire record and return an error to the caller. The default encoder preserves
-`level:"AUDIT"`, `msg:<verb>`, and `audit:{...}`.
+A processor owns destination-specific validation, fan-out, delivery, and
+recovery. A nil error means it accepted the event through its intended
+destination or a durable recovery path. Processor errors and panics return to
+the caller; OpenTDF does not retry or emit a second fallback record. The default
+processor preserves `level:"AUDIT"`, `msg:<verb>`, and `audit:{...}`.
 
 The authenticated request `Principal` is distinct from the event `Actor`; an
 authorization decision may concern a subject other than the requester. JWT
 claim mappings may enrich the legacy payload but must not establish resource
-ownership. Downstream encoders must derive ownership from authoritative
+ownership. Downstream processors must derive ownership from authoritative
 resource identifiers.
 
-The default slog sink acknowledges handler acceptance only. It does not prove
-that stdout, Fluent Bit, or a remote datastore durably persisted the event.
-Deployments requiring durable audit guarantees must provide an acknowledging
-sink, WAL, or transactional outbox.
+The default processor acknowledges slog handler acceptance only. It does not
+prove that stdout, Fluent Bit, or a remote datastore durably persisted the
+event. Deployments requiring durable audit guarantees must implement that
+handoff, such as a WAL or transactional outbox, in their processor.

--- a/service/logger/audit/README.md
+++ b/service/logger/audit/README.md
@@ -12,10 +12,10 @@ err := params.Logger.Audit.Record(ctx, audit.Event{
 })
 ```
 
-`Record` snapshots caller-owned data, stamps request attribution, validates the
-generic event fields, and hands the event to the configured processor before
-returning. Processing uses a bounded context detached from request cancellation.
-Callers therefore do not need to detach contexts or create audit transactions.
+`Record` stamps request attribution, validates the generic event fields, and
+hands the event to the configured processor before returning. Processing uses a
+bounded context detached from request cancellation. Callers therefore do not
+need to detach contexts or create audit transactions.
 
 For operations that require evidence before a side effect, generate an event ID
 and record an `attempted` event first, then a separate `completed` event with
@@ -41,6 +41,10 @@ recovery. A nil error means it accepted the event through its intended
 destination or a durable recovery path. Processor errors and panics return to
 the caller; OpenTDF does not retry or emit a second fallback record. The default
 processor preserves `level:"AUDIT"`, `msg:<verb>`, and `audit:{...}`.
+
+`Record` is synchronous. Callers must not mutate maps, slices, or other
+reference data in an event until it returns. Processors must not mutate or
+retain that reference data.
 
 The authenticated request `Principal` is distinct from the event `Actor`; an
 authorization decision may concern a subject other than the requester. JWT

--- a/service/logger/audit/README.md
+++ b/service/logger/audit/README.md
@@ -4,12 +4,13 @@ OpenTDF records one canonical, externally constructible `Event` through an
 immediate `Recorder`:
 
 ```go
-err := params.Logger.Audit.Record(ctx, audit.Event{
-	Verb:   audit.Verb("read"),
-	Object: audit.Object{Type: "document", ID: documentID},
-	Action: audit.Action{Type: "read", Result: "success"},
-	ClientInfo: audit.ClientInfo{Platform: "extension"},
+event := audit.NewEvent(audit.EventObjectParams{
+	Object: audit.EventObjectInfo{Type: audit.ObjectTypeRegisteredResource, ID: documentID},
+	Action: audit.EventObjectAction{Type: audit.ActionTypeRead, Result: audit.ActionResultSuccess},
+	ClientInfo: audit.EventClientInfo{Platform: "extension"},
 })
+event.Verb = audit.Verb("read")
+err := params.Logger.Audit.Record(ctx, *event)
 ```
 
 `Record` stamps request attribution, validates the generic event fields, and

--- a/service/logger/audit/README.md
+++ b/service/logger/audit/README.md
@@ -1,0 +1,58 @@
+# Extending audit recording
+
+OpenTDF records one canonical, externally constructible `Event` through an
+immediate `Recorder`:
+
+```go
+err := params.Logger.Audit.Record(ctx, audit.Event{
+	Verb:   audit.Verb("read"),
+	Object: audit.Object{Type: "document", ID: documentID},
+	Action: audit.Action{Type: "read", Result: "success"},
+	ClientInfo: audit.ClientInfo{Platform: "extension"},
+})
+```
+
+`Record` snapshots caller-owned data, stamps request attribution, and hands the
+event to the configured sink before returning. Encoding and sink handoff use a
+bounded context detached from request cancellation. Callers therefore do not
+need to detach contexts or create audit transactions.
+
+For operations that require evidence before a side effect, record an
+`attempted` event first and a separate `completed` event afterward with the
+same event ID. If the attempted record is rejected, security-sensitive callers
+should fail closed rather than perform the side effect.
+
+## Encoding and delivery
+
+Embedding applications may install one instance-scoped encoder and sink:
+
+```go
+server.Start(
+	server.WithAuditEncoder(audit.EncoderFunc(
+		func(ctx context.Context, event audit.Event) ([]audit.Emission, error) {
+			return []audit.Emission{{
+				Level: audit.LevelAudit,
+				Message: string(event.Verb),
+				Attrs: []slog.Attr{slog.String("message", encode(event))},
+			}}, nil
+		},
+	)),
+	server.WithAuditSink(mySink),
+)
+```
+
+An encoder may produce one or many ordered emissions. Zero emissions are
+invalid: errors, panics, or empty results fall back to the unchanged OpenTDF
+wire record and return an error to the caller. The default encoder preserves
+`level:"AUDIT"`, `msg:<verb>`, and `audit:{...}`.
+
+The authenticated request `Principal` is distinct from the event `Actor`; an
+authorization decision may concern a subject other than the requester. JWT
+claim mappings may enrich the legacy payload but must not establish resource
+ownership. Downstream encoders must derive ownership from authoritative
+resource identifiers.
+
+The default slog sink acknowledges handler acceptance only. It does not prove
+that stdout, Fluent Bit, or a remote datastore durably persisted the event.
+Deployments requiring durable audit guarantees must provide an acknowledging
+sink, WAL, or transactional outbox.

--- a/service/logger/audit/README.md
+++ b/service/logger/audit/README.md
@@ -1,7 +1,6 @@
 # Extending audit recording
 
-OpenTDF records one canonical, externally constructible `Event` through an
-immediate `Recorder`:
+Use `Record` to submit an audit event:
 
 ```go
 event := audit.NewEvent(audit.EventObjectParams{
@@ -13,20 +12,17 @@ event.Verb = audit.Verb("read")
 err := params.Logger.Audit.Record(ctx, *event)
 ```
 
-`Record` stamps request attribution, validates the generic event fields, and
-hands the event to the configured processor before returning. Processing uses a
-bounded context detached from request cancellation. Callers therefore do not
-need to detach contexts or create audit transactions.
-
-Each call records an independent event. Callers determine when an operation's
-outcome is known and handle recording errors according to their requirements.
+`Record` adds request attribution, validates the event, and calls the processor
+synchronously with a deadline detached from request cancellation. Check its
+returned error.
 
 ## Processing and delivery
 
-Embedding applications may install one instance-scoped processor:
+Register a custom processor at startup:
 
 ```go
 server.Start(
+	server.WithAuditTimeout(15*time.Second),
 	server.WithAuditProcessor(audit.ProcessorFunc(
 		func(ctx context.Context, event audit.Event) error {
 			return processAuditEvent(ctx, event)
@@ -35,23 +31,23 @@ server.Start(
 )
 ```
 
-A processor owns destination-specific validation, fan-out, delivery, and
-recovery. A nil error means it accepted the event through its intended
-destination or a durable recovery path. Processor errors and panics return to
-the caller; OpenTDF does not retry or emit a second fallback record. The default
-processor preserves `level:"AUDIT"`, `msg:<verb>`, and `audit:{...}`.
+The default processing timeout is five seconds. Zero or negative values use the
+default. Processors must honor the context deadline, including during external
+lookups and delivery.
 
-`Record` is synchronous. Callers must not mutate maps, slices, or other
-reference data in an event until it returns. Processors must not mutate or
-retain that reference data.
+Processors handle conversion, destination validation, delivery, and recovery.
+Return nil after the destination or a durable recovery path accepts the event.
+`Record` returns processor errors and recovered panics. OpenTDF does not retry
+or emit a fallback.
 
-The authenticated request `Principal` is distinct from the event `Actor`; an
-authorization decision may concern a subject other than the requester. JWT
-claim mappings may enrich the legacy payload but must not establish resource
-ownership. Downstream processors must derive ownership from authoritative
-resource identifiers.
+Processors may run concurrently. They can change their local event value, but
+must independently copy any maps, slices, or referenced data they modify or
+retain. Callers must leave shared data unchanged until `Record` returns.
 
-The default processor acknowledges slog handler acceptance only. It does not
-prove that stdout, Fluent Bit, or a remote datastore durably persisted the
-event. Deployments requiring durable audit guarantees must implement that
-handoff, such as a WAL or transactional outbox, in their processor.
+`Principal` identifies the authenticated requester; `Actor` may identify a
+different subject. Derive resource ownership from authoritative resource data,
+not the requester's JWT claims.
+
+Without a custom processor, output remains `level:"AUDIT"`, `msg:<verb>`, and
+`audit:{...}`. Success means the slog handler accepted the record, not that a
+downstream datastore persisted it. Durable delivery belongs in the processor.

--- a/service/logger/audit/README.md
+++ b/service/logger/audit/README.md
@@ -18,10 +18,8 @@ hands the event to the configured processor before returning. Processing uses a
 bounded context detached from request cancellation. Callers therefore do not
 need to detach contexts or create audit transactions.
 
-For operations that require evidence before a side effect, generate an event ID
-and record an `attempted` event first, then a separate `completed` event with
-that same ID. If the attempted record is rejected, security-sensitive callers
-should fail closed rather than perform the side effect.
+Each call records an independent event. Callers determine when an operation's
+outcome is known and handle recording errors according to their requirements.
 
 ## Processing and delivery
 

--- a/service/logger/audit/README.md
+++ b/service/logger/audit/README.md
@@ -31,8 +31,9 @@ server.Start(
 )
 ```
 
-The default processing timeout is five seconds. Zero or negative values use the
-default. Processors must honor the context deadline, including during external
+The timeout can also be set with `logger.audit_timeout` in YAML or
+`OPENTDF_LOGGER_AUDIT_TIMEOUT`. An explicit `server.WithAuditTimeout` overrides
+those settings. The default is five seconds; zero or negative values use it. Processors must honor the context deadline, including during external
 lookups and delivery.
 
 Processors handle conversion, destination validation, delivery, and recovery.
@@ -51,3 +52,15 @@ not the requester's JWT claims.
 Without a custom processor, output remains `level:"AUDIT"`, `msg:<verb>`, and
 `audit:{...}`. Success means the slog handler accepted the record, not that a
 downstream datastore persisted it. Durable delivery belongs in the processor.
+
+For a standalone logger, pass audit settings in its config:
+
+```go
+log, err := logger.NewLogger(logger.Config{
+    Level: "info", Output: "stdout", Type: "json",
+    AuditTimeout: 15 * time.Second,
+    AuditProcessor: processor,
+})
+```
+
+`AuditProcessor` is for Go callers and is excluded from serialized configuration.

--- a/service/logger/audit/enrichment.go
+++ b/service/logger/audit/enrichment.go
@@ -19,7 +19,8 @@ func (a *Logger) buildLogEntry(ctx context.Context, event *EventObject) map[stri
 }
 
 func (a *Logger) applyJWTClaimEnrichment(ctx context.Context, entry map[string]any) {
-	if len(a.config.JWTClaimMappings) == 0 {
+	cfg := a.configSnapshot()
+	if len(cfg.JWTClaimMappings) == 0 {
 		return
 	}
 
@@ -34,11 +35,11 @@ func (a *Logger) applyJWTClaimEnrichment(ctx context.Context, entry map[string]a
 		return
 	}
 
-	a.applyMappedJWTClaims(ctx, entry, claimsMap)
+	a.applyMappedJWTClaims(ctx, entry, claimsMap, cfg.JWTClaimMappings)
 }
 
-func (a *Logger) applyMappedJWTClaims(ctx context.Context, entry map[string]any, claimsMap map[string]any) {
-	for _, mapping := range a.config.JWTClaimMappings {
+func (a *Logger) applyMappedJWTClaims(ctx context.Context, entry map[string]any, claimsMap map[string]any, mappings []JWTClaimMapping) {
+	for _, mapping := range mappings {
 		if mapping.Claim == "" || mapping.Path == "" {
 			continue
 		}

--- a/service/logger/audit/enrichment.go
+++ b/service/logger/audit/enrichment.go
@@ -19,8 +19,7 @@ func (a *Logger) buildLogEntry(ctx context.Context, event *EventObject) map[stri
 }
 
 func (a *Logger) applyJWTClaimEnrichment(ctx context.Context, entry map[string]any) {
-	cfg := a.configSnapshot()
-	if len(cfg.JWTClaimMappings) == 0 {
+	if len(a.config.JWTClaimMappings) == 0 {
 		return
 	}
 
@@ -35,7 +34,7 @@ func (a *Logger) applyJWTClaimEnrichment(ctx context.Context, entry map[string]a
 		return
 	}
 
-	a.applyMappedJWTClaims(ctx, entry, claimsMap, cfg.JWTClaimMappings)
+	a.applyMappedJWTClaims(ctx, entry, claimsMap, a.config.JWTClaimMappings)
 }
 
 func (a *Logger) applyMappedJWTClaims(ctx context.Context, entry map[string]any, claimsMap map[string]any, mappings []JWTClaimMapping) {

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -38,8 +38,7 @@ var logLevelNames = map[slog.Leveler]string{
 type Logger struct {
 	logger        *slog.Logger
 	diagnostics   *slog.Logger
-	encoder       Encoder
-	sink          Sink
+	processor     Processor
 	recordTimeout time.Duration
 	configMu      sync.RWMutex
 	config        Config
@@ -48,20 +47,11 @@ type Logger struct {
 // Option configures an audit logger at construction time.
 type Option func(*Logger)
 
-// WithEncoder configures the canonical event encoder.
-func WithEncoder(encoder Encoder) Option {
+// WithProcessor configures canonical event processing.
+func WithProcessor(processor Processor) Option {
 	return func(logger *Logger) {
-		if encoder != nil {
-			logger.encoder = encoder
-		}
-	}
-}
-
-// WithSink configures the emission sink. The default sink writes through slog.
-func WithSink(sink Sink) Option {
-	return func(logger *Logger) {
-		if sink != nil {
-			logger.sink = sink
+		if processor != nil {
+			logger.processor = processor
 		}
 	}
 }
@@ -75,7 +65,7 @@ func WithDiagnosticLogger(diagnostics *slog.Logger) Option {
 	}
 }
 
-// WithRecordTimeout bounds encoding and sink handoff after request cancellation.
+// WithRecordTimeout bounds processing after request cancellation.
 func WithRecordTimeout(timeout time.Duration) Option {
 	return func(logger *Logger) {
 		if timeout > 0 {
@@ -149,21 +139,15 @@ func (a *Logger) With(key string, value string) *Logger {
 		logger: a.logger.With(key, value),
 		//nolint:sloglint // mirror the same scoped attributes on operational diagnostics
 		diagnostics:   diagnostics.With(key, value),
-		encoder:       a.encoder,
-		sink:          a.sink,
+		processor:     a.processor,
 		recordTimeout: a.recordTimeout,
 		config:        a.configSnapshot(),
 	}
 }
 
-// Encoder returns the configured encoder, or nil for the default OpenTDF encoder.
-func (a *Logger) Encoder() Encoder {
-	return a.encoder
-}
-
-// Sink returns the configured sink, or nil for the default slog sink.
-func (a *Logger) Sink() Sink {
-	return a.sink
+// Processor returns the configured processor, or nil for default OpenTDF processing.
+func (a *Logger) Processor() Processor {
+	return a.processor
 }
 
 // addEvent appends a pending audit event to the transaction

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -37,7 +37,6 @@ var logLevelNames = map[slog.Leveler]string{
 
 type Logger struct {
 	logger        *slog.Logger
-	diagnostics   *slog.Logger
 	processor     Processor
 	recordTimeout time.Duration
 	configMu      sync.RWMutex
@@ -52,24 +51,6 @@ func WithProcessor(processor Processor) Option {
 	return func(logger *Logger) {
 		if processor != nil {
 			logger.processor = processor
-		}
-	}
-}
-
-// WithDiagnosticLogger routes recorder failures to an operational logger.
-func WithDiagnosticLogger(diagnostics *slog.Logger) Option {
-	return func(logger *Logger) {
-		if diagnostics != nil {
-			logger.diagnostics = diagnostics
-		}
-	}
-}
-
-// WithRecordTimeout bounds processing after request cancellation.
-func WithRecordTimeout(timeout time.Duration) Option {
-	return func(logger *Logger) {
-		if timeout > 0 {
-			logger.recordTimeout = timeout
 		}
 	}
 }
@@ -96,7 +77,6 @@ func ReplaceAttrAuditLevel(_ []string, a slog.Attr) slog.Attr {
 func CreateAuditLogger(logger slog.Logger, options ...Option) *Logger {
 	auditLogger := &Logger{
 		logger:        &logger,
-		diagnostics:   slog.Default(),
 		recordTimeout: defaultRecordTimeout,
 	}
 	for _, option := range options {
@@ -130,15 +110,9 @@ func (a *Logger) configSnapshot() Config {
 }
 
 func (a *Logger) With(key string, value string) *Logger {
-	diagnostics := a.diagnostics
-	if diagnostics == nil {
-		diagnostics = slog.Default()
-	}
 	return &Logger{
 		//nolint:sloglint // custom logger should support key/value pairs in With attributes
-		logger: a.logger.With(key, value),
-		//nolint:sloglint // mirror the same scoped attributes on operational diagnostics
-		diagnostics:   diagnostics.With(key, value),
+		logger:        a.logger.With(key, value),
 		processor:     a.processor,
 		recordTimeout: a.recordTimeout,
 		config:        a.configSnapshot(),
@@ -170,7 +144,7 @@ func (tx *auditTransaction) logClose(ctx context.Context, auditLogger *Logger, s
 		auditEvent := event.event
 
 		if !success {
-			auditEvent.Action.Result = ActionResultCancel.String()
+			auditEvent.Action.Result = ActionResultCancel
 		}
 
 		if err != nil {

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -3,6 +3,8 @@ package audit
 import (
 	"context"
 	"log/slog"
+	"sync"
+	"time"
 )
 
 // From the Slog docs (https://betterstack.com/community/guides/logging/logging-in-go/#customizing-slog-levels):
@@ -10,8 +12,9 @@ import (
 // associated with an integer value: DEBUG (-4), INFO (0), WARN (4), and ERROR (8).
 const (
 	// Currently setting AUDIT level to 10, a level above ERROR so it is always logged
-	LevelAudit    = slog.Level(10)
-	LevelAuditStr = "AUDIT"
+	LevelAudit           = slog.Level(10)
+	LevelAuditStr        = "AUDIT"
+	defaultRecordTimeout = 5 * time.Second
 )
 
 type Verb string
@@ -33,8 +36,52 @@ var logLevelNames = map[slog.Leveler]string{
 }
 
 type Logger struct {
-	logger *slog.Logger
-	config Config
+	logger        *slog.Logger
+	diagnostics   *slog.Logger
+	encoder       Encoder
+	sink          Sink
+	recordTimeout time.Duration
+	configMu      sync.RWMutex
+	config        Config
+}
+
+// Option configures an audit logger at construction time.
+type Option func(*Logger)
+
+// WithEncoder configures the canonical event encoder.
+func WithEncoder(encoder Encoder) Option {
+	return func(logger *Logger) {
+		if encoder != nil {
+			logger.encoder = encoder
+		}
+	}
+}
+
+// WithSink configures the emission sink. The default sink writes through slog.
+func WithSink(sink Sink) Option {
+	return func(logger *Logger) {
+		if sink != nil {
+			logger.sink = sink
+		}
+	}
+}
+
+// WithDiagnosticLogger routes recorder failures to an operational logger.
+func WithDiagnosticLogger(diagnostics *slog.Logger) Option {
+	return func(logger *Logger) {
+		if diagnostics != nil {
+			logger.diagnostics = diagnostics
+		}
+	}
+}
+
+// WithRecordTimeout bounds encoding and sink handoff after request cancellation.
+func WithRecordTimeout(timeout time.Duration) Option {
+	return func(logger *Logger) {
+		if timeout > 0 {
+			logger.recordTimeout = timeout
+		}
+	}
 }
 
 // Used to support custom log levels showing up with custom labels as well
@@ -56,10 +103,16 @@ func ReplaceAttrAuditLevel(_ []string, a slog.Attr) slog.Attr {
 	return a
 }
 
-func CreateAuditLogger(logger slog.Logger) *Logger {
-	return &Logger{
-		logger: &logger,
+func CreateAuditLogger(logger slog.Logger, options ...Option) *Logger {
+	auditLogger := &Logger{
+		logger:        &logger,
+		diagnostics:   slog.Default(),
+		recordTimeout: defaultRecordTimeout,
 	}
+	for _, option := range options {
+		option(auditLogger)
+	}
+	return auditLogger
 }
 
 func cloneConfig(cfg Config) Config {
@@ -73,16 +126,44 @@ func (a *Logger) ApplyConfig(cfg Config) error {
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
+	a.configMu.Lock()
 	a.config = cloneConfig(cfg)
+	a.configMu.Unlock()
 	return nil
 }
 
+//nolint:funcorder // keep configuration read and write synchronization together
+func (a *Logger) configSnapshot() Config {
+	a.configMu.RLock()
+	defer a.configMu.RUnlock()
+	return cloneConfig(a.config)
+}
+
 func (a *Logger) With(key string, value string) *Logger {
+	diagnostics := a.diagnostics
+	if diagnostics == nil {
+		diagnostics = slog.Default()
+	}
 	return &Logger{
 		//nolint:sloglint // custom logger should support key/value pairs in With attributes
 		logger: a.logger.With(key, value),
-		config: cloneConfig(a.config),
+		//nolint:sloglint // mirror the same scoped attributes on operational diagnostics
+		diagnostics:   diagnostics.With(key, value),
+		encoder:       a.encoder,
+		sink:          a.sink,
+		recordTimeout: a.recordTimeout,
+		config:        a.configSnapshot(),
 	}
+}
+
+// Encoder returns the configured encoder, or nil for the default OpenTDF encoder.
+func (a *Logger) Encoder() Encoder {
+	return a.encoder
+}
+
+// Sink returns the configured sink, or nil for the default slog sink.
+func (a *Logger) Sink() Sink {
+	return a.sink
 }
 
 // addEvent appends a pending audit event to the transaction
@@ -105,7 +186,7 @@ func (tx *auditTransaction) logClose(ctx context.Context, auditLogger *Logger, s
 		auditEvent := event.event
 
 		if !success {
-			auditEvent.Action.Result = ActionResultCancel
+			auditEvent.Action.Result = ActionResultCancel.String()
 		}
 
 		if err != nil {

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -3,7 +3,6 @@ package audit
 import (
 	"context"
 	"log/slog"
-	"sync"
 	"time"
 )
 
@@ -39,7 +38,6 @@ type Logger struct {
 	logger        *slog.Logger
 	processor     Processor
 	recordTimeout time.Duration
-	configMu      sync.RWMutex
 	config        Config
 }
 
@@ -91,22 +89,14 @@ func cloneConfig(cfg Config) Config {
 	return cloned
 }
 
-// ApplyConfig validates and stores the latest audit enrichment configuration.
+// ApplyConfig validates and copies audit enrichment configuration.
+// Call only during setup, before the logger is shared with other goroutines.
 func (a *Logger) ApplyConfig(cfg Config) error {
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
-	a.configMu.Lock()
 	a.config = cloneConfig(cfg)
-	a.configMu.Unlock()
 	return nil
-}
-
-//nolint:funcorder // keep configuration read and write synchronization together
-func (a *Logger) configSnapshot() Config {
-	a.configMu.RLock()
-	defer a.configMu.RUnlock()
-	return cloneConfig(a.config)
 }
 
 func (a *Logger) With(key string, value string) *Logger {
@@ -115,7 +105,7 @@ func (a *Logger) With(key string, value string) *Logger {
 		logger:        a.logger.With(key, value),
 		processor:     a.processor,
 		recordTimeout: a.recordTimeout,
-		config:        a.configSnapshot(),
+		config:        cloneConfig(a.config),
 	}
 }
 

--- a/service/logger/audit/logger.go
+++ b/service/logger/audit/logger.go
@@ -53,6 +53,13 @@ func WithProcessor(processor Processor) Option {
 	}
 }
 
+// WithRecordTimeout sets the processing budget. Non-positive values use five seconds.
+func WithRecordTimeout(timeout time.Duration) Option {
+	return func(logger *Logger) {
+		logger.recordTimeout = timeout
+	}
+}
+
 // Used to support custom log levels showing up with custom labels as well
 // see https://betterstack.com/community/guides/logging/logging-in-go/#creating-custom-log-levels
 func ReplaceAttrAuditLevel(_ []string, a slog.Attr) slog.Attr {
@@ -112,6 +119,14 @@ func (a *Logger) With(key string, value string) *Logger {
 // Processor returns the configured processor, or nil for default OpenTDF processing.
 func (a *Logger) Processor() Processor {
 	return a.processor
+}
+
+// RecordTimeout returns the configured processing budget, or the five-second default.
+func (a *Logger) RecordTimeout() time.Duration {
+	if a.recordTimeout <= 0 {
+		return defaultRecordTimeout
+	}
+	return a.recordTimeout
 }
 
 // addEvent appends a pending audit event to the transaction

--- a/service/logger/audit/recorder.go
+++ b/service/logger/audit/recorder.go
@@ -1,0 +1,258 @@
+package audit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
+)
+
+var (
+	ErrInvalidEvent    = errors.New("invalid audit event")
+	ErrInvalidEmission = errors.New("invalid audit encoder emissions")
+	ErrEncoding        = errors.New("audit event encoding failed")
+	ErrSink            = errors.New("audit sink failed")
+)
+
+// Recorder immediately records an immutable audit event. Implementations must
+// return only after the configured sink has accepted or rejected the event.
+type Recorder interface {
+	Record(context.Context, Event) error
+}
+
+// Emission is one serialized-log input produced from a canonical event.
+type Emission struct {
+	Level   slog.Level
+	Message string
+	Attrs   []slog.Attr
+}
+
+// Encoder transforms one canonical event into one or more emissions. Returning
+// no emissions is invalid so an encoder cannot silently discard audit evidence.
+type Encoder interface {
+	Encode(context.Context, Event) ([]Emission, error)
+}
+
+// EncoderFunc adapts a function to Encoder.
+type EncoderFunc func(context.Context, Event) ([]Emission, error)
+
+func (f EncoderFunc) Encode(ctx context.Context, event Event) ([]Emission, error) {
+	return f(ctx, event)
+}
+
+// Sink acknowledges handoff of one emission. Implementations may be called
+// concurrently and must not retain or mutate emission values.
+type Sink interface {
+	Write(context.Context, Emission) error
+}
+
+// SinkFunc adapts a function to Sink.
+type SinkFunc func(context.Context, Emission) error
+
+func (f SinkFunc) Write(ctx context.Context, emission Emission) error {
+	return f(ctx, emission)
+}
+
+// Record snapshots and stamps an event before encoding it under a bounded
+// context detached from request cancellation. Encoder failure falls back to
+// the default OpenTDF emission and is still returned to the caller.
+func (a *Logger) Record(ctx context.Context, event Event) error {
+	snapshot, err := snapshotEvent(event)
+	if err != nil {
+		return err
+	}
+	a.stampEvent(ctx, &snapshot)
+
+	timeout := a.recordTimeout
+	if timeout <= 0 {
+		timeout = defaultRecordTimeout
+	}
+	recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	defer cancel()
+
+	emissions, encodeErr := a.encode(recordCtx, snapshot)
+	if encodeErr != nil {
+		a.diagnosticLogger().ErrorContext(recordCtx,
+			"audit encoder failed; emitting default event",
+			slog.Any("error", encodeErr),
+		)
+		var fallbackErr error
+		emissions, fallbackErr = a.defaultEncode(recordCtx, snapshot)
+		encodeErr = errors.Join(encodeErr, fallbackErr)
+	}
+
+	return errors.Join(encodeErr, a.writeAll(recordCtx, emissions))
+}
+
+func snapshotEvent(event Event) (snapshot Event, snapshotErr error) { //nolint:nonamedreturns // recovery must replace both values
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			snapshotErr = fmt.Errorf("%w: snapshot panic: %v", ErrInvalidEvent, recovered)
+		}
+	}()
+
+	encoded, err := json.Marshal(event)
+	if err != nil {
+		return Event{}, fmt.Errorf("%w: %w", ErrInvalidEvent, err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	if err := decoder.Decode(&snapshot); err != nil {
+		return Event{}, fmt.Errorf("%w: %w", ErrInvalidEvent, err)
+	}
+	snapshot.Verb = event.Verb
+	snapshot.ID = event.ID
+	snapshot.Phase = event.Phase
+	snapshot.Principal = event.Principal
+	if snapshot.Verb == "" {
+		return Event{}, fmt.Errorf("%w: verb is required", ErrInvalidEvent)
+	}
+	return snapshot, nil
+}
+
+func (a *Logger) stampEvent(ctx context.Context, event *Event) {
+	data := GetAuditDataFromContext(ctx)
+	event.Principal = ctxAuth.Principal{}
+	if principal, ok := ctxAuth.PrincipalFromContext(ctx); ok {
+		event.Principal = principal
+	}
+	if event.Actor.ID == "" {
+		event.Actor.ID = data.ActorID
+	}
+	event.RequestID = data.RequestID
+	event.ClientInfo.UserAgent = data.UserAgent
+	event.ClientInfo.RequestIP = data.RequestIP
+	if event.ID == uuid.Nil {
+		event.ID = uuid.New()
+	}
+	if event.Phase == "" {
+		event.Phase = PhaseCompleted
+	}
+	event.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+func (a *Logger) encode(ctx context.Context, event Event) (emissions []Emission, encodeErr error) { //nolint:nonamedreturns // recovery must replace both values
+	if a.encoder == nil {
+		return a.defaultEncode(ctx, event)
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			emissions = nil
+			encodeErr = fmt.Errorf("%w: panic: %v", ErrEncoding, recovered)
+		}
+	}()
+
+	encoderEvent, err := snapshotEvent(event)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrEncoding, err)
+	}
+	emissions, err = a.encoder.Encode(ctx, encoderEvent)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrEncoding, err)
+	}
+	if err := validateEmissions(emissions); err != nil {
+		return nil, errors.Join(ErrEncoding, err)
+	}
+	return emissions, nil
+}
+
+func validateEmissions(emissions []Emission) error {
+	if len(emissions) == 0 {
+		return fmt.Errorf("%w: encoder returned no emissions", ErrInvalidEmission)
+	}
+	for idx, emission := range emissions {
+		if emission.Message == "" {
+			return fmt.Errorf("%w: emission %d has no message", ErrInvalidEmission, idx)
+		}
+	}
+	return nil
+}
+
+func (a *Logger) defaultEncode(ctx context.Context, event Event) (emissions []Emission, encodeErr error) { //nolint:nonamedreturns // recovery must replace both values
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			emissions = nil
+			encodeErr = fmt.Errorf("%w: default encoder panic: %v", ErrEncoding, recovered)
+		}
+	}()
+	return []Emission{{
+		Level:   LevelAudit,
+		Message: string(event.Verb),
+		Attrs:   []slog.Attr{slog.Any("audit", a.buildLogEntry(ctx, &event))},
+	}}, nil
+}
+
+func (a *Logger) writeAll(ctx context.Context, emissions []Emission) error {
+	var writeErr error
+	for idx, emission := range emissions {
+		if err := a.write(ctx, emission); err != nil {
+			writeErr = errors.Join(writeErr, fmt.Errorf("emission %d: %w", idx, err))
+		}
+	}
+	return writeErr
+}
+
+func (a *Logger) write(ctx context.Context, emission Emission) (writeErr error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			writeErr = fmt.Errorf("%w: panic: %v", ErrSink, recovered)
+		}
+	}()
+	emission = cloneEmission(emission)
+
+	if a.sink != nil {
+		if err := a.sink.Write(ctx, emission); err != nil {
+			return fmt.Errorf("%w: %w", ErrSink, err)
+		}
+		return nil
+	}
+
+	handler := a.logger.Handler()
+	if !handler.Enabled(ctx, emission.Level) {
+		return fmt.Errorf("%w: level %s is disabled", ErrSink, emission.Level)
+	}
+	record := slog.NewRecord(time.Now(), emission.Level, emission.Message, 0)
+	record.AddAttrs(emission.Attrs...)
+	if err := handler.Handle(ctx, record); err != nil {
+		return fmt.Errorf("%w: %w", ErrSink, err)
+	}
+	return nil
+}
+
+func cloneEmission(emission Emission) Emission {
+	cloned := emission
+	cloned.Attrs = make([]slog.Attr, len(emission.Attrs))
+	for idx, attr := range emission.Attrs {
+		cloned.Attrs[idx] = cloneAttr(attr)
+	}
+	return cloned
+}
+
+func cloneAttr(attr slog.Attr) slog.Attr {
+	value := attr.Value.Resolve()
+	if value.Kind() == slog.KindGroup {
+		group := value.Group()
+		cloned := make([]slog.Attr, len(group))
+		for idx, nested := range group {
+			cloned[idx] = cloneAttr(nested)
+		}
+		return slog.Attr{Key: attr.Key, Value: slog.GroupValue(cloned...)}
+	}
+	if value.Kind() == slog.KindAny {
+		return slog.Any(attr.Key, normalizeAuditValue(value.Any()))
+	}
+	return slog.Attr{Key: attr.Key, Value: value}
+}
+
+func (a *Logger) diagnosticLogger() *slog.Logger {
+	if a.diagnostics != nil {
+		return a.diagnostics
+	}
+	return slog.Default()
+}

--- a/service/logger/audit/recorder.go
+++ b/service/logger/audit/recorder.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -14,60 +15,43 @@ import (
 )
 
 var (
-	ErrInvalidEvent    = errors.New("invalid audit event")
-	ErrInvalidEmission = errors.New("invalid audit encoder emissions")
-	ErrEncoding        = errors.New("audit event encoding failed")
-	ErrSink            = errors.New("audit sink failed")
+	ErrInvalidEvent = errors.New("invalid audit event")
+	ErrProcessing   = errors.New("audit event processing failed")
 )
 
 // Recorder immediately records an immutable audit event. Implementations must
-// return only after the configured sink has accepted or rejected the event.
+// return only after the configured processor has accepted or rejected the event.
 type Recorder interface {
 	Record(context.Context, Event) error
 }
 
-// Emission is one serialized-log input produced from a canonical event.
-type Emission struct {
-	Level   slog.Level
-	Message string
-	Attrs   []slog.Attr
+// Processor accepts a fully stamped event. Processors own destination-specific
+// validation, fan-out, delivery, and recovery. A nil error means the event was
+// accepted by the intended destination or a durable recovery path.
+//
+// Implementations may be called concurrently and must honor context cancellation.
+type Processor interface {
+	Process(context.Context, Event) error
 }
 
-// Encoder transforms one canonical event into one or more emissions. Returning
-// no emissions is invalid so an encoder cannot silently discard audit evidence.
-type Encoder interface {
-	Encode(context.Context, Event) ([]Emission, error)
-}
+// ProcessorFunc adapts a function to Processor.
+type ProcessorFunc func(context.Context, Event) error
 
-// EncoderFunc adapts a function to Encoder.
-type EncoderFunc func(context.Context, Event) ([]Emission, error)
-
-func (f EncoderFunc) Encode(ctx context.Context, event Event) ([]Emission, error) {
+func (f ProcessorFunc) Process(ctx context.Context, event Event) error {
 	return f(ctx, event)
 }
 
-// Sink acknowledges handoff of one emission. Implementations may be called
-// concurrently and must not retain or mutate emission values.
-type Sink interface {
-	Write(context.Context, Emission) error
-}
-
-// SinkFunc adapts a function to Sink.
-type SinkFunc func(context.Context, Emission) error
-
-func (f SinkFunc) Write(ctx context.Context, emission Emission) error {
-	return f(ctx, emission)
-}
-
-// Record snapshots and stamps an event before encoding it under a bounded
-// context detached from request cancellation. Encoder failure falls back to
-// the default OpenTDF emission and is still returned to the caller.
+// Record snapshots, stamps, and validates an event before processing it under a
+// bounded context detached from request cancellation.
 func (a *Logger) Record(ctx context.Context, event Event) error {
 	snapshot, err := snapshotEvent(event)
 	if err != nil {
 		return err
 	}
 	a.stampEvent(ctx, &snapshot)
+	if err := validateEvent(snapshot); err != nil {
+		return err
+	}
 
 	timeout := a.recordTimeout
 	if timeout <= 0 {
@@ -76,18 +60,11 @@ func (a *Logger) Record(ctx context.Context, event Event) error {
 	recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
 	defer cancel()
 
-	emissions, encodeErr := a.encode(recordCtx, snapshot)
-	if encodeErr != nil {
-		a.diagnosticLogger().ErrorContext(recordCtx,
-			"audit encoder failed; emitting default event",
-			slog.Any("error", encodeErr),
-		)
-		var fallbackErr error
-		emissions, fallbackErr = a.defaultEncode(recordCtx, snapshot)
-		encodeErr = errors.Join(encodeErr, fallbackErr)
+	if err := a.process(recordCtx, snapshot); err != nil {
+		a.diagnosticLogger().Error("audit processor failed", slog.Any("error", err))
+		return err
 	}
-
-	return errors.Join(encodeErr, a.writeAll(recordCtx, emissions))
+	return nil
 }
 
 func snapshotEvent(event Event) (snapshot Event, snapshotErr error) { //nolint:nonamedreturns // recovery must replace both values
@@ -110,9 +87,6 @@ func snapshotEvent(event Event) (snapshot Event, snapshotErr error) { //nolint:n
 	snapshot.ID = event.ID
 	snapshot.Phase = event.Phase
 	snapshot.Principal = event.Principal
-	if snapshot.Verb == "" {
-		return Event{}, fmt.Errorf("%w: verb is required", ErrInvalidEvent)
-	}
 	return snapshot, nil
 }
 
@@ -134,120 +108,64 @@ func (a *Logger) stampEvent(ctx context.Context, event *Event) {
 	if event.Phase == "" {
 		event.Phase = PhaseCompleted
 	}
-	event.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+	event.Timestamp = time.Now().Format(time.RFC3339)
 }
 
-func (a *Logger) encode(ctx context.Context, event Event) (emissions []Emission, encodeErr error) { //nolint:nonamedreturns // recovery must replace both values
-	if a.encoder == nil {
-		return a.defaultEncode(ctx, event)
+func validateEvent(event Event) error {
+	required := []struct {
+		name  string
+		value string
+	}{
+		{name: "verb", value: string(event.Verb)},
+		{name: "object type", value: event.Object.Type},
+		{name: "action type", value: event.Action.Type},
+		{name: "action result", value: event.Action.Result},
+		{name: "client platform", value: event.ClientInfo.Platform},
 	}
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			emissions = nil
-			encodeErr = fmt.Errorf("%w: panic: %v", ErrEncoding, recovered)
+	for _, field := range required {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("%w: %s is required", ErrInvalidEvent, field.name)
 		}
-	}()
-
-	encoderEvent, err := snapshotEvent(event)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrEncoding, err)
 	}
-	emissions, err = a.encoder.Encode(ctx, encoderEvent)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrEncoding, err)
+	if event.ID == uuid.Nil {
+		return fmt.Errorf("%w: id is required", ErrInvalidEvent)
 	}
-	if err := validateEmissions(emissions); err != nil {
-		return nil, errors.Join(ErrEncoding, err)
+	if event.Phase != PhaseAttempted && event.Phase != PhaseCompleted {
+		return fmt.Errorf("%w: invalid phase %q", ErrInvalidEvent, event.Phase)
 	}
-	return emissions, nil
-}
-
-func validateEmissions(emissions []Emission) error {
-	if len(emissions) == 0 {
-		return fmt.Errorf("%w: encoder returned no emissions", ErrInvalidEmission)
-	}
-	for idx, emission := range emissions {
-		if emission.Message == "" {
-			return fmt.Errorf("%w: emission %d has no message", ErrInvalidEmission, idx)
-		}
+	if _, err := time.Parse(time.RFC3339, event.Timestamp); err != nil {
+		return fmt.Errorf("%w: invalid timestamp: %w", ErrInvalidEvent, err)
 	}
 	return nil
 }
 
-func (a *Logger) defaultEncode(ctx context.Context, event Event) (emissions []Emission, encodeErr error) { //nolint:nonamedreturns // recovery must replace both values
+func (a *Logger) process(ctx context.Context, event Event) (processErr error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			emissions = nil
-			encodeErr = fmt.Errorf("%w: default encoder panic: %v", ErrEncoding, recovered)
+			processErr = fmt.Errorf("%w: panic: %v", ErrProcessing, recovered)
 		}
 	}()
-	return []Emission{{
-		Level:   LevelAudit,
-		Message: string(event.Verb),
-		Attrs:   []slog.Attr{slog.Any("audit", a.buildLogEntry(ctx, &event))},
-	}}, nil
+
+	if a.processor == nil {
+		return a.defaultProcess(ctx, event)
+	}
+	if err := a.processor.Process(ctx, event); err != nil {
+		return fmt.Errorf("%w: %w", ErrProcessing, err)
+	}
+	return nil
 }
 
-func (a *Logger) writeAll(ctx context.Context, emissions []Emission) error {
-	var writeErr error
-	for idx, emission := range emissions {
-		if err := a.write(ctx, emission); err != nil {
-			writeErr = errors.Join(writeErr, fmt.Errorf("emission %d: %w", idx, err))
-		}
-	}
-	return writeErr
-}
-
-func (a *Logger) write(ctx context.Context, emission Emission) (writeErr error) {
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			writeErr = fmt.Errorf("%w: panic: %v", ErrSink, recovered)
-		}
-	}()
-	emission = cloneEmission(emission)
-
-	if a.sink != nil {
-		if err := a.sink.Write(ctx, emission); err != nil {
-			return fmt.Errorf("%w: %w", ErrSink, err)
-		}
-		return nil
-	}
-
+func (a *Logger) defaultProcess(ctx context.Context, event Event) error {
 	handler := a.logger.Handler()
-	if !handler.Enabled(ctx, emission.Level) {
-		return fmt.Errorf("%w: level %s is disabled", ErrSink, emission.Level)
+	if !handler.Enabled(ctx, LevelAudit) {
+		return fmt.Errorf("%w: level %s is disabled", ErrProcessing, LevelAudit)
 	}
-	record := slog.NewRecord(time.Now(), emission.Level, emission.Message, 0)
-	record.AddAttrs(emission.Attrs...)
+	record := slog.NewRecord(time.Now(), LevelAudit, string(event.Verb), 0)
+	record.AddAttrs(slog.Any("audit", a.buildLogEntry(ctx, &event)))
 	if err := handler.Handle(ctx, record); err != nil {
-		return fmt.Errorf("%w: %w", ErrSink, err)
+		return fmt.Errorf("%w: %w", ErrProcessing, err)
 	}
 	return nil
-}
-
-func cloneEmission(emission Emission) Emission {
-	cloned := emission
-	cloned.Attrs = make([]slog.Attr, len(emission.Attrs))
-	for idx, attr := range emission.Attrs {
-		cloned.Attrs[idx] = cloneAttr(attr)
-	}
-	return cloned
-}
-
-func cloneAttr(attr slog.Attr) slog.Attr {
-	value := attr.Value.Resolve()
-	if value.Kind() == slog.KindGroup {
-		group := value.Group()
-		cloned := make([]slog.Attr, len(group))
-		for idx, nested := range group {
-			cloned[idx] = cloneAttr(nested)
-		}
-		return slog.Attr{Key: attr.Key, Value: slog.GroupValue(cloned...)}
-	}
-	if value.Kind() == slog.KindAny {
-		return slog.Any(attr.Key, normalizeAuditValue(value.Any()))
-	}
-	return slog.Attr{Key: attr.Key, Value: value}
 }
 
 func (a *Logger) diagnosticLogger() *slog.Logger {

--- a/service/logger/audit/recorder.go
+++ b/service/logger/audit/recorder.go
@@ -1,9 +1,7 @@
 package audit
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -19,8 +17,8 @@ var (
 	ErrProcessing   = errors.New("audit event processing failed")
 )
 
-// Recorder immediately records an immutable audit event. Implementations must
-// return only after the configured processor has accepted or rejected the event.
+// Recorder immediately records an audit event. Implementations must return only
+// after the configured processor has accepted or rejected the event.
 type Recorder interface {
 	Record(context.Context, Event) error
 }
@@ -30,6 +28,7 @@ type Recorder interface {
 // accepted by the intended destination or a durable recovery path.
 //
 // Implementations may be called concurrently and must honor context cancellation.
+// They must not mutate or retain maps, slices, or other reference data in Event.
 type Processor interface {
 	Process(context.Context, Event) error
 }
@@ -41,15 +40,12 @@ func (f ProcessorFunc) Process(ctx context.Context, event Event) error {
 	return f(ctx, event)
 }
 
-// Record snapshots, stamps, and validates an event before processing it under a
-// bounded context detached from request cancellation.
+// Record stamps and validates an event before processing it under a bounded
+// context detached from request cancellation. Callers must not mutate reference
+// data in event until Record returns.
 func (a *Logger) Record(ctx context.Context, event Event) error {
-	snapshot, err := snapshotEvent(event)
-	if err != nil {
-		return err
-	}
-	a.stampEvent(ctx, &snapshot)
-	if err := validateEvent(snapshot); err != nil {
+	a.stampEvent(ctx, &event)
+	if err := validateEvent(event); err != nil {
 		return err
 	}
 
@@ -60,34 +56,11 @@ func (a *Logger) Record(ctx context.Context, event Event) error {
 	recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
 	defer cancel()
 
-	if err := a.process(recordCtx, snapshot); err != nil {
+	if err := a.process(recordCtx, event); err != nil {
 		a.diagnosticLogger().Error("audit processor failed", slog.Any("error", err))
 		return err
 	}
 	return nil
-}
-
-func snapshotEvent(event Event) (snapshot Event, snapshotErr error) { //nolint:nonamedreturns // recovery must replace both values
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			snapshotErr = fmt.Errorf("%w: snapshot panic: %v", ErrInvalidEvent, recovered)
-		}
-	}()
-
-	encoded, err := json.Marshal(event)
-	if err != nil {
-		return Event{}, fmt.Errorf("%w: %w", ErrInvalidEvent, err)
-	}
-	decoder := json.NewDecoder(bytes.NewReader(encoded))
-	decoder.UseNumber()
-	if err := decoder.Decode(&snapshot); err != nil {
-		return Event{}, fmt.Errorf("%w: %w", ErrInvalidEvent, err)
-	}
-	snapshot.Verb = event.Verb
-	snapshot.ID = event.ID
-	snapshot.Phase = event.Phase
-	snapshot.Principal = event.Principal
-	return snapshot, nil
 }
 
 func (a *Logger) stampEvent(ctx context.Context, event *Event) {

--- a/service/logger/audit/recorder.go
+++ b/service/logger/audit/recorder.go
@@ -56,11 +56,7 @@ func (a *Logger) Record(ctx context.Context, event Event) error {
 	recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
 	defer cancel()
 
-	if err := a.process(recordCtx, event); err != nil {
-		a.diagnosticLogger().Error("audit processor failed", slog.Any("error", err))
-		return err
-	}
-	return nil
+	return a.process(recordCtx, event)
 }
 
 func (a *Logger) stampEvent(ctx context.Context, event *Event) {
@@ -90,9 +86,6 @@ func validateEvent(event Event) error {
 		value string
 	}{
 		{name: "verb", value: string(event.Verb)},
-		{name: "object type", value: event.Object.Type},
-		{name: "action type", value: event.Action.Type},
-		{name: "action result", value: event.Action.Result},
 		{name: "client platform", value: event.ClientInfo.Platform},
 	}
 	for _, field := range required {
@@ -139,11 +132,4 @@ func (a *Logger) defaultProcess(ctx context.Context, event Event) error {
 		return fmt.Errorf("%w: %w", ErrProcessing, err)
 	}
 	return nil
-}
-
-func (a *Logger) diagnosticLogger() *slog.Logger {
-	if a.diagnostics != nil {
-		return a.diagnostics
-	}
-	return slog.Default()
 }

--- a/service/logger/audit/recorder.go
+++ b/service/logger/audit/recorder.go
@@ -49,11 +49,7 @@ func (a *Logger) Record(ctx context.Context, event Event) error {
 		return err
 	}
 
-	timeout := a.recordTimeout
-	if timeout <= 0 {
-		timeout = defaultRecordTimeout
-	}
-	recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), a.RecordTimeout())
 	defer cancel()
 
 	return a.process(recordCtx, event)

--- a/service/logger/audit/recorder.go
+++ b/service/logger/audit/recorder.go
@@ -74,9 +74,6 @@ func (a *Logger) stampEvent(ctx context.Context, event *Event) {
 	if event.ID == uuid.Nil {
 		event.ID = uuid.New()
 	}
-	if event.Phase == "" {
-		event.Phase = PhaseCompleted
-	}
 	event.Timestamp = time.Now().Format(time.RFC3339)
 }
 
@@ -95,9 +92,6 @@ func validateEvent(event Event) error {
 	}
 	if event.ID == uuid.Nil {
 		return fmt.Errorf("%w: id is required", ErrInvalidEvent)
-	}
-	if event.Phase != PhaseAttempted && event.Phase != PhaseCompleted {
-		return fmt.Errorf("%w: invalid phase %q", ErrInvalidEvent, event.Phase)
 	}
 	if _, err := time.Parse(time.RFC3339, event.Timestamp); err != nil {
 		return fmt.Errorf("%w: invalid timestamp: %w", ErrInvalidEvent, err)

--- a/service/logger/audit/recorder_external_test.go
+++ b/service/logger/audit/recorder_external_test.go
@@ -10,25 +10,33 @@ import (
 )
 
 func TestExternalServiceCanConstructCanonicalEvent(t *testing.T) {
+	var processedObjectType string
 	var _ audit.Recorder = audit.CreateAuditLogger(
 		*slog.Default(),
-		audit.WithProcessor(audit.ProcessorFunc(func(context.Context, audit.Event) error { return nil })),
+		audit.WithProcessor(audit.ProcessorFunc(func(_ context.Context, event audit.Event) error {
+			processedObjectType = event.Object.Type.String()
+			return nil
+		})),
 	)
 
-	event := audit.Event{
-		Verb:   audit.Verb("share"),
-		Phase:  audit.PhaseCompleted,
-		Object: audit.Object{Type: "document", ID: "document-1", Attributes: audit.ObjectAttributes{Attrs: []string{"classification"}}},
-		Action: audit.Action{Type: "share", Result: "success"},
-		Actor:  audit.Actor{ID: "subject-1", Attributes: []any{"attribute"}},
-		EventMetaData: audit.EventMetadata{
+	event := audit.NewEvent(audit.EventObjectParams{
+		Object: audit.EventObjectInfo{Type: audit.ObjectTypeRegisteredResource, ID: "document-1", Attributes: audit.EventObjectAttributes{Attrs: []string{"classification"}}},
+		Action: audit.EventObjectAction{Type: audit.ActionTypeRead, Result: audit.ActionResultSuccess},
+		Actor:  audit.EventObjectActor{ID: "subject-1", Attributes: []any{"attribute"}},
+		EventMetaData: audit.EventMetaData{
 			"authoritative_namespace": "https://example.com/attr/organization/value/org-1",
 		},
-		ClientInfo: audit.ClientInfo{Platform: "extension"},
-	}
+		ClientInfo: audit.EventClientInfo{Platform: "extension"},
+	})
+	event.Verb = audit.Verb("share")
+	event.Phase = audit.PhaseCompleted
 
 	require.NoError(t, audit.CreateAuditLogger(
 		*slog.Default(),
-		audit.WithProcessor(audit.ProcessorFunc(func(context.Context, audit.Event) error { return nil })),
-	).Record(t.Context(), event))
+		audit.WithProcessor(audit.ProcessorFunc(func(_ context.Context, event audit.Event) error {
+			processedObjectType = event.Object.Type.String()
+			return nil
+		})),
+	).Record(t.Context(), *event))
+	require.Equal(t, "registered_resource", processedObjectType)
 }

--- a/service/logger/audit/recorder_external_test.go
+++ b/service/logger/audit/recorder_external_test.go
@@ -1,0 +1,34 @@
+package audit_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/opentdf/platform/service/logger/audit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalServiceCanConstructCanonicalEvent(t *testing.T) {
+	var _ audit.Recorder = audit.CreateAuditLogger(
+		*slog.Default(),
+		audit.WithSink(audit.SinkFunc(func(context.Context, audit.Emission) error { return nil })),
+	)
+
+	event := audit.Event{
+		Verb:   audit.Verb("share"),
+		Phase:  audit.PhaseCompleted,
+		Object: audit.Object{Type: "document", ID: "document-1", Attributes: audit.ObjectAttributes{Attrs: []string{"classification"}}},
+		Action: audit.Action{Type: "share", Result: "success"},
+		Actor:  audit.Actor{ID: "subject-1", Attributes: []any{"attribute"}},
+		EventMetaData: audit.EventMetadata{
+			"authoritative_namespace": "https://example.com/attr/organization/value/org-1",
+		},
+		ClientInfo: audit.ClientInfo{Platform: "extension"},
+	}
+
+	require.NoError(t, audit.CreateAuditLogger(
+		*slog.Default(),
+		audit.WithSink(audit.SinkFunc(func(context.Context, audit.Emission) error { return nil })),
+	).Record(t.Context(), event))
+}

--- a/service/logger/audit/recorder_external_test.go
+++ b/service/logger/audit/recorder_external_test.go
@@ -12,7 +12,7 @@ import (
 func TestExternalServiceCanConstructCanonicalEvent(t *testing.T) {
 	var _ audit.Recorder = audit.CreateAuditLogger(
 		*slog.Default(),
-		audit.WithSink(audit.SinkFunc(func(context.Context, audit.Emission) error { return nil })),
+		audit.WithProcessor(audit.ProcessorFunc(func(context.Context, audit.Event) error { return nil })),
 	)
 
 	event := audit.Event{
@@ -29,6 +29,6 @@ func TestExternalServiceCanConstructCanonicalEvent(t *testing.T) {
 
 	require.NoError(t, audit.CreateAuditLogger(
 		*slog.Default(),
-		audit.WithSink(audit.SinkFunc(func(context.Context, audit.Emission) error { return nil })),
+		audit.WithProcessor(audit.ProcessorFunc(func(context.Context, audit.Event) error { return nil })),
 	).Record(t.Context(), event))
 }

--- a/service/logger/audit/recorder_external_test.go
+++ b/service/logger/audit/recorder_external_test.go
@@ -29,7 +29,6 @@ func TestExternalServiceCanConstructCanonicalEvent(t *testing.T) {
 		ClientInfo: audit.EventClientInfo{Platform: "extension"},
 	})
 	event.Verb = audit.Verb("share")
-	event.Phase = audit.PhaseCompleted
 
 	require.NoError(t, audit.CreateAuditLogger(
 		*slog.Default(),

--- a/service/logger/audit/recorder_test.go
+++ b/service/logger/audit/recorder_test.go
@@ -34,174 +34,187 @@ func (n jsonNumber) MarshalJSON() ([]byte, error) {
 	return []byte(n), nil
 }
 
+func quietDiagnostics() Option {
+	return WithDiagnosticLogger(slog.New(slog.DiscardHandler))
+}
+
 func TestRecordUsesBoundedContextAfterRequestCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(createTestContext(t))
 	cancel()
 
-	var encoded Event
-	encoder := EncoderFunc(func(ctx context.Context, event Event) ([]Emission, error) {
+	var processed Event
+	processor := ProcessorFunc(func(ctx context.Context, event Event) error {
 		require.NoError(t, ctx.Err())
 		deadline, ok := ctx.Deadline()
 		require.True(t, ok)
 		require.LessOrEqual(t, time.Until(deadline), time.Second)
-		encoded = event
-		return []Emission{{Level: LevelAudit, Message: "encoded"}}, nil
-	})
-	writes := 0
-	sink := SinkFunc(func(ctx context.Context, emission Emission) error {
-		require.NoError(t, ctx.Err())
-		assert.Equal(t, "encoded", emission.Message)
-		writes++
+		processed = event
 		return nil
 	})
-	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(sink), WithRecordTimeout(time.Second))
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor), WithRecordTimeout(time.Second))
 
-	err := logger.Record(ctx, canonicalTestEvent())
-
+	require.NoError(t, logger.Record(ctx, canonicalTestEvent()))
+	assert.NotEqual(t, uuid.Nil, processed.ID)
+	assert.Equal(t, PhaseCompleted, processed.Phase)
+	assert.Equal(t, TestRequestID, processed.RequestID)
+	assert.Equal(t, TestActorID, processed.Actor.ID)
+	_, err := time.Parse(time.RFC3339, processed.Timestamp)
 	require.NoError(t, err)
-	assert.Equal(t, 1, writes)
-	assert.NotEqual(t, uuid.Nil, encoded.ID)
-	assert.Equal(t, PhaseCompleted, encoded.Phase)
-	assert.Equal(t, TestRequestID, encoded.RequestID)
-	assert.Equal(t, TestActorID, encoded.Actor.ID)
 }
 
-func TestRecordEncoderFailureFallsBackAndReturnsError(t *testing.T) {
-	encoderErr := errors.New("conversion failed")
-	encoder := EncoderFunc(func(context.Context, Event) ([]Emission, error) {
-		return nil, encoderErr
-	})
-	var captured Emission
-	sink := SinkFunc(func(_ context.Context, emission Emission) error {
-		captured = emission
-		return nil
-	})
-	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(sink))
+func TestRecordRejectsInvalidRequiredFieldsBeforeProcessing(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Event)
+	}{
+		{name: "verb", mutate: func(event *Event) { event.Verb = " " }},
+		{name: "object type", mutate: func(event *Event) { event.Object.Type = " " }},
+		{name: "action type", mutate: func(event *Event) { event.Action.Type = " " }},
+		{name: "action result", mutate: func(event *Event) { event.Action.Result = " " }},
+		{name: "client platform", mutate: func(event *Event) { event.ClientInfo.Platform = " " }},
+		{name: "phase", mutate: func(event *Event) { event.Phase = Phase("unknown") }},
+	}
 
-	err := logger.Record(createTestContext(t), canonicalTestEvent())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event := canonicalTestEvent()
+			test.mutate(&event)
+			calls := 0
+			logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(
+				func(context.Context, Event) error {
+					calls++
+					return nil
+				},
+			)))
 
-	require.ErrorIs(t, err, ErrEncoding)
-	require.ErrorIs(t, err, encoderErr)
-	assert.Equal(t, "read", captured.Message)
-	require.Len(t, captured.Attrs, 1)
-	assert.Equal(t, "audit", captured.Attrs[0].Key)
+			err := logger.Record(t.Context(), event)
+
+			require.ErrorIs(t, err, ErrInvalidEvent)
+			assert.Zero(t, calls)
+		})
+	}
 }
 
-func TestRecordEncoderCannotMutateFallbackEvent(t *testing.T) {
-	encoder := EncoderFunc(func(_ context.Context, event Event) ([]Emission, error) {
-		event.Object.ID = "mutated"
-		owner, ok := event.EventMetaData["owner"].(map[string]any)
-		require.True(t, ok)
-		owner["id"] = "mutated"
-		return nil, errors.New("conversion failed")
-	})
-	var payload map[string]any
-	sink := SinkFunc(func(_ context.Context, emission Emission) error {
-		var ok bool
-		payload, ok = emission.Attrs[0].Value.Any().(map[string]any)
-		require.True(t, ok)
-		return nil
-	})
-	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(sink))
+func TestRecordAllowsOptionalFieldsToBeEmpty(t *testing.T) {
+	event := canonicalTestEvent()
+	event.Object.ID = ""
+	event.Actor = Actor{}
+	event.EventMetaData = nil
+	event.Original = nil
+	event.Updated = nil
 
-	err := logger.Record(createTestContext(t), canonicalTestEvent())
-
-	require.ErrorIs(t, err, ErrEncoding)
-	assert.Equal(t, "document-1", requireMap(t, payload["object"])["id"])
-	assert.Equal(t, "org-1", requireMap(t, requireMap(t, payload["eventMetaData"])["owner"])["id"])
-}
-
-func TestRecordRejectsSilentEncoderDrop(t *testing.T) {
-	encoder := EncoderFunc(func(context.Context, Event) ([]Emission, error) {
-		return nil, nil
-	})
-	writes := 0
-	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(SinkFunc(
-		func(context.Context, Emission) error {
-			writes++
+	processed := false
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(
+		func(_ context.Context, event Event) error {
+			processed = true
+			assert.Empty(t, event.Object.ID)
 			return nil
 		},
 	)))
 
-	err := logger.Record(createTestContext(t), canonicalTestEvent())
-
-	require.ErrorIs(t, err, ErrInvalidEmission)
-	assert.Equal(t, 1, writes, "default fallback must preserve the event")
+	require.NoError(t, logger.Record(t.Context(), event))
+	assert.True(t, processed)
 }
 
-func TestRecordAttemptsEveryEmissionAndReturnsSinkFailures(t *testing.T) {
-	encoder := EncoderFunc(func(context.Context, Event) ([]Emission, error) {
-		return []Emission{
-			{Level: LevelAudit, Message: "partition-1"},
-			{Level: LevelAudit, Message: "partition-2"},
-		}, nil
+func TestRecordReturnsProcessorErrorWithoutFallback(t *testing.T) {
+	processorErr := errors.New("delivery unavailable")
+	logger, buffer := createTestLogger()
+	logger.processor = ProcessorFunc(func(context.Context, Event) error { return processorErr })
+	logger.diagnostics = slog.New(slog.DiscardHandler)
+
+	err := logger.Record(createTestContext(t), canonicalTestEvent())
+
+	require.ErrorIs(t, err, ErrProcessing)
+	require.ErrorIs(t, err, processorErr)
+	assert.Empty(t, buffer.String())
+}
+
+func TestRecordReturnsProcessorPanic(t *testing.T) {
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(func(context.Context, Event) error {
+		panic("processor panic")
+	})), quietDiagnostics())
+
+	err := logger.Record(createTestContext(t), canonicalTestEvent())
+
+	require.ErrorIs(t, err, ErrProcessing)
+	require.ErrorContains(t, err, "processor panic")
+}
+
+func TestRecordReturnsProcessorDeadline(t *testing.T) {
+	processor := ProcessorFunc(func(ctx context.Context, _ Event) error {
+		<-ctx.Done()
+		return ctx.Err()
 	})
-	var messages []string
-	sink := SinkFunc(func(_ context.Context, emission Emission) error {
-		messages = append(messages, emission.Message)
-		if emission.Message == "partition-1" {
-			return errors.New("first partition unavailable")
-		}
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor), WithRecordTimeout(time.Millisecond), quietDiagnostics())
+
+	err := logger.Record(t.Context(), canonicalTestEvent())
+
+	require.ErrorIs(t, err, ErrProcessing)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRecordRejectsUnencodableDataBeforeProcessing(t *testing.T) {
+	event := canonicalTestEvent()
+	event.EventMetaData["invalid"] = func() {}
+	calls := 0
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(func(context.Context, Event) error {
+		calls++
 		return nil
-	})
-	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(sink))
-
-	err := logger.Record(createTestContext(t), canonicalTestEvent())
-
-	require.ErrorIs(t, err, ErrSink)
-	assert.Equal(t, []string{"partition-1", "partition-2"}, messages)
-}
-
-func TestRecordReturnsSinkPanic(t *testing.T) {
-	logger := CreateAuditLogger(*slog.Default(), WithSink(SinkFunc(func(context.Context, Emission) error {
-		panic("sink panic")
 	})))
 
-	err := logger.Record(createTestContext(t), canonicalTestEvent())
+	err := logger.Record(t.Context(), event)
 
-	require.ErrorIs(t, err, ErrSink)
-	require.ErrorContains(t, err, "sink panic")
+	require.ErrorIs(t, err, ErrInvalidEvent)
+	assert.Zero(t, calls)
 }
 
 func TestRecordSnapshotsCallerData(t *testing.T) {
 	event := canonicalTestEvent()
-	var captured Event
-	logger := CreateAuditLogger(*slog.Default(), WithEncoder(EncoderFunc(
-		func(_ context.Context, event Event) ([]Emission, error) {
-			captured = event
-			return []Emission{{Level: LevelAudit, Message: "encoded"}}, nil
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(
+		func(_ context.Context, processed Event) error {
+			processed.Object.ID = "mutated"
+			owner, ok := processed.EventMetaData["owner"].(map[string]any)
+			require.True(t, ok)
+			owner["id"] = "mutated"
+			return nil
 		},
-	)), WithSink(SinkFunc(func(context.Context, Emission) error { return nil })))
+	)))
 
 	require.NoError(t, logger.Record(createTestContext(t), event))
-	event.Object.ID = "mutated"
-	eventOwner, ok := event.EventMetaData["owner"].(map[string]any)
+	assert.Equal(t, "document-1", event.Object.ID)
+	owner, ok := event.EventMetaData["owner"].(map[string]any)
 	require.True(t, ok)
-	eventOwner["id"] = "mutated"
+	assert.Equal(t, "org-1", owner["id"])
+}
 
-	assert.Equal(t, "document-1", captured.Object.ID)
-	capturedOwner, ok := captured.EventMetaData["owner"].(map[string]any)
+func TestRecordPreservesJSONNumbersInSnapshot(t *testing.T) {
+	var processed Event
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(
+		func(_ context.Context, event Event) error {
+			processed = event
+			return nil
+		},
+	)))
+
+	require.NoError(t, logger.Record(createTestContext(t), canonicalTestEvent()))
+	count, ok := processed.EventMetaData["count"].(json.Number)
 	require.True(t, ok)
-	assert.Equal(t, "org-1", capturedOwner["id"])
-	capturedCount, ok := captured.EventMetaData["count"].(json.Number)
-	require.True(t, ok)
-	assert.Equal(t, "9007199254740993", capturedCount.String())
+	assert.Equal(t, "9007199254740993", count.String())
 }
 
 func TestRecordDoesNotTrustProducerPrincipal(t *testing.T) {
 	event := canonicalTestEvent()
 	event.Principal = ctxAuth.Principal{Subject: "producer-supplied"}
-	var captured Event
-	logger := CreateAuditLogger(*slog.Default(), WithEncoder(EncoderFunc(
-		func(_ context.Context, event Event) ([]Emission, error) {
-			captured = event
-			return []Emission{{Level: LevelAudit, Message: "encoded"}}, nil
+	var processed Event
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(
+		func(_ context.Context, event Event) error {
+			processed = event
+			return nil
 		},
-	)), WithSink(SinkFunc(func(context.Context, Emission) error { return nil })))
+	)))
 
-	require.NoError(t, logger.Record(createTestContext(t), event))
-
-	assert.Empty(t, captured.Principal)
+	require.NoError(t, logger.Record(t.Context(), event))
+	assert.Empty(t, processed.Principal)
 }
 
 func TestRecordIsSafeForConcurrentUse(t *testing.T) {
@@ -210,13 +223,13 @@ func TestRecordIsSafeForConcurrentUse(t *testing.T) {
 		mu  sync.Mutex
 		ids = make(map[uuid.UUID]struct{}, count)
 	)
-	encoder := EncoderFunc(func(_ context.Context, event Event) ([]Emission, error) {
+	processor := ProcessorFunc(func(_ context.Context, event Event) error {
 		mu.Lock()
 		ids[event.ID] = struct{}{}
 		mu.Unlock()
-		return []Emission{{Level: LevelAudit, Message: "encoded"}}, nil
+		return nil
 	})
-	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(SinkFunc(func(context.Context, Emission) error { return nil })))
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor))
 
 	var wg sync.WaitGroup
 	errs := make(chan error, count)
@@ -232,24 +245,19 @@ func TestRecordIsSafeForConcurrentUse(t *testing.T) {
 	for err := range errs {
 		require.NoError(t, err)
 	}
-
 	assert.Len(t, ids, count)
 }
 
-func TestLoggerWithRetainsAuditPipeline(t *testing.T) {
-	encoder := EncoderFunc(func(context.Context, Event) ([]Emission, error) {
-		return []Emission{{Level: LevelAudit, Message: "encoded"}}, nil
-	})
-	sink := SinkFunc(func(context.Context, Emission) error { return nil })
-	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(sink))
+func TestLoggerWithRetainsAuditProcessor(t *testing.T) {
+	processor := ProcessorFunc(func(context.Context, Event) error { return nil })
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor))
 
 	child := logger.With("namespace", "extension")
 
-	assert.NotNil(t, child.Encoder())
-	assert.NotNil(t, child.Sink())
+	assert.NotNil(t, child.Processor())
 }
 
-func TestDefaultEncoderPreservesLegacyWireShape(t *testing.T) {
+func TestDefaultProcessorPreservesLegacyWireShape(t *testing.T) {
 	logger, buffer := createTestLogger()
 
 	require.NoError(t, logger.Record(createTestContext(t), canonicalTestEvent()))
@@ -262,4 +270,8 @@ func TestDefaultEncoderPreservesLegacyWireShape(t *testing.T) {
 	assert.Equal(t, "success", requireMap(t, payload["action"])["result"])
 	assert.NotContains(t, payload, "id", "recorder lifecycle ID is not part of the legacy wire payload")
 	assert.NotContains(t, payload, "phase", "recorder phase is not part of the legacy wire payload")
+	timestamp, ok := payload["timestamp"].(string)
+	require.True(t, ok)
+	_, err := time.Parse(time.RFC3339, timestamp)
+	require.NoError(t, err)
 }

--- a/service/logger/audit/recorder_test.go
+++ b/service/logger/audit/recorder_test.go
@@ -15,19 +15,16 @@ import (
 )
 
 func canonicalTestEvent() Event {
-	return Event{
-		Verb:   Verb("read"),
-		Object: Object{Type: "document", ID: "document-1"},
-		Action: Action{Type: "read", Result: "success"},
-		EventMetaData: EventMetadata{
+	event := NewEvent(EventObjectParams{
+		Object: EventObjectInfo{Type: ObjectTypeEntityObject, ID: "document-1"},
+		Action: EventObjectAction{Type: ActionTypeRead, Result: ActionResultSuccess},
+		EventMetaData: EventMetaData{
 			"owner": map[string]any{"id": "org-1"},
 		},
-		ClientInfo: ClientInfo{Platform: "test"},
-	}
-}
-
-func quietDiagnostics() Option {
-	return WithDiagnosticLogger(slog.New(slog.DiscardHandler))
+		ClientInfo: EventClientInfo{Platform: "test"},
+	})
+	event.Verb = Verb("read")
+	return *event
 }
 
 func TestRecordUsesBoundedContextAfterRequestCancellation(t *testing.T) {
@@ -43,7 +40,8 @@ func TestRecordUsesBoundedContextAfterRequestCancellation(t *testing.T) {
 		processed = event
 		return nil
 	})
-	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor), WithRecordTimeout(time.Second))
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor))
+	logger.recordTimeout = time.Second
 
 	require.NoError(t, logger.Record(ctx, canonicalTestEvent()))
 	assert.NotEqual(t, uuid.Nil, processed.ID)
@@ -80,9 +78,6 @@ func TestRecordRejectsInvalidRequiredFieldsBeforeProcessing(t *testing.T) {
 		mutate func(*Event)
 	}{
 		{name: "verb", mutate: func(event *Event) { event.Verb = " " }},
-		{name: "object type", mutate: func(event *Event) { event.Object.Type = " " }},
-		{name: "action type", mutate: func(event *Event) { event.Action.Type = " " }},
-		{name: "action result", mutate: func(event *Event) { event.Action.Result = " " }},
 		{name: "client platform", mutate: func(event *Event) { event.ClientInfo.Platform = " " }},
 		{name: "phase", mutate: func(event *Event) { event.Phase = Phase("unknown") }},
 	}
@@ -110,7 +105,7 @@ func TestRecordRejectsInvalidRequiredFieldsBeforeProcessing(t *testing.T) {
 func TestRecordAllowsOptionalFieldsToBeEmpty(t *testing.T) {
 	event := canonicalTestEvent()
 	event.Object.ID = ""
-	event.Actor = Actor{}
+	event.Actor = auditEventActor{}
 	event.EventMetaData = nil
 	event.Original = nil
 	event.Updated = nil
@@ -132,7 +127,6 @@ func TestRecordReturnsProcessorErrorWithoutFallback(t *testing.T) {
 	processorErr := errors.New("delivery unavailable")
 	logger, buffer := createTestLogger()
 	logger.processor = ProcessorFunc(func(context.Context, Event) error { return processorErr })
-	logger.diagnostics = slog.New(slog.DiscardHandler)
 
 	err := logger.Record(createTestContext(t), canonicalTestEvent())
 
@@ -144,7 +138,7 @@ func TestRecordReturnsProcessorErrorWithoutFallback(t *testing.T) {
 func TestRecordReturnsProcessorPanic(t *testing.T) {
 	logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(func(context.Context, Event) error {
 		panic("processor panic")
-	})), quietDiagnostics())
+	})))
 
 	err := logger.Record(createTestContext(t), canonicalTestEvent())
 
@@ -157,7 +151,8 @@ func TestRecordReturnsProcessorDeadline(t *testing.T) {
 		<-ctx.Done()
 		return ctx.Err()
 	})
-	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor), WithRecordTimeout(time.Millisecond), quietDiagnostics())
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor))
+	logger.recordTimeout = time.Millisecond
 
 	err := logger.Record(t.Context(), canonicalTestEvent())
 

--- a/service/logger/audit/recorder_test.go
+++ b/service/logger/audit/recorder_test.go
@@ -1,0 +1,265 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func canonicalTestEvent() Event {
+	return Event{
+		Verb:   Verb("read"),
+		Object: Object{Type: "document", ID: "document-1"},
+		Action: Action{Type: "read", Result: "success"},
+		EventMetaData: EventMetadata{
+			"count": jsonNumber("9007199254740993"),
+			"owner": map[string]any{"id": "org-1"},
+		},
+		ClientInfo: ClientInfo{Platform: "test"},
+	}
+}
+
+type jsonNumber string
+
+func (n jsonNumber) MarshalJSON() ([]byte, error) {
+	return []byte(n), nil
+}
+
+func TestRecordUsesBoundedContextAfterRequestCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(createTestContext(t))
+	cancel()
+
+	var encoded Event
+	encoder := EncoderFunc(func(ctx context.Context, event Event) ([]Emission, error) {
+		require.NoError(t, ctx.Err())
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.LessOrEqual(t, time.Until(deadline), time.Second)
+		encoded = event
+		return []Emission{{Level: LevelAudit, Message: "encoded"}}, nil
+	})
+	writes := 0
+	sink := SinkFunc(func(ctx context.Context, emission Emission) error {
+		require.NoError(t, ctx.Err())
+		assert.Equal(t, "encoded", emission.Message)
+		writes++
+		return nil
+	})
+	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(sink), WithRecordTimeout(time.Second))
+
+	err := logger.Record(ctx, canonicalTestEvent())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, writes)
+	assert.NotEqual(t, uuid.Nil, encoded.ID)
+	assert.Equal(t, PhaseCompleted, encoded.Phase)
+	assert.Equal(t, TestRequestID, encoded.RequestID)
+	assert.Equal(t, TestActorID, encoded.Actor.ID)
+}
+
+func TestRecordEncoderFailureFallsBackAndReturnsError(t *testing.T) {
+	encoderErr := errors.New("conversion failed")
+	encoder := EncoderFunc(func(context.Context, Event) ([]Emission, error) {
+		return nil, encoderErr
+	})
+	var captured Emission
+	sink := SinkFunc(func(_ context.Context, emission Emission) error {
+		captured = emission
+		return nil
+	})
+	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(sink))
+
+	err := logger.Record(createTestContext(t), canonicalTestEvent())
+
+	require.ErrorIs(t, err, ErrEncoding)
+	require.ErrorIs(t, err, encoderErr)
+	assert.Equal(t, "read", captured.Message)
+	require.Len(t, captured.Attrs, 1)
+	assert.Equal(t, "audit", captured.Attrs[0].Key)
+}
+
+func TestRecordEncoderCannotMutateFallbackEvent(t *testing.T) {
+	encoder := EncoderFunc(func(_ context.Context, event Event) ([]Emission, error) {
+		event.Object.ID = "mutated"
+		owner, ok := event.EventMetaData["owner"].(map[string]any)
+		require.True(t, ok)
+		owner["id"] = "mutated"
+		return nil, errors.New("conversion failed")
+	})
+	var payload map[string]any
+	sink := SinkFunc(func(_ context.Context, emission Emission) error {
+		var ok bool
+		payload, ok = emission.Attrs[0].Value.Any().(map[string]any)
+		require.True(t, ok)
+		return nil
+	})
+	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(sink))
+
+	err := logger.Record(createTestContext(t), canonicalTestEvent())
+
+	require.ErrorIs(t, err, ErrEncoding)
+	assert.Equal(t, "document-1", requireMap(t, payload["object"])["id"])
+	assert.Equal(t, "org-1", requireMap(t, requireMap(t, payload["eventMetaData"])["owner"])["id"])
+}
+
+func TestRecordRejectsSilentEncoderDrop(t *testing.T) {
+	encoder := EncoderFunc(func(context.Context, Event) ([]Emission, error) {
+		return nil, nil
+	})
+	writes := 0
+	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(SinkFunc(
+		func(context.Context, Emission) error {
+			writes++
+			return nil
+		},
+	)))
+
+	err := logger.Record(createTestContext(t), canonicalTestEvent())
+
+	require.ErrorIs(t, err, ErrInvalidEmission)
+	assert.Equal(t, 1, writes, "default fallback must preserve the event")
+}
+
+func TestRecordAttemptsEveryEmissionAndReturnsSinkFailures(t *testing.T) {
+	encoder := EncoderFunc(func(context.Context, Event) ([]Emission, error) {
+		return []Emission{
+			{Level: LevelAudit, Message: "partition-1"},
+			{Level: LevelAudit, Message: "partition-2"},
+		}, nil
+	})
+	var messages []string
+	sink := SinkFunc(func(_ context.Context, emission Emission) error {
+		messages = append(messages, emission.Message)
+		if emission.Message == "partition-1" {
+			return errors.New("first partition unavailable")
+		}
+		return nil
+	})
+	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(sink))
+
+	err := logger.Record(createTestContext(t), canonicalTestEvent())
+
+	require.ErrorIs(t, err, ErrSink)
+	assert.Equal(t, []string{"partition-1", "partition-2"}, messages)
+}
+
+func TestRecordReturnsSinkPanic(t *testing.T) {
+	logger := CreateAuditLogger(*slog.Default(), WithSink(SinkFunc(func(context.Context, Emission) error {
+		panic("sink panic")
+	})))
+
+	err := logger.Record(createTestContext(t), canonicalTestEvent())
+
+	require.ErrorIs(t, err, ErrSink)
+	require.ErrorContains(t, err, "sink panic")
+}
+
+func TestRecordSnapshotsCallerData(t *testing.T) {
+	event := canonicalTestEvent()
+	var captured Event
+	logger := CreateAuditLogger(*slog.Default(), WithEncoder(EncoderFunc(
+		func(_ context.Context, event Event) ([]Emission, error) {
+			captured = event
+			return []Emission{{Level: LevelAudit, Message: "encoded"}}, nil
+		},
+	)), WithSink(SinkFunc(func(context.Context, Emission) error { return nil })))
+
+	require.NoError(t, logger.Record(createTestContext(t), event))
+	event.Object.ID = "mutated"
+	eventOwner, ok := event.EventMetaData["owner"].(map[string]any)
+	require.True(t, ok)
+	eventOwner["id"] = "mutated"
+
+	assert.Equal(t, "document-1", captured.Object.ID)
+	capturedOwner, ok := captured.EventMetaData["owner"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "org-1", capturedOwner["id"])
+	capturedCount, ok := captured.EventMetaData["count"].(json.Number)
+	require.True(t, ok)
+	assert.Equal(t, "9007199254740993", capturedCount.String())
+}
+
+func TestRecordDoesNotTrustProducerPrincipal(t *testing.T) {
+	event := canonicalTestEvent()
+	event.Principal = ctxAuth.Principal{Subject: "producer-supplied"}
+	var captured Event
+	logger := CreateAuditLogger(*slog.Default(), WithEncoder(EncoderFunc(
+		func(_ context.Context, event Event) ([]Emission, error) {
+			captured = event
+			return []Emission{{Level: LevelAudit, Message: "encoded"}}, nil
+		},
+	)), WithSink(SinkFunc(func(context.Context, Emission) error { return nil })))
+
+	require.NoError(t, logger.Record(createTestContext(t), event))
+
+	assert.Empty(t, captured.Principal)
+}
+
+func TestRecordIsSafeForConcurrentUse(t *testing.T) {
+	const count = 50
+	var (
+		mu  sync.Mutex
+		ids = make(map[uuid.UUID]struct{}, count)
+	)
+	encoder := EncoderFunc(func(_ context.Context, event Event) ([]Emission, error) {
+		mu.Lock()
+		ids[event.ID] = struct{}{}
+		mu.Unlock()
+		return []Emission{{Level: LevelAudit, Message: "encoded"}}, nil
+	})
+	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(SinkFunc(func(context.Context, Emission) error { return nil })))
+
+	var wg sync.WaitGroup
+	errs := make(chan error, count)
+	for range count {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- logger.Record(createTestContext(t), canonicalTestEvent())
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	assert.Len(t, ids, count)
+}
+
+func TestLoggerWithRetainsAuditPipeline(t *testing.T) {
+	encoder := EncoderFunc(func(context.Context, Event) ([]Emission, error) {
+		return []Emission{{Level: LevelAudit, Message: "encoded"}}, nil
+	})
+	sink := SinkFunc(func(context.Context, Emission) error { return nil })
+	logger := CreateAuditLogger(*slog.Default(), WithEncoder(encoder), WithSink(sink))
+
+	child := logger.With("namespace", "extension")
+
+	assert.NotNil(t, child.Encoder())
+	assert.NotNil(t, child.Sink())
+}
+
+func TestDefaultEncoderPreservesLegacyWireShape(t *testing.T) {
+	logger, buffer := createTestLogger()
+
+	require.NoError(t, logger.Record(createTestContext(t), canonicalTestEvent()))
+	entry, _ := extractLogEntry(t, buffer)
+	payload := decodeAuditPayload(t, entry.Audit)
+
+	assert.Equal(t, LevelAuditStr, entry.Level)
+	assert.Equal(t, "read", entry.Msg)
+	assert.Equal(t, "document-1", requireMap(t, payload["object"])["id"])
+	assert.Equal(t, "success", requireMap(t, payload["action"])["result"])
+	assert.NotContains(t, payload, "id", "recorder lifecycle ID is not part of the legacy wire payload")
+	assert.NotContains(t, payload, "phase", "recorder phase is not part of the legacy wire payload")
+}

--- a/service/logger/audit/recorder_test.go
+++ b/service/logger/audit/recorder_test.go
@@ -2,7 +2,6 @@ package audit
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log/slog"
 	"sync"
@@ -21,17 +20,10 @@ func canonicalTestEvent() Event {
 		Object: Object{Type: "document", ID: "document-1"},
 		Action: Action{Type: "read", Result: "success"},
 		EventMetaData: EventMetadata{
-			"count": jsonNumber("9007199254740993"),
 			"owner": map[string]any{"id": "org-1"},
 		},
 		ClientInfo: ClientInfo{Platform: "test"},
 	}
-}
-
-type jsonNumber string
-
-func (n jsonNumber) MarshalJSON() ([]byte, error) {
-	return []byte(n), nil
 }
 
 func quietDiagnostics() Option {
@@ -60,6 +52,26 @@ func TestRecordUsesBoundedContextAfterRequestCancellation(t *testing.T) {
 	assert.Equal(t, TestActorID, processed.Actor.ID)
 	_, err := time.Parse(time.RFC3339, processed.Timestamp)
 	require.NoError(t, err)
+}
+
+func TestRecordStampsItsEventCopy(t *testing.T) {
+	event := canonicalTestEvent()
+	var processed Event
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(
+		func(_ context.Context, event Event) error {
+			processed = event
+			return nil
+		},
+	)))
+
+	require.NoError(t, logger.Record(createTestContext(t), event))
+
+	assert.Equal(t, uuid.Nil, event.ID)
+	assert.Empty(t, event.Phase)
+	assert.Empty(t, event.RequestID)
+	assert.Empty(t, event.Timestamp)
+	assert.NotEqual(t, uuid.Nil, processed.ID)
+	assert.Equal(t, PhaseCompleted, processed.Phase)
 }
 
 func TestRecordRejectsInvalidRequiredFieldsBeforeProcessing(t *testing.T) {
@@ -151,55 +163,6 @@ func TestRecordReturnsProcessorDeadline(t *testing.T) {
 
 	require.ErrorIs(t, err, ErrProcessing)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
-}
-
-func TestRecordRejectsUnencodableDataBeforeProcessing(t *testing.T) {
-	event := canonicalTestEvent()
-	event.EventMetaData["invalid"] = func() {}
-	calls := 0
-	logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(func(context.Context, Event) error {
-		calls++
-		return nil
-	})))
-
-	err := logger.Record(t.Context(), event)
-
-	require.ErrorIs(t, err, ErrInvalidEvent)
-	assert.Zero(t, calls)
-}
-
-func TestRecordSnapshotsCallerData(t *testing.T) {
-	event := canonicalTestEvent()
-	logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(
-		func(_ context.Context, processed Event) error {
-			processed.Object.ID = "mutated"
-			owner, ok := processed.EventMetaData["owner"].(map[string]any)
-			require.True(t, ok)
-			owner["id"] = "mutated"
-			return nil
-		},
-	)))
-
-	require.NoError(t, logger.Record(createTestContext(t), event))
-	assert.Equal(t, "document-1", event.Object.ID)
-	owner, ok := event.EventMetaData["owner"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "org-1", owner["id"])
-}
-
-func TestRecordPreservesJSONNumbersInSnapshot(t *testing.T) {
-	var processed Event
-	logger := CreateAuditLogger(*slog.Default(), WithProcessor(ProcessorFunc(
-		func(_ context.Context, event Event) error {
-			processed = event
-			return nil
-		},
-	)))
-
-	require.NoError(t, logger.Record(createTestContext(t), canonicalTestEvent()))
-	count, ok := processed.EventMetaData["count"].(json.Number)
-	require.True(t, ok)
-	assert.Equal(t, "9007199254740993", count.String())
 }
 
 func TestRecordDoesNotTrustProducerPrincipal(t *testing.T) {

--- a/service/logger/audit/recorder_test.go
+++ b/service/logger/audit/recorder_test.go
@@ -45,7 +45,6 @@ func TestRecordUsesBoundedContextAfterRequestCancellation(t *testing.T) {
 
 	require.NoError(t, logger.Record(ctx, canonicalTestEvent()))
 	assert.NotEqual(t, uuid.Nil, processed.ID)
-	assert.Equal(t, PhaseCompleted, processed.Phase)
 	assert.Equal(t, TestRequestID, processed.RequestID)
 	assert.Equal(t, TestActorID, processed.Actor.ID)
 	_, err := time.Parse(time.RFC3339, processed.Timestamp)
@@ -65,11 +64,9 @@ func TestRecordStampsItsEventCopy(t *testing.T) {
 	require.NoError(t, logger.Record(createTestContext(t), event))
 
 	assert.Equal(t, uuid.Nil, event.ID)
-	assert.Empty(t, event.Phase)
 	assert.Empty(t, event.RequestID)
 	assert.Empty(t, event.Timestamp)
 	assert.NotEqual(t, uuid.Nil, processed.ID)
-	assert.Equal(t, PhaseCompleted, processed.Phase)
 }
 
 func TestRecordRejectsInvalidRequiredFieldsBeforeProcessing(t *testing.T) {
@@ -79,7 +76,6 @@ func TestRecordRejectsInvalidRequiredFieldsBeforeProcessing(t *testing.T) {
 	}{
 		{name: "verb", mutate: func(event *Event) { event.Verb = " " }},
 		{name: "client platform", mutate: func(event *Event) { event.ClientInfo.Platform = " " }},
-		{name: "phase", mutate: func(event *Event) { event.Phase = Phase("unknown") }},
 	}
 
 	for _, test := range tests {
@@ -226,8 +222,7 @@ func TestDefaultProcessorPreservesLegacyWireShape(t *testing.T) {
 	assert.Equal(t, "read", entry.Msg)
 	assert.Equal(t, "document-1", requireMap(t, payload["object"])["id"])
 	assert.Equal(t, "success", requireMap(t, payload["action"])["result"])
-	assert.NotContains(t, payload, "id", "recorder lifecycle ID is not part of the legacy wire payload")
-	assert.NotContains(t, payload, "phase", "recorder phase is not part of the legacy wire payload")
+	assert.NotContains(t, payload, "id", "recorder event ID is not part of the legacy wire payload")
 	timestamp, ok := payload["timestamp"].(string)
 	require.True(t, ok)
 	_, err := time.Parse(time.RFC3339, timestamp)

--- a/service/logger/audit/recorder_test.go
+++ b/service/logger/audit/recorder_test.go
@@ -40,8 +40,7 @@ func TestRecordUsesBoundedContextAfterRequestCancellation(t *testing.T) {
 		processed = event
 		return nil
 	})
-	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor))
-	logger.recordTimeout = time.Second
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor), WithRecordTimeout(time.Second))
 
 	require.NoError(t, logger.Record(ctx, canonicalTestEvent()))
 	assert.NotEqual(t, uuid.Nil, processed.ID)
@@ -147,13 +146,43 @@ func TestRecordReturnsProcessorDeadline(t *testing.T) {
 		<-ctx.Done()
 		return ctx.Err()
 	})
-	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor))
-	logger.recordTimeout = time.Millisecond
+	logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor), WithRecordTimeout(time.Millisecond))
 
 	err := logger.Record(t.Context(), canonicalTestEvent())
 
 	require.ErrorIs(t, err, ErrProcessing)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRecordTimeoutOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Duration
+	}{
+		{name: "custom", timeout: 30 * time.Second, want: 30 * time.Second},
+		{name: "zero", want: defaultRecordTimeout},
+		{name: "negative", timeout: -time.Second, want: defaultRecordTimeout},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var deadline time.Time
+			processor := ProcessorFunc(func(ctx context.Context, _ Event) error {
+				var ok bool
+				deadline, ok = ctx.Deadline()
+				require.True(t, ok)
+				require.NoError(t, ctx.Err())
+				return nil
+			})
+			logger := CreateAuditLogger(*slog.Default(), WithProcessor(processor), WithRecordTimeout(test.timeout)).With("namespace", "test")
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			before := time.Now()
+			require.NoError(t, logger.Record(ctx, canonicalTestEvent()))
+			assert.False(t, deadline.Before(before.Add(test.want)))
+			assert.False(t, deadline.After(time.Now().Add(test.want)))
+		})
+	}
 }
 
 func TestRecordDoesNotTrustProducerPrincipal(t *testing.T) {

--- a/service/logger/audit/utils.go
+++ b/service/logger/audit/utils.go
@@ -13,15 +13,9 @@ const (
 	defaultNone = "None"
 )
 
-// Public event DTOs are intentionally separate from internal log types.
-// This keeps downstream consumers decoupled from internal logging behavior (e.g. LogValue),
-// while still allowing them to construct events via NewEvent.
 type EventMetaData map[string]any
 
-// Internal log type uses the same shape as public metadata.
 type auditEventMetadata = EventMetaData
-
-// --- Public event DTOs (for downstream consumers) ---
 
 // EventObjectInfo describes the object an audited action was performed on.
 type EventObjectInfo struct {
@@ -65,10 +59,22 @@ type EventObjectParams struct {
 	Timestamp     string
 }
 
-// --- Internal log types (used by logger/audit) ---
+// Phase identifies an event's position in an append-only operation lifecycle.
+type Phase string
 
-// event
-type EventObject struct {
+const (
+	PhaseAttempted Phase = "attempted"
+	PhaseCompleted Phase = "completed"
+)
+
+// Event is the canonical audit event passed to a Processor. Recorder metadata
+// is excluded from the existing OpenTDF log payload.
+type Event struct {
+	Verb      Verb              `json:"-" audit:"-"`
+	ID        uuid.UUID         `json:"-" audit:"-"`
+	Phase     Phase             `json:"-" audit:"-"`
+	Principal ctxAuth.Principal `json:"-" audit:"-"`
+
 	Object        auditEventObject   `json:"object"`
 	Action        eventAction        `json:"action"`
 	Actor         auditEventActor    `json:"actor"`
@@ -80,6 +86,9 @@ type EventObject struct {
 	RequestID uuid.UUID      `json:"requestID" audit:"reserved"`
 	Timestamp string         `json:"timestamp" audit:"reserved"`
 }
+
+// EventObject is retained for compatibility with existing audit constructors.
+type EventObject = Event
 
 // NewEvent converts public DTOs into the internal log event type.
 func NewEvent(params EventObjectParams) *EventObject {
@@ -109,11 +118,11 @@ func NewEvent(params EventObjectParams) *EventObject {
 	}
 }
 
-func (e EventObject) LogValue() slog.Value {
+func (e Event) LogValue() slog.Value {
 	return slog.AnyValue(e.emittedPayloadMap())
 }
 
-func (e EventObject) emittedPayloadMap() map[string]any {
+func (e Event) emittedPayloadMap() map[string]any {
 	entry, ok := normalizeAuditValue(e).(map[string]any)
 	if !ok {
 		panic("normalized audit payload must be a map")
@@ -121,7 +130,6 @@ func (e EventObject) emittedPayloadMap() map[string]any {
 	return entry
 }
 
-// event.object
 type auditEventObject struct {
 	Type       ObjectType            `json:"type" audit:"reserved"`
 	ID         string                `json:"id"`
@@ -137,7 +145,6 @@ func (e auditEventObject) LogValue() slog.Value {
 		slog.Any("attributes", e.Attributes))
 }
 
-// event.object.attributes
 type eventObjectAttributes struct {
 	EventObjectAttributes
 }
@@ -149,7 +156,6 @@ func (e eventObjectAttributes) LogValue() slog.Value {
 		slog.Any("permissions", e.Permissions))
 }
 
-// event.action
 type eventAction struct {
 	EventObjectAction
 }
@@ -160,7 +166,6 @@ func (e eventAction) LogValue() slog.Value {
 		slog.String("result", e.Result.String()))
 }
 
-// event.actor
 type auditEventActor struct {
 	EventObjectActor
 }
@@ -171,7 +176,6 @@ func (e auditEventActor) LogValue() slog.Value {
 		slog.Any("attributes", e.Attributes))
 }
 
-// event.clientInfo
 type eventClientInfo struct {
 	EventClientInfo
 }

--- a/service/logger/audit/utils.go
+++ b/service/logger/audit/utils.go
@@ -59,20 +59,11 @@ type EventObjectParams struct {
 	Timestamp     string
 }
 
-// Phase identifies an event's position in an append-only operation lifecycle.
-type Phase string
-
-const (
-	PhaseAttempted Phase = "attempted"
-	PhaseCompleted Phase = "completed"
-)
-
 // Event is the canonical audit event passed to a Processor. Recorder metadata
 // is excluded from the existing OpenTDF log payload.
 type Event struct {
 	Verb      Verb              `json:"-" audit:"-"`
 	ID        uuid.UUID         `json:"-" audit:"-"`
-	Phase     Phase             `json:"-" audit:"-"`
 	Principal ctxAuth.Principal `json:"-" audit:"-"`
 
 	Object        auditEventObject   `json:"object"`

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -47,13 +47,39 @@ func (c Config) traceCorrelationEnabled() bool {
 	return c.TraceCorrelation == nil || *c.TraceCorrelation
 }
 
+// Option configures a Logger at construction time.
+type Option func(*loggerOptions)
+
+type loggerOptions struct {
+	auditEncoder audit.Encoder
+	auditSink    audit.Sink
+}
+
+// WithAuditEncoder configures the encoder used for canonical audit events.
+func WithAuditEncoder(encoder audit.Encoder) Option {
+	return func(options *loggerOptions) {
+		options.auditEncoder = encoder
+	}
+}
+
+// WithAuditSink configures the sink used for encoded audit emissions.
+func WithAuditSink(sink audit.Sink) Option {
+	return func(options *loggerOptions) {
+		options.auditSink = sink
+	}
+}
+
 const (
 	LevelTrace = slog.Level(-8)
 )
 
-func NewLogger(config Config) (*Logger, error) {
+func NewLogger(config Config, options ...Option) (*Logger, error) {
 	var sLogger *slog.Logger
 	logger := new(Logger)
+	loggerOpts := loggerOptions{}
+	for _, option := range options {
+		option(&loggerOpts)
+	}
 
 	w, err := getWriter(config)
 	if err != nil {
@@ -92,7 +118,14 @@ func NewLogger(config Config) (*Logger, error) {
 	// Audit events skip requestContextAttrs on purpose: the request metadata it
 	// adds is already inside the audit payload. They still need trace correlation.
 	auditLoggerBase := slog.New(newContextAttrsHandler(auditLoggerHandler, contextAttrSources(config)...))
-	auditLogger := audit.CreateAuditLogger(*auditLoggerBase)
+	auditOptions := []audit.Option{audit.WithDiagnosticLogger(sLogger)}
+	if loggerOpts.auditEncoder != nil {
+		auditOptions = append(auditOptions, audit.WithEncoder(loggerOpts.auditEncoder))
+	}
+	if loggerOpts.auditSink != nil {
+		auditOptions = append(auditOptions, audit.WithSink(loggerOpts.auditSink))
+	}
+	auditLogger := audit.CreateAuditLogger(*auditLoggerBase, auditOptions...)
 
 	logger.Logger = sLogger
 	logger.Audit = auditLogger

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -110,7 +110,7 @@ func NewLogger(config Config, options ...Option) (*Logger, error) {
 	// Audit events skip requestContextAttrs on purpose: the request metadata it
 	// adds is already inside the audit payload. They still need trace correlation.
 	auditLoggerBase := slog.New(newContextAttrsHandler(auditLoggerHandler, contextAttrSources(config)...))
-	auditOptions := []audit.Option{audit.WithDiagnosticLogger(sLogger)}
+	var auditOptions []audit.Option
 	if loggerOpts.auditProcessor != nil {
 		auditOptions = append(auditOptions, audit.WithProcessor(loggerOpts.auditProcessor))
 	}

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -51,21 +51,13 @@ func (c Config) traceCorrelationEnabled() bool {
 type Option func(*loggerOptions)
 
 type loggerOptions struct {
-	auditEncoder audit.Encoder
-	auditSink    audit.Sink
+	auditProcessor audit.Processor
 }
 
-// WithAuditEncoder configures the encoder used for canonical audit events.
-func WithAuditEncoder(encoder audit.Encoder) Option {
+// WithAuditProcessor configures canonical audit event processing.
+func WithAuditProcessor(processor audit.Processor) Option {
 	return func(options *loggerOptions) {
-		options.auditEncoder = encoder
-	}
-}
-
-// WithAuditSink configures the sink used for encoded audit emissions.
-func WithAuditSink(sink audit.Sink) Option {
-	return func(options *loggerOptions) {
-		options.auditSink = sink
+		options.auditProcessor = processor
 	}
 }
 
@@ -119,11 +111,8 @@ func NewLogger(config Config, options ...Option) (*Logger, error) {
 	// adds is already inside the audit payload. They still need trace correlation.
 	auditLoggerBase := slog.New(newContextAttrsHandler(auditLoggerHandler, contextAttrSources(config)...))
 	auditOptions := []audit.Option{audit.WithDiagnosticLogger(sLogger)}
-	if loggerOpts.auditEncoder != nil {
-		auditOptions = append(auditOptions, audit.WithEncoder(loggerOpts.auditEncoder))
-	}
-	if loggerOpts.auditSink != nil {
-		auditOptions = append(auditOptions, audit.WithSink(loggerOpts.auditSink))
+	if loggerOpts.auditProcessor != nil {
+		auditOptions = append(auditOptions, audit.WithProcessor(loggerOpts.auditProcessor))
 	}
 	auditLogger := audit.CreateAuditLogger(*auditLoggerBase, auditOptions...)
 

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -42,45 +42,23 @@ type Config struct {
 	// TraceCorrelation adds the active trace and span IDs to log and audit
 	// records. No-op unless tracing is enabled via `server.trace`. Nil means enabled.
 	TraceCorrelation *bool `mapstructure:"trace_correlation" json:"trace_correlation" default:"true"`
+	// AuditTimeout is the audit processing budget. Non-positive values use five seconds.
+	AuditTimeout time.Duration `mapstructure:"audit_timeout" json:"audit_timeout" yaml:"audit_timeout" default:"5s"`
+	// AuditProcessor overrides audit delivery for Go callers and is never serialized.
+	AuditProcessor audit.Processor `mapstructure:"-" json:"-" yaml:"-"`
 }
 
 func (c Config) traceCorrelationEnabled() bool {
 	return c.TraceCorrelation == nil || *c.TraceCorrelation
 }
 
-// Option configures a Logger at construction time.
-type Option func(*loggerOptions)
-
-type loggerOptions struct {
-	auditProcessor audit.Processor
-	auditTimeout   time.Duration
-}
-
-// WithAuditProcessor configures canonical audit event processing.
-func WithAuditProcessor(processor audit.Processor) Option {
-	return func(options *loggerOptions) {
-		options.auditProcessor = processor
-	}
-}
-
-// WithAuditTimeout sets the audit processing budget. Non-positive values use five seconds.
-func WithAuditTimeout(timeout time.Duration) Option {
-	return func(options *loggerOptions) {
-		options.auditTimeout = timeout
-	}
-}
-
 const (
 	LevelTrace = slog.Level(-8)
 )
 
-func NewLogger(config Config, options ...Option) (*Logger, error) {
+func NewLogger(config Config) (*Logger, error) {
 	var sLogger *slog.Logger
 	logger := new(Logger)
-	loggerOpts := loggerOptions{}
-	for _, option := range options {
-		option(&loggerOpts)
-	}
 
 	w, err := getWriter(config)
 	if err != nil {
@@ -119,9 +97,9 @@ func NewLogger(config Config, options ...Option) (*Logger, error) {
 	// Audit events skip requestContextAttrs on purpose: the request metadata it
 	// adds is already inside the audit payload. They still need trace correlation.
 	auditLoggerBase := slog.New(newContextAttrsHandler(auditLoggerHandler, contextAttrSources(config)...))
-	auditOptions := []audit.Option{audit.WithRecordTimeout(loggerOpts.auditTimeout)}
-	if loggerOpts.auditProcessor != nil {
-		auditOptions = append(auditOptions, audit.WithProcessor(loggerOpts.auditProcessor))
+	auditOptions := []audit.Option{audit.WithRecordTimeout(config.AuditTimeout)}
+	if config.AuditProcessor != nil {
+		auditOptions = append(auditOptions, audit.WithProcessor(config.AuditProcessor))
 	}
 	auditLogger := audit.CreateAuditLogger(*auditLoggerBase, auditOptions...)
 

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/opentdf/platform/service/logger/audit"
 )
@@ -52,12 +53,20 @@ type Option func(*loggerOptions)
 
 type loggerOptions struct {
 	auditProcessor audit.Processor
+	auditTimeout   time.Duration
 }
 
 // WithAuditProcessor configures canonical audit event processing.
 func WithAuditProcessor(processor audit.Processor) Option {
 	return func(options *loggerOptions) {
 		options.auditProcessor = processor
+	}
+}
+
+// WithAuditTimeout sets the audit processing budget. Non-positive values use five seconds.
+func WithAuditTimeout(timeout time.Duration) Option {
+	return func(options *loggerOptions) {
+		options.auditTimeout = timeout
 	}
 }
 
@@ -110,7 +119,7 @@ func NewLogger(config Config, options ...Option) (*Logger, error) {
 	// Audit events skip requestContextAttrs on purpose: the request metadata it
 	// adds is already inside the audit payload. They still need trace correlation.
 	auditLoggerBase := slog.New(newContextAttrsHandler(auditLoggerHandler, contextAttrSources(config)...))
-	var auditOptions []audit.Option
+	auditOptions := []audit.Option{audit.WithRecordTimeout(loggerOpts.auditTimeout)}
 	if loggerOpts.auditProcessor != nil {
 		auditOptions = append(auditOptions, audit.WithProcessor(loggerOpts.auditProcessor))
 	}

--- a/service/logger/logger_test.go
+++ b/service/logger/logger_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/opentdf/platform/service/logger/audit"
@@ -199,4 +200,36 @@ func Test_NewLogger_UntracedRequestHasNoTraceFields(t *testing.T) {
 	entry := decodeLine(t, lines[0])
 	assert.NotContains(t, entry, traceIDKey)
 	assert.NotContains(t, entry, spanIDKey)
+}
+
+func TestNewLoggerConfiguresAuditProcessorAndTimeout(t *testing.T) {
+	for _, timeout := range []time.Duration{0, -time.Second, 12 * time.Second} {
+		t.Run(timeout.String(), func(t *testing.T) {
+			called := false
+			cfg := Config{
+				Level: "info", Output: "stdout", Type: "json", AuditTimeout: timeout,
+				AuditProcessor: audit.ProcessorFunc(func(ctx context.Context, _ audit.Event) error {
+					called = true
+					_, ok := ctx.Deadline()
+					require.True(t, ok)
+					return nil
+				}),
+			}
+			lg, err := NewLogger(cfg)
+			require.NoError(t, err)
+			expected := timeout
+			if expected <= 0 {
+				expected = 5 * time.Second
+			}
+			require.Equal(t, expected, lg.Audit.RecordTimeout())
+			event := audit.NewEvent(audit.EventObjectParams{ClientInfo: audit.EventClientInfo{Platform: "test"}})
+			event.Verb = audit.Verb("test")
+			require.NoError(t, lg.Audit.Record(t.Context(), *event))
+			require.True(t, called)
+			serialized, err := json.Marshal(cfg)
+			require.NoError(t, err, "the runtime processor must not reach JSON serialization")
+			require.NotContains(t, string(serialized), "AuditProcessor")
+			require.NotContains(t, string(serialized), "audit_processor")
+		})
+	}
 }

--- a/service/pkg/config/legacy_loader.go
+++ b/service/pkg/config/legacy_loader.go
@@ -41,6 +41,7 @@ func NewLegacyLoader(key, file string) (*LegacyLoader, error) {
 	// Registered so AutomaticEnv can resolve it without the key also being
 	// present in the config file. Must match the struct tag default.
 	v.SetDefault("logger.trace_correlation", true)
+	v.SetDefault("logger.audit_timeout", "5s")
 
 	// Environment variable settings
 	v.SetEnvPrefix(key)

--- a/service/pkg/config/trace_correlation_test.go
+++ b/service/pkg/config/trace_correlation_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,4 +64,20 @@ func Test_LoggerTraceCorrelation_EnvOverride(t *testing.T) {
 
 	require.NotNil(t, cfg.Logger.TraceCorrelation)
 	assert.False(t, *cfg.Logger.TraceCorrelation)
+}
+
+func TestLoggerAuditTimeoutConfig(t *testing.T) {
+	require.Equal(t, 5*time.Second, loadWithDefaults(t, "logger:\n  level: debug\n").Logger.AuditTimeout)
+	require.Equal(t, 17*time.Second, loadWithDefaults(t, "logger:\n  audit_timeout: 17s\n").Logger.AuditTimeout)
+	t.Setenv("TEST_LOGGER_AUDIT_TIMEOUT", "23s")
+	legacy, err := NewLegacyLoader(configKey, writeConfig(t, "logger:\n  level: debug\n"))
+	require.NoError(t, err)
+	defaults, err := NewDefaultSettingsLoader()
+	require.NoError(t, err)
+	cfg, err := Load(t.Context(), legacy, defaults)
+	require.NoError(t, err)
+	require.Equal(t, 23*time.Second, cfg.Logger.AuditTimeout)
+	keys, err := defaults.GetConfigKeys()
+	require.NoError(t, err)
+	require.NotContains(t, keys, "logger.audit_processor")
 }

--- a/service/pkg/server/options.go
+++ b/service/pkg/server/options.go
@@ -54,8 +54,7 @@ type StartConfig struct {
 
 	authzRoleProvider          authz.RoleProvider
 	authzRoleProviderFactories map[string]authz.RoleProviderFactory
-	auditEncoder               audit.Encoder
-	auditSink                  audit.Sink
+	auditProcessor             audit.Processor
 
 	// CORS additive configuration - appended to YAML/env config values
 	additionalCORSHeaders        []string
@@ -95,18 +94,10 @@ func formatAuditTypeRegistrationConflicts(conflicts []auditTypeRegistrationConfl
 	return strings.Join(entries, "; ")
 }
 
-// WithAuditEncoder configures an instance-scoped canonical audit encoder.
-func WithAuditEncoder(encoder audit.Encoder) StartOptions {
+// WithAuditProcessor configures instance-scoped canonical audit processing.
+func WithAuditProcessor(processor audit.Processor) StartOptions {
 	return func(c StartConfig) StartConfig {
-		c.auditEncoder = encoder
-		return c
-	}
-}
-
-// WithAuditSink configures an instance-scoped audit emission sink.
-func WithAuditSink(sink audit.Sink) StartOptions {
-	return func(c StartConfig) StartConfig {
-		c.auditSink = sink
+		c.auditProcessor = processor
 		return c
 	}
 }

--- a/service/pkg/server/options.go
+++ b/service/pkg/server/options.go
@@ -54,6 +54,8 @@ type StartConfig struct {
 
 	authzRoleProvider          authz.RoleProvider
 	authzRoleProviderFactories map[string]authz.RoleProviderFactory
+	auditEncoder               audit.Encoder
+	auditSink                  audit.Sink
 
 	// CORS additive configuration - appended to YAML/env config values
 	additionalCORSHeaders        []string
@@ -91,6 +93,22 @@ func formatAuditTypeRegistrationConflicts(conflicts []auditTypeRegistrationConfl
 		entries = append(entries, fmt.Sprintf("%s %d: %q vs %q", conflict.Category, conflict.Key, conflict.ExistingName, conflict.NewName))
 	}
 	return strings.Join(entries, "; ")
+}
+
+// WithAuditEncoder configures an instance-scoped canonical audit encoder.
+func WithAuditEncoder(encoder audit.Encoder) StartOptions {
+	return func(c StartConfig) StartConfig {
+		c.auditEncoder = encoder
+		return c
+	}
+}
+
+// WithAuditSink configures an instance-scoped audit emission sink.
+func WithAuditSink(sink audit.Sink) StartOptions {
+	return func(c StartConfig) StartConfig {
+		c.auditSink = sink
+		return c
+	}
 }
 
 // Deprecated: Use WithConfigKey

--- a/service/pkg/server/options.go
+++ b/service/pkg/server/options.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/casbin/casbin/v2/persist"
@@ -55,6 +56,7 @@ type StartConfig struct {
 	authzRoleProvider          authz.RoleProvider
 	authzRoleProviderFactories map[string]authz.RoleProviderFactory
 	auditProcessor             audit.Processor
+	auditTimeout               time.Duration
 
 	// CORS additive configuration - appended to YAML/env config values
 	additionalCORSHeaders        []string
@@ -98,6 +100,14 @@ func formatAuditTypeRegistrationConflicts(conflicts []auditTypeRegistrationConfl
 func WithAuditProcessor(processor audit.Processor) StartOptions {
 	return func(c StartConfig) StartConfig {
 		c.auditProcessor = processor
+		return c
+	}
+}
+
+// WithAuditTimeout sets the audit processing budget. Non-positive values use five seconds.
+func WithAuditTimeout(timeout time.Duration) StartOptions {
+	return func(c StartConfig) StartConfig {
+		c.auditTimeout = timeout
 		return c
 	}
 }

--- a/service/pkg/server/options.go
+++ b/service/pkg/server/options.go
@@ -56,7 +56,7 @@ type StartConfig struct {
 	authzRoleProvider          authz.RoleProvider
 	authzRoleProviderFactories map[string]authz.RoleProviderFactory
 	auditProcessor             audit.Processor
-	auditTimeout               time.Duration
+	auditTimeout               *time.Duration
 
 	// CORS additive configuration - appended to YAML/env config values
 	additionalCORSHeaders        []string
@@ -107,9 +107,20 @@ func WithAuditProcessor(processor audit.Processor) StartOptions {
 // WithAuditTimeout sets the audit processing budget. Non-positive values use five seconds.
 func WithAuditTimeout(timeout time.Duration) StartOptions {
 	return func(c StartConfig) StartConfig {
-		c.auditTimeout = timeout
+		c.auditTimeout = &timeout
 		return c
 	}
+}
+
+// loggerConfig applies explicit startup overrides after YAML and environment loading.
+func (c StartConfig) loggerConfig(cfg logger.Config) logger.Config {
+	if c.auditProcessor != nil {
+		cfg.AuditProcessor = c.auditProcessor
+	}
+	if c.auditTimeout != nil {
+		cfg.AuditTimeout = *c.auditTimeout
+	}
+	return cfg
 }
 
 // Deprecated: Use WithConfigKey

--- a/service/pkg/server/options_test.go
+++ b/service/pkg/server/options_test.go
@@ -15,17 +15,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithAuditPipeline(t *testing.T) {
-	encoder := audit.EncoderFunc(func(context.Context, audit.Event) ([]audit.Emission, error) {
-		return []audit.Emission{{Level: audit.LevelAudit, Message: "encoded"}}, nil
-	})
-	sink := audit.SinkFunc(func(context.Context, audit.Emission) error { return nil })
+func TestWithAuditProcessor(t *testing.T) {
+	processor := audit.ProcessorFunc(func(context.Context, audit.Event) error { return nil })
 
-	cfg := WithAuditEncoder(encoder)(StartConfig{})
-	cfg = WithAuditSink(sink)(cfg)
+	cfg := WithAuditProcessor(processor)(StartConfig{})
 
-	require.NotNil(t, cfg.auditEncoder)
-	require.NotNil(t, cfg.auditSink)
+	require.NotNil(t, cfg.auditProcessor)
 }
 
 // noopInterceptor returns a connect.UnaryInterceptorFunc that passes through.

--- a/service/pkg/server/options_test.go
+++ b/service/pkg/server/options_test.go
@@ -15,6 +15,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWithAuditPipeline(t *testing.T) {
+	encoder := audit.EncoderFunc(func(context.Context, audit.Event) ([]audit.Emission, error) {
+		return []audit.Emission{{Level: audit.LevelAudit, Message: "encoded"}}, nil
+	})
+	sink := audit.SinkFunc(func(context.Context, audit.Emission) error { return nil })
+
+	cfg := WithAuditEncoder(encoder)(StartConfig{})
+	cfg = WithAuditSink(sink)(cfg)
+
+	require.NotNil(t, cfg.auditEncoder)
+	require.NotNil(t, cfg.auditSink)
+}
+
 // noopInterceptor returns a connect.UnaryInterceptorFunc that passes through.
 func noopInterceptor() connect.Interceptor {
 	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {

--- a/service/pkg/server/options_test.go
+++ b/service/pkg/server/options_test.go
@@ -26,7 +26,8 @@ func TestWithAuditProcessor(t *testing.T) {
 
 func TestWithAuditTimeout(t *testing.T) {
 	cfg := WithAuditTimeout(30 * time.Second)(StartConfig{})
-	require.Equal(t, 30*time.Second, cfg.auditTimeout)
+	require.NotNil(t, cfg.auditTimeout)
+	require.Equal(t, 30*time.Second, *cfg.auditTimeout)
 }
 
 // noopInterceptor returns a connect.UnaryInterceptorFunc that passes through.
@@ -428,4 +429,19 @@ func TestFormatAuditTypeRegistrationConflictsIsDeterministic(t *testing.T) {
 
 func TestFormatAuditTypeRegistrationConflictsEmpty(t *testing.T) {
 	assert.Empty(t, formatAuditTypeRegistrationConflicts(nil))
+}
+
+func TestLoggerConfigPreservesFileSettingsUnlessExplicitlyOverridden(t *testing.T) {
+	const fileTimeout = 12 * time.Second
+	fileConfig := logger.Config{Level: "debug", Output: "stderr", Type: "json", AuditTimeout: fileTimeout}
+	require.Equal(t, fileConfig, (StartConfig{}).loggerConfig(fileConfig))
+	for _, timeout := range []time.Duration{30 * time.Second, 0, -time.Second} {
+		cfg := WithAuditTimeout(timeout)(StartConfig{}).loggerConfig(fileConfig)
+		require.Equal(t, timeout, cfg.AuditTimeout)
+		require.Equal(t, fileTimeout, fileConfig.AuditTimeout, "startup overrides must not mutate the input")
+	}
+	processor := audit.ProcessorFunc(func(context.Context, audit.Event) error { return nil })
+	cfg := WithAuditProcessor(processor)(StartConfig{}).loggerConfig(fileConfig)
+	require.NotNil(t, cfg.AuditProcessor)
+	require.Equal(t, fileTimeout, cfg.AuditTimeout)
 }

--- a/service/pkg/server/options_test.go
+++ b/service/pkg/server/options_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/go-viper/mapstructure/v2"
@@ -21,6 +22,11 @@ func TestWithAuditProcessor(t *testing.T) {
 	cfg := WithAuditProcessor(processor)(StartConfig{})
 
 	require.NotNil(t, cfg.auditProcessor)
+}
+
+func TestWithAuditTimeout(t *testing.T) {
+	cfg := WithAuditTimeout(30 * time.Second)(StartConfig{})
+	require.Equal(t, 30*time.Second, cfg.auditTimeout)
 }
 
 // noopInterceptor returns a connect.UnaryInterceptorFunc that passes through.

--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -291,11 +291,8 @@ func buildNamespaceLogger(baseLogger *logging.Logger, cfg *config.Config, ns, le
 	newLoggerConfig.Level = level
 
 	var loggerOptions []logging.Option
-	if baseLogger.Audit.Encoder() != nil {
-		loggerOptions = append(loggerOptions, logging.WithAuditEncoder(baseLogger.Audit.Encoder()))
-	}
-	if baseLogger.Audit.Sink() != nil {
-		loggerOptions = append(loggerOptions, logging.WithAuditSink(baseLogger.Audit.Sink()))
+	if baseLogger.Audit.Processor() != nil {
+		loggerOptions = append(loggerOptions, logging.WithAuditProcessor(baseLogger.Audit.Processor()))
 	}
 	namespaceLogger, loggerErr := logging.NewLogger(newLoggerConfig, loggerOptions...)
 	if loggerErr != nil {

--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -290,7 +290,14 @@ func buildNamespaceLogger(baseLogger *logging.Logger, cfg *config.Config, ns, le
 	newLoggerConfig := cfg.Logger
 	newLoggerConfig.Level = level
 
-	namespaceLogger, loggerErr := logging.NewLogger(newLoggerConfig)
+	var loggerOptions []logging.Option
+	if baseLogger.Audit.Encoder() != nil {
+		loggerOptions = append(loggerOptions, logging.WithAuditEncoder(baseLogger.Audit.Encoder()))
+	}
+	if baseLogger.Audit.Sink() != nil {
+		loggerOptions = append(loggerOptions, logging.WithAuditSink(baseLogger.Audit.Sink()))
+	}
+	namespaceLogger, loggerErr := logging.NewLogger(newLoggerConfig, loggerOptions...)
 	if loggerErr != nil {
 		return nil, fmt.Errorf("invalid namespace logger config for %s: %w", ns, loggerErr)
 	}

--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -290,11 +290,9 @@ func buildNamespaceLogger(baseLogger *logging.Logger, cfg *config.Config, ns, le
 	newLoggerConfig := cfg.Logger
 	newLoggerConfig.Level = level
 
-	loggerOptions := []logging.Option{logging.WithAuditTimeout(baseLogger.Audit.RecordTimeout())}
-	if baseLogger.Audit.Processor() != nil {
-		loggerOptions = append(loggerOptions, logging.WithAuditProcessor(baseLogger.Audit.Processor()))
-	}
-	namespaceLogger, loggerErr := logging.NewLogger(newLoggerConfig, loggerOptions...)
+	newLoggerConfig.AuditTimeout = baseLogger.Audit.RecordTimeout()
+	newLoggerConfig.AuditProcessor = baseLogger.Audit.Processor()
+	namespaceLogger, loggerErr := logging.NewLogger(newLoggerConfig)
 	if loggerErr != nil {
 		return nil, fmt.Errorf("invalid namespace logger config for %s: %w", ns, loggerErr)
 	}

--- a/service/pkg/server/services.go
+++ b/service/pkg/server/services.go
@@ -290,7 +290,7 @@ func buildNamespaceLogger(baseLogger *logging.Logger, cfg *config.Config, ns, le
 	newLoggerConfig := cfg.Logger
 	newLoggerConfig.Level = level
 
-	var loggerOptions []logging.Option
+	loggerOptions := []logging.Option{logging.WithAuditTimeout(baseLogger.Audit.RecordTimeout())}
 	if baseLogger.Audit.Processor() != nil {
 		loggerOptions = append(loggerOptions, logging.WithAuditProcessor(baseLogger.Audit.Processor()))
 	}

--- a/service/pkg/server/services_test.go
+++ b/service/pkg/server/services_test.go
@@ -5,9 +5,11 @@ import (
 	"embed"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/opentdf/platform/service/internal/server"
 	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/logger/audit"
 	"github.com/opentdf/platform/service/pkg/config"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
 	"github.com/stretchr/testify/suite"
@@ -230,6 +232,32 @@ func (suite *ServiceTestSuite) TestBuildNamespaceLoggerRejectsInvalidOverrideLev
 	suite.Require().Error(err)
 	suite.Nil(namespaceLogger)
 	suite.ErrorContains(err, "invalid namespace logger config for policy")
+}
+
+func (suite *ServiceTestSuite) TestBuildNamespaceLoggerPreservesAuditTimeout() {
+	const timeout = 30 * time.Second
+	cfg := &config.Config{Logger: logger.Config{Output: "stdout", Level: "info", Type: "json"}}
+	var deadline time.Time
+	processor := audit.ProcessorFunc(func(ctx context.Context, _ audit.Event) error {
+		var ok bool
+		deadline, ok = ctx.Deadline()
+		suite.Require().True(ok)
+		return nil
+	})
+	base, err := logger.NewLogger(cfg.Logger, logger.WithAuditProcessor(processor), logger.WithAuditTimeout(timeout))
+	suite.Require().NoError(err)
+	for _, level := range []string{"info", "debug"} {
+		suite.Run(level, func() {
+			scoped, err := buildNamespaceLogger(base, cfg, "policy", level)
+			suite.Require().NoError(err)
+			event := audit.NewEvent(audit.EventObjectParams{ClientInfo: audit.EventClientInfo{Platform: "test"}})
+			event.Verb = audit.Verb("test")
+			before := time.Now()
+			suite.Require().NoError(scoped.Audit.Record(suite.T().Context(), *event))
+			suite.False(deadline.Before(before.Add(timeout)))
+			suite.False(deadline.After(time.Now().Add(timeout)))
+		})
+	}
 }
 
 func (suite *ServiceTestSuite) TestStartServicesWithVariousCases() {

--- a/service/pkg/server/services_test.go
+++ b/service/pkg/server/services_test.go
@@ -244,7 +244,10 @@ func (suite *ServiceTestSuite) TestBuildNamespaceLoggerPreservesAuditTimeout() {
 		suite.Require().True(ok)
 		return nil
 	})
-	base, err := logger.NewLogger(cfg.Logger, logger.WithAuditProcessor(processor), logger.WithAuditTimeout(timeout))
+	baseConfig := cfg.Logger
+	baseConfig.AuditProcessor = processor
+	baseConfig.AuditTimeout = timeout
+	base, err := logger.NewLogger(baseConfig)
 	suite.Require().NoError(err)
 	for _, level := range []string{"info", "debug"} {
 		suite.Run(level, func() {

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -115,7 +115,14 @@ func Start(f ...StartOptions) error {
 	}
 
 	slog.Debug("configuring logger")
-	logger, err := logger.NewLogger(cfg.Logger)
+	var loggerOptions []logger.Option
+	if startConfig.auditEncoder != nil {
+		loggerOptions = append(loggerOptions, logger.WithAuditEncoder(startConfig.auditEncoder))
+	}
+	if startConfig.auditSink != nil {
+		loggerOptions = append(loggerOptions, logger.WithAuditSink(startConfig.auditSink))
+	}
+	logger, err := logger.NewLogger(cfg.Logger, loggerOptions...)
 	if err != nil {
 		return fmt.Errorf("could not start logger: %w", err)
 	}

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -116,11 +116,8 @@ func Start(f ...StartOptions) error {
 
 	slog.Debug("configuring logger")
 	var loggerOptions []logger.Option
-	if startConfig.auditEncoder != nil {
-		loggerOptions = append(loggerOptions, logger.WithAuditEncoder(startConfig.auditEncoder))
-	}
-	if startConfig.auditSink != nil {
-		loggerOptions = append(loggerOptions, logger.WithAuditSink(startConfig.auditSink))
+	if startConfig.auditProcessor != nil {
+		loggerOptions = append(loggerOptions, logger.WithAuditProcessor(startConfig.auditProcessor))
 	}
 	logger, err := logger.NewLogger(cfg.Logger, loggerOptions...)
 	if err != nil {

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -115,11 +115,8 @@ func Start(f ...StartOptions) error {
 	}
 
 	slog.Debug("configuring logger")
-	loggerOptions := []logger.Option{logger.WithAuditTimeout(startConfig.auditTimeout)}
-	if startConfig.auditProcessor != nil {
-		loggerOptions = append(loggerOptions, logger.WithAuditProcessor(startConfig.auditProcessor))
-	}
-	logger, err := logger.NewLogger(cfg.Logger, loggerOptions...)
+	cfg.Logger = startConfig.loggerConfig(cfg.Logger)
+	logger, err := logger.NewLogger(cfg.Logger)
 	if err != nil {
 		return fmt.Errorf("could not start logger: %w", err)
 	}

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -115,7 +115,7 @@ func Start(f ...StartOptions) error {
 	}
 
 	slog.Debug("configuring logger")
-	var loggerOptions []logger.Option
+	loggerOptions := []logger.Option{logger.WithAuditTimeout(startConfig.auditTimeout)}
 	if startConfig.auditProcessor != nil {
 		loggerOptions = append(loggerOptions, logger.WithAuditProcessor(startConfig.auditProcessor))
 	}


### PR DESCRIPTION
### Proposed Changes

Injected services need a public audit API that works without a request transaction and reports validation or delivery failures. Add synchronous `Recorder.Record(ctx, Event)` and an instance-scoped `Processor`, configurable through `server.WithAuditProcessor`.

PEPs and other consumers configure `AuditProcessor` and `AuditTimeout` through `logger.Config`, passed to `logger.NewLogger` without functional options. `AuditProcessor` is runtime-only and excluded from serialized configuration.

- Apply audit configuration only during setup; copy input mappings once and read them without config locks or per-event cloning.
- Reuse the existing typed event model and retain `EventObject` as a compatibility alias.
- Stamp request attribution and the authenticated principal, validate generic fields, and process under a deadline detached from request cancellation.
- Configure the processing budget through `logger.audit_timeout` in YAML or `OPENTDF_LOGGER_AUDIT_TIMEOUT`. An explicit `server.WithAuditTimeout` overrides those settings; five seconds remains the default, including for non-positive values. Namespace loggers inherit the effective processor and budget.
- Let embedding applications own destination-specific conversion, validation, fan-out, delivery, and recovery.
- Treat each call as an independent event; no attempted/completed lifecycle API is introduced.
- Preserve the existing `level:"AUDIT"`, `msg:<verb>`, `audit:{...}` output with the default processor.

`Record` returns processing errors directly. Default slog acceptance does not guarantee downstream persistence. Buffered compatibility methods are integrated in #3902.

PR 1 of 3 in stack #3976. Base: `main`. Next: #3902.

### Checklist

- [x] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Full local integration validation

### Testing Instructions

- `make fmt`
- `go test -race ./service/logger/... ./service/pkg/config ./service/pkg/server`
- `cd sdk && go test -run TestREADMECodeBlocks`
- Focused Go lint passed with zero new issues for the combined updates.
- `git diff --check`

Full `make lint` stops at an invalid Buf API token. Full `make test` passes the focused packages but fails in integration suites requiring a working Colima test-container socket and running Platform/Keycloak services.
