### PR TITLE
fix(ers): fix direct entitlements silently dropped on token-identifier decisions

### DIFF
--- a/service/entity/entity.go
+++ b/service/entity/entity.go
@@ -1,3 +1,7 @@
 package entity
 
 const EntityIDPrefix string = "entity_idx_"
+
+// DirectEntitlementClaimKeys are the claim names that may carry inline direct
+// entitlements on a subject's claims
+var DirectEntitlementClaimKeys = []string{"direct_entitlements", "directEntitlements"}

--- a/service/entityresolution/claims/v2/entity_resolution.go
+++ b/service/entityresolution/claims/v2/entity_resolution.go
@@ -35,6 +35,8 @@ type Config struct {
 	AllowDirectEntitlements bool `mapstructure:"allow_direct_entitlements" json:"allow_direct_entitlements"`
 }
 
+var DirectEntitlementClaimKeys = []string{"direct_entitlements", "directEntitlements"}
+
 func RegisterClaimsERS(cfg config.ServiceConfig, logger *logger.Logger) (EntityResolutionServiceV2, serviceregistry.HandlerServer) {
 	var inputConfig Config
 	if err := mapstructure.Decode(cfg, &inputConfig); err != nil {
@@ -133,11 +135,16 @@ func parseDirectEntitlementsFromClaims(entityStruct *structpb.Struct) ([]*entity
 		return nil, nil
 	}
 	claims := entityStruct.AsMap()
-	rawEntitlements, ok := claims["direct_entitlements"]
-	if !ok {
-		rawEntitlements, ok = claims["directEntitlements"]
+	var rawEntitlements interface{}
+	found := false
+	for _, key := range DirectEntitlementClaimKeys {
+		if raw, ok := claims[key]; ok {
+			rawEntitlements = raw
+			found = true
+			break
+		}
 	}
-	if !ok {
+	if !found {
 		return nil, nil
 	}
 

--- a/service/entityresolution/claims/v2/entity_resolution.go
+++ b/service/entityresolution/claims/v2/entity_resolution.go
@@ -35,8 +35,6 @@ type Config struct {
 	AllowDirectEntitlements bool `mapstructure:"allow_direct_entitlements" json:"allow_direct_entitlements"`
 }
 
-var DirectEntitlementClaimKeys = []string{"direct_entitlements", "directEntitlements"}
-
 func RegisterClaimsERS(cfg config.ServiceConfig, logger *logger.Logger) (EntityResolutionServiceV2, serviceregistry.HandlerServer) {
 	var inputConfig Config
 	if err := mapstructure.Decode(cfg, &inputConfig); err != nil {
@@ -137,7 +135,7 @@ func parseDirectEntitlementsFromClaims(entityStruct *structpb.Struct) ([]*entity
 	claims := entityStruct.AsMap()
 	var rawEntitlements interface{}
 	found := false
-	for _, key := range DirectEntitlementClaimKeys {
+	for _, key := range ent.DirectEntitlementClaimKeys {
 		if raw, ok := claims[key]; ok {
 			rawEntitlements = raw
 			found = true

--- a/service/internal/access/v2/just_in_time_pdp.go
+++ b/service/internal/access/v2/just_in_time_pdp.go
@@ -408,6 +408,21 @@ func filterEntityChain(entityChain *entity.EntityChain, skipEnvironmentEntities 
 	return filteredEntities
 }
 
+// directEntitlementClaimKeys mirrors the claim names the claims ERS recognizes in
+// parseDirectEntitlementsFromClaims. Keep the two in sync.
+var directEntitlementClaimKeys = []string{"direct_entitlements", "directEntitlements"}
+
+// directEntitlementClaimKey reports whether the resolved claims carry direct
+// entitlements, and under which claim name.
+func directEntitlementClaimKey(claimsStruct *structpb.Struct) (string, bool) {
+	for _, key := range directEntitlementClaimKeys {
+		if _, ok := claimsStruct.GetFields()[key]; ok {
+			return key, true
+		}
+	}
+	return "", false
+}
+
 func entityRepresentationsFromResolvedChain(entityChain *entity.EntityChain, skipEnvironmentEntities bool) ([]*entityresolutionV2.EntityRepresentation, error) {
 	filteredEntities := filterEntityChain(entityChain, skipEnvironmentEntities)
 	if len(filteredEntities) == 0 {
@@ -424,6 +439,14 @@ func entityRepresentationsFromResolvedChain(entityChain *entity.EntityChain, ski
 		var claimsStruct structpb.Struct
 		if err := claims.UnmarshalTo(&claimsStruct); err != nil {
 			return nil, fmt.Errorf("failed to unpack resolved token chain entity %s: %w", chained.GetEphemeralId(), err)
+		}
+
+		// Direct entitlements are carried inline on the claims, but only ERS can project
+		// them onto EntityRepresentation.DirectEntitlements. Taking the no-rehydrate
+		// shortcut here would silently drop them and deny every direct-entitlement
+		// decision, so defer to ERS whenever the claim is present.
+		if key, ok := directEntitlementClaimKey(&claimsStruct); ok {
+			return nil, fmt.Errorf("%w: entity %s carries %q claims", errResolvedTokenChainRequiresHydration, chained.GetEphemeralId(), key)
 		}
 
 		originalID := chained.GetEphemeralId()

--- a/service/internal/access/v2/just_in_time_pdp.go
+++ b/service/internal/access/v2/just_in_time_pdp.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy/subjectmapping"
 	otdfSDK "github.com/opentdf/platform/sdk"
 	ent "github.com/opentdf/platform/service/entity"
+	claimsERSV2 "github.com/opentdf/platform/service/entityresolution/claims/v2"
 	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -408,14 +409,10 @@ func filterEntityChain(entityChain *entity.EntityChain, skipEnvironmentEntities 
 	return filteredEntities
 }
 
-// directEntitlementClaimKeys mirrors the claim names the claims ERS recognizes in
-// parseDirectEntitlementsFromClaims. Keep the two in sync.
-var directEntitlementClaimKeys = []string{"direct_entitlements", "directEntitlements"}
-
 // directEntitlementClaimKey reports whether the resolved claims carry direct
 // entitlements, and under which claim name.
 func directEntitlementClaimKey(claimsStruct *structpb.Struct) (string, bool) {
-	for _, key := range directEntitlementClaimKeys {
+	for _, key := range claimsERSV2.DirectEntitlementClaimKeys {
 		if _, ok := claimsStruct.GetFields()[key]; ok {
 			return key, true
 		}
@@ -441,10 +438,8 @@ func entityRepresentationsFromResolvedChain(entityChain *entity.EntityChain, ski
 			return nil, fmt.Errorf("failed to unpack resolved token chain entity %s: %w", chained.GetEphemeralId(), err)
 		}
 
-		// Direct entitlements are carried inline on the claims, but only ERS can project
-		// them onto EntityRepresentation.DirectEntitlements. Taking the no-rehydrate
-		// shortcut here would silently drop them and deny every direct-entitlement
-		// decision, so defer to ERS whenever the claim is present.
+		// Direct entitlements are carried inline on the claims. Taking the no-rehydrate
+		// shortcut here would silently drop them, so defer to ERS whenever the claim is present.
 		if key, ok := directEntitlementClaimKey(&claimsStruct); ok {
 			return nil, fmt.Errorf("%w: entity %s carries %q claims", errResolvedTokenChainRequiresHydration, chained.GetEphemeralId(), key)
 		}

--- a/service/internal/access/v2/just_in_time_pdp.go
+++ b/service/internal/access/v2/just_in_time_pdp.go
@@ -16,7 +16,6 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy/subjectmapping"
 	otdfSDK "github.com/opentdf/platform/sdk"
 	ent "github.com/opentdf/platform/service/entity"
-	claimsERSV2 "github.com/opentdf/platform/service/entityresolution/claims/v2"
 	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -412,7 +411,7 @@ func filterEntityChain(entityChain *entity.EntityChain, skipEnvironmentEntities 
 // directEntitlementClaimKey reports whether the resolved claims carry direct
 // entitlements, and under which claim name.
 func directEntitlementClaimKey(claimsStruct *structpb.Struct) (string, bool) {
-	for _, key := range claimsERSV2.DirectEntitlementClaimKeys {
+	for _, key := range ent.DirectEntitlementClaimKeys {
 		if _, ok := claimsStruct.GetFields()[key]; ok {
 			return key, true
 		}

--- a/service/internal/access/v2/just_in_time_pdp_test.go
+++ b/service/internal/access/v2/just_in_time_pdp_test.go
@@ -187,11 +187,7 @@ func claimsAnyForTest(t *testing.T, claims map[string]interface{}) *anypb.Any {
 	return claimsAny
 }
 
-// TestResolveEntitiesFromTokenPreservesDirectEntitlements is the end-to-end regression
-// for the no-rehydrate shortcut silently dropping direct entitlements. Only ERS can
-// project the inline `direct_entitlements` claim onto
-// EntityRepresentation.DirectEntitlements; building the representation locally leaves
-// the field empty and every direct-entitlement decision denies.
+// end-to-end regression for the no-rehydrate shortcut silently dropping direct entitlements
 func TestResolveEntitiesFromTokenPreservesDirectEntitlements(t *testing.T) {
 	directEntitlements := []*entityresolutionV2.DirectEntitlement{{
 		AttributeValueFqn: "https://example.com/attr/workspace/value/sdk-test",

--- a/service/internal/access/v2/just_in_time_pdp_test.go
+++ b/service/internal/access/v2/just_in_time_pdp_test.go
@@ -186,3 +186,74 @@ func claimsAnyForTest(t *testing.T, claims map[string]interface{}) *anypb.Any {
 	require.NoError(t, err)
 	return claimsAny
 }
+
+// TestResolveEntitiesFromTokenPreservesDirectEntitlements is the end-to-end regression
+// for the no-rehydrate shortcut silently dropping direct entitlements. Only ERS can
+// project the inline `direct_entitlements` claim onto
+// EntityRepresentation.DirectEntitlements; building the representation locally leaves
+// the field empty and every direct-entitlement decision denies.
+func TestResolveEntitiesFromTokenPreservesDirectEntitlements(t *testing.T) {
+	directEntitlements := []*entityresolutionV2.DirectEntitlement{{
+		AttributeValueFqn: "https://example.com/attr/workspace/value/sdk-test",
+		Actions:           []string{"read", "view"},
+	}}
+	claimsAny := claimsAnyForTest(t, map[string]interface{}{
+		"username": "alice",
+		"direct_entitlements": []interface{}{
+			map[string]interface{}{
+				"attribute_value_fqn": "https://example.com/attr/workspace/value/sdk-test",
+				"actions":             []interface{}{"read", "view"},
+			},
+		},
+	})
+	client := &recordingERSV2Client{
+		createResponse: &entityresolutionV2.CreateEntityChainsFromTokensResponse{
+			EntityChains: []*entity.EntityChain{{Entities: []*entity.Entity{{
+				EphemeralId: "jwtentity-claims",
+				EntityType:  &entity.Entity_Claims{Claims: claimsAny},
+				Category:    entity.Entity_CATEGORY_SUBJECT,
+			}}}},
+		},
+		resolveResponse: &entityresolutionV2.ResolveEntitiesResponse{
+			EntityRepresentations: []*entityresolutionV2.EntityRepresentation{{
+				OriginalId:         "jwtentity-claims",
+				DirectEntitlements: directEntitlements,
+			}},
+		},
+	}
+	pdp := testJITPDP(client)
+
+	reps, err := pdp.resolveEntitiesFromToken(t.Context(), &entity.Token{EphemeralId: "alice-token", Jwt: "token"}, true, nil)
+	require.NoError(t, err)
+	require.Len(t, reps, 1)
+
+	// Must defer to ERS so the claim is projected onto the representation.
+	require.Equal(t, 1, client.resolveCalls, "direct entitlements require ERS hydration")
+	require.Len(t, reps[0].GetDirectEntitlements(), 1, "direct entitlements must survive token resolution")
+	require.Equal(t, "https://example.com/attr/workspace/value/sdk-test", reps[0].GetDirectEntitlements()[0].GetAttributeValueFqn())
+	require.ElementsMatch(t, []string{"read", "view"}, reps[0].GetDirectEntitlements()[0].GetActions())
+}
+
+func TestEntityRepresentationsFromResolvedChainRequiresHydrationForDirectEntitlements(t *testing.T) {
+	for _, claimKey := range []string{"direct_entitlements", "directEntitlements"} {
+		t.Run(claimKey, func(t *testing.T) {
+			claimsAny := claimsAnyForTest(t, map[string]interface{}{
+				"username": "alice",
+				claimKey: []interface{}{
+					map[string]interface{}{
+						"attribute_value_fqn": "https://example.com/attr/workspace/value/sdk-test",
+						"actions":             []interface{}{"read"},
+					},
+				},
+			})
+			chain := &entity.EntityChain{Entities: []*entity.Entity{{
+				EphemeralId: "jwtentity-claims",
+				EntityType:  &entity.Entity_Claims{Claims: claimsAny},
+				Category:    entity.Entity_CATEGORY_SUBJECT,
+			}}}
+
+			_, err := entityRepresentationsFromResolvedChain(chain, true)
+			require.ErrorIs(t, err, errResolvedTokenChainRequiresHydration)
+		})
+	}
+}

--- a/tests-bdd/cukes/steps_directentitlements.go
+++ b/tests-bdd/cukes/steps_directentitlements.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cucumber/godog"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/opentdf/platform/protocol/go/entity"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -18,6 +21,7 @@ type DirectEntitlementsStepDefinitions struct{}
 const (
 	directEntitlementColumnAttributeFQN = "attribute_value_fqn"
 	directEntitlementColumnActions      = "actions"
+	directEntitlementsClaimKey          = "direct_entitlements"
 )
 
 // thereIsAClaimsSubjectEntityReferencedAsWithDirectEntitlements records a claims subject entity
@@ -31,7 +35,7 @@ func (s *DirectEntitlementsStepDefinitions) thereIsAClaimsSubjectEntityReference
 	}
 
 	claims := map[string]interface{}{
-		"direct_entitlements": directEntitlements,
+		directEntitlementsClaimKey: directEntitlements,
 	}
 	structClaims, err := structpb.NewStruct(claims)
 	if err != nil {
@@ -49,6 +53,51 @@ func (s *DirectEntitlementsStepDefinitions) thereIsAClaimsSubjectEntityReference
 	}
 	scenarioContext.RecordObject(referenceID, subjectEntity)
 	return ctx, nil
+}
+
+// thereIsATokenReferencedAsWithDirectEntitlements records a raw JWT whose claims carry
+// direct_entitlements, exercising the EntityIdentifier_Token decision path. That path resolves the
+// token through the claims ERS CreateEntityChainsFromTokens and must still hydrate the chain into an
+// entity representation carrying DirectEntitlements — building the representation locally from the
+// chain drops them and denies every direct-entitlement decision.
+func (s *DirectEntitlementsStepDefinitions) thereIsATokenReferencedAsWithDirectEntitlements(ctx context.Context, referenceID string, tbl *godog.Table) (context.Context, error) {
+	scenarioContext := GetPlatformScenarioContext(ctx)
+	directEntitlements, err := parseDirectEntitlementsTable(tbl)
+	if err != nil {
+		return ctx, err
+	}
+
+	rawToken, err := mintDirectEntitlementsToken(referenceID, directEntitlements)
+	if err != nil {
+		return ctx, err
+	}
+	scenarioContext.RecordObject(referenceID, rawToken)
+	return ctx, nil
+}
+
+// directEntitlementsTokenSigningKey signs the subject tokens minted for these scenarios. The claims
+// ERS parses subject tokens with jwt.WithVerify(false) — the JWT is decision *input*, not the
+// caller's credential — so the key only has to produce a well-formed JWS.
+var directEntitlementsTokenSigningKey = []byte("cukes-direct-entitlements-signing-key")
+
+func mintDirectEntitlementsToken(subject string, directEntitlements []interface{}) (string, error) {
+	now := time.Now()
+	token, err := jwt.NewBuilder().
+		Subject(subject).
+		Issuer("cukes-direct-entitlements").
+		IssuedAt(now).
+		Expiration(now.Add(time.Hour)).
+		Claim(directEntitlementsClaimKey, directEntitlements).
+		Build()
+	if err != nil {
+		return "", fmt.Errorf("building direct entitlements token for %s: %w", subject, err)
+	}
+
+	signed, err := jwt.Sign(token, jwt.WithKey(jwa.HS256, directEntitlementsTokenSigningKey))
+	if err != nil {
+		return "", fmt.Errorf("signing direct entitlements token for %s: %w", subject, err)
+	}
+	return string(signed), nil
 }
 
 // iAddClaimsToSubjectEntityWith merges additional claims into an existing claims subject entity so a
@@ -197,5 +246,6 @@ func parseClaimsTable(tbl *godog.Table) (map[string]interface{}, error) {
 func RegisterDirectEntitlementsStepDefinitions(ctx *godog.ScenarioContext) {
 	stepDefinitions := &DirectEntitlementsStepDefinitions{}
 	ctx.Step(`^there is a claims subject entity referenced as "([^"]*)" with direct entitlements:$`, stepDefinitions.thereIsAClaimsSubjectEntityReferencedAsWithDirectEntitlements)
+	ctx.Step(`^there is a token referenced as "([^"]*)" with direct entitlements:$`, stepDefinitions.thereIsATokenReferencedAsWithDirectEntitlements)
 	ctx.Step(`^I add claims to subject entity "([^"]*)" with:$`, stepDefinitions.iAddClaimsToSubjectEntityWith)
 }

--- a/tests-bdd/features/direct-entitlements.feature
+++ b/tests-bdd/features/direct-entitlements.feature
@@ -22,6 +22,25 @@ Feature: Direct entitlements decisioning
     Then the response should be successful
     And I should get a "PERMIT" decision response
 
+  # The token identifier resolves through the claims ERS CreateEntityChainsFromTokens and must
+  # still hydrate the resolved chain into an entity representation carrying the direct
+  # entitlements. Regression coverage for the token path silently dropping them.
+  Scenario: Direct entitlement on a token permits a matching action
+    Given there is a token referenced as "alice_token" with direct entitlements:
+      | attribute_value_fqn                           | actions |
+      | https://example.com/attr/department/value/eng | read    |
+    When I send a decision request for token "alice_token" for "read" action on resource "https://example.com/attr/department/value/eng"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response
+
+  Scenario: Direct entitlement on a token denies an action mismatch
+    Given there is a token referenced as "alice_token" with direct entitlements:
+      | attribute_value_fqn                           | actions |
+      | https://example.com/attr/department/value/eng | read    |
+    When I send a decision request for token "alice_token" for "update" action on resource "https://example.com/attr/department/value/eng"
+    Then the response should be successful
+    And I should get a "DENY" decision response
+
   Scenario: Direct entitlement denies an action mismatch
     Given there is a claims subject entity referenced as "alice" with direct entitlements:
       | attribute_value_fqn                           | actions |

--- a/tests-bdd/go.mod
+++ b/tests-bdd/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cucumber/godog v0.15.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
+	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/opentdf/platform/lib/fixtures v0.3.0
 	github.com/opentdf/platform/lib/identifier v0.0.2
 	github.com/opentdf/platform/lib/ocrypto v0.14.0
@@ -136,7 +137,6 @@ require (
 	github.com/lestrrat-go/httprc v1.0.6 // indirect
 	github.com/lestrrat-go/httprc/v3 v3.0.1 // indirect
 	github.com/lestrrat-go/iter v1.0.2 // indirect
-	github.com/lestrrat-go/jwx/v2 v2.1.6 // indirect
 	github.com/lestrrat-go/jwx/v3 v3.0.11 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect


### PR DESCRIPTION
### Proposed Changes

Fixes a regression in the access decision flow where **direct entitlements present on JWT claims were silently dropped** when decisions were made via **token identifiers** (token → entity chain shortcut path), and adds regression coverage across unit + BDD tests.

**Changes:**
- Force ERS hydration when resolved token-chain claims include direct-entitlements claim keys so entitlements are preserved on entity representations.
- Add unit tests to verify hydration is triggered and that both `direct_entitlements` and `directEntitlements` claim keys are handled.
- Add BDD scenarios + step support to mint JWTs with direct entitlements and exercise the token-identifier decision path.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Direct entitlements are now preserved when resolving permissions through token identifiers.
  * Supports both `direct_entitlements` and `directEntitlements` claim formats.
  * Prevents direct entitlements from being omitted during token-chain processing.
* **Tests**
  * Added regression coverage confirming matching actions return `PERMIT` and mismatched actions return `DENY`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->