### PR TITLE
docs(spec): add IC-TDF v1alpha specification suite

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -30,6 +30,16 @@ focused documents inspired by the JOSE RFC factoring.
 - [`schema/BaseTDF/kao.schema.json`](schema/BaseTDF/kao.schema.json)
 - [`schema/BaseTDF/policy.schema.json`](schema/BaseTDF/policy.schema.json)
 
+## Related Suites
+
+Parallel suites that reorganize other TDF encodings into the same module architecture.
+They share BaseTDF's factoring and vocabulary but describe different wire formats.
+
+| Suite | Encoding | Directory |
+|---|---|---|
+| BinaryTDF v1alpha | CBOR-framed binary objects | [binarytdf/v1alpha/](binarytdf/v1alpha/) |
+| IC-TDF v1alpha | IC XML Trusted Data Format, `2014-DEC-r2017-JUL` | [ictdf/v1alpha/](ictdf/v1alpha/) |
+
 ## Previous Versions
 
 - [v4.3 (legacy)](legacy/v4.3/) — Previous monolithic specification

--- a/spec/ictdf/v1alpha/README.md
+++ b/spec/ictdf/v1alpha/README.md
@@ -1,0 +1,102 @@
+# IC-TDF Specification Suite — Version 1 Alpha
+
+IC-TDF is the Intelligence Community XML encoding of the Trusted Data Format. An IC-TDF
+instance binds handling metadata, discovery and mission metadata, and one payload into a
+single XML document whose parts may be cryptographically bound to one another and
+individually encrypted.
+
+This suite reorganizes the *XML Data Encoding Specification for Trusted Data Format*,
+version 2014-DEC-r2017-JUL, into components aligned with the BaseTDF 5 architecture. The
+refactoring changes document ownership, not the XML vocabulary, the schema, the
+controlled vocabularies, the Schematron constraint rules, or the validation semantics.
+The source DES, its XSD, its CVEs, and its 49 constraint rules remain the authority for
+every requirement restated here.
+
+## Core modules
+
+| Layer | Document | Responsibility | File |
+|---|---|---|---|
+| Foundation | ICTDF-SEC | Security model and validation hazards | [ictdf-sec.md](ictdf-sec.md) |
+| Foundation | ICTDF-ALG | Algorithm, vocabulary, and normalization registries | [ictdf-alg.md](ictdf-alg.md) |
+| Model | ICTDF-MTD | Assertions, statements, and statement metadata | [ictdf-mtd.md](ictdf-mtd.md) |
+| Model | ICTDF-SCP | Assertion scope, transitivity, and extraction | [ictdf-scp.md](ictdf-scp.md) |
+| Policy | ICTDF-POL | Handling assertions and access policy | [ictdf-pol.md](ictdf-pol.md) |
+| Operations | ICTDF-BND | Cryptographic binding and signature coverage | [ictdf-bnd.md](ictdf-bnd.md) |
+| Operations | ICTDF-KAO | Key access and encryption method | [ictdf-kao.md](ictdf-kao.md) |
+| Operations | ICTDF-KAS | Key retrieval and policy decision interfaces | [ictdf-kas.md](ictdf-kas.md) |
+| Operations | ICTDF-PAY | Payload carriage | [ictdf-pay.md](ictdf-pay.md) |
+| Storage | ICTDF-LOC | External references and fetch policy | [ictdf-loc.md](ictdf-loc.md) |
+| Storage | ICTDF-PKG | XML serialization and document order | [ictdf-pkg.md](ictdf-pkg.md) |
+| Schema | ICTDF-SCH | Schema, controlled vocabularies, and constraint rules | [ictdf-sch.md](ictdf-sch.md) |
+| Assembly | ICTDF-VAL | Conformance validation procedure | [ictdf-val.md](ictdf-val.md) |
+| Assembly | ICTDF-CORE | Object model and end-to-end processing | [ictdf-core.md](ictdf-core.md) |
+| Examples | ICTDF-EX | Worked examples | [ictdf-ex.md](ictdf-ex.md) |
+
+## Profiles and guides
+
+| Kind | Document | Extends | File |
+|---|---|---|---|
+| Profile | ICTDF-OPENTDF | POL, KAO, KAS, and BND | [ictdf-profile-opentdf.md](ictdf-profile-opentdf.md) |
+| Guide | ICTDF-MIG | CORE, POL, KAO, and PAY | [ictdf-migration.md](ictdf-migration.md) |
+
+## Architecture
+
+Arrows point from prerequisites to consumers.
+
+```text
+SEC ──► ALG, MTD, SCP, POL, BND, KAO, PAY, LOC, PKG
+ALG ──► MTD, BND, KAO
+MTD, SCP ──► POL, BND
+POL, KAO ──► KAS
+KAO ──► PAY
+LOC ──► PAY, KAO
+MTD, SCP, POL, BND, KAO, PAY, LOC ──► PKG ──► SCH ──► VAL
+
+SEC, ALG, MTD, SCP, POL, BND, KAO, KAS, PAY, LOC, PKG, SCH, VAL ──► CORE ──► EX
+
+POL, KAO, KAS, BND ──► OPENTDF
+CORE, POL, KAO, PAY ──► MIG
+```
+
+## Alignment with BaseTDF 5
+
+The suites use the same names for shared responsibilities: SEC, ALG, POL, KAO, KAS, LOC,
+PKG, CORE, and EX. ICTDF-MTD and ICTDF-SCP split what BaseTDF-ASN calls assertions into the
+metadata carrier and the scope algebra, because IC-TDF scope is a first-class processing
+instruction rather than a property of one assertion. ICTDF-BND covers the signature half of
+BaseTDF-ASN.
+
+Three documents have no BaseTDF counterpart. ICTDF-SCH exists because IC-TDF ships
+normative artifacts — an XSD, three controlled vocabularies, and a Schematron rule set —
+that BaseTDF states inline in each module. ICTDF-VAL exists because IC-TDF conformance is a
+multi-pass procedure over foreign-namespace content rather than a single manifest check.
+ICTDF-PAY exists because payload carriage in XML has attributes of its own; BaseTDF folds
+the equivalent into CORE.
+
+Going the other way, IC-TDF has no INT module: it defines no segmentation, no Merkle
+layout, and no per-segment integrity, so payload integrity comes from the selected
+encryption method and from binding coverage. These differences are format boundaries rather
+than missing placeholder documents.
+
+## Conventions
+
+BCP 14 requirement terms are normative only when written in all capitals, matching the
+source DES convention. Element and attribute names are written as they appear in the
+`urn:us:gov:ic:tdf` namespace; the `tdf:` prefix is elided where context is unambiguous.
+Constraint rules are cited by their source identifier, for example `IC-TDF-ID-00042`.
+Attributes are written `@name`.
+
+## Status and source
+
+The suite is an alpha draft. Its normative source is the *XML Data Encoding Specification
+for Trusted Data Format*, `IC-TDF.XML.V2014-DEC-r2017-JUL`, published by the Office of the
+Director of National Intelligence, together with the `IC-TDF.xsd` schema, the IC-TDF
+controlled vocabulary enumerations, and the `IC-TDF_XML.sch` Schematron rule set from the
+same package. Where this suite and the source package disagree, the source package wins.
+
+The source distribution notice reads: "This document has been approved for Public Release
+and is available for use without restriction."
+
+## License
+
+This specification is licensed under the repository's license terms.

--- a/spec/ictdf/v1alpha/ictdf-alg.md
+++ b/spec/ictdf/v1alpha/ictdf-alg.md
@@ -1,0 +1,140 @@
+# ICTDF-ALG: Algorithms, Vocabularies, and Normalization
+
+| | |
+|---|---|
+| Document | ICTDF-ALG |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC |
+| Referenced by | ICTDF-MTD, ICTDF-BND, ICTDF-KAO, ICTDF-SCH, ICTDF-CORE |
+
+## 1. Controlled vocabularies
+
+IC-TDF defines three controlled vocabulary enumerations. Each is published as an XML CVE
+document and as a generated XSD; the XML values are normative and the PDF renderings are
+informative. A value outside the governing enumeration is a schema validation failure.
+
+| Vocabulary | Namespace | Used by |
+|---|---|---|
+| `CVEnumTDFAppliesToState` | `urn:us:gov:ic:cvenum:tdf:state` | `@tdf:appliesToState` |
+| `CVEnumTDFHashAlgorithm` | `urn:us:gov:ic:cvenum:tdf:hashalgorithm` | `BoundValue/@hashAlgorithm` |
+| `CVEnumTDFSignatureAlgorithm` | `urn:us:gov:ic:cvenum:tdf:signaturealgorithm` | `SignatureValue/@signatureAlgorithm` |
+
+### 1.1 Data state
+
+| Value | Meaning |
+|---|---|
+| `encrypted` | The marking describes the part in its encrypted state |
+| `unencrypted` | The marking describes the part in its decrypted state |
+
+The enumeration is closed. ICTDF-MTD §4 defines when each value is required.
+
+### 1.2 Hash algorithms
+
+| Value | Status in this suite |
+|---|---|
+| `SHA1` | Permitted by the source CVE; MUST NOT be produced |
+| `SHA256` | Recommended |
+| `SHA384` | Permitted |
+| `SHA512` | Permitted |
+
+### 1.3 Signature algorithms
+
+The signature CVE is pattern-based rather than an explicit value list. Four patterns are
+defined:
+
+```text
+SHA(1|256|384|512)withRSA
+SHA(1|256|384|512)withRSAand[A-Z]+[0-9]*
+SHA(1|256|384|512)withECDSA
+SHA(1|256|384|512)withECDSAand[A-Z]+[0-9]*
+```
+
+The `and…` variants name a mask generation or padding qualifier, for example
+`SHA256withRSAandMGF1`. A verifier MUST match the declared value against its configured
+allow-list rather than parsing the pattern to derive parameters, and MUST reject any
+`SHA1with…` value.
+
+Because the CVE is pattern-based, syntactically valid values naming algorithms the
+verifier does not implement will occur. That is a rejection, not a fallback.
+
+## 2. Normalization methods
+
+`SignatureValue/@normalizationMethod` and `BoundValue/@normalizationMethod` are `xs:anyURI`
+and are unconstrained by the schema. They identify the canonicalization applied before
+hashing or signing. The source specification lists the following as sample values.
+
+| URI | Method |
+|---|---|
+| `http://www.w3.org/TR/2001/REC-xml-c14n-20010315` | Canonical XML 1.0 |
+| `http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments` | Canonical XML 1.0 with comments |
+| `http://www.w3.org/2001/10/xml-exc-c14n#` | Exclusive XML Canonicalization 1.0 |
+| `http://www.w3.org/2001/10/xml-exc-c14n#WithComments` | Exclusive XML Canonicalization 1.0 with comments |
+| `http://www.w3.org/2006/12/xml-c14n11` | Canonical XML 1.1 |
+| `http://www.w3.org/2006/12/xml-c14n11#WithComments` | Canonical XML 1.1 with comments |
+
+Rules:
+
+- The attribute is REQUIRED on every `SignatureValue` and every `BoundValue`. There is no
+  default and none may be inferred.
+- A producer MUST apply exactly the method it declares to every fragment covered by that
+  signature or bound value.
+- A verifier MUST reject a URI outside its allow-list before canonicalizing anything.
+- Exclusive canonicalization does not carry inherited namespace declarations into the
+  fragment. Because IC-TDF fragments rely on ancestor namespace and version declarations,
+  a deployment choosing an exclusive method MUST state how those declarations are
+  supplied. See ICTDF-BND §5.
+- Comment handling changes the signed byte sequence. Producer and verifier MUST agree,
+  and the declared URI is what they agree on.
+
+## 3. Encryption algorithms
+
+`EncryptionMethod/@algorithm` is `xs:anyURI` and is not drawn from an IC-TDF controlled
+vocabulary. IC-TDF carries the identifier and its parameters; it does not register
+algorithms. Deployments draw identifiers from XML Encryption or an equivalent registry
+and MUST publish the set they accept.
+
+The parameter children an algorithm requires are algorithm-specific. ICTDF-KAO §4
+enumerates the available parameter elements and the consistency requirements over them.
+
+## 4. Version identifiers
+
+`@tdf:version` is a string matching:
+
+```text
+[0-9]{6}(\.[0-9]{6})?(\-.{1,23})?
+```
+
+which corresponds to `Year Month [ "." Revision ] [ "-" CustomizationSuffix ]`. The base
+value for this suite is `201412.201707`: a December 2014 specification with a July 2017
+revision. `IC-TDF-ID-00054` raises a warning when `@tdf:version` is not `201412.201707`
+with an optional customization suffix.
+
+Namespaces do not carry versions. Every dependent specification declares its version
+through an attribute — `@ism:DESVersion`, `@ntk:DESVersion`, `@arh:DESVersion`,
+`@edh:DESVersion`, `@icid:DESVersion`, `@revrecall:DESVersion`, `@usagency:CESVersion`,
+and `@ism:ISMCATCESVersion`. ICTDF-VAL §6 defines the consistency rules over these.
+
+## 5. Identifiers and references
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `@tdf:id` | `xs:ID` | Unique within the XML document, not merely within the TDO |
+| `@tdf:idRef` | `xs:IDREF` | Must resolve to a descendant of the same TDO (`IC-TDF-ID-00011`) |
+| `@tdf:filename` | `xs:string` | Advisory; unencrypted metadata |
+| `@tdf:mediaType` | pattern `[a-zA-Z]*/[a-zA-Z+-.]*` | Weaker than RFC 6838; do not rely on it for validation |
+| `@tdf:normalizationMethod` | `xs:anyURI` | See §2 |
+| `@tdf:isEncrypted` | `xs:boolean` | Absence means `false` |
+| `@tdf:includesStatementMetadata` | `xs:boolean` | See ICTDF-BND §3 |
+
+Every attribute in the `urn:us:gov:ic:tdf` namespace MUST contain at least one
+non-whitespace character (`IC-TDF-ID-00001`).
+
+## 6. Media type
+
+An IC-TDF document is labeled `application/dni-tdf+xml`. The type is not registered with
+IANA. Deployments crossing an interface that requires a registered type MUST map it
+explicitly rather than substituting `application/xml`, which discards the signal that the
+document is a TDF.

--- a/spec/ictdf/v1alpha/ictdf-bnd.md
+++ b/spec/ictdf/v1alpha/ictdf-bnd.md
@@ -1,0 +1,181 @@
+# ICTDF-BND: Cryptographic Binding
+
+| | |
+|---|---|
+| Document | ICTDF-BND |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC, ICTDF-ALG, ICTDF-MTD, ICTDF-SCP |
+| Referenced by | ICTDF-PKG, ICTDF-VAL, ICTDF-CORE, ICTDF-OPENTDF |
+
+## 1. Structure
+
+A binding attaches a signature to an assertion. Either kind of assertion may carry one.
+
+```text
+Binding                                   1..unbounded
+  Signer
+    @subject    optional, RFC 5280 distinguished name
+    @issuer     optional, RFC 5280 distinguished name
+    @serial     optional
+  SignatureValue                          1
+    base64Binary
+    @signatureAlgorithm                required, CVEnumTDFSignatureAlgorithm
+    @normalizationMethod               required, xs:anyURI
+    @includesStatementMetadata         conditional, xs:boolean
+  BoundValueList                          0..1
+```
+
+The alternative to `Binding` is `ReferenceList`, which is reserved and not permitted in
+this version (§6).
+
+Multiple `Binding` elements on one assertion are independent signatures over the same
+coverage. Each carries its own signer, algorithm, and normalization method. A verifier MUST
+treat them as separate claims and MUST NOT combine them; a deployment requiring more than
+one valid signature states that requirement itself.
+
+`Signer` MUST specify `@issuer` and at least one of `@serial` or `@subject`
+(`IC-TDF-ID-00038`). It identifies a certificate; it does not contain one. Resolution and
+path validation are deployment responsibilities (ICTDF-SEC §2).
+
+## 2. What a signature covers
+
+A `SignatureValue` is computed over the concatenation, **in document order**, of the
+normalized form of each element the assertion's scope covers. The scope of the assertion
+carrying the binding determines that set; the binding itself does not enumerate it.
+
+```text
+signed-bytes = normalize(e₁) ‖ normalize(e₂) ‖ … ‖ normalize(eₙ)
+```
+
+where `e₁ … eₙ` are the covered elements in document order and `normalize` is the method
+named by `@normalizationMethod` (ICTDF-ALG §2).
+
+Coverage follows the scope semantics of ICTDF-SCP. The tables below restate the shape of
+each scope's coverage; the source DES Table 2 and Table 3 give the exact XPath enumeration
+and are authoritative where the two differ.
+
+### 2.1 Bindings inside a TDO
+
+| Scope | Covered, in document order |
+|---|---|
+| `PAYL` | The assertion's own statement; its `StatementMetadata` if and only if `@includesStatementMetadata="true"`; the sibling `Payload` |
+| `TDO` | Every `HandlingStatement` in the TDO; every assertion statement; every `StatementMetadata` for which `@includesStatementMetadata="true"`; the `Payload` |
+
+A `TDO`-scope binding covers everything in the TDO except the binding elements themselves.
+A `PAYL`-scope binding covers the payload and the assertion that describes it, and nothing
+else — in particular it does not cover the object's handling assertion.
+
+### 2.2 Bindings inside a TDC
+
+| Scope | Covered, in document order |
+|---|---|
+| `TDC` | The collection's own handling and assertion statements and their qualifying `StatementMetadata`, plus, recursively for every descendant `TrustedDataObject`, its handling statements, assertion statements, qualifying `StatementMetadata`, and `Payload`, and for every descendant `TrustedDataCollection`, its handling statements, assertion statements, and qualifying `StatementMetadata` |
+| `TDC_MEMBER` | The assertion's own statement and qualifying `StatementMetadata`, plus the same per-member content as `TDC` for each collection member, excluding the collection's peer assertions |
+| `DESC_TDO` | The assertion's own statement and qualifying `StatementMetadata`, plus the same per-descendant content as `TDC` for every descendant TDO |
+| `DESC_PAYL` | The assertion's own statement; its `StatementMetadata` if and only if `@includesStatementMetadata="true"`; the `Payload` of every descendant TDO |
+
+A `TDC`-scope binding is expensive: it covers the whole collection transitively, so adding
+or removing any member invalidates it. `TDC_MEMBER` and `DESC_TDO` bindings survive changes
+to the collection's own assertions but not to its membership.
+
+## 3. Statement metadata inclusion
+
+`@includesStatementMetadata` decides whether `StatementMetadata` elements are inside the
+signature. It is not optional in practice:
+
+| `BoundValueList` | `SignatureValue/@includesStatementMetadata` | Rule |
+|---|---|---|
+| absent | MUST be specified | `IC-TDF-ID-00010` |
+| present | MUST NOT be specified | `IC-TDF-ID-00009` |
+
+When a `BoundValueList` is present the per-value attribute governs instead, so a
+signature-level declaration would be ambiguous. When it is absent, an unspecified value
+would leave coverage undefined; a verifier MUST reject such a document rather than
+assuming `false`.
+
+The attribute applies uniformly across the coverage set. A signature cannot include the
+statement metadata of one covered assertion and exclude another's.
+
+## 4. Producing and verifying
+
+Producing a binding:
+
+1. Determine the coverage set from the assertion's scope and the containing TDO or TDC.
+2. Order it by document order.
+3. Normalize each covered element with the chosen method, without re-serializing anything
+   else.
+4. Concatenate the normalized octets.
+5. Sign with the chosen algorithm.
+6. Emit `Signer`, then `SignatureValue` carrying the base64 signature, the algorithm, the
+   normalization method, and `@includesStatementMetadata`.
+
+Verifying:
+
+1. Reject the document if `@signatureAlgorithm` or `@normalizationMethod` is outside the
+   verifier's allow-list, before any parsing work that depends on them.
+2. Reject `SHA1with…` values.
+3. Recompute the coverage set from the scope, independently of any hint in the document.
+4. Recompute the concatenation and verify.
+5. Resolve `Signer` to a certificate through trusted configuration; validate the path.
+6. Treat content outside the coverage set as unauthenticated, even where it is inside the
+   same TDO.
+
+A signature that verifies proves only that the covered bytes are as the signer produced
+them. It does not prove the marking is correct, that the signer was authorized to make it,
+or that content outside the coverage set is intact.
+
+## 5. Normalization and fragment context
+
+Normalization operates on element fragments taken out of their document. Whether ancestor
+namespace declarations, `xml:base`, `xml:lang`, and the dependent-specification version
+attributes travel with a fragment depends on the method chosen.
+
+- An inclusive method (Canonical XML 1.0 or 1.1) carries inherited namespace declarations
+  into each fragment, so the signed bytes include context the fragment did not declare.
+- An exclusive method carries only the namespaces the fragment visibly uses. Because
+  IC-TDF fragments inherit version declarations from the enclosing TDF (ICTDF-MTD §5.1),
+  a deployment choosing an exclusive method MUST state how those declarations enter the
+  signed bytes, or accept that they are unauthenticated.
+
+Producer and verifier MUST use the same method and the same fragment boundaries. The
+declared URI is the whole of the agreement between them, so an implementation MUST NOT
+apply local adjustments — whitespace trimming, attribute reordering, prefix rewriting — on
+either side.
+
+## 6. Reserved: bound value lists and reference lists
+
+Two structures are defined in the schema and disallowed in this version.
+
+```text
+BoundValueList
+  BoundValue                     base64Binary
+    @idRef                       required, xs:IDREF
+    @hashAlgorithm               required, CVEnumTDFHashAlgorithm
+    @normalizationMethod         required, xs:anyURI
+    @includesStatementMetadata   optional, xs:boolean
+
+ReferenceList
+  Reference
+    @idRef                       required, xs:IDREF
+    @includesStatementMetadata   optional, xs:boolean
+```
+
+`BoundValueList` would let a signature enumerate exactly what it covers: each `BoundValue`
+holds the hash of one referenced element, and the `SignatureValue` would then be computed
+over the normalized `BoundValueList` rather than over the referenced content directly. That
+indirection makes coverage explicit and lets a verifier check a subset without normalizing
+the whole object.
+
+`ReferenceList` is the unhashed form, enumerating covered elements without committing to
+their content.
+
+Both are reserved (`IC-TDF-ID-00013`), as is the `EXPLICIT` scope that would use them
+(`IC-TDF-ID-00008`, `IC-TDF-ID-00012`). Where a `BoundValue` or `Reference` does appear,
+its `@idRef` MUST resolve to a descendant of the same TDO (`IC-TDF-ID-00011`); a validator
+MUST enforce that itself, because XML ID uniqueness alone permits cross-TDO references
+inside a collection.
+
+Producers MUST NOT emit either structure. Consumers MUST reject them.

--- a/spec/ictdf/v1alpha/ictdf-core.md
+++ b/spec/ictdf/v1alpha/ictdf-core.md
@@ -1,0 +1,179 @@
+# ICTDF-CORE: Object Model and End-to-End Processing
+
+| | |
+|---|---|
+| Document | ICTDF-CORE |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC, ICTDF-ALG, ICTDF-MTD, ICTDF-SCP, ICTDF-POL, ICTDF-BND, ICTDF-KAO, ICTDF-KAS, ICTDF-PAY, ICTDF-LOC, ICTDF-PKG, ICTDF-SCH, ICTDF-VAL |
+| Referenced by | ICTDF-EX, ICTDF-MIG, IC-TDF profiles |
+
+## 1. Scope
+
+This module defines the IC-TDF object model and the end-to-end procedures for producing and
+consuming an object. It composes the other modules and adds no wire format of its own.
+
+The key words MUST, MUST NOT, REQUIRED, SHOULD, SHOULD NOT, and MAY are interpreted as
+described by BCP 14 when written in all capitals.
+
+## 2. Object model
+
+Two objects exist.
+
+A **Trusted Data Object** is a payload plus the assertions that describe it. It is the unit
+of protection.
+
+```text
+TrustedDataObject
+  HandlingAssertion   @scope="TDO"       object marking, rolled up, never encrypted
+  HandlingAssertion   @scope="PAYL"      payload marking; two when the payload is encrypted
+  Assertion*                             other metadata, individually scoped and encryptable
+  EncryptionInformation*                 payload encryption, layered by @sequenceNum
+  Payload                                exactly one, of four forms
+```
+
+A **Trusted Data Collection** is a set of TDOs and nested TDCs plus the assertions that
+describe them.
+
+```text
+TrustedDataCollection
+  HandlingAssertion   @scope="TDC"       collection marking, rolled up
+  HandlingAssertion   @scope="TDC"       optional revision recall
+  Assertion*                             scoped TDC, TDC_MEMBER, DESC_TDO, or DESC_PAYL
+  ( TrustedDataObject | TrustedDataCollection )+
+```
+
+Four properties define the model:
+
+- **Scope** decides what an assertion is about and, when the assertion carries a binding,
+  what that binding authenticates. Scope is the load-bearing concept (ICTDF-SCP).
+- **Rollup** makes the outermost marking safe to act on alone, so a guard need not parse
+  the interior (ICTDF-POL §4).
+- **State** separates the marking of ciphertext from the marking of the plaintext it
+  protects, keeping the latter out of rollup (ICTDF-MTD §4).
+- **Composition** means IC-TDF defines placement and consistency, not markings, key
+  services, or algorithms. Those come from IC-EDH, ARH, ISM, NTK, and deployment choices.
+
+## 3. Producing an object
+
+1. **Select the container.** One protected item is a TDO; a set that must travel and be
+   marked together is a TDC.
+2. **Place the payload.** Choose the form by content: text as `StringPayload`, octets or
+   ciphertext as `Base64BinaryPayload`, foreign XML as `StructuredPayload`, absent content
+   as `ReferenceValuePayload` (ICTDF-PAY §3).
+3. **Encrypt, if required.** Emit `EncryptionInformation` per layer, number layers from 1
+   with the highest outermost, set `@tdf:isEncrypted="true"`, and choose key access
+   (ICTDF-KAO).
+4. **Mark the payload.** One `PAYL` handling assertion if unencrypted; two, one per data
+   state with the `unencrypted` one external, if encrypted (ICTDF-POL §5).
+5. **Add other assertions.** Give each a legal scope for its container, mark it with
+   `StatementMetadata`, and pair states if its statement is encrypted (ICTDF-MTD).
+6. **Roll up.** Compute the object-scope marking as at least as restrictive as everything
+   the object contains, including `ntk:Access`. Exclude the `unencrypted` markings of
+   encrypted parts and the classifications of linked resources.
+7. **Emit the object-scope handling assertion first**, containing an EDH whose ARH security
+   block bears `@ism:resourceElement="true"`.
+8. **Bind, if required.** For each assertion needing authenticity, compute the coverage set
+   from its scope, normalize in document order, sign, and emit
+   `Signer → SignatureValue → …` with the algorithm, normalization method, and
+   `@includesStatementMetadata` (ICTDF-BND §4).
+9. **Serialize.** One XML document, `@tdf:version` on the root, namespaces declared once,
+   no gratuitous whitespace in signed regions (ICTDF-PKG).
+10. **Validate before release.** Run ICTDF-VAL against the object you are about to emit. A
+    producer that emits without validating ships rollup errors.
+
+## 4. Consuming an object
+
+1. **Parse defensively.** Entities off, parser limits on, nothing dereferenced
+   (ICTDF-SEC §1).
+2. **Validate.** Run the ICTDF-VAL procedure in full, including Step 2 over extension-point
+   content. Fail closed.
+3. **Read the object marking.** The first handling assertion is the rolled-up marking. It is
+   the correct input to a whole-object release decision, and it is available without
+   parsing further.
+4. **Verify bindings, if authenticity is needed.** Reject unacceptable algorithms and
+   normalization methods first, recompute coverage from scope independently of the
+   document, verify, then resolve the signer through trusted configuration
+   (ICTDF-BND §4).
+5. **Treat uncovered content as unauthenticated.** Content outside a verified binding's
+   coverage set has no integrity guarantee, even inside the same TDO.
+6. **Authorize.** Evaluate markings against the requester through a decision function
+   outside this suite. Presence of a marking is not authority; a key access descriptor is
+   not authorization (ICTDF-KAS §4).
+7. **Recover keys.** Resolve `RemoteStoredKey` through trusted configuration, unwrap layer
+   by layer from the highest `@sequenceNum` down, and report every failure as one opaque
+   class (ICTDF-KAO §5).
+8. **Decrypt and authenticate.** Verify the authentication tag, or a binding covering the
+   payload, before treating plaintext as complete. There is no segmentation, so the unit of
+   authentication is the whole payload.
+9. **Resolve references only if policy allows.** After validation, through a catalog, with
+   bounded redirects and size, and with no trust inferred from the URI (ICTDF-LOC §4).
+
+## 5. Extracting from a collection
+
+Extraction produces a new object and is not a copy.
+
+1. Take the TDO or nested TDC out of its collection.
+2. Carry transitive assertions with it and rewrite their scope: `DESC_TDO` becomes `TDO`
+   and `DESC_PAYL` becomes `PAYL` when the result is a TDO; both are unchanged when the
+   result is a TDC. Non-transitive assertions — `TDC` and `TDC_MEMBER` — are not carried
+   (ICTDF-SCP §4).
+3. Copy in the dependent-specification version declarations the content inherited from the
+   enclosing TDF (ICTDF-MTD §5.1).
+4. Recompute rollup for the extracted object.
+5. Discard bindings whose coverage no longer matches. A rewritten scope changes the
+   coverage set, so any signature over it is invalid. Re-sign or emit unsigned.
+6. Set `@tdf:version` on the new root and validate the result.
+
+## 6. Conformance
+
+A **conforming producer** emits documents that pass ICTDF-VAL §4 or §5 in full, obeys the
+MUST NOT requirements in ICTDF-SEC, and does not emit reserved structures (ICTDF-SCH §5) or
+deprecated algorithms (ICTDF-ALG §1).
+
+A **conforming consumer** runs the ICTDF-VAL procedure including Step 2, fails closed on
+any step it cannot run, verifies bindings against an explicit allow-list before acting on
+covered content, and treats markings as descriptions rather than authorizations.
+
+A **conforming validator** implements ICTDF-VAL §§3–7 and reports its rule set version,
+schema catalog, and which steps ran (ICTDF-VAL §9).
+
+An implementation that validates the schema alone is not conforming. The schema cannot
+express scope legality, rollup, state pairing, sequence continuity, or version consistency;
+those live in the constraint rules and in the multi-pass procedure.
+
+## 7. Deliberate absences
+
+IC-TDF does not define:
+
+| Absent | Consequence |
+|---|---|
+| Segmentation and per-segment integrity | The whole payload is the unit of authentication; no verified prefix release |
+| A key access protocol | `RemoteStoredKey` carries a URI and a protocol name only (ICTDF-KAS §1) |
+| A policy language | `EncryptedPolicyObject` is opaque; markings come from ISM and NTK |
+| An algorithm registry | `EncryptionMethod/@algorithm` is an unconstrained URI |
+| Content hashes for referenced content | A reference is authenticated; its referent is not (ICTDF-LOC §5) |
+| Explicit binding coverage | `BoundValueList` and `EXPLICIT` scope are reserved (ICTDF-BND §6) |
+
+These are format boundaries. A deployment needing any of them composes IC-TDF with an
+external specification and states the composition explicitly.
+
+## References
+
+- [RFC 2119](https://www.rfc-editor.org/info/rfc2119) — Key words for use in RFCs
+- [RFC 8174](https://www.rfc-editor.org/info/rfc8174) — Ambiguity of uppercase vs lowercase
+- [RFC 5280](https://www.rfc-editor.org/info/rfc5280) — X.509 certificate and CRL profile
+- [RFC 3986](https://www.rfc-editor.org/info/rfc3986) — Uniform Resource Identifier
+- [RFC 6838](https://www.rfc-editor.org/info/rfc6838) — Media type specifications
+- [XML 1.0](https://www.w3.org/TR/xml/) — Extensible Markup Language
+- [XML Namespaces](https://www.w3.org/TR/xml-names/) — Namespaces in XML
+- [XML Schema Part 1](https://www.w3.org/TR/xmlschema11-1/) and
+  [Part 2](https://www.w3.org/TR/xmlschema11-2/) — Structures and datatypes
+- [Canonical XML 1.0](https://www.w3.org/TR/2001/REC-xml-c14n-20010315) and
+  [1.1](https://www.w3.org/TR/xml-c14n11/)
+- [Exclusive XML Canonicalization 1.0](https://www.w3.org/TR/xml-exc-c14n/)
+- [XML Encryption Syntax and Processing](https://www.w3.org/TR/xmlenc-core1/)
+- [ISO/IEC 19757-3](https://www.iso.org/standard/55982.html) — Schematron
+- [XSLT 2.0](https://www.w3.org/TR/xslt20/) and [XPath 2.0](https://www.w3.org/TR/xpath20/)

--- a/spec/ictdf/v1alpha/ictdf-ex.md
+++ b/spec/ictdf/v1alpha/ictdf-ex.md
@@ -1,0 +1,379 @@
+# ICTDF-EX: Worked Examples
+
+| | |
+|---|---|
+| Document | ICTDF-EX |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Informational |
+| Depends on | ICTDF-CORE |
+| Referenced by | None |
+
+All classification markings below are illustrative. No example contains real classified
+data. Examples are non-normative; the modules and the source artifacts govern.
+
+## 1. Conventions used here
+
+Every example declares the TDF namespace and version on the root:
+
+```xml
+<TrustedDataObject xmlns="urn:us:gov:ic:tdf"
+                   xmlns:tdf="urn:us:gov:ic:tdf"
+                   tdf:version="201412.201707">
+```
+
+Handling statements repeat a bulky IC-EDH block. It is written out once in §2 and
+thereafter abbreviated as:
+
+```xml
+<!-- EDH: see §2, with arh:Security ism:classification="U" -->
+```
+
+Namespace bindings used throughout:
+
+| Prefix | Namespace |
+|---|---|
+| `tdf` | `urn:us:gov:ic:tdf` |
+| `edh` | `urn:us:gov:ic:edh` |
+| `arh` | `urn:us:gov:ic:arh` |
+| `ism` | `urn:us:gov:ic:ism` |
+| `ntk` | `urn:us:gov:ic:ntk` |
+| `icid` | `urn:us:gov:ic:id` |
+| `usagency` | `urn:us:gov:ic:usagency` |
+
+## 2. Minimal TDO
+
+The smallest conforming object: a string payload, an object-scope handling assertion, and a
+payload-scope handling assertion.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<TrustedDataObject xmlns="urn:us:gov:ic:tdf"
+                   xmlns:tdf="urn:us:gov:ic:tdf"
+                   tdf:version="201412.201707">
+  <tdf:HandlingAssertion tdf:scope="TDO">
+    <tdf:HandlingStatement>
+      <edh:Edh xmlns:edh="urn:us:gov:ic:edh"
+               xmlns:usagency="urn:us:gov:ic:usagency"
+               xmlns:icid="urn:us:gov:ic:id"
+               xmlns:arh="urn:us:gov:ic:arh"
+               xmlns:ism="urn:us:gov:ic:ism"
+               usagency:CESVersion="201609"
+               icid:DESVersion="1"
+               edh:DESVersion="201609"
+               arh:DESVersion="3"
+               ism:DESVersion="201609.201707"
+               ism:ISMCATCESVersion="201709">
+        <icid:Identifier>guide://999001/EdhExample</icid:Identifier>
+        <edh:DataItemCreateDateTime>2012-05-29T09:00:00Z</edh:DataItemCreateDateTime>
+        <edh:ResponsibleEntity edh:role="Custodian">
+          <edh:Country>USA</edh:Country>
+          <edh:Organization>DIA</edh:Organization>
+        </edh:ResponsibleEntity>
+        <arh:Security ism:compliesWith="OtherAuthority"
+                      ism:resourceElement="true"
+                      ism:createDate="2012-05-29"
+                      ism:classification="U"
+                      ism:ownerProducer="ABW"/>
+      </edh:Edh>
+    </tdf:HandlingStatement>
+  </tdf:HandlingAssertion>
+  <tdf:HandlingAssertion tdf:scope="PAYL">
+    <tdf:HandlingStatement>
+      <!-- EDH: as above -->
+    </tdf:HandlingStatement>
+  </tdf:HandlingAssertion>
+  <tdf:StringPayload>I am an example payload of a string</tdf:StringPayload>
+</TrustedDataObject>
+```
+
+What makes it conforming:
+
+| Requirement | Where satisfied |
+|---|---|
+| `@tdf:version` on the root (`IC-TDF-ID-00002`) | Root attribute |
+| Exactly one `TDO`-scope handling assertion with an EDH (`IC-TDF-ID-00004`) | First assertion |
+| It is first in document order (`IC-TDF-ID-00042`) | First assertion |
+| Its ARH block bears `@ism:resourceElement="true"` (`IC-TDF-ID-00016`) | `arh:Security` |
+| At least one `PAYL` handling assertion (`IC-TDF-ID-00003`) | Second assertion |
+| No `@appliesToState`, because nothing is encrypted (`IC-TDF-ID-00025`) | Absent |
+| Exactly one payload | `tdf:StringPayload` |
+
+## 3. Signed assertions
+
+A binding on each handling assertion. Coverage comes from each assertion's scope, not from
+the binding.
+
+```xml
+<tdf:HandlingAssertion tdf:id="handlingAssertion1" tdf:scope="TDO">
+  <tdf:HandlingStatement>
+    <!-- EDH: see §2 -->
+  </tdf:HandlingStatement>
+  <tdf:Binding>
+    <tdf:Signer tdf:subject="CN=Example Signer,O=Example,C=US" tdf:issuer="C=US"/>
+    <tdf:SignatureValue
+        tdf:signatureAlgorithm="SHA256withECDSA"
+        tdf:normalizationMethod="http://www.w3.org/2006/12/xml-c14n11"
+        tdf:includesStatementMetadata="false"
+      >RXhwZWN0ZWQgU3RyaW5nIFZhbHVl</tdf:SignatureValue>
+  </tdf:Binding>
+</tdf:HandlingAssertion>
+
+<tdf:HandlingAssertion tdf:id="handlingAssertion2" tdf:scope="PAYL">
+  <tdf:HandlingStatement>
+    <!-- EDH: see §2 -->
+  </tdf:HandlingStatement>
+  <tdf:Binding>
+    <tdf:Signer tdf:subject="CN=Example Signer,O=Example,C=US" tdf:issuer="C=US"/>
+    <tdf:SignatureValue
+        tdf:signatureAlgorithm="SHA256withECDSA"
+        tdf:normalizationMethod="http://www.w3.org/2006/12/xml-c14n11"
+        tdf:includesStatementMetadata="false"
+      >RXhwZWN0ZWQgU3RyaW5nIFZhbHVl</tdf:SignatureValue>
+  </tdf:Binding>
+</tdf:HandlingAssertion>
+
+<tdf:Assertion tdf:id="assertion1" tdf:scope="TDO">
+  <tdf:StringStatement tdf:isEncrypted="false">This is the first assertion</tdf:StringStatement>
+</tdf:Assertion>
+<tdf:Assertion tdf:id="assertion2" tdf:scope="TDO">
+  <tdf:Base64BinaryStatement tdf:isEncrypted="false"
+    >VGhpcyBpcyBhIGJpbmFyeSBzdGF0ZW1lbnQ=</tdf:Base64BinaryStatement>
+</tdf:Assertion>
+<tdf:StringPayload tdf:filename="myText.txt" tdf:id="payload1" tdf:isEncrypted="false"
+  >This is a text document</tdf:StringPayload>
+```
+
+Points to read off:
+
+- The `TDO`-scope binding covers all handling statements, both assertion statements, and
+  the payload. The `PAYL`-scope binding covers only its own statement and the payload
+  (ICTDF-BND §2.1).
+- `@includesStatementMetadata` is present because no `BoundValueList` is
+  (`IC-TDF-ID-00010`). Its value is `false`, so no `StatementMetadata` is inside either
+  signature.
+- `Signer` gives `@issuer` and `@subject`, satisfying `IC-TDF-ID-00038`. It names a
+  certificate; it does not carry one.
+- Two bindings on one object are two independent claims. Requiring both is a deployment
+  decision, not something the document states.
+- The source example writes `tdf:normalizationMethod="Normalization Method"`, a placeholder.
+  A real object MUST use a URI from ICTDF-ALG §2.
+
+## 4. Encrypted payload
+
+AES-GCM over the payload, with the two markings an encrypted part requires.
+
+```xml
+<TrustedDataObject xmlns="urn:us:gov:ic:tdf"
+                   xmlns:tdf="urn:us:gov:ic:tdf"
+                   tdf:version="201412.201707">
+  <tdf:HandlingAssertion tdf:scope="TDO">
+    <tdf:HandlingStatement>
+      <!-- EDH: see §2, ism:classification="U" -->
+    </tdf:HandlingStatement>
+  </tdf:HandlingAssertion>
+
+  <tdf:HandlingAssertion tdf:scope="PAYL" tdf:appliesToState="unencrypted">
+    <tdf:HandlingStatement>
+      <edh:ExternalEdh xmlns:edh="urn:us:gov:ic:edh"
+                       xmlns:arh="urn:us:gov:ic:arh"
+                       xmlns:ism="urn:us:gov:ic:ism"
+                       edh:DESVersion="201609" arh:DESVersion="3"
+                       ism:DESVersion="201609.201707">
+        <!-- identifier, create time, responsible entity elided -->
+        <arh:ExternalSecurity ism:compliesWith="USGov USIC"
+                              ism:resourceElement="true"
+                              ism:createDate="2012-05-28"
+                              ism:classification="U"
+                              ism:ownerProducer="USA"
+                              ism:excludeFromRollup="true"/>
+      </edh:ExternalEdh>
+    </tdf:HandlingStatement>
+  </tdf:HandlingAssertion>
+
+  <tdf:HandlingAssertion tdf:scope="PAYL" tdf:appliesToState="encrypted">
+    <tdf:HandlingStatement>
+      <!-- EDH: regular edh:Edh, describing the ciphertext -->
+    </tdf:HandlingStatement>
+  </tdf:HandlingAssertion>
+
+  <tdf:EncryptionInformation>
+    <tdf:KeyAccess>
+      <tdf:AttachedKey>
+        <tdf:KeyValue>abcdefghijklmnop</tdf:KeyValue>
+      </tdf:AttachedKey>
+    </tdf:KeyAccess>
+    <tdf:EncryptionMethod tdf:algorithm="AES">
+      <tdf:KeySize>32</tdf:KeySize>
+      <tdf:IVParams>YW55IGNhcm5hbCBwbGVhcwYW55IGNhcm5hbCBwbGVhcw</tdf:IVParams>
+      <tdf:AdditionalAuthenticatedData>5sA55IG49d5hbCBwbGVhcwa3</tdf:AdditionalAuthenticatedData>
+      <tdf:AuthenticationTag>B20abww4lLmNOqa43sas</tdf:AuthenticationTag>
+    </tdf:EncryptionMethod>
+  </tdf:EncryptionInformation>
+
+  <tdf:Base64BinaryPayload tdf:isEncrypted="true">rTLZ0kO2c3g9</tdf:Base64BinaryPayload>
+</TrustedDataObject>
+```
+
+Points to read off:
+
+- Two `PAYL` handling assertions, one per data state (`IC-TDF-ID-00026`). The `unencrypted`
+  one uses `edh:ExternalEdh` (`IC-TDF-ID-00027`); the `encrypted` one uses a regular
+  `edh:Edh` (`IC-TDF-ID-00028`).
+- `@ism:excludeFromRollup="true"` keeps the plaintext marking out of the object's rolled-up
+  classification (ICTDF-POL §4).
+- `@tdf:isEncrypted="true"` and the presence of `EncryptionInformation` agree
+  (`IC-TDF-ID-00014`, `IC-TDF-ID-00015`).
+- No `@sequenceNum`, because there is one layer (`IC-TDF-ID-00040`).
+- `AuthenticationTag` is the payload's only integrity protection here — no binding covers
+  the payload.
+- Two things in this example are deliberately not production-safe. `@algorithm="AES"` names
+  a family rather than a mode, and `AttachedKey` places the key in the document, so the
+  object provides no confidentiality (ICTDF-KAO §3.6). The source examples use both for
+  brevity.
+
+## 5. Layered encryption
+
+Two layers over one payload. Layer 2 is outermost, so decryption removes it first.
+
+```xml
+<tdf:EncryptionInformation tdf:sequenceNum="1">
+  <tdf:KeyAccess>
+    <tdf:WrappedKey tdf:keyIdentifier="mission-kek-2017">
+      <tdf:KeyValue>d3JhcHBlZC1pbm5lci1rZXk=</tdf:KeyValue>
+    </tdf:WrappedKey>
+  </tdf:KeyAccess>
+  <tdf:EncryptionMethod tdf:algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm">
+    <tdf:KeySize>32</tdf:KeySize>
+    <tdf:IVParams>MTIzNDU2Nzg5MDEy</tdf:IVParams>
+    <tdf:AuthenticationTag>dGFnLWZvci1sYXllci0x</tdf:AuthenticationTag>
+  </tdf:EncryptionMethod>
+</tdf:EncryptionInformation>
+
+<tdf:EncryptionInformation tdf:sequenceNum="2">
+  <tdf:KeyAccess>
+    <tdf:RemoteStoredKey tdf:protocol="kas" tdf:uri="https://kas.example.gov/keys/9f2a"/>
+  </tdf:KeyAccess>
+  <tdf:EncryptionMethod tdf:algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm">
+    <tdf:KeySize>32</tdf:KeySize>
+    <tdf:IVParams>OTg3NjU0MzIxMDk4</tdf:IVParams>
+    <tdf:AuthenticationTag>dGFnLWZvci1sYXllci0y</tdf:AuthenticationTag>
+  </tdf:EncryptionMethod>
+</tdf:EncryptionInformation>
+```
+
+Points to read off:
+
+- `@sequenceNum` is required on each because there is more than one (`IC-TDF-ID-00040`),
+  and the numbers run 1, 2 with no gap or duplicate (`IC-TDF-ID-00041`).
+- Encryption applied layer 1 then layer 2; decryption removes layer 2 then layer 1.
+- Each layer has its own IV. Reusing one across layers or objects breaks GCM.
+- `@protocol="kas"` is not an IC-TDF-registered name. A consumer matches it against local
+  configuration and rejects it otherwise (ICTDF-KAS §2), and resolves the URI through a
+  catalog rather than dereferencing it.
+
+## 6. Collection
+
+A TDC with two member TDOs, one collection-scope assertion, and no payload of its own.
+
+```xml
+<TrustedDataCollection xmlns="urn:us:gov:ic:tdf"
+                       xmlns:tdf="urn:us:gov:ic:tdf"
+                       tdf:version="201412.201707">
+  <tdf:HandlingAssertion tdf:scope="TDC">
+    <tdf:HandlingStatement>
+      <!-- EDH: rolled up over both members -->
+    </tdf:HandlingStatement>
+  </tdf:HandlingAssertion>
+
+  <tdf:Assertion tdf:scope="TDC">
+    <tdf:StringStatement>Collection-level description</tdf:StringStatement>
+  </tdf:Assertion>
+
+  <tdf:TrustedDataObject>
+    <tdf:HandlingAssertion tdf:scope="TDO">
+      <tdf:HandlingStatement><!-- EDH --></tdf:HandlingStatement>
+    </tdf:HandlingAssertion>
+    <tdf:HandlingAssertion tdf:scope="PAYL">
+      <tdf:HandlingStatement><!-- EDH --></tdf:HandlingStatement>
+    </tdf:HandlingAssertion>
+    <tdf:Assertion tdf:scope="PAYL">
+      <tdf:StringStatement>First member</tdf:StringStatement>
+    </tdf:Assertion>
+    <tdf:StringPayload>First payload</tdf:StringPayload>
+  </tdf:TrustedDataObject>
+
+  <tdf:TrustedDataObject>
+    <tdf:HandlingAssertion tdf:scope="TDO">
+      <tdf:HandlingStatement><!-- EDH --></tdf:HandlingStatement>
+    </tdf:HandlingAssertion>
+    <tdf:HandlingAssertion tdf:scope="PAYL">
+      <tdf:HandlingStatement><!-- EDH --></tdf:HandlingStatement>
+    </tdf:HandlingAssertion>
+    <tdf:StringPayload>Second payload</tdf:StringPayload>
+  </tdf:TrustedDataObject>
+</TrustedDataCollection>
+```
+
+Points to read off:
+
+- Exactly one `TDC`-scope handling assertion with an EDH (`IC-TDF-ID-00005`), first in
+  document order (`IC-TDF-ID-00042`), with `@ism:resourceElement="true"`
+  (`IC-TDF-ID-00017`).
+- Collection assertions use TDC-legal scopes only (`IC-TDF-ID-00007`); member assertions
+  use TDO-legal scopes only (`IC-TDF-ID-00006`).
+- Member TDOs omit `@tdf:version`; they inherit the collection's (`IC-TDF-ID-00052`
+  requires one version across the skeleton).
+- The TDC handling assertion is rolled up over both members, including their `ntk:Access`
+  (`IC-TDF-ID-00044`).
+- Validation recurses: the collection is validated by ICTDF-VAL §5, then each member by §4.
+
+## 7. Scope under extraction
+
+Given a collection carrying:
+
+```xml
+<tdf:Assertion tdf:scope="DESC_PAYL">
+  <tdf:StringStatement>Applies to every descendant payload</tdf:StringStatement>
+</tdf:Assertion>
+<tdf:Assertion tdf:scope="TDC_MEMBER">
+  <tdf:StringStatement>Applies to each member individually</tdf:StringStatement>
+</tdf:Assertion>
+```
+
+Extracting one member TDO yields:
+
+```xml
+<tdf:Assertion tdf:scope="PAYL">
+  <tdf:StringStatement>Applies to every descendant payload</tdf:StringStatement>
+</tdf:Assertion>
+<!-- the TDC_MEMBER assertion is not carried -->
+```
+
+The `DESC_PAYL` assertion is transitive, so it travels and its scope is rewritten to `PAYL`
+in the extracted TDO. The `TDC_MEMBER` assertion is non-transitive and describes the
+container, which no longer exists.
+
+The extractor also copies in the version declarations inherited from the enclosing TDF,
+recomputes rollup, sets `@tdf:version` on the new root, and discards any binding whose
+coverage set changed (ICTDF-CORE §5).
+
+## 8. Non-conforming: what each failure looks like
+
+| Document | Rule violated |
+|---|---|
+| TDO whose first handling assertion is `@scope="PAYL"` | `IC-TDF-ID-00042` |
+| TDO with two `TDO`-scope handling assertions | `IC-TDF-ID-00004` |
+| `@tdf:appliesToState` on an unencrypted payload's handling assertion | `IC-TDF-ID-00025` |
+| Encrypted payload with only one `PAYL` handling assertion | `IC-TDF-ID-00026` |
+| `@tdf:isEncrypted="true"` with no `EncryptionInformation` | `IC-TDF-ID-00015` |
+| Two `EncryptionInformation` numbered 1 and 3 | `IC-TDF-ID-00041` |
+| `SignatureValue` with no `@includesStatementMetadata` and no `BoundValueList` | `IC-TDF-ID-00010` |
+| `Signer` with `@subject` but no `@issuer` | `IC-TDF-ID-00038` |
+| `tdf:Assertion tdf:scope="DESC_TDO"` inside a TDO | `IC-TDF-ID-00006` |
+| Any assertion with `@tdf:scope="EXPLICIT"` | `IC-TDF-ID-00008` |
+| `ReferenceValuePayload` with no `edh:ExternalEdh` in the `PAYL` handling assertion | `IC-TDF-ID-00033` |
+| Two different `@ism:DESVersion` values in one skeleton | `IC-TDF-ID-00046` |
+| `tdf:scope=" "` | `IC-TDF-ID-00001` |
+| `@tdf:version="201412"` | `IC-TDF-ID-00054`, Warning |

--- a/spec/ictdf/v1alpha/ictdf-kao.md
+++ b/spec/ictdf/v1alpha/ictdf-kao.md
@@ -1,0 +1,176 @@
+# ICTDF-KAO: Key Access and Encryption Method
+
+| | |
+|---|---|
+| Document | ICTDF-KAO |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC, ICTDF-ALG, ICTDF-LOC |
+| Referenced by | ICTDF-PAY, ICTDF-KAS, ICTDF-VAL, ICTDF-CORE, ICTDF-OPENTDF, ICTDF-MIG |
+
+## 1. Structure
+
+`EncryptionInformation` describes one layer of encryption applied to one part of a TDO. It
+pairs a means of obtaining the key with a description of the algorithm the key is used
+with.
+
+```text
+EncryptionInformation          0..unbounded
+  KeyAccess                    1
+  EncryptionMethod             1
+  @sequenceNum                 optional, xs:integer
+```
+
+It appears in two places:
+
+- directly under `TrustedDataObject`, describing encryption of the payload; and
+- under `tdf:Assertion`, describing encryption of that assertion's statement.
+
+It never appears under `tdf:HandlingAssertion`: handling assertions are not encrypted
+(ICTDF-POL §1).
+
+The presence of `EncryptionInformation` and the value of the corresponding
+`@tdf:isEncrypted` MUST agree. Encryption information without an encrypted-labeled part is
+a failure (`IC-TDF-ID-00014`), and an encrypted-labeled part without encryption
+information is a failure (`IC-TDF-ID-00015`).
+
+## 2. Layered encryption
+
+Several `EncryptionInformation` elements on one part describe encryption applied in
+layers — the innermost layer applied first, each subsequent layer applied over the
+previous one's output.
+
+| Requirement | Rule |
+|---|---|
+| More than one `EncryptionInformation` on a part requires `@sequenceNum` on each | `IC-TDF-ID-00040` |
+| Sequence numbers start at 1, increment by 1, and contain no duplicates | `IC-TDF-ID-00041` |
+
+The **highest** sequence number is the **outermost** layer. Decryption proceeds from the
+highest number down to 1; encryption proceeds from 1 up.
+
+```text
+plaintext ──[seq 1]──► ──[seq 2]──► ──[seq 3]──► ciphertext as carried
+                                                 decrypt 3, then 2, then 1
+```
+
+A single `EncryptionInformation` MAY omit `@sequenceNum`; a consumer treats it as the only
+layer. A consumer MUST reject a gap, a duplicate, a value below 1, or a partially numbered
+set rather than inferring an order — layering ambiguity is a decryption failure at best and
+a silent wrong-plaintext at worst.
+
+Layering is how one part is made available to disjoint key holders in sequence, for example
+a mission-system key inside an enterprise key. It does not by itself express a threshold or
+split; each layer must be removable by whoever holds that layer's key.
+
+## 3. Key access
+
+`KeyAccess` carries one or more key descriptors. The schema permits repetition and
+mixing of kinds: each descriptor is an alternative route to the same layer's key, so a
+consumer takes the first it can satisfy.
+
+| Element | Required attributes | Optional | Content |
+|---|---|---|---|
+| `RemoteStoredKey` | `@protocol`, `@uri` | — | empty |
+| `WrappedKey` | — | `@keyIdentifier` | `KeyValue`, `EncryptionInformation`* |
+| `WrappedPDPKey` | — | `@keyIdentifier` | `EncryptedPolicyObject`, `EncryptionInformation`* |
+| `PasswordKey` | `@algorithm` | — | empty |
+| `PreSharedKey` | `@alias` | `@store` | empty |
+| `AttachedKey` | — | — | `KeyValue` |
+
+`KeyValue` and `EncryptedPolicyObject` are `xs:base64Binary`.
+
+### 3.1 Remote stored key
+
+The key is held by a service. `@protocol` names how to talk to it and `@uri` names where.
+IC-TDF defines neither the protocol nor its message format; see ICTDF-KAS.
+
+A consumer MUST resolve `@uri` through deployment policy and MUST NOT dereference it
+merely because it appears in the document (ICTDF-SEC §2, ICTDF-LOC §4).
+
+### 3.2 Wrapped key
+
+The key travels in the document, encrypted to a recipient. `KeyValue` holds the wrapped
+key material; the nested `EncryptionInformation` describes how it was wrapped, recursively
+using this same structure. `@keyIdentifier` names the wrapping key so a recipient holding
+several can select without trial decryption.
+
+The nesting terminates: a wrapping layer must eventually reach a `RemoteStoredKey`,
+`PreSharedKey`, `PasswordKey`, or a recipient key held out of band. A consumer MUST bound
+the nesting depth it will follow.
+
+### 3.3 Wrapped PDP key
+
+The same as a wrapped key, except that what is wrapped is an `EncryptedPolicyObject` — a
+policy that a decision point evaluates before releasing the key. The requester does not
+hold the key and cannot obtain it by holding a certificate alone; the decision point
+applies the policy first. See ICTDF-KAS §3.
+
+### 3.4 Password key
+
+The key is derived from a secret the user supplies. `@algorithm` names the derivation. The
+document carries no salt, iteration count, or memory parameter of its own, so those must
+come from the algorithm identifier or from deployment configuration. A deployment using
+`PasswordKey` MUST specify them and MUST select a memory-hard derivation.
+
+### 3.5 Pre-shared key
+
+The key is already held by both parties. `@alias` names it within an agreement established
+out of band; `@store` optionally names the keystore holding it. The document proves nothing
+about that agreement, and an alias collision across two agreements yields the wrong key
+without any signal.
+
+### 3.6 Attached key
+
+`KeyValue` holds the key itself, unwrapped. This provides no confidentiality: anyone who
+can read the document can decrypt the part. It exists for structural completeness and for
+cases where confidentiality comes entirely from the transport.
+
+Producers MUST NOT use `AttachedKey` for data requiring protection in transit or at rest.
+
+## 4. Encryption method
+
+```text
+EncryptionMethod
+  KeySize                       xs:integer         optional
+  KeyEncodingFormat             xs:string          optional
+  IVParams                      base64Binary       optional
+  OaepParams                    base64Binary       optional
+  HashAlgorithm                 xs:anyURI          optional
+  MGFAlgorithm                  xs:anyURI          optional
+  Tweak                         base64Binary       optional
+  Nonce                         base64Binary       optional
+  AdditionalAuthenticatedData   base64Binary       optional
+  AuthenticationTag             base64Binary       optional
+  @algorithm                    xs:anyURI          required
+```
+
+Every child is optional in the schema, so the schema cannot tell whether the supplied
+parameters match the declared algorithm. That check belongs to the consumer:
+
+- A consumer MUST reject an `@algorithm` outside its allow-list rather than approximating
+  (ICTDF-SEC §4).
+- A consumer MUST verify that every parameter the algorithm requires is present and
+  correctly sized, and SHOULD reject parameters the algorithm does not use rather than
+  ignoring them.
+- `IVParams` and `Nonce` MUST be unique per key. Reuse breaks counter and GCM modes
+  outright.
+- `AuthenticationTag` is the only integrity IC-TDF provides for a payload that no binding
+  covers. An unauthenticated algorithm leaves such a payload malleable.
+- `AdditionalAuthenticatedData` is authenticated but not encrypted, so it is readable by
+  anyone holding the document.
+- `OaepParams`, `HashAlgorithm`, and `MGFAlgorithm` parameterize asymmetric wrapping and
+  are normally meaningful only inside a `WrappedKey`'s nested encryption information.
+
+`KeySize` and `KeyEncodingFormat` are descriptive. A consumer MUST NOT let a declared key
+size override what the algorithm and the recovered key material actually are.
+
+## 5. Failure handling
+
+Unwrap, decrypt, and authentication failures MUST be reported as one opaque class.
+Distinguishing an unknown `@keyIdentifier` from a padding error from a policy denial gives
+an attacker an oracle over both the key hierarchy and the policy.
+
+Recovered key material MUST NOT be logged, returned in an error, or retained beyond the
+operation.

--- a/spec/ictdf/v1alpha/ictdf-kas.md
+++ b/spec/ictdf/v1alpha/ictdf-kas.md
@@ -1,0 +1,116 @@
+# ICTDF-KAS: Key Retrieval and Policy Decision Interfaces
+
+| | |
+|---|---|
+| Document | ICTDF-KAS |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC, ICTDF-POL, ICTDF-KAO |
+| Referenced by | ICTDF-CORE, ICTDF-OPENTDF, ICTDF-MIG |
+
+## 1. What IC-TDF defines and what it does not
+
+IC-TDF defines **carriage** of key retrieval information. It does not define a key access
+service, a wire protocol, a request or response format, an authentication mechanism, or a
+policy language.
+
+| Concern | Defined by IC-TDF |
+|---|---|
+| Where a remote key lives | Yes — `RemoteStoredKey/@uri` |
+| Which protocol reaches it | Named only — `RemoteStoredKey/@protocol` |
+| Request and response messages | No |
+| Requester authentication | No |
+| Policy language for a PDP | No — `EncryptedPolicyObject` is opaque |
+| Audit and denial semantics | No |
+
+Everything in the second column is a deployment or profile responsibility. This module
+states the constraints IC-TDF does impose on whatever fills those gaps.
+ICTDF-OPENTDF describes one concrete filling; ICTDF-MIG §5 compares it with the BaseTDF
+key access service.
+
+## 2. Remote stored keys
+
+```text
+RemoteStoredKey
+  @protocol   required
+  @uri        required
+```
+
+`@protocol` is an uncontrolled string. There is no IC-TDF registry of protocol names, so a
+consumer MUST match it against a locally configured set and MUST reject an unrecognized
+value rather than inferring one from the URI scheme.
+
+`@uri` identifies the key. It is not a capability and not a trust statement:
+
+- A consumer MUST resolve it through trusted local configuration — a catalog, an allow-list
+  of authorities, or a service registry — and MUST NOT dereference an arbitrary URI found
+  in a document (ICTDF-SEC §2, ICTDF-LOC §4).
+- URI ownership gives uniqueness, not authority. A document can name any URI it likes.
+- Resolution happens after validation, never during it. A validator that fetches keys turns
+  every malformed document into an outbound request.
+
+The retrieval exchange authenticates the requester and authorizes the release. IC-TDF
+carries neither the requester's identity nor the decision; both live in the protocol.
+
+## 3. Policy decision points
+
+`WrappedPDPKey` differs from `WrappedKey` in what it wraps: an `EncryptedPolicyObject`
+rather than a `KeyValue`.
+
+```text
+WrappedPDPKey
+  EncryptedPolicyObject     base64Binary
+  EncryptionInformation*
+  @keyIdentifier            optional
+```
+
+The policy object is encrypted to a decision point, which is the only party that can read
+it. A requester therefore cannot see the policy it must satisfy, and cannot obtain the key
+by holding a certificate alone — the decision point evaluates the policy and releases the
+key, or does not.
+
+Requirements on a deployment using `WrappedPDPKey`:
+
+- The policy object's content is opaque to IC-TDF. Its language, versioning, and evaluation
+  semantics MUST be specified separately.
+- The decision point MUST bind its decision to the object it was asked about. A policy
+  object detached from its TDO and replayed against another proves nothing.
+- The nested `EncryptionInformation` describes how the policy object was wrapped and
+  follows ICTDF-KAO §3.2, including the requirement to bound nesting depth.
+- Denials MUST be indistinguishable from key-recovery failures at the consumer
+  (ICTDF-KAO §5). A distinguishable denial reveals policy content the encryption was
+  meant to hide.
+
+## 4. Relationship to handling assertions
+
+A key access descriptor says how to get a key. A handling assertion says what controls
+govern the data. They are separate, and the separation is deliberate.
+
+- A key service MUST NOT treat the presence of a `RemoteStoredKey` pointing at it as
+  authorization to release. Release is decided by evaluating the object's markings against
+  the requester.
+- The markings a decision uses MUST come from a source the decision point trusts. Reading
+  them out of the requester's copy of the document is only sound if a binding over them
+  verifies and the signer is trusted (ICTDF-BND §4).
+- The TDO- or TDC-scope handling assertion is the rolled-up marking (ICTDF-POL §4) and is
+  the correct input for a whole-object release decision. A `PAYL`-scope marking is the
+  correct input for a payload-only release.
+- `ntk:Access` rolled up into the object-scope handling assertion is what a decision point
+  evaluates for need-to-know; it MUST NOT be reconstructed by walking the interior, because
+  interior markings may be encrypted.
+
+## 5. Non-goals
+
+This suite does not define:
+
+- rewrap, split-key, or threshold protocols;
+- key rotation, revocation, or epoch handling;
+- attribute or entitlement resolution for a requester; or
+- a canonical policy representation.
+
+A deployment needing any of these composes IC-TDF carriage with an external specification
+and states the composition explicitly. Silently extending `@protocol` with locally
+meaningful values is interoperable only within that deployment, and a document so produced
+is not portable — a consumer elsewhere sees an unrecognized protocol and must reject it.

--- a/spec/ictdf/v1alpha/ictdf-loc.md
+++ b/spec/ictdf/v1alpha/ictdf-loc.md
@@ -1,0 +1,99 @@
+# ICTDF-LOC: External References and Fetch Policy
+
+| | |
+|---|---|
+| Document | ICTDF-LOC |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC |
+| Referenced by | ICTDF-PAY, ICTDF-KAO, ICTDF-KAS, ICTDF-VAL, ICTDF-CORE |
+
+## 1. Where references appear
+
+An IC-TDF document names four kinds of thing that live outside it.
+
+| Reference | Names | Resolved by |
+|---|---|---|
+| `ReferenceValuePayload/@uri` | Payload content | Consumer, after validation |
+| `ReferenceStatement/@uri` | Statement content | Consumer, after validation |
+| `RemoteStoredKey/@uri` | A key, via `@protocol` | Key retrieval (ICTDF-KAS §2) |
+| `edh:ExternalEdh`, `arh:ExternalSecurity` | A marking held elsewhere | Marking resolution |
+| `PreSharedKey/@alias`, `@store` | A key in an out-of-band arrangement | Local keystore |
+
+The last two are not URIs but are references in the same sense: the document names
+something it does not contain.
+
+## 2. External markings
+
+An external marking is not a weaker marking. It is a marking that is deliberately not
+stated in this document, for one of two reasons:
+
+- the marked content is not here, so there is nothing to mark in place — a
+  `ReferenceValuePayload` or `ReferenceStatement`; or
+- stating it here would disclose it — the `unencrypted` marking of an encrypted part,
+  which would otherwise raise the object's rolled-up classification (ICTDF-POL §5).
+
+Where external markings are required:
+
+| Situation | Required | Rule |
+|---|---|---|
+| Payload is a `ReferenceValuePayload` | `edh:ExternalEdh` in the `PAYL` handling assertion | `IC-TDF-ID-00033` |
+| Statement is a `ReferenceStatement` | `edh:ExternalEdh` or `arh:ExternalSecurity` in `StatementMetadata` | `IC-TDF-ID-00034` |
+| Payload is encrypted | `edh:ExternalEdh` in the `unencrypted` `PAYL` handling assertion | `IC-TDF-ID-00027` |
+| Statement is encrypted | `arh:ExternalSecurity` in the `unencrypted` `StatementMetadata` | `IC-TDF-ID-00030` |
+
+Object-scope handling assertions are the exception: a `TDO`- or `TDC`-scope handling
+assertion MUST NOT use `edh:ExternalEdh` (`IC-TDF-ID-00018`, `IC-TDF-ID-00019`). The
+object's own marking is always present in the object, so that a guard can act on the
+document alone.
+
+## 3. Linked versus embedded
+
+A linked resource's classification does not raise the linking TDO's classification. An
+embedded resource's does.
+
+This distinction is what makes references useful: a low-classification object can point at
+higher-classification content without itself becoming high. It also means that resolving a
+reference and inlining the result is not a neutral transformation — it changes the object's
+marking obligations, requires recomputed rollup (ICTDF-POL §4), and invalidates any binding
+that covered the payload.
+
+An intermediary MUST NOT inline a reference on a consumer's behalf.
+
+## 4. Fetch policy
+
+Resolution is a consumer action governed by deployment policy, never a validator action.
+
+- A validator MUST NOT dereference any URI in the document. Doing so turns every malformed
+  or hostile document into an outbound request, leaks the fact and timing of validation,
+  and makes validation depend on network reachability.
+- A consumer MUST resolve URIs through trusted local configuration — a catalog, an
+  allow-list of authorities, or a service registry — rather than by scheme dispatch on the
+  literal value.
+- A consumer MUST NOT infer trust from the URI. Ownership of a name gives uniqueness, not
+  authority; a document may name any URI.
+- A consumer MUST bound redirects, response size, and time, and MUST apply the same parser
+  limits to fetched content as to the document itself (ICTDF-SEC §1).
+- Fetching leaks. The request discloses to the resolver, and to anyone observing, that a
+  particular consumer holds a particular object. Where that matters, the deployment SHOULD
+  proxy or prefetch.
+
+## 5. Integrity of referenced content
+
+The document does not authenticate what a reference points at.
+
+- No binding can cover absent content. A binding whose scope includes a
+  `ReferenceValuePayload` authenticates the URI and the surrounding structure, not the
+  referent (ICTDF-PAY §3.4).
+- There is no hash of referenced content in this version. `BoundValue` would have provided
+  one for in-document elements, and it is reserved (ICTDF-BND §6); nothing covers external
+  content at all.
+- A consumer therefore MUST obtain integrity for fetched content from the transport, from a
+  signature the referenced resource carries itself, or from the resolver's own guarantees,
+  and MUST state which.
+- Referenced content is mutable. Two consumers resolving the same object at different times
+  may see different content, and the object gives no way to detect it.
+- Where these properties are unacceptable, the content is embedded rather than referenced,
+  and the object's markings and bindings are recomputed accordingly.

--- a/spec/ictdf/v1alpha/ictdf-migration.md
+++ b/spec/ictdf/v1alpha/ictdf-migration.md
@@ -1,0 +1,180 @@
+# ICTDF-MIG: IC-TDF and BaseTDF Interoperability
+
+| | |
+|---|---|
+| Document | ICTDF-MIG |
+| Guide version | 0.1 |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Non-normative |
+| Depends on | ICTDF-CORE, ICTDF-POL, ICTDF-KAO, ICTDF-PAY |
+
+This guide compares IC-TDF with BaseTDF 5 and describes what conversion between them costs.
+It is non-normative: nothing here changes either format.
+
+## 1. The short version
+
+The two formats solve overlapping problems from opposite ends.
+
+| | IC-TDF | BaseTDF 5 |
+|---|---|---|
+| Serialization | One XML document | ZIP container with a JSON manifest |
+| Metadata model | Assertions with scope over a document tree | Assertions and a policy object in a manifest |
+| Access control | IC markings (ISM, NTK) evaluated by a decision function | Attribute FQNs evaluated by a KAS |
+| Key access | Descriptors only; no protocol | KAOs plus a defined rewrap protocol |
+| Payload integrity | Encryption tag, or binding coverage | Segmented Merkle integrity information |
+| Collections | Native, recursive, with transitive scope | Not modeled |
+| Validation | Multi-pass over foreign-namespace content | Manifest schema plus signature checks |
+
+Neither is a superset of the other. Conversion in either direction loses something, and the
+loss is structural rather than a gap in tooling.
+
+## 2. Concept mapping
+
+| IC-TDF | BaseTDF 5 | Fidelity |
+|---|---|---|
+| `TrustedDataObject` | TDF object with manifest and payload | Close |
+| `TrustedDataCollection` | — | No counterpart |
+| `HandlingAssertion` `@scope="TDO"` | Policy object plus a handling assertion | Lossy; see §4 |
+| `HandlingAssertion` `@scope="PAYL"` | No distinct payload-level marking | Lossy |
+| `tdf:Assertion` | BaseTDF-ASN assertion | Close for the statement; scope is lost |
+| `@tdf:scope` | — | No counterpart; see §3 |
+| `StatementMetadata` | Assertion `statement` metadata | Partial |
+| `@tdf:appliesToState` | — | No counterpart; see §5 |
+| `Binding` / `SignatureValue` | Assertion binding and manifest signature | Different coverage model |
+| `EncryptionInformation` | `encryptionInformation` | Close |
+| `KeyAccess` / `RemoteStoredKey` | KAO with `kas`, `kid`, `alg` | Close under ICTDF-OPENTDF |
+| `WrappedPDPKey` | KAO plus policy object | Close in intent |
+| `@tdf:sequenceNum` layering | — | No counterpart; see §6 |
+| `StringPayload` etc. | `payload` entry with `mimeType` | Close |
+| `ReferenceValuePayload` | BaseTDF-LOC detached storage | Close in intent |
+| — | `integrityInformation` segments | No IC-TDF counterpart |
+| — | Key splitting (`sid`) | No IC-TDF counterpart |
+
+## 3. Scope has no counterpart
+
+Scope is the concept that does not survive conversion in either direction, and it is the
+one IC-TDF is built around.
+
+An IC-TDF assertion states what it is about — the payload, the object, each member of a
+collection, every descendant payload — and a binding over that assertion authenticates
+exactly that set (ICTDF-BND §2). BaseTDF assertions attach to the object; there is no
+sub-object addressing and no transitive form.
+
+Consequences:
+
+- Converting IC-TDF to BaseTDF collapses `PAYL`, `TDO`, `TDC_MEMBER`, `DESC_TDO`, and
+  `DESC_PAYL` into one level. Assertions that meant different things become
+  indistinguishable, and their bindings' coverage sets cannot be reconstructed.
+- Converting BaseTDF to IC-TDF requires inventing a scope for every assertion. `TDO` is the
+  safe choice and is also the most conservative, because it is the widest coverage.
+- A round trip does not restore the original. Scope information destroyed in the first
+  direction is not recoverable in the second.
+
+## 4. Markings and policy
+
+IC-TDF carries markings; BaseTDF carries attributes. Neither derives from the other
+automatically.
+
+Going from IC-TDF to BaseTDF requires the mapping described in ICTDF-OPENTDF §3: a total,
+deterministic, deployment-published function from marking values to attribute FQNs. That
+mapping is a security boundary — an error in it silently over-releases and no validation
+step catches it.
+
+Going from BaseTDF to IC-TDF is harder. An IC-TDF object requires an IC-EDH handling
+assertion with an ARH security block bearing `@ism:resourceElement="true"`
+(`IC-TDF-ID-00016`), and there is no way to synthesize valid ISM markings from attribute
+FQNs. In practice the producer must already know the markings; the BaseTDF object does not
+contain them.
+
+Rollup is also unmatched. IC-TDF requires the object-scope marking to dominate everything
+inside (ICTDF-POL §4), which lets a guard act on the head of the document alone. BaseTDF's
+policy object is authoritative by construction rather than by rollup, so there is nothing to
+compute in that direction and nothing to derive in the other.
+
+## 5. Data state
+
+IC-TDF marks an encrypted part twice: once for the ciphertext and once for the plaintext,
+with the plaintext marking held externally and excluded from rollup (ICTDF-POL §5).
+
+BaseTDF has one policy. It describes what is required to open the object, which is closest
+to IC-TDF's `unencrypted` marking; the `encrypted` marking, describing the ciphertext as it
+travels, has no representation at all.
+
+Converting IC-TDF to BaseTDF therefore discards the marking a guard uses to decide whether
+the ciphertext may cross a boundary. For deployments where that decision matters, the
+converted object is not a substitute for the original.
+
+## 6. Layering versus splitting
+
+Both formats can involve more than one key, and they mean different things by it.
+
+IC-TDF `@sequenceNum` layers encryption: layer 1 innermost, highest number outermost, every
+layer removable in turn. Recovery requires all of them.
+
+BaseTDF splits the data encryption key: KAOs sharing an `sid` are alternative routes to one
+share, and different `sid` values are shares that must be combined. Recovery requires one
+KAO per share.
+
+Neither expresses the other. An `allOf` split is not a set of layers, and a set of layers
+is not a split. A converter MUST NOT map one onto the other; where a deployment needs split
+semantics, IC-TDF cannot carry them (ICTDF-OPENTDF §2.4).
+
+## 7. Integrity
+
+BaseTDF-INT defines segmented integrity: the payload is chunked, each chunk hashed, and the
+hashes are covered by the manifest signature. That allows large payloads, streaming, and
+verified partial reads.
+
+IC-TDF has none of this. Payload integrity comes from the encryption method's
+`AuthenticationTag`, from a binding whose scope covers the payload, or from both — and the
+unit is the whole payload. There is no conforming way to release a verified prefix
+(ICTDF-CORE §7).
+
+Converting BaseTDF to IC-TDF discards the segment tree. Converting the other way requires
+computing one, which means reading the whole payload.
+
+## 8. Collections
+
+IC-TDF collections are native and recursive, with transitive scope and recursive validation
+(ICTDF-VAL §5). BaseTDF has no collection type.
+
+A converter has three options, none of them lossless:
+
+- emit one BaseTDF object per member TDO, losing the collection's own assertions and its
+  rolled-up marking;
+- emit one BaseTDF object whose payload is the serialized collection, which preserves the
+  bytes but makes the members opaque to BaseTDF tooling; or
+- refuse.
+
+The first is usually right for dissemination and the third is usually right for archival.
+
+## 9. Converting in practice
+
+If converting IC-TDF to BaseTDF:
+
+1. Validate the source with ICTDF-VAL in full. Do not convert an object you have not
+   validated.
+2. Verify every binding, and record which assertions were authenticated. Assertions that
+   were not stay unauthenticated in the result.
+3. Decrypt and re-encrypt. The formats' encryption structures are not interchangeable at
+   the byte level, so conversion is a re-protect, and the converter briefly holds plaintext.
+4. Apply the marking-to-attribute mapping (§4). Fail on any unmapped marking.
+5. Record what was dropped: scope, the `encrypted`-state marking, payload-level markings,
+   and collection structure. A converter that drops these silently produces an object that
+   looks equivalent and is not.
+
+If converting BaseTDF to IC-TDF, the producer must supply IC markings out of band (§4),
+choose a scope for each assertion (§3), and accept that segment integrity is replaced by
+whole-payload authentication (§7).
+
+## 10. When not to convert
+
+Conversion is a re-protect performed by a party who sees plaintext and re-asserts markings.
+That party becomes part of the trust chain, and the original signer's bindings do not
+survive.
+
+Where the original object's provenance is what matters, carry the IC-TDF document as a
+BaseTDF payload rather than converting it. The bytes and their bindings stay intact, a
+BaseTDF consumer can handle the outer object, and an IC-TDF consumer can extract and verify
+the inner one.

--- a/spec/ictdf/v1alpha/ictdf-mtd.md
+++ b/spec/ictdf/v1alpha/ictdf-mtd.md
@@ -1,0 +1,167 @@
+# ICTDF-MTD: Assertions, Statements, and Statement Metadata
+
+| | |
+|---|---|
+| Document | ICTDF-MTD |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC, ICTDF-ALG |
+| Referenced by | ICTDF-SCP, ICTDF-POL, ICTDF-BND, ICTDF-PKG, ICTDF-VAL, ICTDF-CORE |
+
+## 1. Two kinds of assertion
+
+IC-TDF carries metadata in assertions. There are exactly two kinds, and they are distinct
+element types rather than variants of one type.
+
+| Element | Purpose | May be encrypted |
+|---|---|---|
+| `tdf:HandlingAssertion` | Dissemination controls that govern the object | No |
+| `tdf:Assertion` | Any other metadata about the object | Yes |
+
+Both appear in the assertion group at the head of a TDO or TDC:
+
+```text
+AssertionGroup
+  HandlingAssertion   1..unbounded
+  Assertion           0..unbounded
+```
+
+Handling assertions precede ordinary assertions in document order. ICTDF-POL governs
+handling assertions; this module governs `tdf:Assertion` and the state model shared by
+both.
+
+## 2. Assertion structure
+
+```text
+Assertion
+  StatementMetadata          0..2
+  EncryptionInformation      0..unbounded
+  <one statement>            1
+  Binding | ReferenceList    0..1
+
+  @scope    required
+  @type     optional
+  @id       optional
+```
+
+- `@scope` states which part of the object the assertion describes. Its values and
+  semantics are in ICTDF-SCP.
+- `@type` is an uncontrolled string naming the assertion's kind. It is producer-defined;
+  a consumer MUST NOT derive security decisions from it.
+- `@id` is `xs:ID` and is what a `BoundValue/@idRef` or `Reference/@idRef` points at.
+- `EncryptionInformation` describes encryption applied to the statement. See ICTDF-KAO.
+- The binding group is defined in ICTDF-BND.
+
+Exactly one statement is present. The choice is:
+
+| Element | Content | Extension point |
+|---|---|---|
+| `tdf:StringStatement` | `xs:string` | Yes |
+| `tdf:Base64BinaryStatement` | `xs:base64Binary` | Yes |
+| `tdf:StructuredStatement` | `xs:any` from another namespace, `processContents="skip"` | Yes |
+| `tdf:ReferenceStatement` | Empty; `@uri` names the content | No |
+
+`StringStatement`, `Base64BinaryStatement`, and `StructuredStatement` carry the same value
+types as their payload counterparts; ICTDF-PAY §2 defines the shared attributes
+`@filename`, `@mediaType`, and `@isEncrypted`.
+
+## 3. Statement metadata
+
+`StatementMetadata` describes the statement the way a handling assertion describes the
+object. It carries exactly one of:
+
+| Child | Use |
+|---|---|
+| `edh:Edh` | Enterprise data header for the statement |
+| `edh:ExternalEdh` | Data header held outside this document |
+| `arh:Security` | Access rights and handling security block |
+| `arh:ExternalSecurity` | Security block held outside this document |
+
+`StatementMetadata/@appliesToState` is the only place, besides `HandlingAssertion`, where
+data state appears.
+
+An assertion has zero, one, or two `StatementMetadata` elements. Two are permitted only in
+the encrypted case described in §4.
+
+An assertion whose statement is a `ReferenceStatement` MUST carry an `edh:ExternalEdh` or
+`arh:ExternalSecurity` in `StatementMetadata` (`IC-TDF-ID-00034`), because the referenced
+content is not present to be marked.
+
+## 4. Data state
+
+Encrypting a part of a TDO creates two things that need separate markings: the ciphertext
+that travels in the clear, and the plaintext it protects. `@tdf:appliesToState` names
+which of the two a marking describes.
+
+```text
+@tdf:appliesToState = "encrypted" | "unencrypted"
+```
+
+Rules:
+
+- The attribute MAY appear only where the described part is actually encrypted. On a
+  statement it requires `@tdf:isEncrypted="true"` on that statement (`IC-TDF-ID-00032`);
+  on a payload handling assertion it requires `@tdf:isEncrypted="true"` on the payload
+  (`IC-TDF-ID-00025`).
+- On a handling assertion the attribute is permitted only when the scope is `PAYL`
+  (`IC-TDF-ID-00039`). A TDO- or TDC-scope handling assertion has no state.
+- An encrypted statement MUST have exactly two `StatementMetadata` elements, one
+  `encrypted` and one `unencrypted` (`IC-TDF-ID-00031`).
+- The `unencrypted` `StatementMetadata` MUST contain `arh:ExternalSecurity`
+  (`IC-TDF-ID-00030`). The plaintext marking is deliberately external so that it does not
+  raise the visible classification of the object that carries the ciphertext.
+- An unencrypted statement carries at most one `StatementMetadata`, and that element MUST
+  NOT specify `@appliesToState`.
+
+The parallel requirements for encrypted payloads are in ICTDF-POL §5.
+
+## 5. Extension points
+
+Six elements are extension points — places where content governed by another
+specification is embedded:
+
+```text
+tdf:StringStatement          tdf:StringPayload
+tdf:Base64BinaryStatement    tdf:Base64BinaryPayload
+tdf:StructuredStatement      tdf:StructuredPayload
+```
+
+`tdf:ReferenceStatement` and `tdf:ReferenceValuePayload` are not extension points; they
+carry no content.
+
+Extension point content:
+
+- is not validated by the IC-TDF schema — `StructuredStatement` uses
+  `processContents="skip"`;
+- is validated in isolation, against its own governing schema and rules, by ICTDF-VAL
+  Step 2; and
+- MUST be treated as untrusted input until that step completes. See ICTDF-SEC §1.
+
+### 5.1 Version declaration inheritance
+
+Content at an extension point inherits the dependent-specification versions declared by
+its enclosing TDF. It does not restate them, and the version-consistency rules
+(`IC-TDF-ID-00046` through `IC-TDF-ID-00053`) require a single version per dependent
+specification across the enclosing skeleton.
+
+When such content is extracted from the TDF and processed on its own, the inherited
+version declarations MUST be copied onto the extracted content. An extractor that omits
+them produces a fragment whose marking semantics cannot be resolved.
+
+The ISM version governing structured content is the first `@ism:DESVersion` in document
+order within that content; if the content declares none, it inherits the enclosing TDF's.
+
+## 6. Element ordering
+
+Within an assertion, order is fixed by the schema and is significant:
+
+```text
+StatementMetadata* → EncryptionInformation* → statement → binding group?
+```
+
+Within a `Binding`, the order `Signer → SignatureValue → BoundValueList?` exists so that a
+streaming parser can verify a signature in one pass over the document. A producer MUST
+emit this order; a consumer MUST NOT act on unverified content merely because the order
+permits early verification. See ICTDF-SEC §3.

--- a/spec/ictdf/v1alpha/ictdf-pay.md
+++ b/spec/ictdf/v1alpha/ictdf-pay.md
@@ -1,0 +1,134 @@
+# ICTDF-PAY: Payload Carriage
+
+| | |
+|---|---|
+| Document | ICTDF-PAY |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC, ICTDF-KAO, ICTDF-LOC |
+| Referenced by | ICTDF-PKG, ICTDF-VAL, ICTDF-CORE, ICTDF-MIG |
+
+## 1. One payload per object
+
+A `TrustedDataObject` carries exactly one payload, chosen from four forms. A
+`TrustedDataCollection` carries none; it carries member objects, each with its own.
+
+| Element | Content | Value type |
+|---|---|---|
+| `tdf:StringPayload` | `xs:string` | `StringValueType` |
+| `tdf:Base64BinaryPayload` | `xs:base64Binary` | `Base64BinaryValueType` |
+| `tdf:StructuredPayload` | `xs:any` from another namespace, `processContents="skip"` | `StructuredValueType` |
+| `tdf:ReferenceValuePayload` | empty; `@uri` names the content | `ReferenceValueType` |
+
+Each payload element also carries `@tdf:id` of type `xs:ID`. The same four value types back
+the statement elements in ICTDF-MTD §2, so the attribute semantics below apply to both.
+
+## 2. Value type attributes
+
+| Attribute | `StringValue` | `Base64BinaryValue` | `StructuredValue` | `ReferenceValue` |
+|---|---|---|---|---|
+| `@tdf:filename` | yes | yes | yes | — |
+| `@tdf:mediaType` | — | yes | — | yes |
+| `@tdf:isEncrypted` | yes | yes | yes | yes |
+| `@uri` | — | — | — | required |
+
+- `@tdf:filename` is advisory. It is unencrypted even when the payload is not, and a
+  consumer MUST NOT use it as a filesystem path without sanitizing it — path traversal and
+  device-name attacks apply.
+- `@tdf:mediaType` matches the loose pattern `[a-zA-Z]*/[a-zA-Z+-.]*`, which is weaker than
+  RFC 6838. It is a hint. A consumer MUST NOT dispatch a parser on it without sniffing or
+  validating the content, and MUST NOT treat it as evidence of the content's structure.
+- `@tdf:isEncrypted` is `xs:boolean` and defaults to `false` by absence. Its value MUST
+  agree with the presence of `EncryptionInformation` (`IC-TDF-ID-00014`,
+  `IC-TDF-ID-00015`).
+
+`@filename` and `@mediaType` describe protected content while remaining in the clear. They
+are part of the object's disclosure surface (ICTDF-SEC §5) and a producer encrypting a
+payload SHOULD omit both unless they are needed and are themselves releasable at the
+object's marking.
+
+## 3. Payload forms
+
+### 3.1 String payload
+
+Text, carried as XML character data. XML 1.0 excludes most control characters, so raw
+octets MUST NOT be forced into a `StringPayload`.
+
+The schema permits `@tdf:isEncrypted="true"` on a `StringPayload`, and the source examples
+use it. That is only well defined when the ciphertext has itself been text-encoded by the
+producer. Ciphertext is octets, so a producer SHOULD use `Base64BinaryPayload` for an
+encrypted payload and MUST NOT place raw ciphertext in a `StringPayload`.
+
+### 3.2 Base64 binary payload
+
+Arbitrary octets, base64-encoded. This is the form for ciphertext and for any non-text
+content. A parser MUST bound the decoded length before allocating (ICTDF-SEC §1); the
+encoded form is roughly a third larger than the octets it carries, and the document gives
+no length hint.
+
+### 3.3 Structured payload
+
+XML from another namespace, embedded directly. The schema declares
+`processContents="skip"`, so the IC-TDF validator checks nothing inside it.
+
+- It is an extension point (ICTDF-MTD §5) and is validated in isolation by ICTDF-VAL
+  Step 2 against its own governing schema.
+- It inherits the enclosing TDF's dependent-specification version declarations, which MUST
+  be copied in on extraction.
+- The ISM version governing it is the first `@ism:DESVersion` in document order within it,
+  or the enclosing TDF's if it declares none.
+- Until Step 2 completes it is untrusted input, and it can declare any namespace, any
+  depth, and any size the parser limits allow.
+
+### 3.4 Reference value payload
+
+The payload is not present; `@uri` names where it is.
+
+- `@uri` is REQUIRED.
+- The TDO MUST carry an `edh:ExternalEdh` in its `PAYL` handling assertion
+  (`IC-TDF-ID-00033`), because content that is absent cannot be marked in place.
+- The classification of referenced content does not raise the TDO's classification
+  (ICTDF-POL §4). Inlining that content instead of referencing it does.
+- Resolution is governed by ICTDF-LOC and never happens during validation.
+- No binding can cover content that is not in the document. A `PAYL`-scope binding over a
+  `ReferenceValuePayload` authenticates the reference, not the referent.
+
+## 4. Encrypted payloads
+
+An encrypted payload is ciphertext carried as `Base64BinaryPayload`, described by one or
+more `EncryptionInformation` elements under the TDO (ICTDF-KAO), and marked twice — once
+for the ciphertext and once for the plaintext (ICTDF-POL §5).
+
+The full set of obligations:
+
+| Obligation | Source |
+|---|---|
+| `@tdf:isEncrypted="true"` on the payload | `IC-TDF-ID-00015` |
+| At least one `EncryptionInformation` under the TDO | `IC-TDF-ID-00015` |
+| `@sequenceNum` on each when there is more than one, sequential from 1 | `IC-TDF-ID-00040`, `IC-TDF-ID-00041` |
+| Exactly two `PAYL` handling assertions, `encrypted` and `unencrypted` | `IC-TDF-ID-00026` |
+| The `unencrypted` one contains `edh:ExternalEdh` | `IC-TDF-ID-00027` |
+| The `encrypted` one contains a regular `edh:Edh`, unless the payload is external | `IC-TDF-ID-00028` |
+
+Integrity of the ciphertext comes from the encryption method's `AuthenticationTag`, from a
+binding whose scope covers the payload, or from both. Where neither is present the payload
+has no integrity protection at all, and a consumer SHOULD refuse it.
+
+A consumer MUST authenticate before releasing plaintext. IC-TDF defines no segmentation and
+no per-segment integrity, so there is no conforming way to release a verified prefix of a
+payload: the unit of authentication is the whole payload.
+
+## 5. Size and streaming
+
+IC-TDF is a single XML document with the payload inline. There is no chunking, no length
+prefix, and no external data reference other than `ReferenceValuePayload`.
+
+Consequences a producer must weigh:
+
+- A large payload becomes a large document, and base64 expansion applies.
+- Signature verification requires normalizing the covered elements, including the payload,
+  so it is not free at any size.
+- A payload too large to carry inline is carried by reference (§3.4), which moves integrity
+  and marking obligations outside the object.

--- a/spec/ictdf/v1alpha/ictdf-pkg.md
+++ b/spec/ictdf/v1alpha/ictdf-pkg.md
@@ -1,0 +1,145 @@
+# ICTDF-PKG: XML Serialization and Document Order
+
+| | |
+|---|---|
+| Document | ICTDF-PKG |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC, ICTDF-MTD, ICTDF-SCP, ICTDF-POL, ICTDF-BND, ICTDF-KAO, ICTDF-PAY, ICTDF-LOC |
+| Referenced by | ICTDF-SCH, ICTDF-VAL, ICTDF-CORE |
+
+## 1. Document form
+
+An IC-TDF instance is a well-formed XML 1.0 document with exactly one root element, either
+`tdf:TrustedDataObject` or `tdf:TrustedDataCollection`. There is no DTD, no XML Schema
+instance requirement, and no external subset.
+
+| Property | Value |
+|---|---|
+| Target namespace | `urn:us:gov:ic:tdf` |
+| Element form | qualified |
+| Attribute form | qualified |
+| Media type | `application/dni-tdf+xml` |
+| Character encoding | UTF-8 RECOMMENDED; the XML declaration governs |
+
+Attributes are namespace-qualified, so IC-TDF attributes are written `tdf:scope`,
+`tdf:version`, `tdf:isEncrypted`, and so on, including on IC-TDF's own elements.
+
+`xsi:schemaLocation`, where present, is a hint only. A validator MUST resolve schemas from
+a trusted local catalog and MUST ignore locations named in the instance (ICTDF-SEC §1).
+
+## 2. Namespaces
+
+| Prefix | Namespace |
+|---|---|
+| `tdf` | `urn:us:gov:ic:tdf` |
+| `edh` | IC Enterprise Data Header |
+| `arh` | Access Rights and Handling |
+| `ism` | Information Security Marking |
+| `ntk` | Need-To-Know Metadata |
+| `revrecall` | Revision Recall |
+| `usagency` | US Agency Acronyms |
+| `icid` | IC Identifier |
+
+Namespace URIs carry no version. Every dependent specification states its version through
+an attribute, and those attributes must be consistent within a skeleton (ICTDF-VAL §6).
+Prefixes are conventional; a document may bind any prefix to any namespace and a consumer
+MUST resolve by namespace URI.
+
+Namespace declarations are inherited. A fragment taken out of the document loses the
+declarations it did not make itself, which is why extraction copies them in
+(ICTDF-MTD §5.1) and why normalization method choice matters to bindings
+(ICTDF-BND §5).
+
+## 3. Document structure
+
+```text
+TrustedDataObject
+  @tdf:version                            required on a root TDO
+  @tdf:id                                 optional
+  HandlingAssertion             1..*
+  Assertion                     0..*
+  EncryptionInformation         0..*
+  <one payload>                 1
+
+TrustedDataCollection
+  @tdf:version                            required
+  HandlingAssertion             1..*
+  Assertion                     0..*
+  ( TrustedDataCollection | TrustedDataObject )   1..*
+```
+
+A root `TrustedDataObject` MUST specify `@tdf:version` (`IC-TDF-ID-00002`); a nested one
+inherits it. A `TrustedDataCollection` always specifies it. The value matches the pattern in
+ICTDF-ALG §4 and SHOULD be `201412.201707` with an optional customization suffix
+(`IC-TDF-ID-00054`).
+
+Collections nest to arbitrary depth. A parser MUST bound that depth (ICTDF-SEC §1).
+
+## 4. Document order
+
+Order is not incidental in IC-TDF. Three separate mechanisms depend on it.
+
+### 4.1 Schema-imposed order
+
+Every content model in the schema is a sequence, not an all-group. Within an assertion:
+
+```text
+StatementMetadata* → EncryptionInformation* → statement → binding group?
+```
+
+Within a `Binding`:
+
+```text
+Signer → SignatureValue → BoundValueList?
+```
+
+Within a TDO or TDC, handling assertions precede ordinary assertions, and in a TDC the
+member objects follow both.
+
+### 4.2 Rule-imposed order
+
+The first handling assertion in document order MUST be the `TDO`- or `TDC`-scope one, and
+it MUST contain an EDH (`IC-TDF-ID-00042`). A guard can then read the object's rolled-up
+marking from the head of the document without parsing the rest.
+
+The ISM version governing structured content is the first `@ism:DESVersion` in document
+order within that content (ICTDF-MTD §5.1).
+
+### 4.3 Signature-imposed order
+
+A `SignatureValue` covers the concatenation of covered elements **in document order**
+(ICTDF-BND §2). Reordering elements that a signature covers invalidates it, even where the
+schema would permit the new order.
+
+The `Signer → SignatureValue → BoundValueList` order exists so a streaming parser can
+verify in one pass. That is a performance property, not a security one: a verifier MUST NOT
+act on content before the signature covering it verifies (ICTDF-SEC §3).
+
+## 5. Byte-level stability
+
+Signed content is bytes, not an information set. An implementation that round-trips a
+document through a parser and serializer will not in general reproduce the original bytes,
+and any binding over the changed region will fail.
+
+- An intermediary MUST NOT re-serialize, reindent, reorder attributes, rewrite prefixes,
+  normalize whitespace, strip comments, or change entity forms in a signed document.
+- Re-encoding a document to a different character encoding changes the bytes.
+- Where a transformation is unavoidable, the object is re-signed by a party authorized to
+  do so, and the new signature reflects the new content.
+- Normalization for signing is applied to the elements a binding covers, as declared by
+  `@normalizationMethod`, and to nothing else. A producer MUST NOT canonicalize the whole
+  document as a convenience.
+
+## 6. Whitespace and empty content
+
+Every attribute in the `urn:us:gov:ic:tdf` namespace MUST contain at least one
+non-whitespace character (`IC-TDF-ID-00001`). This forecloses the empty-string values that
+would otherwise satisfy `xs:string` and `xs:anyURI` attributes.
+
+Whitespace between elements is insignificant to the schema and significant to
+normalization. A producer SHOULD emit signed regions without gratuitous formatting
+whitespace, because that whitespace becomes part of the signed bytes under an inclusive
+canonicalization method.

--- a/spec/ictdf/v1alpha/ictdf-pol.md
+++ b/spec/ictdf/v1alpha/ictdf-pol.md
@@ -1,0 +1,161 @@
+# ICTDF-POL: Handling Assertions and Access Policy
+
+| | |
+|---|---|
+| Document | ICTDF-POL |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC, ICTDF-MTD, ICTDF-SCP |
+| Referenced by | ICTDF-BND, ICTDF-KAS, ICTDF-VAL, ICTDF-CORE, ICTDF-OPENTDF, ICTDF-MIG |
+
+## 1. Role
+
+A handling assertion carries the dissemination controls that govern the object. It is the
+part a guard reads to decide whether the object may cross a boundary, and it is therefore
+the one part of a TDF that MUST remain in the clear. Handling assertions are never
+encrypted, and no `EncryptionInformation` applies to them.
+
+```text
+HandlingAssertion
+  HandlingStatement
+    edh:Edh | edh:ExternalEdh | rr:RevisionRecall
+  Binding | ReferenceList    0..1
+
+  @scope             required
+  @id                optional
+  @appliesToState    optional, PAYL scope only
+```
+
+Unlike `tdf:Assertion`, a handling assertion has no `StatementMetadata` and no
+`EncryptionInformation`. Its statement is the marking.
+
+## 2. Handling statement content
+
+| Child | Meaning |
+|---|---|
+| `edh:Edh` | An IC Enterprise Data Header describing this object |
+| `edh:ExternalEdh` | A data header held outside this document, identified by reference |
+| `rr:RevisionRecall` | A revision or recall notice for the object |
+
+An `edh:Edh` block carries the identifier, creation time, responsible entity, and — inside
+it — the ARH security block that holds the ISM classification markings and any NTK access
+information. IC-TDF does not define those markings; it defines where they live and how
+they must agree across the object.
+
+Required content by scope:
+
+| Scope | Requirement | Rule |
+|---|---|---|
+| `TDO` | Exactly one handling assertion, containing an EDH | `IC-TDF-ID-00004` |
+| `TDO` | The EDH MUST contain an ARH security block with `@ism:resourceElement="true"` | `IC-TDF-ID-00016` |
+| `TDO` | MUST NOT use `edh:ExternalEdh` | `IC-TDF-ID-00018` |
+| `TDC` | Exactly one handling assertion, containing an EDH | `IC-TDF-ID-00005` |
+| `TDC` | The EDH MUST contain an ARH security block with `@ism:resourceElement="true"` | `IC-TDF-ID-00017` |
+| `TDC` | MUST NOT use `edh:ExternalEdh` | `IC-TDF-ID-00019` |
+| `TDC` | Handling assertions use no other scope | `IC-TDF-ID-00035` |
+| any | The first handling assertion in document order is the `TDO`- or `TDC`-scope one and contains an EDH | `IC-TDF-ID-00042` |
+
+The resource-element requirement is what makes the object's own marking authoritative:
+`@ism:resourceElement="true"` designates the marking that applies to the resource as a
+whole rather than to a portion of it.
+
+A revision recall handling assertion is optional and additional. It uses the same scope as
+the object's primary handling assertion and carries `@revrecall:DESVersion` of at least
+`201412` (`IC-TDF-ID-00045`).
+
+## 3. Payload handling assertions
+
+A TDO MUST carry at least one handling assertion with `@scope="PAYL"` (`IC-TDF-ID-00003`).
+The payload's marking is separate from the object's because the two differ: an object
+whose payload is a reference to remote content is marked differently from the content it
+points at.
+
+- An unencrypted payload has at most one `PAYL` handling assertion containing an EDH
+  (`IC-TDF-ID-00055`).
+- A TDO whose payload is a `ReferenceValuePayload` MUST carry an `edh:ExternalEdh` in its
+  `PAYL` handling assertion (`IC-TDF-ID-00033`), because the payload content is not
+  present to be marked directly.
+- An encrypted payload requires two, as described in §5.
+
+## 4. Rollup
+
+The TDO- or TDC-scope handling assertion states the marking of the object as a whole. That
+marking MUST be at least as restrictive as everything the object contains — the producer
+rolls up the markings of the payload, the statements, and, for a collection, its members.
+
+Rollup is what makes the outermost marking safe to act on without parsing the interior. A
+guard that reads only the first handling assertion must not be able to release something
+the interior would have prohibited.
+
+`ntk:Access` is rolled up the same way: need-to-know access information from the interior
+MUST be reflected in the `TDO`-scope handling assertion (`IC-TDF-ID-00043`) and, for a
+collection, in the `TDC`-scope handling assertion (`IC-TDF-ID-00044`).
+
+Two things are outside rollup:
+
+- the `unencrypted` marking of an encrypted part (§5), which describes plaintext that is
+  not disclosed by this object. A producer signals the exclusion with
+  `@ism:excludeFromRollup="true"` on the external security block; and
+- the classification of a linked resource, which does not raise the classification of the
+  TDO that links to it. Embedding that resource instead of linking to it does.
+
+Extraction changes what an object contains, so an extractor MUST recompute rollup for the
+result (ICTDF-SCP §4).
+
+## 5. Encrypted payloads and data state
+
+An encrypted payload needs two markings: one for the ciphertext travelling in the clear
+and one for the plaintext it protects.
+
+| Requirement | Rule |
+|---|---|
+| Exactly two `PAYL` handling assertions, one `@appliesToState="encrypted"` and one `"unencrypted"` | `IC-TDF-ID-00026` |
+| `@appliesToState` permitted only when the payload has `@tdf:isEncrypted="true"` | `IC-TDF-ID-00025` |
+| `@appliesToState` permitted only on `PAYL`-scope handling assertions | `IC-TDF-ID-00039` |
+| The `unencrypted` assertion MUST contain `edh:ExternalEdh` | `IC-TDF-ID-00027` |
+| If the payload is not itself external, the `encrypted` assertion MUST contain a regular `edh:Edh` | `IC-TDF-ID-00028` |
+
+The external security block in the `unencrypted` assertion carries
+`@ism:excludeFromRollup="true"`, which is what keeps the plaintext marking out of the
+object's rolled-up classification.
+
+The `unencrypted` marking is external by construction. Carrying the plaintext marking
+inline would state the protected content's classification in the clear and would force
+rollup to raise the whole object to that level, defeating the purpose of encrypting it.
+
+The equivalent requirements for encrypted statements are in ICTDF-MTD §4.
+
+## 6. Dependent specifications
+
+IC-TDF does not define markings. It composes specifications that do, and constrains their
+versions.
+
+| Specification | Prefix | Minimum version | Carried in |
+|---|---|---|---|
+| IC Enterprise Data Header | `edh` | V4 | `HandlingStatement`, `StatementMetadata` |
+| Access Rights and Handling | `arh` | V3 | Inside EDH, and in `StatementMetadata` |
+| Information Security Marking | `ism` | V13 | Inside ARH |
+| Need-To-Know Metadata | `ntk` | V10 | Inside ARH |
+| Revision Recall | `revrecall` | V2014-DEC | `HandlingStatement` |
+| US Agency Acronyms | `usagency` | V2016-SEP | Inside EDH |
+| IC Identifier | `icid` | — | Inside EDH |
+
+Version floors enforced by rule: `@edh:DESVersion` at least 1 (`IC-TDF-ID-00036`),
+`@arh:DESVersion` at least 1 (`IC-TDF-ID-00037`), `@revrecall:DESVersion` at least 201412
+(`IC-TDF-ID-00045`). ICTDF-VAL §6 covers the consistency rules that require one version
+per dependent specification across a skeleton.
+
+## 7. Policy is not authorization
+
+A handling assertion is a description of the data. It states what controls apply; it does
+not decide whether a given requester satisfies them.
+
+- A consumer MUST evaluate markings against the requester's attributes through a policy
+  decision function outside this suite. The document has no opinion about who may read it.
+- Trust in a marking comes from the binding over it and the trust anchor of its signer,
+  not from its presence (ICTDF-SEC §2).
+- Mapping IC markings onto an attribute-based policy model is deployment-specific and MUST
+  be explicit, total, and deterministic. ICTDF-OPENTDF §3 defines one such mapping;
+  ICTDF-MIG §4 discusses the general problem.

--- a/spec/ictdf/v1alpha/ictdf-profile-opentdf.md
+++ b/spec/ictdf/v1alpha/ictdf-profile-opentdf.md
@@ -1,0 +1,164 @@
+# ICTDF-OPENTDF: OpenTDF Interoperability Profile
+
+| | |
+|---|---|
+| Document | ICTDF-OPENTDF |
+| Profile version | 0.1 |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft, optional |
+| Depends on | ICTDF-SEC, ICTDF-POL, ICTDF-BND, ICTDF-KAO, ICTDF-KAS, ICTDF-SCH |
+
+This profile constrains IC-TDF for deployments where an OpenTDF key access service holds
+the keys. It narrows choices; it does not change the XML vocabulary, the schema, the
+constraint rules, or the validation procedure. A document conforming to this profile is an
+ordinary conforming IC-TDF document.
+
+## 1. Purpose
+
+IC-TDF leaves four things to the deployment: which encryption algorithms are acceptable,
+which normalization method and signature algorithm are used, what `RemoteStoredKey/@protocol`
+means, and how IC markings become an access decision (ICTDF-KAS §1). A document that
+answers those questions differently from its consumer is valid and unusable.
+
+This profile fixes all four for OpenTDF deployments and states the mapping from IC markings
+to BaseTDF policy attributes.
+
+## 2. Key access
+
+### 2.1 Required form
+
+An object under this profile uses `RemoteStoredKey` for every layer whose key is held by a
+KAS:
+
+```xml
+<tdf:KeyAccess>
+  <tdf:RemoteStoredKey tdf:protocol="kas" tdf:uri="https://kas.example.com"/>
+</tdf:KeyAccess>
+```
+
+| Attribute | Value under this profile |
+|---|---|
+| `@tdf:protocol` | `kas` |
+| `@tdf:uri` | The fully qualified KAS base URL, matching BaseTDF-KAO's `kas` field |
+
+`@protocol="kas"` denotes the OpenTDF rewrap interface. It is not registered by IC-TDF; a
+consumer outside an OpenTDF deployment sees an unrecognized protocol and MUST reject the
+object (ICTDF-KAS §2). Producers MUST NOT rely on this profile for cross-community
+interchange.
+
+### 2.2 Prohibited forms
+
+| Form | Status | Reason |
+|---|---|---|
+| `AttachedKey` | MUST NOT | Provides no confidentiality (ICTDF-KAO §3.6) |
+| `PasswordKey` | MUST NOT | Carries no salt or work factor; not a KAS-mediated release |
+| `PreSharedKey` | SHOULD NOT | Bypasses policy evaluation entirely |
+| `WrappedKey` | MAY | Only where the wrapping key is itself reachable through a `RemoteStoredKey` |
+| `WrappedPDPKey` | MAY | See §2.3 |
+
+### 2.3 Policy decision keys
+
+Where `WrappedPDPKey` is used, the `EncryptedPolicyObject` MUST contain a BaseTDF policy
+object (BaseTDF-POL §2) — a JSON document with `uuid` and `body.dataAttributes` — encrypted
+to the KAS. The KAS evaluates it as it would a policy from a BaseTDF manifest.
+
+The KAS MUST bind its decision to the specific TDO. A policy object lifted from one object
+and replayed against another proves nothing (ICTDF-KAS §3).
+
+### 2.4 Splits
+
+IC-TDF has no split identifier. `@sequenceNum` expresses layering, not splitting: every
+layer must be removable in turn, so an object under this profile is recoverable only by a
+party who can obtain every layer's key.
+
+A deployment needing BaseTDF's `sid` semantics — several KAOs protecting the same share,
+any one sufficient — cannot express them in IC-TDF. Use multiple `RemoteStoredKey` children
+within one `KeyAccess` for alternative routes to the same key, and do not model an
+`allOf` split as layers.
+
+## 3. Mapping markings to policy
+
+IC markings describe data. BaseTDF attributes authorize release. A deployment using this
+profile MUST publish a total, deterministic mapping between them, and the producer applies
+it at creation.
+
+| IC marking | BaseTDF attribute FQN |
+|---|---|
+| `ism:classification="S"` | `https://example.gov/attr/classification/value/secret` |
+| `ism:ownerProducer="USA"` | `https://example.gov/attr/ownerproducer/value/usa` |
+| `ism:releasableTo="USA FVEY"` | `https://example.gov/attr/relto/value/usa`, `…/value/fvey` |
+| `ntk:Access` profile identifier | `https://example.gov/attr/ntk/value/<profile>` |
+
+Deployments substitute their own controlled namespace for `example.gov`.
+
+Requirements:
+
+- The mapping MUST be total over the markings the deployment emits. An unmapped marking is
+  a creation error, not a permitted omission.
+- The marking remains authoritative. The policy is its enforcement projection, and a
+  disagreement between them is a validation failure, not a resolution to the more permissive
+  side.
+- The KAS authorizes against the policy only. It MUST NOT parse IC markings, because doing
+  so would put marking semantics — ISM version handling, rollup, portion marking — inside
+  the key service.
+- The rolled-up object-scope marking is the input to a whole-object decision; a `PAYL`-scope
+  marking is the input to a payload-only decision (ICTDF-KAS §4).
+- Dissemination lists (BaseTDF-POL `body.dissem`) have no IC-TDF counterpart and are a
+  deployment addition, not a projection of any marking.
+
+## 4. Cryptography
+
+| Choice | Required value |
+|---|---|
+| Payload encryption | `http://www.w3.org/2009/xmlenc11#aes256-gcm` |
+| `EncryptionMethod/@algorithm` | Exactly the URI above; a family name such as `AES` MUST NOT be used |
+| `IVParams` | 96 bits, unique per key |
+| `AuthenticationTag` | REQUIRED; 128 bits |
+| Signature algorithm | `SHA256withECDSA` or `SHA256withRSAandMGF1` |
+| Hash algorithm | `SHA256` or stronger |
+| Normalization method | `http://www.w3.org/2006/12/xml-c14n11` |
+
+`SHA1` and every `SHA1with…` value MUST NOT be produced and MUST be rejected on receipt,
+notwithstanding their presence in the source controlled vocabularies (ICTDF-ALG §1).
+
+An inclusive canonicalization method is required so that the dependent-specification
+version declarations a fragment inherits are inside the signed bytes (ICTDF-BND §5).
+
+## 5. Bindings
+
+- Every object MUST carry a binding on its `TDO`- or `TDC`-scope handling assertion, so
+  that the rolled-up marking a decision point reads is authenticated.
+- `@includesStatementMetadata="true"` is REQUIRED on that binding, so that statement
+  metadata used in the mapping of §3 is covered.
+- Where the payload is not covered by a binding, its integrity comes from the GCM
+  authentication tag alone; the profile permits this but a deployment SHOULD add a
+  `PAYL`-scope binding where provenance matters.
+- Signers are resolved through the deployment's trust anchors. This profile defines no
+  certificate distribution mechanism.
+
+## 6. Structural constraints
+
+- `@tdf:version` MUST be `201412.201707`, with a customization suffix only where the
+  deployment registers one.
+- `StructuredPayload` and `StructuredStatement` MUST name a schema the deployment can
+  validate in ICTDF-VAL Step 2. A producer MUST NOT emit structured content whose governing
+  schema is not in the deployment catalog.
+- `ReferenceValuePayload` MUST NOT be used for content the KAS protects. A referenced
+  payload is unauthenticated and unfetched at validation time (ICTDF-LOC §5), so the
+  object's protection guarantees do not extend to it.
+- The reserved structures — `EXPLICIT` scope, `BoundValueList`, `ReferenceList` — MUST NOT
+  be emitted (ICTDF-SCH §5).
+
+## 7. Security
+
+- A `RemoteStoredKey` URI naming a KAS is not authorization to release. The KAS decides by
+  evaluating policy against the requester (ICTDF-KAS §4).
+- Denials MUST be indistinguishable from key-recovery failures at the consumer. A
+  distinguishable denial leaks policy content.
+- The mapping in §3 is a security boundary. A bug that maps `S` to an attribute value with
+  weaker entitlement requirements silently over-releases, and no validation step detects
+  it. Mappings SHOULD be reviewed as policy, versioned, and audited.
+- This profile does not make an IC-TDF object interchangeable with a BaseTDF object. They
+  remain different formats with different validation procedures; ICTDF-MIG covers
+  conversion.

--- a/spec/ictdf/v1alpha/ictdf-sch.md
+++ b/spec/ictdf/v1alpha/ictdf-sch.md
@@ -1,0 +1,198 @@
+# ICTDF-SCH: Schema, Vocabularies, and Constraint Rules
+
+| | |
+|---|---|
+| Document | ICTDF-SCH |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-ALG, ICTDF-PKG |
+| Referenced by | ICTDF-VAL, ICTDF-CORE |
+
+## 1. Normative artifacts
+
+| Artifact | Form | Normative |
+|---|---|---|
+| `IC-TDF.xsd` | W3C XML Schema | Yes |
+| `CVEnumTDFAppliesToState`, `CVEnumTDFHashAlgorithm`, `CVEnumTDFSignatureAlgorithm` | CVE XML values | Yes |
+| Generated CVE schemas | W3C XML Schema | Yes |
+| `IC-TDF_XML.sch` | Schematron | Yes |
+| `Lib/CompareVersionsInSkeleton.sch` | Schematron abstract patterns | Yes |
+| Data encoding specification prose | PDF, Markdown | Informative |
+| Schema guide | HTML | Informative |
+| CVE renderings | PDF | Informative |
+
+Where prose and artifact disagree, the artifact governs. Where this suite and the source
+package disagree, the source package governs.
+
+## 2. Schema
+
+The schema declares two global elements, `TrustedDataObject` and `TrustedDataCollection`,
+and the global attributes listed in ICTDF-ALG §5. It imports IC-EDH, ARH, Revision Recall,
+and the three generated CVE schemas.
+
+What the schema does check:
+
+- element and attribute names, cardinality, and sequence order;
+- simple types, including the `@tdf:version` and `@tdf:mediaType` patterns; and
+- CVE membership for `@appliesToState`, `@hashAlgorithm`, and `@signatureAlgorithm`.
+
+What the schema cannot check, and Schematron therefore must:
+
+- scope legality by container and the required handling assertions;
+- agreement between `@isEncrypted` and `EncryptionInformation`;
+- data-state pairing for encrypted parts;
+- `@sequenceNum` continuity;
+- `@idRef` targets within the correct TDO;
+- version floors and version consistency across a skeleton; and
+- rollup of `ntk:Access`.
+
+What nothing checks in this suite: the content of `StructuredPayload` and
+`StructuredStatement`, which are `processContents="skip"`. ICTDF-VAL Step 2 validates that
+content against its own governing schema.
+
+## 3. Constraint rules
+
+Rules are Schematron, using the XSLT 2.0 query language binding. The Jelliffe reference
+implementation defines the normative behavior where an implementation's interpretation of
+the rule set could differ.
+
+Identifiers are `IC-TDF-ID-` followed by five digits, allocated by classification of the
+rule's own text:
+
+| Range | Classification of the rule |
+|---|---|
+| 00001–09999 | Unclassified |
+| 10001–19999 | FOUO |
+| 20001–20999 | S//REL FVEY |
+| 21001–21999 | S//NF |
+| 22001–29999 | S//TBD |
+| 30001 and above | Other |
+
+Every rule in this version is in the unclassified range. Severity is Error or Warning;
+`IC-TDF-ID-00054` is the only Warning.
+
+Rules are living: a rule may be added, changed, or removed in a revision without a
+namespace change. A validator MUST NOT validate a document against a rule set from an older
+integer version of the specification, and MAY validate against a newer one.
+
+Constraint rules are of two types. Data validation rules constrain instance content and are
+what this module catalogs. Data rendering rules would constrain presentation; there are
+none in this version.
+
+## 4. Rule catalog
+
+Forty-nine rules are active. Identifiers 00020 through 00024 were removed in a prior
+revision and 00029 is unallocated; the gaps are permanent.
+
+### 4.1 General
+
+| ID | Requirement |
+|---|---|
+| 00001 | Every attribute in the TDF namespace contains at least one non-whitespace character |
+| 00002 | A root `TrustedDataObject` specifies `@tdf:version` |
+| 00054 | `@tdf:version` SHOULD be `201412.201707`, optionally with a customization suffix — Warning |
+
+### 4.2 Required handling assertions
+
+| ID | Requirement |
+|---|---|
+| 00003 | A TDO has at least one handling assertion with `@scope="PAYL"` |
+| 00004 | A TDO has exactly one handling assertion with `@scope="TDO"` containing an EDH |
+| 00005 | A TDC has exactly one handling assertion with `@scope="TDC"` containing an EDH |
+| 00016 | The `TDO`-scope EDH handling assertion contains an ARH security block with `@ism:resourceElement="true"` |
+| 00017 | The same for the `TDC`-scope handling assertion |
+| 00018 | A `TDO`-scope handling assertion does not use `edh:ExternalEdh` |
+| 00019 | A `TDC`-scope handling assertion does not use `edh:ExternalEdh` |
+| 00035 | Handling assertions in a TDC use only `@scope="TDC"` |
+| 00042 | The first handling assertion in document order has `@scope="TDO"` or `"TDC"` and contains an EDH |
+| 00055 | A non-encrypted payload has at most one `PAYL` handling assertion containing an EDH |
+| 00043 | `ntk:Access` is rolled up into the `TDO`-scope handling assertion |
+| 00044 | `ntk:Access` is rolled up into the `TDC`-scope handling assertion |
+
+### 4.3 Scope
+
+| ID | Requirement |
+|---|---|
+| 00006 | Assertions in a TDO use only `PAYL`, `TDO`, or `EXPLICIT` scope |
+| 00007 | Assertions in a TDC use only `TDC`, `DESC_PAYL`, `DESC_TDO`, `TDC_MEMBER`, or `EXPLICIT` scope |
+| 00008 | `EXPLICIT` scope is not permitted in this version |
+| 00012 | An `EXPLICIT`-scope assertion requires a `BoundValueList` or a `ReferenceList` |
+
+### 4.4 Binding
+
+| ID | Requirement |
+|---|---|
+| 00009 | When a `BoundValueList` is present, `SignatureValue` does not specify `@includesStatementMetadata` |
+| 00010 | When a `BoundValueList` is absent, `SignatureValue` specifies `@includesStatementMetadata` |
+| 00011 | A `BoundValue` or `Reference` `@idRef` resolves to a descendant of the same TDO |
+| 00013 | `ReferenceList` and `BoundValueList` are not permitted in this version |
+| 00038 | Every `Signer` specifies `@issuer` and at least one of `@serial` or `@subject` |
+
+### 4.5 Encryption
+
+| ID | Requirement |
+|---|---|
+| 00014 | `EncryptionInformation` requires the described data to be labeled encrypted |
+| 00015 | Data labeled encrypted requires `EncryptionInformation` |
+| 00040 | More than one `EncryptionInformation` on a part requires `@tdf:sequenceNum` on each |
+| 00041 | Sequence numbers start at 1, increment by 1, and contain no duplicates |
+
+### 4.6 Data state
+
+| ID | Requirement |
+|---|---|
+| 00025 | `@appliesToState` appears only where the payload has `@tdf:isEncrypted="true"` |
+| 00026 | An encrypted payload has two `PAYL` handling assertions, one `encrypted` and one `unencrypted` |
+| 00027 | The `unencrypted` `PAYL` handling assertion contains `edh:ExternalEdh` |
+| 00028 | Where the payload is encrypted and not external, the `encrypted` handling assertion contains a regular `edh:Edh` |
+| 00030 | The `unencrypted` `StatementMetadata` of an encrypted statement contains `arh:ExternalSecurity` |
+| 00031 | An encrypted statement has two `StatementMetadata` elements, one `encrypted` and one `unencrypted` |
+| 00032 | `@appliesToState` on `StatementMetadata` appears only where the statement has `@tdf:isEncrypted="true"` |
+| 00039 | `@appliesToState` on a handling assertion appears only at `PAYL` scope |
+
+### 4.7 External content
+
+| ID | Requirement |
+|---|---|
+| 00033 | A TDO with a `ReferenceValuePayload` carries `edh:ExternalEdh` in its `PAYL` handling assertion |
+| 00034 | An assertion with a `ReferenceStatement` carries `edh:ExternalEdh` or `arh:ExternalSecurity` in `StatementMetadata` |
+
+### 4.8 Versions
+
+| ID | Requirement |
+|---|---|
+| 00036 | `@edh:DESVersion` is at least 1 |
+| 00037 | `@arh:DESVersion` is at least 1 |
+| 00045 | `@revrecall:DESVersion` is at least 201412 |
+| 00046 | A single `ism` version across the TDF skeleton |
+| 00047 | A single `ntk` version across the TDF skeleton |
+| 00048 | A single `arh` version across the TDF skeleton |
+| 00049 | A single `edh` version across the TDF skeleton |
+| 00050 | A single `icid` version across the TDF skeleton |
+| 00051 | A single `usagency` `@CESVersion` across the TDF skeleton |
+| 00052 | A single `tdf` `@version` across the TDF skeleton |
+| 00053 | A single `@ism:ISMCATCESVersion` across the TDF skeleton |
+
+Rules 00046 through 00053 are expressed through the shared abstract pattern in
+`Lib/CompareVersionsInSkeleton.sch`. "Skeleton" is defined in ICTDF-VAL §2: it is the TDF
+with extension-point content removed, so a version declared inside embedded foreign content
+does not participate.
+
+## 5. Reserved rules
+
+Four rules forbid structures the schema admits: 00008 and 00012 for `EXPLICIT` scope, and
+00013 for `BoundValueList` and `ReferenceList`. They exist so that a future revision can
+enable those features by changing rules rather than the schema, which would require a new
+namespace.
+
+A producer MUST NOT emit the reserved structures, and a consumer MUST reject them rather
+than treating them as forward-compatible extensions (ICTDF-SCP §6, ICTDF-BND §6).
+
+## 6. Running the rules
+
+Validation is not a single Schematron pass over the document. ISM and NTK rules are not
+TDO-aware and produce both false positives and false negatives when run across a whole TDF;
+extension-point content must be validated in isolation. ICTDF-VAL defines the ordered
+procedure, the fragments each rule set runs against, and the assembly of results.

--- a/spec/ictdf/v1alpha/ictdf-scp.md
+++ b/spec/ictdf/v1alpha/ictdf-scp.md
@@ -1,0 +1,132 @@
+# ICTDF-SCP: Assertion Scope
+
+| | |
+|---|---|
+| Document | ICTDF-SCP |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC, ICTDF-MTD |
+| Referenced by | ICTDF-POL, ICTDF-BND, ICTDF-VAL, ICTDF-CORE |
+
+## 1. Purpose
+
+`@tdf:scope` states what an assertion is about. Scope is the mechanism that lets one
+document carry a marking for the payload, a different marking for the whole object, and
+further markings for each member of a collection, without ambiguity about which applies to
+what. Scope also determines what a binding over that assertion covers, so a scope error is
+a security error, not a labeling error.
+
+Scope is required on both `tdf:HandlingAssertion` and `tdf:Assertion`.
+
+## 2. Scope values
+
+| Value | Valid in | Transitive | Covers |
+|---|---|---|---|
+| `PAYL` | TDO | — | The payload only |
+| `TDO` | TDO | — | Every element of the TDO other than the assertion itself |
+| `TDC` | TDC | No | Every element of the collection, taken collectively |
+| `TDC_MEMBER` | TDC | No | Each member of the collection, but not peer assertions |
+| `DESC_TDO` | TDC | Yes | Every descendant TDO |
+| `DESC_PAYL` | TDC | Yes | The payload of every descendant TDO |
+| `EXPLICIT` | TDO, TDC | — | Only what a `BoundValueList` or `ReferenceList` enumerates |
+
+An assertion inside a TDO MUST use `PAYL`, `TDO`, or `EXPLICIT` (`IC-TDF-ID-00006`). An
+assertion inside a TDC MUST use `TDC`, `TDC_MEMBER`, `DESC_TDO`, `DESC_PAYL`, or
+`EXPLICIT` (`IC-TDF-ID-00007`). A handling assertion inside a TDC MUST use `TDC`
+(`IC-TDF-ID-00035`).
+
+`EXPLICIT` is reserved. It is not permitted in this version (`IC-TDF-ID-00008`), and
+neither are the `BoundValueList` and `ReferenceList` structures it would depend on
+(`IC-TDF-ID-00013`). See §6.
+
+## 3. Transitivity
+
+A **non-transitive** scope applies to the level at which it is declared and does not
+descend into nested collections. A **transitive** scope applies at every depth beneath the
+declaring collection.
+
+A **collection member** is a direct `TrustedDataObject` or `TrustedDataCollection` child of
+a TDC. A **descendant** is a member, or a member of a member, at any depth.
+
+```text
+TDC-A
+├── Assertion @scope="TDC"          → all of TDC-A, collectively; stops here
+├── Assertion @scope="TDC_MEMBER"   → TDO-1 and TDC-B individually; stops here
+├── Assertion @scope="DESC_TDO"     → TDO-1, TDO-2, TDO-3
+├── Assertion @scope="DESC_PAYL"    → payloads of TDO-1, TDO-2, TDO-3
+├── TDO-1
+└── TDC-B
+    ├── TDO-2
+    └── TDO-3
+```
+
+`TDC` and `TDC_MEMBER` differ in what they treat as the unit. `TDC` describes the
+collection as a single thing — the aggregate. `TDC_MEMBER` describes each member
+separately and deliberately excludes the collection's own peer assertions, so a member's
+marking is not contaminated by metadata that belongs to the container.
+
+## 4. Scope under extraction
+
+Extracting a TDO or a nested TDC from its enclosing collection changes the frame of
+reference. Transitive assertions travel with the extracted content, and their scope is
+rewritten so that they continue to mean the same thing.
+
+| Original scope | Extracted into a TDO | Extracted into a TDC |
+|---|---|---|
+| `DESC_TDO` | becomes `TDO` | stays `DESC_TDO` |
+| `DESC_PAYL` | becomes `PAYL` | stays `DESC_PAYL` |
+| `TDC` | not carried | not carried |
+| `TDC_MEMBER` | not carried | not carried |
+
+Non-transitive scopes are not carried because they describe the container, which no longer
+exists in the extracted result.
+
+An extractor MUST also copy the dependent-specification version declarations that the
+extracted content inherited from its enclosing TDF (ICTDF-MTD §5.1), and MUST re-evaluate
+rollup for the resulting object (ICTDF-POL §4). A rewritten scope invalidates any binding
+that covered the assertion in its original form; the extracted object needs a new binding
+or none.
+
+## 5. Required assertions by container
+
+### 5.1 TDO
+
+A conforming TDO has at least two handling assertions:
+
+- exactly one with `@scope="TDO"` containing an IC-EDH (`IC-TDF-ID-00004`); and
+- at least one with `@scope="PAYL"` (`IC-TDF-ID-00003`).
+
+The first handling assertion in document order MUST be the `TDO`-scope one and MUST
+contain an EDH (`IC-TDF-ID-00042`). An unencrypted payload has at most one `PAYL` handling
+assertion containing an EDH (`IC-TDF-ID-00055`); an encrypted payload has exactly two, one
+per data state (`IC-TDF-ID-00026`).
+
+### 5.2 TDC
+
+A conforming TDC has exactly one handling assertion with `@scope="TDC"` containing an
+IC-EDH (`IC-TDF-ID-00005`), and it MUST be first in document order (`IC-TDF-ID-00042`). A
+TDC MAY carry a second handling assertion carrying a revision recall statement, also at
+`TDC` scope. It carries no other handling assertions.
+
+Ordinary assertions at `TDC`, `TDC_MEMBER`, `DESC_TDO`, or `DESC_PAYL` scope are optional
+and unbounded.
+
+## 6. Reserved: explicit scope
+
+`EXPLICIT` scope is defined so that an assertion can name exactly the elements it
+describes, rather than deriving them from position. It depends on one of:
+
+- a `BoundValueList`, whose `BoundValue` children each carry an `@idRef` and a hash of the
+  referenced element; or
+- a `ReferenceList`, whose `Reference` children each carry an `@idRef` and no hash.
+
+Both structures and the scope itself are disallowed in this version
+(`IC-TDF-ID-00008`, `IC-TDF-ID-00012`, `IC-TDF-ID-00013`). An `EXPLICIT`-scope assertion
+that reaches a validator is a rejection. The schema admits them so that a future revision
+can enable them without a namespace change; ICTDF-BND §6 records the intended signature
+semantics.
+
+Producers MUST NOT emit `EXPLICIT` scope, `BoundValueList`, or `ReferenceList`. Consumers
+MUST reject them rather than treating them as unrecognized extensions.

--- a/spec/ictdf/v1alpha/ictdf-sec.md
+++ b/spec/ictdf/v1alpha/ictdf-sec.md
@@ -1,0 +1,129 @@
+# ICTDF-SEC: Security Considerations
+
+| | |
+|---|---|
+| Document | ICTDF-SEC |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | None |
+| Referenced by | All IC-TDF components |
+
+## 1. Parser limits
+
+An IC-TDF instance is an XML document from an untrusted source. Every parser MUST apply
+the following before schema validation, binding verification, or key retrieval.
+
+| Input | Required handling |
+|---|---|
+| External entities | Disable entity expansion and external DTD loading; IC-TDF uses no DTD |
+| Entity expansion | Reject recursive and quadratic expansion regardless of entity source |
+| `xsi:schemaLocation` | Ignore for validation; resolve schemas from a trusted local catalog only |
+| Element depth | Enforce a finite maximum; TDC nesting is recursive and unbounded in the schema |
+| Document and node count | Enforce finite maxima before building a tree |
+| `base64Binary` content | Bound the decoded length before allocation |
+| `ReferenceValuePayload/@uri` | Never dereferenced during validation; see ICTDF-LOC |
+| `RemoteStoredKey/@uri` | Never dereferenced during validation; see ICTDF-KAS |
+
+`StructuredPayload` and `StructuredStatement` admit `xs:any` with
+`processContents="skip"`. The XSD therefore imposes no constraint on their content, and
+a validator MUST treat that content as hostile until ICTDF-VAL Step 2 has validated it in
+isolation against its own governing schema.
+
+## 2. Trust boundaries
+
+- A TDF instance carries handling metadata; it does not carry authority. Trust in an
+  IC-EDH or ARH security block derives from the binding over it and from the trust anchor
+  of the signer, never from its presence in the document.
+- `Signer/@subject`, `@issuer`, and `@serial` are RFC 5280 identifiers, not certificates.
+  The verifier resolves them to a certificate through trusted local configuration and
+  performs path building, validity, and revocation checking outside this suite.
+- `RemoteStoredKey/@uri` and `ReferenceValuePayload/@uri` identify resources; URI
+  ownership gives uniqueness, not trust. Resolution policy is a deployment decision.
+- `PreSharedKey/@alias` and `@store` name a key in an out-of-band arrangement. The
+  document proves nothing about that arrangement.
+- `AttachedKey` places key material in the document. It has no confidentiality value and
+  MUST NOT be used for data requiring protection in transit or at rest.
+
+## 3. Binding and verification order
+
+- A binding authenticates the normalized bytes enumerated for its scope, and nothing
+  else. Content outside the scope's coverage table is unauthenticated even when it sits
+  inside the same TDO. See ICTDF-BND.
+- The `Signer`, `SignatureValue`, `BoundValueList` child order exists so that a streaming
+  parser can verify in a single pass. Implementations MUST NOT rely on that order for
+  security; a streaming verifier MUST NOT act on any part of a TDO before the signature
+  covering it verifies.
+- `SignatureValue/@normalizationMethod` and `@signatureAlgorithm` are attacker-controlled
+  inputs. A verifier MUST reject values outside its configured allow-list before
+  performing any canonicalization or signature operation, and MUST NOT infer a default.
+- `@includesStatementMetadata` changes what the signature covers. A verifier MUST use the
+  declared value, and MUST reject a document that omits it when `BoundValueList` is
+  absent (`IC-TDF-ID-00010`), because an absent declaration makes coverage ambiguous.
+- Canonicalization is a rewriting step over untrusted input. Comment-preserving
+  normalization methods enlarge the signed surface; comment-stripping methods leave
+  comments unauthenticated and removable. Neither is safe by default; a deployment MUST
+  choose and enforce one.
+- SHA-1 and `SHA1with*` are permitted by the source controlled vocabularies. Producers
+  MUST NOT emit them, and verifiers SHOULD reject them, because collision resistance is
+  broken.
+
+## 4. Encryption and key access
+
+- An encrypted part is described by `EncryptionInformation`. Presence of that element and
+  the value of `@isEncrypted` MUST agree (`IC-TDF-ID-00014`, `IC-TDF-ID-00015`); a
+  mismatch is a validation failure, not a hint to be repaired.
+- Layered encryption is ordered by `@sequenceNum`, highest outermost. A gap, duplicate,
+  or missing sequence number makes the layering ambiguous and MUST be rejected
+  (`IC-TDF-ID-00040`, `IC-TDF-ID-00041`).
+- `EncryptionMethod/@algorithm` is a URI chosen by the producer. A consumer MUST reject
+  unknown algorithm URIs rather than guessing a near match, and MUST validate that the
+  supplied `IVParams`, `Nonce`, `Tweak`, `AuthenticationTag`, and
+  `AdditionalAuthenticatedData` are those the algorithm requires.
+- Nonce and IV reuse under one key breaks the selected mode. Producers MUST use a secure
+  random source and MUST NOT reuse an IV across encryptions with the same key.
+- Unauthenticated modes leave ciphertext malleable. Where the payload is not covered by a
+  binding and the encryption method provides no authentication tag, the object provides
+  no integrity for that payload at all.
+- Failures to unwrap, decrypt, or authenticate MUST be reported as a single opaque class.
+  Distinguishing "wrong key" from "bad padding" from "policy denied" is an oracle.
+- Key material, plaintext, and unwrapped keys MUST NOT be logged or returned on failure.
+
+## 5. Markings, states, and disclosure
+
+- The handling assertion for a TDO or TDC MUST NOT be encrypted. Its cleartext is what
+  allows a guard to route the object, and it is therefore visible to everyone who can see
+  the object at all.
+- An encrypted part needs two markings: one describing the ciphertext as it travels and
+  one describing the plaintext it protects. The `unencrypted` marking is carried
+  externally, as `edh:ExternalEdh` or `arh:ExternalSecurity`, and is deliberately outside
+  the rollup so that it does not raise the object's visible classification. See
+  ICTDF-POL §5.
+- Rollup means the TDO- or TDC-scope handling assertion reflects the most restrictive
+  markings of everything it covers. A producer that fails to roll up under-marks the
+  object; a producer that rolls up the plaintext marking of an encrypted part over-marks
+  it and may itself be a disclosure.
+- Filenames, media types, URIs, and identifiers are unencrypted metadata. `@filename`,
+  `@mediaType`, and `ReferenceValuePayload/@uri` leak information about the protected
+  content and MUST be treated as part of the object's disclosure surface.
+- A linked resource's classification does not raise the classification of the TDO that
+  links to it, but an embedded resource's does. A producer that inlines a reference
+  changes the object's marking obligations.
+
+## 6. Validation hazards
+
+- ISM and NTK constraint rules are not TDO-aware. Running them across a whole TDF
+  produces both false positives and false negatives; they MUST be run only on the
+  fragments ICTDF-VAL defines.
+- Extension-point content is validated in isolation. A validator that skips Step 2
+  accepts arbitrary foreign XML inside a conforming-looking TDO.
+- `xs:ID` and `xs:IDREF` are document-scoped. `IC-TDF-ID-00011` requires that a bound
+  `@idRef` resolve to a descendant of the same TDO; a validator relying only on XML ID
+  uniqueness will accept cross-TDO references inside a TDC.
+- Version consistency rules (`IC-TDF-ID-00046` through `IC-TDF-ID-00053`) exist because
+  mixed versions of a dependent specification inside one skeleton make marking semantics
+  undecidable. They are not stylistic.
+- A validator MUST fail closed. An unresolvable schema, an unsupported normalization
+  method, an unrecognized CVE value, or an unrunnable rule set is a rejection, not a
+  warning.

--- a/spec/ictdf/v1alpha/ictdf-val.md
+++ b/spec/ictdf/v1alpha/ictdf-val.md
@@ -1,0 +1,164 @@
+# ICTDF-VAL: Conformance Validation
+
+| | |
+|---|---|
+| Document | ICTDF-VAL |
+| Version | 1 Alpha |
+| Source spec | IC-TDF.XML.V2014-DEC-r2017-JUL |
+| TDF version | 201412.201707 |
+| Status | Draft |
+| Depends on | ICTDF-SEC, ICTDF-MTD, ICTDF-SCP, ICTDF-POL, ICTDF-BND, ICTDF-PKG, ICTDF-SCH |
+| Referenced by | ICTDF-CORE, ICTDF-EX |
+
+## 1. Why validation is multi-pass
+
+A TDF carries content governed by other specifications. Those specifications' rule sets
+were written for documents of their own kind and are not TDO-aware: run across a whole TDF
+they compare markings that belong to different assertions, miss markings that belong
+together, and reach into extension-point content that is not theirs to judge.
+
+Validation therefore decomposes the document into fragments, runs each rule set against the
+fragments it was written for, and assembles the results. Skipping the decomposition
+produces both false positives and false negatives, and skipping the extension-point pass
+accepts arbitrary foreign XML inside a conforming-looking object.
+
+## 2. Fragments
+
+| Term | Definition |
+|---|---|
+| **TDO structure** | The elements of a TDO in the TDF namespace, with their attributes |
+| **Placeholder element** | An element with local name `PlaceHolderContent` in namespace `urn:placeholder`, substituted for removed content |
+| **TDF skeleton** | The TDF with the content of every extension point replaced by a placeholder element |
+| **TDO skeleton** | The skeleton of a single TDO |
+| **TDC skeleton** | The skeleton of a collection, including its members' skeletons |
+| **Resource element** | An element bearing `@ism:resourceElement="true"` |
+| **TDO handling assertion** | The `TDO`-scope handling assertion |
+| **TDC handling assertion** | The `TDC`-scope handling assertion |
+| **Payload handling assertion** | A `PAYL`-scope handling assertion |
+| **Assertion fragment** | One `tdf:Assertion` with its statement content |
+| **Structured assertion fragment** | An assertion fragment whose statement is a `StructuredStatement` |
+| **Payload fragment** | The payload with its describing handling assertion |
+| **Structured payload fragment** | A payload fragment whose payload is a `StructuredPayload` |
+
+Content kinds at an extension point are **binary**, **string**, or **structured**.
+Structured content is XML from another namespace; binary and string content are opaque to
+IC-TDF and are interpreted by whatever governs them.
+
+The skeleton is what version-consistency rules operate over (ICTDF-SCH §4.8). Replacing
+extension-point content with a placeholder is what keeps a version declared inside embedded
+foreign content from participating in the enclosing document's consistency check.
+
+## 3. Preconditions
+
+Before Step 1, a validator MUST:
+
+1. parse with external entity resolution and DTD loading disabled, and with the parser
+   limits of ICTDF-SEC §1 in force;
+2. resolve every schema from a trusted local catalog, ignoring `xsi:schemaLocation`; and
+3. dereference nothing. No URI in the document is resolved during validation
+   (ICTDF-LOC §4).
+
+A validator MUST fail closed. An unresolvable schema, an unrunnable rule set, an
+unrecognized CVE value, or an unsupported normalization method is a rejection.
+
+## 4. Validating a TDO
+
+**Step 1 — TDF rules over the whole TDO.**
+Run the IC-TDF constraint rules. These are the TDO-aware and cross-assertion rules: scope
+legality, required handling assertions, encryption agreement, data-state pairing, sequence
+continuity, `@idRef` targets, and version floors. ISM and NTK rules MUST NOT be run in this
+step.
+
+**Step 2 — extension-point content in isolation.**
+For each of the six extension points present, extract its content and validate it against
+its own governing schema and rules, outside the TDF. The content inherits the enclosing
+TDF's dependent-specification version declarations, which MUST be supplied to the
+validation (ICTDF-MTD §5.1). The ISM version governing structured content is the first
+`@ism:DESVersion` in document order within it, or the enclosing TDF's if it declares none.
+
+**Step 3 — the TDO skeleton against ISM.**
+Build the TDO skeleton and validate it against the ISM rule set. With extension-point
+content replaced by placeholders, the ISM rules see only markings that belong to the TDO
+itself.
+
+**Step 4 — ISM consistency across the TDO.** Three checks:
+
+- **4a** — assertions carrying resource-level portion markings are consistent with the
+  object's markings;
+- **4b** — a payload carrying a resource-level portion marking is consistent with its
+  payload handling assertion; and
+- **4c** — non-resource-level markings are consistent with the resource-level marking that
+  governs them.
+
+Step 4 is where rollup is checked: the object-scope marking must be at least as restrictive
+as the interior it covers (ICTDF-POL §4).
+
+## 5. Validating a TDC
+
+**Step 1** — run the IC-TDF constraint rules over the collection.
+
+**Step 2** — validate extension-point content in isolation, as in §4 Step 2.
+
+**Step 3** — build the TDC skeleton and validate it against ISM.
+
+**Step 4** — check ISM consistency across the collection, including that the TDC handling
+assertion's markings roll up its members'.
+
+**Step 5** — recursively validate each member. A member `TrustedDataObject` is validated by
+§4; a member `TrustedDataCollection` by §5. Recursion terminates at the leaf TDOs.
+
+Recursion is where transitive scope is resolved: an assertion at `DESC_TDO` or `DESC_PAYL`
+scope applies at every depth, so each level's validation sees the assertions that reach it
+(ICTDF-SCP §3).
+
+## 6. Version consistency
+
+Within a skeleton, each dependent specification appears at exactly one version:
+
+| Namespace | Attribute | Rule |
+|---|---|---|
+| `ism` | `@ism:DESVersion` | `IC-TDF-ID-00046` |
+| `ntk` | `@ntk:DESVersion` | `IC-TDF-ID-00047` |
+| `arh` | `@arh:DESVersion` | `IC-TDF-ID-00048` |
+| `edh` | `@edh:DESVersion` | `IC-TDF-ID-00049` |
+| `icid` | `@icid:DESVersion` | `IC-TDF-ID-00050` |
+| `usagency` | `@usagency:CESVersion` | `IC-TDF-ID-00051` |
+| `tdf` | `@tdf:version` | `IC-TDF-ID-00052` |
+| ISM CAT CES | `@ism:ISMCATCESVersion` | `IC-TDF-ID-00053` |
+
+Mixed versions make marking semantics undecidable — two versions of ISM may assign
+different meanings to the same marking, and nothing in the document says which applies.
+These rules are not stylistic (ICTDF-SEC §6).
+
+## 7. Revision handling
+
+A validator MUST NOT validate a document against a rule set from an older integer version
+of the specification than the document declares, and MAY validate against a newer one. An
+older rule set does not know the constraints the document was built to satisfy and will
+report spurious failures; a newer one is a superset of what the document was checked
+against and reports genuine gaps.
+
+Rules are living. A revision may add, change, or remove a rule without a namespace change,
+so a validator's rule set version is an operational fact that MUST be recorded with a
+validation result.
+
+## 8. Binding verification
+
+Binding verification is not part of schema or Schematron validation and is not implied by
+a validation result.
+
+A consumer that needs authenticity performs it separately, following ICTDF-BND §4, after
+validation and before acting on any content. A document may be fully valid and carry no
+binding at all, or carry a binding that verifies under an algorithm the consumer does not
+accept.
+
+## 9. Reporting
+
+- A validation result names the rule set version, the schema catalog, and which steps ran.
+- Errors and warnings are distinguished; `IC-TDF-ID-00054` is the only Warning in this
+  version.
+- A result that omits Step 2 is not a conformance result, because extension-point content
+  was never checked. An implementation that cannot run Step 2 for a given content type MUST
+  say so rather than report success.
+- Validation output describes the document. It MUST NOT include recovered plaintext, key
+  material, or the content of an `EncryptedPolicyObject`.


### PR DESCRIPTION
Stacked on #3887.

### Proposed Changes

* Reorganize the IC XML Data Encoding Specification for Trusted Data Format, `IC-TDF.XML.V2014-DEC-r2017-JUL`, into parallel BaseTDF-style components under `spec/ictdf/v1alpha`.
* Preserve the XML vocabulary, schema, controlled vocabularies, constraint rules, and validation semantics. The refactoring changes document ownership only.
* Cover the full normative surface: the `IC-TDF.xsd` structure, all three CVEs, all 49 Schematron constraint rules, the TDO/TDC object model, assertion scope and transitivity, binding coverage, layered encryption, and the multi-pass conformance procedure.
* Add two documents with no BaseTDF counterpart: `ICTDF-SCP` for the assertion scope algebra (scope determines binding coverage in IC-TDF, so it is load-bearing rather than an assertion property) and `ICTDF-VAL` for the four-to-five step validation procedure over foreign-namespace content.
* Add an OpenTDF interoperability profile and an IC-TDF/BaseTDF migration guide.
* List the BinaryTDF and IC-TDF suites in `spec/README.md`, which previously referenced neither.

### Module layout

| Layer | Documents |
|---|---|
| Foundation | SEC, ALG |
| Model | MTD, SCP |
| Policy | POL |
| Operations | BND, KAO, KAS, PAY |
| Storage | LOC, PKG |
| Schema | SCH |
| Assembly | VAL, CORE |
| Examples | EX |
| Profile and guide | ICTDF-OPENTDF, ICTDF-MIG |

`ICTDF-BND` covers the signature half of `BaseTDF-ASN`. IC-TDF has no `INT` counterpart: it defines no segmentation and no per-segment integrity, so payload integrity comes from the encryption method or from binding coverage. The suite README states these boundaries explicitly.

### Notes for reviewers

The source specification permits several things a current spec should not bless: `SHA1` and `SHA1with*` in the signature CVE, `AttachedKey`, and examples using `@algorithm="AES"` (a family, not a mode) and a literal `normalizationMethod="Normalization Method"` placeholder. Those are reproduced faithfully in `ICTDF-EX` and annotated as not production-safe, and `ICTDF-SEC`/`ICTDF-ALG` mark SHA-1 and `AttachedKey` as MUST NOT produce. That security guidance is an addition to the source and is scoped to guidance, not wire format.

`ICTDF-KAS` documents what IC-TDF actually carries — `RemoteStoredKey/@protocol` and `@uri`, `WrappedPDPKey`/`EncryptedPolicyObject` — and states explicitly that IC-TDF defines no key-release protocol.

Source: DI2E `ICS-Data_Standards`, Public Release, available for use without restriction.

### Checklist

- [ ] I have added or updated unit tests (not applicable: documentation only)
- [ ] I have added or updated integration tests (not applicable: documentation only)
- [x] I have added or updated documentation

### Testing Instructions

Documentation-only change. Verified that all 49 source rule IDs (`00001`-`00019`, `00025`-`00028`, `00030`-`00055`) appear in the `ICTDF-SCH` catalog with no gaps or extras, that every `IC-TDF-ID-*` cited across the suite is a valid rule, that all relative Markdown links resolve, and that all 17 `ICTDF-*` cross-references name real modules. No Go changes, so `make lint` and `make fmt` do not apply; the repository has no Markdown linter.