### PR TITLE
docs(spec): add NanoTDF v1alpha specification suite

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -39,6 +39,7 @@ They share BaseTDF's factoring and vocabulary but describe different wire format
 |---|---|---|
 | BinaryTDF v1alpha | CBOR-framed binary objects | [binarytdf/v1alpha/](binarytdf/v1alpha/) |
 | IC-TDF v1alpha | IC XML Trusted Data Format, `2014-DEC-r2017-JUL` | [ictdf/v1alpha/](ictdf/v1alpha/) |
+| NanoTDF v1alpha | Compact ECC binary format, sub-200-byte overhead | [nanotdf/v1alpha/](nanotdf/v1alpha/) |
 
 ## Previous Versions
 

--- a/spec/nanotdf/v1alpha/README.md
+++ b/spec/nanotdf/v1alpha/README.md
@@ -1,0 +1,100 @@
+# NanoTDF Specification Suite — Version 1 Alpha
+
+NanoTDF is a compact binary format for protecting one payload under one policy. It
+carries no wrapped key: the symmetric key is derived on both sides from an ECDH exchange
+between an ephemeral key pair and the Key Access Service's key pair, which removes the
+largest fixed cost in a conventional TDF. Objects can be produced offline, and fixed
+overhead stays under 200 bytes.
+
+This suite reorganizes the nanotdf version 1 specification into components aligned with
+the BaseTDF 5 architecture. The refactoring changes document ownership, not wire format,
+algorithms, validation, or security semantics. Where the source specification is
+internally inconsistent, this suite states the corrected value and records the correction
+in NanoTDF-CORE §6.
+
+## Core modules
+
+| Layer | Document | Responsibility | File |
+|---|---|---|---|
+| Foundation | NanoTDF-SEC | Security considerations, parser limits, trust boundaries | [nanotdf-sec.md](nanotdf-sec.md) |
+| Foundation | NanoTDF-ALG | Curve and cipher registries, key derivation, encodings | [nanotdf-alg.md](nanotdf-alg.md) |
+| Policy | NanoTDF-POL | Policy object, type enumeration, remote and embedded bodies | [nanotdf-pol.md](nanotdf-pol.md) |
+| Operations | NanoTDF-KAO | Ephemeral key agreement, HKDF derivation, Policy Key Access | [nanotdf-kao.md](nanotdf-kao.md) |
+| Operations | NanoTDF-BND | Policy binding and the optional creator signature | [nanotdf-bnd.md](nanotdf-bnd.md) |
+| Operations | NanoTDF-PAY | Payload framing, IV, ciphertext, and MAC | [nanotdf-pay.md](nanotdf-pay.md) |
+| Operations | NanoTDF-KAS | Key Access Service protocol | [nanotdf-kas.md](nanotdf-kas.md) |
+| Storage | NanoTDF-LOC | Resource Locators and fetch policy | [nanotdf-loc.md](nanotdf-loc.md) |
+| Storage | NanoTDF-PKG | Binary frame, magic number, bitfields, size bounds | [nanotdf-pkg.md](nanotdf-pkg.md) |
+| Assembly | NanoTDF-CORE | Object model, end-to-end processing, source deviations | [nanotdf-core.md](nanotdf-core.md) |
+| Examples | NanoTDF-EX | Two verified interoperability vectors | [nanotdf-ex.md](nanotdf-ex.md) |
+
+## Architecture
+
+Arrows point from prerequisites to consumers.
+
+```text
+SEC ──► ALG, LOC, PKG, KAO, POL, BND, PAY, KAS
+
+ALG ──► PKG, KAO, POL, BND, PAY
+LOC ──► PKG, POL, KAS
+PKG ──► KAO, POL, BND, PAY
+KAO ──► POL, BND, PAY, KAS
+POL ──► BND, KAS
+BND ──► KAS
+
+SEC, ALG, LOC, PKG, KAO, POL, BND, PAY, KAS ──► CORE ──► EX
+```
+
+## Alignment with BaseTDF 5
+
+The suites use the same names for shared responsibilities: SEC, ALG, POL, KAO, KAS, LOC,
+PKG, CORE, and EX.
+
+Two modules have no direct BaseTDF counterpart. NanoTDF-BND owns both the policy binding
+and the creator signature, because in NanoTDF the binding is a load-bearing wire field
+sized by a header bitfield rather than a property of an assertion; BaseTDF covers the
+signature half of this in BaseTDF-ASN. NanoTDF-PAY exists because payload carriage has
+its own length field, reserved IV, and implied MAC length; BaseTDF folds the equivalent
+into BaseTDF-CORE and BaseTDF-INT.
+
+Four BaseTDF modules are deliberately absent:
+
+- **INT.** NanoTDF defines no segmentation, no Merkle layout, and no per-segment
+  integrity. One payload is one AEAD operation, and object-wide integrity exists only
+  when a creator signature is present.
+- **ASN.** There are no assertions. The only signed claim is the creator signature, owned
+  by NanoTDF-BND.
+- **MTD.** Version 1 carries no metadata. There is no extension socket to carry any.
+- **SCH.** NanoTDF ships no external schema artifact. BinaryTDF has CDDL and IC-TDF has an
+  XSD; here the byte tables in NanoTDF-PKG are the grammar.
+
+These absences are format boundaries rather than missing placeholder documents.
+
+## Conventions
+
+BCP 14 requirement terms are normative only when written in all capitals. Unless
+specified otherwise, all integers are unsigned and big-endian, `||` means byte
+concatenation, bit indices within a byte are numbered from 7 down to 0, and elliptic
+curve public keys are X9.62 compressed points.
+
+Several field lengths are implied rather than carried: the ephemeral key, an ECDSA policy
+binding, the payload MAC, and the signature are all sized by an enumerated value in one of
+the two configuration bytes. Parse order is therefore constrained; see NanoTDF-CORE §2.2.
+
+## Status and source
+
+The suite is an alpha draft. Its normative source is the nanotdf version 1
+specification, whose magic number and version serialize as `4c 31 4c`, ASCII `L1L`. The
+version count starts at 12 as an artifact of the original design, so every version below
+12 is invalid by construction.
+
+The two worked examples in NanoTDF-EX are reproduced from the source and have been
+verified: each decodes to the stated byte count, and every field offset and section
+length reconciles.
+
+There are no extension, profile, or migration documents in this suite. NanoTDF version 1
+defines no extension mechanism, so a new capability requires a new format version.
+
+## License
+
+This specification is licensed under the repository's license terms.

--- a/spec/nanotdf/v1alpha/nanotdf-alg.md
+++ b/spec/nanotdf/v1alpha/nanotdf-alg.md
@@ -1,0 +1,126 @@
+# NanoTDF-ALG: Algorithm Registry and Encodings
+
+| | |
+|---|---|
+| Document | NanoTDF-ALG |
+| Version | 1 Alpha |
+| Source spec | nanotdf v1 |
+| Format version | 12 (`L1L`) |
+| Status | Draft |
+| Depends on | NanoTDF-SEC |
+| Referenced by | NanoTDF-PKG, NanoTDF-KAO, NanoTDF-POL, NanoTDF-BND, NanoTDF-PAY, NanoTDF-CORE |
+
+## 1. Elliptic curve registry
+
+NanoTDF does not permit arbitrary curve parameters. The registry is closed, and the
+same enumeration is used by the Ephemeral ECC Params field and the Signature ECC Mode
+field (NanoTDF-PKG §3).
+
+| Value | Curve | Compressed public key (B) | ECDSA `r \|\| s` (B) |
+|---|---|---:|---:|
+| `0x00` | `secp256r1` | 33 | 64 |
+| `0x01` | `secp384r1` | 49 | 96 |
+| `0x02` | `secp521r1` | 67 | 132 |
+| `0x03` | `secp256k1` | 33 | 64 |
+
+The key and signature lengths are derived, not carried on the wire. A parser locates the
+ephemeral public key and the signature by the curve alone, so the field selecting the
+curve MUST be parsed first.
+
+Values outside this table are unreserved. A parser MUST reject an unlisted value rather
+than falling back to a default. No curve below 256 bits is supported.
+
+## 2. Symmetric cipher registry
+
+One cipher selection governs both the payload and, when the policy is encrypted, the
+policy. Every entry is AES-256-GCM; the entries differ only in authentication tag
+length.
+
+| Value | Cipher | Tag (bits) | Tag (B) |
+|---|---|---:|---:|
+| `0x00` | AES-256-GCM | 64 | 8 |
+| `0x01` | AES-256-GCM | 96 | 12 |
+| `0x02` | AES-256-GCM | 104 | 13 |
+| `0x03` | AES-256-GCM | 112 | 14 |
+| `0x04` | AES-256-GCM | 120 | 15 |
+| `0x05` | AES-256-GCM | 128 | 16 |
+
+This table may be extended in a future point release. Values outside it are unreserved
+and MUST be rejected.
+
+Because the key length is fixed at 256 bits across every entry, the HKDF output length
+in §3 is 32 bytes for all currently registered ciphers. The short-tag hazard is discussed
+in NanoTDF-SEC §3.
+
+## 3. Key derivation
+
+An ECDH exchange yields a shared secret whose length is a property of the curve, not of
+the symmetric algorithm. NanoTDF decouples the two with HKDF.
+
+| Parameter | Value |
+|---|---|
+| Function | HKDF (RFC 5869) |
+| Hash | SHA-256 |
+| Input keying material | The ECDH shared secret |
+| Output length | The key length of the selected cipher; 32 bytes for every registered value |
+| `salt` | `SHA256(MAGIC_NUMBER \|\| VERSION)` |
+| `info` | Empty |
+
+The salt is a fixed, non-random value tied to the magic number and version, so it is a
+constant per format version rather than a per-object input. For format version 12, the
+three magic-and-version bytes are `4c 31 4c` and the salt is:
+
+```text
+3de3ca1e50cf62d8b6aba603a96fca6761387a7ac86c3d3afe85ae2d1812edfc
+```
+
+A future format version changes the magic-and-version bytes and therefore changes the
+salt, which domain-separates derived keys across versions.
+
+## 4. Public key encoding
+
+Elliptic curve public keys are encoded as X9.62 compressed points: a single leading byte
+of `0x02` or `0x03` indicating the parity of the y-coordinate, followed by the
+big-endian x-coordinate padded to the curve's field size.
+
+Compressed encoding is used everywhere a public key appears — the header ephemeral key,
+the Policy Key Access ephemeral key, and the creator signature's public key. Uncompressed
+and hybrid encodings are not permitted.
+
+A decoder MUST verify that the recovered point lies on the declared curve before using
+it (NanoTDF-SEC §4).
+
+## 5. ECDSA signature encoding
+
+ECDSA signatures are the big-endian encodings of `r` and `s` concatenated, each padded
+to the curve's field size. DER is not used, and there is no length prefix: the total
+length follows from the curve.
+
+For example, `r = 1` and `s = 2` over `secp256k1` encode as the following 64 bytes. Line
+breaks and spaces are added for readability only.
+
+```text
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 02
+```
+
+A verifier MUST reject a signature whose length does not match the curve exactly.
+
+## 6. Integer and byte-order conventions
+
+All multi-byte integers in NanoTDF are unsigned and big-endian. `||` denotes byte
+concatenation. Bit indices within a single-byte bitfield are numbered from 7, the most
+significant bit, down to 0.
+
+## 7. References
+
+- [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [RFC 5869: HKDF](https://www.rfc-editor.org/rfc/rfc5869)
+- [RFC 6090: Fundamental Elliptic Curve Cryptography Algorithms](https://www.rfc-editor.org/rfc/rfc6090)
+- [RFC 6637: ECC in OpenPGP](https://www.rfc-editor.org/rfc/rfc6637)
+- [SEC 1: Elliptic Curve Cryptography](https://www.secg.org/sec1-v2.pdf)
+- [FIPS 186-5: Digital Signature Standard](https://csrc.nist.gov/pubs/fips/186-5/final)
+- [FIPS 197: AES](https://csrc.nist.gov/pubs/fips/197/final)
+- [NIST SP 800-38D: GCM and GMAC](https://csrc.nist.gov/pubs/sp/800/38/d/final)

--- a/spec/nanotdf/v1alpha/nanotdf-alg.md
+++ b/spec/nanotdf/v1alpha/nanotdf-alg.md
@@ -49,8 +49,15 @@ This table may be extended in a future point release. Values outside it are unre
 and MUST be rejected.
 
 Because the key length is fixed at 256 bits across every entry, the HKDF output length
-in §3 is 32 bytes for all currently registered ciphers. The short-tag hazard is discussed
-in NanoTDF-SEC §3.
+in §3 is 32 bytes for all currently registered ciphers.
+
+The entries are not interchangeable. The forgery resistance of a tag depends on the
+length of the message it authenticates as well as on the tag itself, and a NanoTDF
+payload can reach 2^20 blocks, which costs 21 bits at every entry in the table. A
+64-bit tag over a maximum-size payload is worth about 43 bits. NanoTDF-SEC §3 tabulates
+the advantage for each entry at each payload size, gives the SP 800-38D Appendix C
+constraints that apply to cipher `0x00`, and states when a producer SHOULD NOT select
+it.
 
 ## 3. Key derivation
 
@@ -88,7 +95,7 @@ the Policy Key Access ephemeral key, and the creator signature's public key. Unc
 and hybrid encodings are not permitted.
 
 A decoder MUST verify that the recovered point lies on the declared curve before using
-it (NanoTDF-SEC §4).
+it (NanoTDF-SEC §5).
 
 ## 5. ECDSA signature encoding
 

--- a/spec/nanotdf/v1alpha/nanotdf-bnd.md
+++ b/spec/nanotdf/v1alpha/nanotdf-bnd.md
@@ -1,0 +1,139 @@
+# NanoTDF-BND: Policy Binding and Creator Signature
+
+| | |
+|---|---|
+| Document | NanoTDF-BND |
+| Version | 1 Alpha |
+| Source spec | nanotdf v1 |
+| Format version | 12 (`L1L`) |
+| Status | Draft |
+| Depends on | NanoTDF-SEC, NanoTDF-ALG, NanoTDF-PKG, NanoTDF-KAO, NanoTDF-POL |
+| Referenced by | NanoTDF-KAS, NanoTDF-CORE, NanoTDF-EX |
+
+## 1. Scope
+
+NanoTDF has two cryptographic bindings, and they answer different questions.
+
+| Mechanism | Question answered | Required |
+|---|---|---|
+| Policy binding | Is this policy the one the producer attached to this payload? | Always |
+| Creator signature | Which persistent identity produced this object? | Optional |
+
+The policy binding lives inside the Policy section and is verified by the KAS before it
+releases a key. The creator signature is a separate trailing section and is verified by
+the consumer, if at all. This document owns both.
+
+## 2. Policy binding
+
+### 2.1 Construction
+
+```text
+PB = the exact policy body bytes as serialized
+BM = the binding method, ECDSA or GMAC
+BS = BM(SHA256(PB))
+```
+
+The input is a SHA-256 digest over the policy body bytes only. The type enum and the
+binding itself are excluded, as are all other header fields.
+
+`PB` is the body as it appears on the wire. A verifier MUST use the bytes it received and
+MUST NOT re-serialize the policy to recompute them (NanoTDF-POL §6).
+
+### 2.2 Method selection and length
+
+`USE_ECDSA_BINDING`, bit 7 of the ECC and Binding Mode byte (NanoTDF-PKG §3.3), selects
+the method.
+
+| `USE_ECDSA_BINDING` | Method | Length (B) | Key |
+|---|---|---:|---|
+| `0` | 64-bit GMAC tag, AES-256-GCM | 8 | Derived symmetric key |
+| `1` | ECDSA signature, `r \|\| s` | 64 – 132 | Ephemeral private key |
+
+For the ECDSA case the signature length follows the **Ephemeral ECC Params Enum** in the
+ECC and Binding Mode byte — the curve of the header's ephemeral key. It does **not**
+follow the Signature ECC Mode, which sizes the creator signature only. The source
+specification leaves this implicit; this suite states it normatively because the two
+fields can name different curves in the same object.
+
+For the GMAC case the key is the symmetric key derived in NanoTDF-KAO §2 — the payload
+key. This holds even when Policy Key Access supplies a separate policy key: the binding
+exists to tie the policy to *this payload*, and computing it under the policy key would
+sever that tie.
+
+### 2.3 Verification
+
+A KAS MUST verify the policy binding before evaluating the policy or releasing a key. A
+consumer that receives a key MUST verify the binding before acting on the policy.
+
+Verification failure MUST be reported in the same indistinguishable error class as key
+derivation and authorization failure (NanoTDF-SEC §8).
+
+### 2.4 What the binding does not do
+
+- It does not authenticate the producer. A GMAC binding is computable by anyone holding
+  the derived key, which includes the KAS. An ECDSA binding is verifiable against an
+  ephemeral key that exists only for this object and is tied to no identity.
+- For a remote policy it covers the locator, not the policy content (NanoTDF-LOC §4).
+- It does not cover the payload ciphertext, the KAS locator, or the configuration bytes.
+  Integrity of the payload comes from the AEAD tag (NanoTDF-PAY §4); integrity of the
+  whole object comes only from the creator signature.
+
+## 3. Creator signature
+
+### 3.1 Presence and structure
+
+The Signature section is present if and only if `HAS_SIGNATURE`, bit 7 of the Symmetric
+and Payload Config byte, is set (NanoTDF-PKG §3.4).
+
+| Field | Minimum (B) | Maximum (B) |
+|---|---:|---:|
+| Creator Public Key | 33 | 67 |
+| Signature (`r \|\| s`) | 64 | 132 |
+| **Total** | **97** | **199** |
+
+Both lengths follow the Signature ECC Mode, bits 6–4 of the Symmetric and Payload Config
+byte, resolved through the curve registry in NanoTDF-ALG §1. The public key is a
+compressed point; the signature is fixed-width big-endian `r || s`, not DER
+(NanoTDF-ALG §5).
+
+### 3.2 Coverage and key
+
+The signature covers the Header and the Payload — every byte of the object preceding the
+Signature section.
+
+The signing key is a **persistent** key belonging to an individual, entity, or device
+that produces NanoTDFs. It is distinct from the ephemeral key in the header, which exists
+only for one object and carries no identity. Including the creator's public key in the
+section makes the signature self-contained: a verifier needs no directory lookup to check
+the mathematics.
+
+### 3.3 Verification
+
+A verifier MUST decode the creator public key as a point on the curve named by the
+Signature ECC Mode, reject a signature whose length does not match that curve exactly,
+and verify over the exact received header and payload bytes.
+
+### 3.4 What the signature does not do
+
+Carriage is not endorsement. A valid signature proves that the holder of the named
+private key signed these bytes. It does not establish that:
+
+- the signer is authorized to produce objects under this policy;
+- the policy is correct or the attributes truthful;
+- the key has not been revoked, or was valid at the time of signing — there is no
+  timestamp in the object; or
+- the key belongs to the identity a consumer expects. Binding the key to an identity is a
+  deployment concern, handled by a certificate, a directory, or pinned trust
+  configuration outside the format.
+
+The signature is also removable: re-encoding the object with `HAS_SIGNATURE` cleared and
+the section stripped yields a well-formed, openable NanoTDF. Nothing else in the object
+records that a signature was ever present. An application requiring provenance MUST
+reject an unsigned object rather than treating absence as acceptable (NanoTDF-SEC §5).
+
+## 4. References
+
+- [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [FIPS 180-4: Secure Hash Standard](https://csrc.nist.gov/pubs/fips/180-4/upd1/final)
+- [FIPS 186-5: Digital Signature Standard](https://csrc.nist.gov/pubs/fips/186-5/final)
+- [NIST SP 800-38D: GCM and GMAC](https://csrc.nist.gov/pubs/sp/800/38/d/final)

--- a/spec/nanotdf/v1alpha/nanotdf-bnd.md
+++ b/spec/nanotdf/v1alpha/nanotdf-bnd.md
@@ -60,13 +60,20 @@ key. This holds even when Policy Key Access supplies a separate policy key: the 
 exists to tie the policy to *this payload*, and computing it under the policy key would
 sever that tie.
 
+A 64-bit GMAC tag is short, but the message it authenticates is a fixed 32-byte digest,
+so the forgery bound is far better than the same tag length over a long payload: about
+2^-61.42 per attempt, against 2^-43.00 for a maximum-size payload. The exposure is of a
+different kind rather than a different degree, because the verifier here is a network
+service that answers as often as it is asked. NanoTDF-SEC §3.6 gives the numbers and the
+deployment controls, and NanoTDF-KAS §5 states them normatively.
+
 ### 2.3 Verification
 
 A KAS MUST verify the policy binding before evaluating the policy or releasing a key. A
 consumer that receives a key MUST verify the binding before acting on the policy.
 
 Verification failure MUST be reported in the same indistinguishable error class as key
-derivation and authorization failure (NanoTDF-SEC §8).
+derivation and authorization failure (NanoTDF-SEC §9).
 
 ### 2.4 What the binding does not do
 
@@ -129,7 +136,7 @@ private key signed these bytes. It does not establish that:
 The signature is also removable: re-encoding the object with `HAS_SIGNATURE` cleared and
 the section stripped yields a well-formed, openable NanoTDF. Nothing else in the object
 records that a signature was ever present. An application requiring provenance MUST
-reject an unsigned object rather than treating absence as acceptable (NanoTDF-SEC §5).
+reject an unsigned object rather than treating absence as acceptable (NanoTDF-SEC §6).
 
 ## 4. References
 

--- a/spec/nanotdf/v1alpha/nanotdf-core.md
+++ b/spec/nanotdf/v1alpha/nanotdf-core.md
@@ -1,0 +1,212 @@
+# NanoTDF-CORE: Object and End-to-End Processing
+
+| | |
+|---|---|
+| Document | NanoTDF-CORE |
+| Version | 1 Alpha |
+| Source spec | nanotdf v1 |
+| Format version | 12 (`L1L`) |
+| Status | Draft |
+| Depends on | NanoTDF-SEC, NanoTDF-ALG, NanoTDF-LOC, NanoTDF-PKG, NanoTDF-KAO, NanoTDF-POL, NanoTDF-BND, NanoTDF-PAY, NanoTDF-KAS |
+| Referenced by | NanoTDF-EX |
+
+## 1. Scope
+
+NanoTDF is a compact binary format for protecting one payload under one policy. It exists
+because the JSON-based TDF, expressive as it is, is too verbose for environments with
+constrained storage or bandwidth. NanoTDF keeps attribute-based access control and
+cryptographic policy binding while reducing fixed overhead to under 200 bytes.
+
+Format version 12 defines:
+
+- a three-section binary frame containing one payload;
+- a single key access, with the symmetric key derived by ECDH and HKDF rather than
+  wrapped;
+- one policy, remote or embedded, plaintext or encrypted;
+- a policy binding that is either a 64-bit GMAC tag or an ECDSA signature;
+- a closed registry of four elliptic curves and six AES-256-GCM tag lengths;
+- an optional detachable creator signature; and
+- offline creation, requiring no network access at production time.
+
+The core does not define a policy language, segmentation, key splitting, multi-KAS
+access, assertions, metadata carriage, or streaming. Objects needing those capabilities
+use BaseTDF.
+
+The key words MUST, MUST NOT, REQUIRED, SHOULD, SHOULD NOT, and MAY are interpreted as
+described by BCP 14 when written in all capitals.
+
+### 1.1 Terminology
+
+- A producer creates a NanoTDF. An opener decrypts one.
+- A Key Access Service, or KAS, holds the private key against which an object was
+  produced and decides whether to release the derived key.
+- The ephemeral key pair is generated for one object and discarded. Its public half is
+  carried in the header.
+- The creator key is a persistent identity key used only for the optional signature. It
+  is unrelated to the ephemeral key.
+- The derived key, or payload key, is the AES-256 key produced by ECDH followed by HKDF.
+- ECDH is the elliptic-curve Diffie-Hellman key agreement. HKDF derives a fixed-length
+  key from a shared secret.
+- AEAD encrypts data and detects changes to the ciphertext. GMAC is the
+  authentication-only mode of AES-GCM, used here for the policy binding.
+- A compressed point is the X9.62 encoding of an elliptic-curve public key as a parity
+  byte followed by the x-coordinate.
+- The policy binding cryptographically ties the policy to the payload key.
+
+## 2. Object model
+
+A NanoTDF is immutable. Three sections define what governs release, what is protected,
+and who produced it:
+
+```text
++-----------------------+
+| Header                |   sent to the KAS
++-----------------------+
+| Payload               |   never leaves the client
++-----------------------+
+| Signature  (optional) |   detachable provenance
++-----------------------+
+```
+
+The Header is self-delimiting and self-sufficient: it can be parsed and transmitted
+without the rest of the object. That property is what keeps a rewrap request small
+regardless of payload size (NanoTDF-KAS §2).
+
+The Signature is genuinely optional and genuinely detachable. Stripping it and clearing
+`HAS_SIGNATURE` yields a well-formed object, and nothing records that it was ever present
+(NanoTDF-BND §3.4).
+
+### 2.1 Design assumptions
+
+- Elliptic curve cryptography with ECDH and HKDF derives every key. No RSA, and no
+  wrapped key material on the wire.
+- No curve below 256 bits is supported, and the curve registry is closed.
+- All integers are unsigned and big-endian.
+- One object carries one policy and one key access.
+
+### 2.2 Length dependencies
+
+Several fields are sized by other fields rather than by a length prefix. This constrains
+parse order, and an implementation that reads the object out of order will not work.
+
+| Field | Sized by |
+|---|---|
+| Ephemeral public key | Ephemeral ECC Params Enum (ECC and Binding Mode) |
+| Policy binding, ECDSA case | Ephemeral ECC Params Enum |
+| Policy Key Access ephemeral key | Ephemeral ECC Params Enum |
+| Payload MAC | Symmetric Cipher Enum (Symmetric and Payload Config) |
+| Creator public key and signature | Signature ECC Mode (Symmetric and Payload Config) |
+| Presence of the Signature section | `HAS_SIGNATURE` (Symmetric and Payload Config) |
+
+Both configuration bytes therefore MUST be parsed before the policy, the ephemeral key,
+or the payload can be located.
+
+### 2.3 Producer lifecycle
+
+This subsection is non-normative; the referenced component requirements are normative.
+
+1. Generate an ephemeral key pair on the selected curve and derive the symmetric key
+   against the KAS public key (NanoTDF-KAO §2).
+2. Serialize the policy body — a Resource Locator, or embedded content encrypted under
+   the reserved IV where required (NanoTDF-POL §3).
+3. Compute the policy binding over those exact bytes (NanoTDF-BND §2).
+4. Encrypt the payload under a fresh IV that is not `0x000000` (NanoTDF-PAY §3).
+5. Serialize the header and payload per NanoTDF-PKG §2.
+6. If a signature is required, sign the serialized header and payload with the persistent
+   creator key and append the Signature section (NanoTDF-BND §3).
+
+Step 2 completes before step 3 because the binding is computed over the serialized policy
+body bytes. Step 5 completes before step 6 because the signature covers those bytes.
+
+## 3. Opening procedure
+
+A conforming opener performs:
+
+1. Frame validation per NanoTDF-PKG §4: magic, version, section bounds, reserved IV, and
+   absence of trailing bytes.
+2. Curve and cipher validation against the registries in NanoTDF-ALG §1 and §2, rejecting
+   unlisted values.
+3. Creator signature verification, if present and if the application requires provenance
+   (NanoTDF-BND §3.3).
+4. A key request to the KAS named in the header, sending the header (NanoTDF-KAS §2).
+5. Policy binding verification against the returned key (NanoTDF-BND §2.3).
+6. Payload authentication under the declared cipher, before any plaintext is released
+   (NanoTDF-PAY §5).
+
+An opener that holds the KAS private key itself performs step 4 locally, deriving the key
+per NanoTDF-KAO §2 rather than making a request.
+
+## 4. Size characteristics
+
+The minimum object is 67 bytes: a 53-byte header and a 14-byte payload with empty
+plaintext. Realistic objects are larger, dominated by the two Resource Locators and the
+policy binding.
+
+The second worked example in NanoTDF-EX carries a 15-byte KAS hostname, a 29-byte remote
+policy locator, an ECDSA binding, and a 128-bit tag, for 173 bytes of overhead — which is
+the basis of the format's sub-200-byte claim. The first example, with a signature
+attached, costs 253 bytes.
+
+## 5. Conformance
+
+At minimum, interoperability tests SHOULD cover:
+
+- byte-identical production and parsing of both vectors in NanoTDF-EX across
+  implementations;
+- rejection of a version below 12 and of an unrecognized magic number;
+- rejection of a payload IV of `0x000000`;
+- rejection of unlisted curve, cipher, and policy-type values;
+- rejection of a non-zero reserved field in the ECC and Binding Mode byte;
+- rejection of trailing bytes with and without a signature;
+- both binding modes, GMAC and ECDSA, including an object whose Signature ECC Mode names
+  a different curve than its Ephemeral ECC Params Enum;
+- all four curves and all six cipher settings, checking derived field lengths;
+- signature present, signature absent, and signature stripped from a signed object;
+- all four policy types, including Policy Key Access;
+- a policy body modified by one byte, which must fail binding verification;
+- a ciphertext modified by one byte, which must fail payload authentication; and
+- KAS denial, malformed header, and unresolvable remote policy, which must be
+  indistinguishable to the requester.
+
+Cross-language vectors SHOULD include the complete object, the header bytes as sent to
+the KAS, the policy body bytes, the ephemeral and creator key pairs, the HKDF salt, the
+derived key, and the expected failure class.
+
+## 6. Deviations from the source specification
+
+This suite reorganizes the nanotdf version 1 specification without changing its wire
+format. Where the source is internally inconsistent, incomplete, or in error, this suite
+states the corrected value and records the correction here. Every deviation below is
+editorial or clarifying; none alters the bytes an implementation produces.
+
+| # | Source | Issue | Resolution |
+|---|---|---|---|
+| 1 | §3.3.1.3.2 | Describes the Ephemeral ECC Params Enum as a "7-bit length enum" while the same section's table gives it 3 bits with 4 unused | 3 bits at indices 2–0, with 4 reserved bits at 6–3, per NanoTDF-PKG §3.3. Both worked examples confirm the 3-bit reading. |
+| 2 | §3.4.2.3.2.3.2 | Gives the Policy Key Access ephemeral public key as 33–133 bytes | 33–67 bytes, the compressed-point range used everywhere else in the format (NanoTDF-ALG §1). |
+| 3 | §3.4.2.3.2.3 | Gives Policy Key Access a total of 36–136 bytes, which its own sub-table contradicts | 36–324 bytes: a 3–257 byte Resource Locator plus a 33–67 byte compressed key (NanoTDF-KAO §4). |
+| 4 | §3.3.1 | Gives the Policy section as 3–257 bytes, omitting the type enum and the binding | 12–714 bytes (NanoTDF-POL §2). |
+| 5 | §3.3 | Gives the Header as 43–584 bytes | 53–1,043 bytes, following from the corrected Policy range (NanoTDF-PKG §2). |
+| 6 | §3.3 | Gives the Signature as 97–133 bytes; the maximum is `67 + 132` for `secp521r1` | 97–199 bytes (NanoTDF-BND §3.1). |
+| 7 | §3.4.2.4 | Does not state which curve sizes an ECDSA policy binding, though two curve fields exist | The Ephemeral ECC Params Enum, not the Signature ECC Mode (NanoTDF-BND §2.2). |
+| 8 | §3.3.1.2 | Cross-reference to the Resource Locator definition is an unresolved placeholder, `[section X.X.X.X]()` | Resolved to NanoTDF-LOC §1. |
+| 9 | §3.4.2 | Subsection numbering skips §3.4.2.2 | Renumbered contiguously in NanoTDF-POL. |
+| 10 | §3.4.1.1.1 | Describes the Shared Resource Directory protocol `0xff` as experimental but defines no resolution procedure or failure behaviour | Non-normative for version 1; rejected unless the deployment opts in out of band (NanoTDF-LOC §2.1). |
+| 11 | §6.1.6 | The parsing breakdown omits the three-byte payload Length field and nests Payload and Signature beneath the Header heading | Corrected in NanoTDF-EX: Length is shown, and the three sections are siblings. |
+
+One figure that looks wrong is correct and has been preserved. The Payload range of
+14–16,777,218 bytes reconciles: the three-byte Length field caps the IV, ciphertext, and
+MAC together at 16,777,215, and the stated 16,777,204-byte ciphertext maximum pairs with
+the 8-byte minimum MAC. Adding the two independent maxima overshoots because they cannot
+co-occur (NanoTDF-PAY §2).
+
+## 7. References
+
+- [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [RFC 5869: HKDF](https://www.rfc-editor.org/rfc/rfc5869)
+- [RFC 6090: Fundamental Elliptic Curve Cryptography Algorithms](https://www.rfc-editor.org/rfc/rfc6090)
+- [RFC 6637: ECC in OpenPGP](https://www.rfc-editor.org/rfc/rfc6637)
+- [SEC 1: Elliptic Curve Cryptography](https://www.secg.org/sec1-v2.pdf)
+- [FIPS 180-4: Secure Hash Standard](https://csrc.nist.gov/pubs/fips/180-4/upd1/final)
+- [FIPS 186-5: Digital Signature Standard](https://csrc.nist.gov/pubs/fips/186-5/final)
+- [FIPS 197: AES](https://csrc.nist.gov/pubs/fips/197/final)
+- [NIST SP 800-38D: GCM and GMAC](https://csrc.nist.gov/pubs/sp/800/38/d/final)

--- a/spec/nanotdf/v1alpha/nanotdf-core.md
+++ b/spec/nanotdf/v1alpha/nanotdf-core.md
@@ -32,6 +32,16 @@ The core does not define a policy language, segmentation, key splitting, multi-K
 access, assertions, metadata carriage, or streaming. Objects needing those capabilities
 use BaseTDF.
 
+That boundary is quantitative, and it is a property of the frame rather than a policy
+choice. The payload Length field is three bytes, so the IV, ciphertext, and MAC of one
+object together cannot exceed 16,777,215 bytes, and the largest ciphertext is
+16,777,204 bytes at the shortest tag (NanoTDF-PAY §2). The Amazon S3 single-object
+maximum is 5 TiB, 5,497,558,138,880 bytes — about 327,680 times a whole NanoTDF payload
+frame. NanoTDF is not an object-storage format and cannot become one within version 1,
+because the ceiling is the width of a length field. Payloads at that scale belong to
+BaseTDF 5, whose partition keys bound the plaintext volume under any one key, or to
+BinaryTDF content-encryption suite 2, the segmented streaming suite.
+
 The key words MUST, MUST NOT, REQUIRED, SHOULD, SHOULD NOT, and MAY are interpreted as
 described by BCP 14 when written in all capitals.
 
@@ -161,6 +171,16 @@ At minimum, interoperability tests SHOULD cover:
 - both binding modes, GMAC and ECDSA, including an object whose Signature ECC Mode names
   a different curve than its Ephemeral ECC Params Enum;
 - all four curves and all six cipher settings, checking derived field lengths;
+- a decrypt vector that pins the three-byte IV to the AES-GCM nonce, distinguishing the
+  24-bit-nonce reading from a twelve-byte nonce zero-padded on either side, and failing
+  the two padded readings explicitly rather than only passing the correct one
+  (NanoTDF-PAY §3);
+- a decrypt vector at cipher `0x00` and one at cipher `0x05`, confirming that the MAC is
+  the leftmost bytes of the full 128-bit tag at both lengths;
+- rejection of an object at cipher `0x05` whose 16-byte MAC has the correct leading
+  eight bytes and incorrect trailing eight, which a verifier comparing only a prefix
+  would wrongly accept, and rejection of an object whose payload Length implies a MAC
+  shorter than the declared cipher requires (NanoTDF-SEC §3.5);
 - signature present, signature absent, and signature stripped from a signed object;
 - all four policy types, including Policy Key Access;
 - a policy body modified by one byte, which must fail binding verification;
@@ -192,6 +212,9 @@ editorial or clarifying; none alters the bytes an implementation produces.
 | 9 | §3.4.2 | Subsection numbering skips §3.4.2.2 | Renumbered contiguously in NanoTDF-POL. |
 | 10 | §3.4.1.1.1 | Describes the Shared Resource Directory protocol `0xff` as experimental but defines no resolution procedure or failure behaviour | Non-normative for version 1; rejected unless the deployment opts in out of band (NanoTDF-LOC §2.1). |
 | 11 | §6.1.6 | The parsing breakdown omits the three-byte payload Length field and nests Payload and Signature beneath the Header heading | Corrected in NanoTDF-EX: Length is shown, and the three sections are siblings. |
+| 12 | Whole document | Does not state how the three-byte payload IV is presented to AES-GCM; a 24-bit nonce and two twelve-byte zero-padded nonces all fit the text and give different ciphertext | The three bytes are the whole nonce and `J0` comes from GHASH, per SP 800-38D §7.1 Algorithm 4 step 2. Both worked examples decrypt only under this reading (NanoTDF-PAY §3, NanoTDF-SEC §2.1). |
+| 13 | Whole document | Registers a 64-bit tag with no guidance coupling tag length to payload length, though the forgery bound and SP 800-38D Appendix C depend on both together | Tabulated in NanoTDF-SEC §3, with the Appendix C Table 2 constraints on 64-bit tags and producer guidance in NanoTDF-SEC §3.5. |
+| 14 | Whole document | States no limit on the plaintext volume one derived key may protect, and no numeric ceiling for the format | At most 2^40 bytes per derived key, which one object cannot approach (NanoTDF-SEC §4); the frame ceiling is quantified in §1 above. |
 
 One figure that looks wrong is correct and has been preserved. The Payload range of
 14–16,777,218 bytes reconciles: the three-byte Length field caps the IV, ciphertext, and
@@ -205,8 +228,12 @@ co-occur (NanoTDF-PAY §2).
 - [RFC 5869: HKDF](https://www.rfc-editor.org/rfc/rfc5869)
 - [RFC 6090: Fundamental Elliptic Curve Cryptography Algorithms](https://www.rfc-editor.org/rfc/rfc6090)
 - [RFC 6637: ECC in OpenPGP](https://www.rfc-editor.org/rfc/rfc6637)
+- [RFC 8446: TLS 1.3](https://www.rfc-editor.org/rfc/rfc8446)
 - [SEC 1: Elliptic Curve Cryptography](https://www.secg.org/sec1-v2.pdf)
 - [FIPS 180-4: Secure Hash Standard](https://csrc.nist.gov/pubs/fips/180-4/upd1/final)
 - [FIPS 186-5: Digital Signature Standard](https://csrc.nist.gov/pubs/fips/186-5/final)
 - [FIPS 197: AES](https://csrc.nist.gov/pubs/fips/197/final)
 - [NIST SP 800-38D: GCM and GMAC](https://csrc.nist.gov/pubs/sp/800/38/d/final)
+- [Luykx and Paterson 2017: Limits on Authenticated Encryption Use in TLS](https://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf)
+- [Iwata, Ohashi, and Minematsu 2012: Breaking and Repairing GCM Security Proofs](https://eprint.iacr.org/2012/438)
+- [Amazon S3 object size limits](https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html)

--- a/spec/nanotdf/v1alpha/nanotdf-ex.md
+++ b/spec/nanotdf/v1alpha/nanotdf-ex.md
@@ -1,0 +1,457 @@
+# NanoTDF-EX: Worked Examples
+
+| | |
+|---|---|
+| Document | NanoTDF-EX |
+| Version | 1 Alpha |
+| Source spec | nanotdf v1 |
+| Format version | 12 (`L1L`) |
+| Status | Informational |
+| Depends on | NanoTDF-CORE, NanoTDF-PKG, NanoTDF-POL, NanoTDF-BND, NanoTDF-PAY |
+
+Two complete objects. Unlike the placeholder values used in some suites, these are real
+interoperability vectors: each base64 blob decodes to the exact bytes shown, every field
+offset below lands on a real boundary, and the section lengths sum to the stated total.
+Private keys are included so that an implementation can reproduce the derivations.
+
+| Example | Header | Payload | Signature | Total | Overhead |
+|---|---:|---:|---:|---:|---:|
+| §1 signed, remote policy, 64-bit tag | 142 | 19 | 97 | 258 | 253 |
+| §2 unsigned, remote policy, 128-bit tag | 151 | 46 | — | 197 | 173 |
+
+Example 2 is the basis of the format's sub-200-byte overhead claim.
+
+## 1. Basic example
+
+### 1.1 Parameters
+
+- KAS URL: `https://kas.virtru.com`
+- Policy URL: `https://kas.virtru.com/policy`, a remote policy
+- ECC and Binding Mode: `USE_ECDSA_BINDING` is true, curve `0x00` (`secp256r1`)
+- Symmetric and Payload Config: `HAS_SIGNATURE` is true, cipher `0x00`
+  (AES-256-GCM, 64-bit tag)
+- Plaintext payload: `DON'T`
+
+The plaintext is an easter egg: it was the message in the first TDF email sent with the
+browser extension on Gmail.
+
+### 1.2 Creator private key
+
+DER encoded, base64. Included so the signature can be verified.
+
+```text
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgcal1YrV0QohnYoBBlcBLrRETfJlqFOkG
+LSmUOKizW0KhRANCAATVz7l/VSTFkD9ic2IFkzaqcaTC7hbQW3g0A5firgcdLv4sj0OJHZ5zf8U0oUiy
+IrwNU28ahFSfjCTYvzw/bvPg
+```
+
+### 1.3 Recipient private key
+
+DER encoded, base64. Included so the payload key can be derived.
+
+```text
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgRywXmrI1J07LZni8xaoKhXj8WbdDHdjd
+N62+tgxjdhihRANCAARon4RjqRNA40eEdBT172emATq3I2siKccLcXl07nTrbAu4enVDo9T4LfQ4eZ0y
+x/KkIX2HylxzkAEoBxzVpBLN
+```
+
+### 1.4 Recipient compressed public key
+
+```text
+A2ifhGOpE0DjR4R0FPXvZ6YBOrcjayIpxwtxeXTudOts
+```
+
+### 1.5 Complete object
+
+Base64:
+
+```text
+TDFMAQ5rYXMudmlydHJ1LmNvbYCAAAEVa2FzLnZpcnRydS5jb20vcG9saWN5teQTpgIR5fF7IjSgzT82
+/3u6bY/o3yP2LJ0JNW+FgvipzxUSbIqdpGxeTgy8yCaXGawFG4BiXMdUAwNv+4KHHwL3f7rlJgnaxejr
+94bhG3rt1w+JgPlIDH5nHLqrjiRQkgAAEJ69CRdSJo4D+f2AFK98ywYC1c+5f1UkxZA/YnNiBZM2qnGk
+wu4W0Ft4NAOX4q4HHS6dm4rjMO9wI+pWmbUgS7x9Vo3/+j/6U1fh/NKQ8xrR72LORvDZXfQxa8rzco1P
+dc0VlQEL8gQgdKyU3il2ugLz
+```
+
+Hex, 258 bytes:
+
+```text
+4c 31 4c 01 0e 6b 61 73 2e 76 69 72 74 72 75 2e 63 6f 6d 80
+80 00 01 15 6b 61 73 2e 76 69 72 74 72 75 2e 63 6f 6d 2f 70
+6f 6c 69 63 79 b5 e4 13 a6 02 11 e5 f1 7b 22 34 a0 cd 3f 36
+ff 7b ba 6d 8f e8 df 23 f6 2c 9d 09 35 6f 85 82 f8 a9 cf 15
+12 6c 8a 9d a4 6c 5e 4e 0c bc c8 26 97 19 ac 05 1b 80 62 5c
+c7 54 03 03 6f fb 82 87 1f 02 f7 7f ba e5 26 09 da c5 e8 eb
+f7 86 e1 1b 7a ed d7 0f 89 80 f9 48 0c 7e 67 1c ba ab 8e 24
+50 92 00 00 10 9e bd 09 17 52 26 8e 03 f9 fd 80 14 af 7c cb
+06 02 d5 cf b9 7f 55 24 c5 90 3f 62 73 62 05 93 36 aa 71 a4
+c2 ee 16 d0 5b 78 34 03 97 e2 ae 07 1d 2e 9d 9b 8a e3 30 ef
+70 23 ea 56 99 b5 20 4b bc 7d 56 8d ff fa 3f fa 53 57 e1 fc
+d2 90 f3 1a d1 ef 62 ce 46 f0 d9 5d f4 31 6b ca f3 72 8d 4f
+75 cd 15 95 01 0b f2 04 20 74 ac 94 de 29 76 ba 02 f3
+```
+
+### 1.6 Layout
+
+| Offset | Section | Field | Bytes |
+|---:|---|---|---:|
+| `0x000` | Header | Magic Number and Version | 3 |
+| `0x003` | Header | KAS Resource Locator | 16 |
+| `0x013` | Header | ECC and Binding Mode | 1 |
+| `0x014` | Header | Symmetric and Payload Config | 1 |
+| `0x015` | Header | Policy Type Enum | 1 |
+| `0x016` | Header | Policy Body | 23 |
+| `0x02d` | Header | Policy Binding | 64 |
+| `0x06d` | Header | Ephemeral Public Key | 33 |
+| `0x08e` | Payload | Length | 3 |
+| `0x091` | Payload | IV | 3 |
+| `0x094` | Payload | Ciphertext | 5 |
+| `0x099` | Payload | MAC | 8 |
+| `0x0a1` | Signature | Creator Public Key | 33 |
+| `0x0c2` | Signature | Signature (`r \|\| s`) | 64 |
+
+Header 142, Payload 19, Signature 97, total 258.
+
+### 1.7 Fields
+
+#### 1.7.1 Magic Number and Version
+
+```text
+4c 31 4c
+```
+
+ASCII `L1L`, format version 12.
+
+#### 1.7.2 KAS Resource Locator
+
+```text
+01 0e 6b 61 73 2e 76 69 72 74 72 75 2e 63 6f 6d
+```
+
+Protocol `0x01` is `https`; body length `0x0e` is 14; the body is `kas.virtru.com`.
+
+#### 1.7.3 ECC and Binding Mode
+
+```text
+80
+```
+
+`1000 0000`: `USE_ECDSA_BINDING` is 1, the reserved bits are zero, and the Ephemeral ECC
+Params Enum is `000` for `secp256r1`. The ephemeral key is therefore 33 bytes and the
+ECDSA policy binding 64 bytes.
+
+#### 1.7.4 Symmetric and Payload Config
+
+```text
+80
+```
+
+`1000 0000`: `HAS_SIGNATURE` is 1, the Signature ECC Mode is `000` for `secp256r1`, and
+the Symmetric Cipher Enum is `0000` for AES-256-GCM with a 64-bit tag. The MAC is
+therefore 8 bytes and the Signature section 97 bytes.
+
+#### 1.7.5 Policy
+
+Type enum:
+
+```text
+00
+```
+
+Type `0x00` is a remote policy, so the body is a Resource Locator.
+
+Body:
+
+```text
+01 15 6b 61 73 2e 76 69 72 74 72 75 2e 63 6f 6d 2f 70 6f 6c
+69 63 79
+```
+
+Protocol `0x01` is `https`; body length `0x15` is 21; the body is
+`kas.virtru.com/policy`.
+
+Binding:
+
+```text
+b5 e4 13 a6 02 11 e5 f1 7b 22 34 a0 cd 3f 36 ff 7b ba 6d 8f
+e8 df 23 f6 2c 9d 09 35 6f 85 82 f8 a9 cf 15 12 6c 8a 9d a4
+6c 5e 4e 0c bc c8 26 97 19 ac 05 1b 80 62 5c c7 54 03 03 6f
+fb 82 87 1f
+```
+
+An ECDSA signature over `SHA256` of the 23 policy body bytes, sized by the ephemeral
+curve.
+
+#### 1.7.6 Ephemeral Public Key
+
+```text
+02 f7 7f ba e5 26 09 da c5 e8 eb f7 86 e1 1b 7a ed d7 0f 89
+80 f9 48 0c 7e 67 1c ba ab 8e 24 50 92
+```
+
+A compressed point on `secp256r1`; the leading `02` is the y-parity byte.
+
+#### 1.7.7 Payload
+
+Length:
+
+```text
+00 00 10
+```
+
+16 bytes follow: a 3-byte IV, 5 bytes of ciphertext, and an 8-byte MAC.
+
+IV:
+
+```text
+9e bd 09
+```
+
+Not `0x000000`, as required.
+
+Ciphertext:
+
+```text
+17 52 26 8e 03
+```
+
+Five bytes, matching the five-character plaintext.
+
+MAC:
+
+```text
+f9 fd 80 14 af 7c cb 06
+```
+
+#### 1.7.8 Signature
+
+Creator public key, a compressed point belonging to the producer's persistent key:
+
+```text
+02 d5 cf b9 7f 55 24 c5 90 3f 62 73 62 05 93 36 aa 71 a4 c2
+ee 16 d0 5b 78 34 03 97 e2 ae 07 1d 2e
+```
+
+Signature, `r || s`:
+
+```text
+9d 9b 8a e3 30 ef 70 23 ea 56 99 b5 20 4b bc 7d 56 8d ff fa
+3f fa 53 57 e1 fc d2 90 f3 1a d1 ef 62 ce 46 f0 d9 5d f4 31
+6b ca f3 72 8d 4f 75 cd 15 95 01 0b f2 04 20 74 ac 94 de 29
+76 ba 02 f3
+```
+
+## 2. No-signature example
+
+### 2.1 Parameters
+
+- KAS URL: `https://kas.example.com`
+- Policy URL: `https://kas.example.com/policy/abcdef`, a remote policy
+- ECC and Binding Mode: `USE_ECDSA_BINDING` is true, curve `0x00` (`secp256r1`)
+- Symmetric and Payload Config: `HAS_SIGNATURE` is false, cipher `0x05`
+  (AES-256-GCM, 128-bit tag)
+- Plaintext payload: `Keep this message secret`
+
+### 2.2 Creator private key
+
+None. This object carries no signature, so there is no creator key.
+
+### 2.3 Recipient private key
+
+DER encoded, base64.
+
+```text
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgWmLjd6gDd2rwU48m2vVsDfVJ6fKCYt4y
+ZA8kSu9O3hehRANCAAQwmFsrcVyKJpSQBMVVrIZ0v0XIin+BSdS/ENvcyIc2YKKIK43zkpPR13ibjsy1
+UhZJItQFlBChYCFDPUkANqcs
+```
+
+### 2.4 Recipient compressed public key
+
+```text
+AjCYWytxXIomlJAExVWshnS/RciKf4FJ1L8Q29zIhzZg
+```
+
+### 2.5 Complete object
+
+Base64:
+
+```text
+TDFMAQ9rYXMuZXhhbXBsZS5jb22ANQABHWthcy5leGFtcGxlLmNvbS9wb2xpY3kvYWJjZGVmYaoGjXbC
+DfOlY3YzmGKfUjBy0IbUTUvmbiV04TvDLMcCKkzceqfvy6YDwZg/h3LvHRDoLg1ABvS93ZJ4eTVmcwPo
+sz9EmnOSdxPUpKK05elFLi8FNDOdNZEb36Fe4Ys62wAAK1DknPqraRhSJhstY2CDGsvV8gP77xf5Rr7+
+x57lEZugkjM7LA7qy54vjcg=
+```
+
+Hex, 197 bytes:
+
+```text
+4c 31 4c 01 0f 6b 61 73 2e 65 78 61 6d 70 6c 65 2e 63 6f 6d
+80 35 00 01 1d 6b 61 73 2e 65 78 61 6d 70 6c 65 2e 63 6f 6d
+2f 70 6f 6c 69 63 79 2f 61 62 63 64 65 66 61 aa 06 8d 76 c2
+0d f3 a5 63 76 33 98 62 9f 52 30 72 d0 86 d4 4d 4b e6 6e 25
+74 e1 3b c3 2c c7 02 2a 4c dc 7a a7 ef cb a6 03 c1 98 3f 87
+72 ef 1d 10 e8 2e 0d 40 06 f4 bd dd 92 78 79 35 66 73 03 e8
+b3 3f 44 9a 73 92 77 13 d4 a4 a2 b4 e5 e9 45 2e 2f 05 34 33
+9d 35 91 1b df a1 5e e1 8b 3a db 00 00 2b 50 e4 9c fa ab 69
+18 52 26 1b 2d 63 60 83 1a cb d5 f2 03 fb ef 17 f9 46 be fe
+c7 9e e5 11 9b a0 92 33 3b 2c 0e ea cb 9e 2f 8d c8
+```
+
+### 2.6 Layout
+
+| Offset | Section | Field | Bytes |
+|---:|---|---|---:|
+| `0x000` | Header | Magic Number and Version | 3 |
+| `0x003` | Header | KAS Resource Locator | 17 |
+| `0x014` | Header | ECC and Binding Mode | 1 |
+| `0x015` | Header | Symmetric and Payload Config | 1 |
+| `0x016` | Header | Policy Type Enum | 1 |
+| `0x017` | Header | Policy Body | 31 |
+| `0x036` | Header | Policy Binding | 64 |
+| `0x076` | Header | Ephemeral Public Key | 33 |
+| `0x097` | Payload | Length | 3 |
+| `0x09a` | Payload | IV | 3 |
+| `0x09d` | Payload | Ciphertext | 24 |
+| `0x0b5` | Payload | MAC | 16 |
+
+Header 151, Payload 46, no Signature, total 197.
+
+### 2.7 Fields
+
+#### 2.7.1 Magic Number and Version
+
+```text
+4c 31 4c
+```
+
+#### 2.7.2 KAS Resource Locator
+
+```text
+01 0f 6b 61 73 2e 65 78 61 6d 70 6c 65 2e 63 6f 6d
+```
+
+Protocol `0x01` is `https`; body length `0x0f` is 15; the body is `kas.example.com`.
+
+#### 2.7.3 ECC and Binding Mode
+
+```text
+80
+```
+
+As in §1.7.3: ECDSA binding on `secp256r1`.
+
+#### 2.7.4 Symmetric and Payload Config
+
+```text
+35
+```
+
+`0011 0101`: `HAS_SIGNATURE` is 0, so no Signature section follows and the object ends
+with the payload. The Signature ECC Mode is `011`, which would name `secp256k1` but is
+unused and MUST NOT cause rejection. The Symmetric Cipher Enum is `0101`, cipher `0x05`,
+AES-256-GCM with a 128-bit tag, so the MAC is 16 bytes.
+
+#### 2.7.5 Policy
+
+Type enum:
+
+```text
+00
+```
+
+Remote policy.
+
+Body:
+
+```text
+01 1d 6b 61 73 2e 65 78 61 6d 70 6c 65 2e 63 6f 6d 2f 70 6f
+6c 69 63 79 2f 61 62 63 64 65 66
+```
+
+Protocol `0x01` is `https`; body length `0x1d` is 29; the body is
+`kas.example.com/policy/abcdef`.
+
+Binding:
+
+```text
+61 aa 06 8d 76 c2 0d f3 a5 63 76 33 98 62 9f 52 30 72 d0 86
+d4 4d 4b e6 6e 25 74 e1 3b c3 2c c7 02 2a 4c dc 7a a7 ef cb
+a6 03 c1 98 3f 87 72 ef 1d 10 e8 2e 0d 40 06 f4 bd dd 92 78
+79 35 66 73
+```
+
+#### 2.7.6 Ephemeral Public Key
+
+```text
+03 e8 b3 3f 44 9a 73 92 77 13 d4 a4 a2 b4 e5 e9 45 2e 2f 05
+34 33 9d 35 91 1b df a1 5e e1 8b 3a db
+```
+
+Leading `03`, the opposite y-parity to §1.7.6.
+
+#### 2.7.7 Payload
+
+Length:
+
+```text
+00 00 2b
+```
+
+43 bytes follow: a 3-byte IV, 24 bytes of ciphertext, and a 16-byte MAC.
+
+IV:
+
+```text
+50 e4 9c
+```
+
+Ciphertext:
+
+```text
+fa ab 69 18 52 26 1b 2d 63 60 83 1a cb d5 f2 03 fb ef 17 f9
+46 be fe c7
+```
+
+Twenty-four bytes, matching the 24-character plaintext.
+
+MAC:
+
+```text
+9e e5 11 9b a0 92 33 3b 2c 0e ea cb 9e 2f 8d c8
+```
+
+#### 2.7.8 Signature
+
+Absent. `HAS_SIGNATURE` is 0 and no bytes follow the payload.
+
+## 3. Derived values
+
+Both examples use format version 12, so both share the HKDF salt from NanoTDF-ALG §3:
+
+```text
+salt = SHA256(4c 31 4c)
+     = 3de3ca1e50cf62d8b6aba603a96fca6761387a7ac86c3d3afe85ae2d1812edfc
+```
+
+The payload key in each case is:
+
+```text
+shared_secret = ECDH(ephemeral_public, recipient_private)
+payload_key   = HKDF(shared_secret, salt = salt, info = "", len = 32)
+```
+
+The policy binding in each case is:
+
+```text
+binding = ECDSA(ephemeral_private, SHA256(policy_body_bytes))
+```
+
+where `policy_body_bytes` is the 23 bytes at `0x016` in §1 and the 31 bytes at `0x017` in
+§2 — the type enum and the binding itself are excluded (NanoTDF-BND §2.1).
+
+## 4. References
+
+- [RFC 4648: Base16 and Base64 Encodings](https://www.rfc-editor.org/rfc/rfc4648)
+- [RFC 5869: HKDF](https://www.rfc-editor.org/rfc/rfc5869)
+- [RFC 5915: Elliptic Curve Private Key Structure](https://www.rfc-editor.org/rfc/rfc5915)

--- a/spec/nanotdf/v1alpha/nanotdf-kao.md
+++ b/spec/nanotdf/v1alpha/nanotdf-kao.md
@@ -60,7 +60,7 @@ NanoTDF-BND §2).
   random source, MUST NOT reuse it across objects, and MUST discard the private key once
   the object is written.
 - A party performing ECDH MUST validate the received public key as a point on the
-  declared curve before use (NanoTDF-SEC §4).
+  declared curve before use (NanoTDF-SEC §5).
 - Both parties MUST use the curve named in the header. The curve is not negotiated, and
   a receiver MUST NOT substitute another.
 

--- a/spec/nanotdf/v1alpha/nanotdf-kao.md
+++ b/spec/nanotdf/v1alpha/nanotdf-kao.md
@@ -1,0 +1,123 @@
+# NanoTDF-KAO: Key Access and Derivation
+
+| | |
+|---|---|
+| Document | NanoTDF-KAO |
+| Version | 1 Alpha |
+| Source spec | nanotdf v1 |
+| Format version | 12 (`L1L`) |
+| Status | Draft |
+| Depends on | NanoTDF-SEC, NanoTDF-ALG, NanoTDF-PKG |
+| Referenced by | NanoTDF-POL, NanoTDF-BND, NanoTDF-PAY, NanoTDF-KAS, NanoTDF-CORE |
+
+## 1. Scope
+
+This document defines how a NanoTDF object's symmetric key comes into existence. Unlike
+formats that wrap a randomly generated content key, NanoTDF carries no wrapped key at
+all: the key is *derived* on both sides from an ECDH exchange between the producer's
+ephemeral key pair and the KAS key pair. The saving is the whole wrapped-key structure,
+which is why the format's fixed overhead can stay under 200 bytes.
+
+The consequence is that the header carries one public key and nothing else. There is no
+key identifier, no algorithm negotiation, and no support for more than one key access
+per object.
+
+## 2. Ephemeral key agreement
+
+At creation, the producer generates a fresh ephemeral key pair on the curve selected by
+the Ephemeral ECC Params Enum (NanoTDF-PKG §3.3), and holds the KAS public key obtained
+out of band.
+
+```text
+producer:  shared_secret = ECDH(ephemeral_private, kas_public)
+KAS:       shared_secret = ECDH(kas_private, ephemeral_public)
+```
+
+Both parties reach the same shared secret. The producer writes only `ephemeral_public`,
+as a compressed point, into the header, and discards `ephemeral_private`.
+
+The symmetric key follows from the shared secret through HKDF, with the parameters fixed
+in NanoTDF-ALG §3:
+
+```text
+symmetric_key = HKDF(
+    ikm  = shared_secret,
+    salt = SHA256(MAGIC_NUMBER || VERSION),
+    info = "",
+    len  = key length of the selected cipher)
+```
+
+For every currently registered cipher the output is 32 bytes, because all of them are
+AES-256-GCM.
+
+The derived key protects the payload (NanoTDF-PAY §3), and — unless Policy Key Access is
+in use — an encrypted policy and a GMAC policy binding as well (NanoTDF-POL §4,
+NanoTDF-BND §2).
+
+### 2.1 Requirements
+
+- The producer MUST generate the ephemeral key pair from a cryptographically secure
+  random source, MUST NOT reuse it across objects, and MUST discard the private key once
+  the object is written.
+- A party performing ECDH MUST validate the received public key as a point on the
+  declared curve before use (NanoTDF-SEC §4).
+- Both parties MUST use the curve named in the header. The curve is not negotiated, and
+  a receiver MUST NOT substitute another.
+
+## 3. Offline creation
+
+Creating an object requires only the KAS public key, so production needs no network
+access. The producer cannot discover at creation time that the KAS key has rotated, and
+an object produced against a retired key cannot be opened. Deployments SHOULD publish key
+rotation schedules and SHOULD retain superseded KAS private keys for as long as objects
+produced against them must remain readable.
+
+## 4. Policy Key Access
+
+By default the policy and the payload are protected by the same derived key. Policy Key
+Access is an optional structure, carried inside an embedded policy body, that lets the
+policy be encrypted to a *different* key than the payload.
+
+| Field | Minimum (B) | Maximum (B) |
+|---|---:|---:|
+| Resource Locator | 3 | 257 |
+| Ephemeral Public Key | 33 | 67 |
+| **Total** | **36** | **324** |
+
+The Resource Locator names the remote public key to be combined with the accompanying
+ephemeral public key. The ephemeral public key is a compressed point whose length follows
+the same Ephemeral ECC Params Enum as the header key (NanoTDF-PKG §3.3); it is a
+*second, independent* ephemeral key pair, not a copy of the header's.
+
+The policy key is derived exactly as in §2, substituting this ephemeral key and the key
+named by the locator.
+
+Policy Key Access is present only when the policy type is `0x03` (NanoTDF-POL §2). It is
+worth its size mainly when the payload is encrypted to a KAS hardware security module: it
+lets a policy be evaluated by a party that cannot decrypt the payload.
+
+### 4.1 Requirements
+
+- The policy key derived here MUST NOT be used to encrypt the payload, and MUST NOT be
+  reused for another object's policy. The encrypted-policy IV is the fixed value
+  `0x000000`, so reuse of the key repeats an IV under one key (NanoTDF-SEC §2).
+- A client MUST resolve the Resource Locator through trusted local configuration and MUST
+  NOT dereference it during validation (NanoTDF-LOC §3).
+- When Policy Key Access is present and the policy binding is a GMAC tag, the binding is
+  computed under the *payload* key, not the policy key (NanoTDF-BND §2). The binding
+  exists to tie the policy to the payload; computing it under the policy key would break
+  that tie.
+
+## 5. Limits
+
+NanoTDF version 1 supports exactly one key access. There is no key splitting, no
+multi-KAS access, no key identifier, and no algorithm agility beyond the curve and cipher
+enumerations. An object that must be released by more than one authority is outside this
+format's scope.
+
+## 6. References
+
+- [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [RFC 5869: HKDF](https://www.rfc-editor.org/rfc/rfc5869)
+- [RFC 6090: Fundamental Elliptic Curve Cryptography Algorithms](https://www.rfc-editor.org/rfc/rfc6090)
+- [NIST SP 800-56A: Key Establishment Using Discrete Logarithm Cryptography](https://csrc.nist.gov/pubs/sp/800/56/a/r3/final)

--- a/spec/nanotdf/v1alpha/nanotdf-kas.md
+++ b/spec/nanotdf/v1alpha/nanotdf-kas.md
@@ -1,0 +1,106 @@
+# NanoTDF-KAS: Key Access Service Protocol
+
+| | |
+|---|---|
+| Document | NanoTDF-KAS |
+| Version | 1 Alpha |
+| Source spec | nanotdf v1 |
+| Format version | 12 (`L1L`) |
+| Status | Draft |
+| Depends on | NanoTDF-SEC, NanoTDF-LOC, NanoTDF-KAO, NanoTDF-POL, NanoTDF-BND |
+| Referenced by | NanoTDF-CORE |
+
+## 1. The KAS reference
+
+The header names one Key Access Service through a Resource Locator (NanoTDF-LOC §1),
+placed immediately after the magic-and-version bytes. Exactly one KAS governs an object;
+there is no list, no alternative, and no quorum.
+
+The locator is a name, not a trust anchor. A client MUST resolve it through trusted local
+configuration and MUST NOT dispatch on the literal value or dereference it during parsing
+(NanoTDF-SEC §6).
+
+The KAS public key used to produce the object is not carried in the header and is not
+identified by any key identifier. Producer and KAS must therefore agree on which key is
+current out of band, and a deployment MUST retain superseded private keys for as long as
+objects produced against them need to remain readable (NanoTDF-KAO §3).
+
+## 2. The exchange
+
+The header is the unit sent to the KAS. It is self-delimiting and contains everything the
+KAS needs: the ephemeral public key, the policy, the binding, and the configuration bytes
+that size them.
+
+The payload never leaves the client. This is the property that makes the exchange
+practical for constrained links — the request is bounded by the header size, at most
+about a kilobyte, regardless of how large the protected content is.
+
+A conforming KAS performs, in order:
+
+1. Parse the header and enforce parser limits (NanoTDF-SEC §1).
+2. Recompute the shared secret by ECDH between its own private key and the ephemeral
+   public key from the header, validating that key as a point on the declared curve.
+3. Derive the symmetric key through HKDF (NanoTDF-KAO §2).
+4. Verify the policy binding (NanoTDF-BND §2).
+5. Resolve the policy: read the embedded body, decrypting it if required, or retrieve the
+   remote policy named by the locator.
+6. Authenticate the requester and evaluate the policy against the requester's attributes.
+7. On success, return the derived key to the requester over a confidential channel.
+
+Steps 2 through 4 come before step 6. A KAS MUST NOT evaluate or act on a policy whose
+binding it has not verified, because an unverified policy is attacker-controlled.
+
+## 3. Returning the key
+
+The derived key is the payload key. Returning it in the clear would expose the payload to
+anyone observing the response, so the response MUST be protected.
+
+- The exchange MUST occur over a channel providing confidentiality, integrity, and server
+  authentication. Where the KAS locator names `http`, that channel MUST be supplied by
+  the deployment; a plain `http` exchange is not conforming (NanoTDF-LOC §2).
+- A KAS SHOULD additionally rewrap the key to a requester-supplied session public key, so
+  that the released key is protected end to end rather than only in transit. NanoTDF does
+  not define the rewrap encoding; the transport protocol does.
+- The requester MUST authenticate to the KAS. NanoTDF defines no authentication mechanism
+  and carries no requester identity; this is supplied by the transport.
+
+## 4. Policy resolution
+
+For an embedded policy the KAS has the bytes in hand. For type `0x02` or `0x03` it
+decrypts them first, using the payload key or, where Policy Key Access is present, the key
+derived from the Policy Key Access structure (NanoTDF-KAO §4).
+
+For a remote policy the KAS retrieves the content named by the locator. Because the
+binding covers only the locator bytes, the retrieved content is not authenticated by the
+object (NanoTDF-LOC §4). A KAS SHOULD resolve remote policy only through infrastructure
+it controls or explicitly trusts, and MUST apply the fetch constraints in NanoTDF-LOC §3.
+
+Failure to retrieve a remote policy MUST result in denial. A KAS MUST NOT release a key
+under a default or fallback policy when the named policy is unavailable.
+
+## 5. Failure handling
+
+Header parse failure, curve validation failure, binding verification failure, policy
+resolution failure, and authorization denial MUST be reported to the requester as one
+indistinguishable error class. Distinguishing them turns the KAS into an oracle for
+policy structure, key validity, and object well-formedness (NanoTDF-SEC §8).
+
+A KAS MUST NOT return the derived key, the shared secret, or decrypted policy content on
+any failure path, and MUST NOT log them.
+
+## 6. Auditing
+
+The rewrap request is the first and only point at which the KAS learns an object exists;
+creation is offline (NanoTDF-KAO §3). A deployment that requires an audit trail therefore
+records access, not creation, and MUST NOT assume that the absence of a record means an
+object was never produced.
+
+An audit record SHOULD identify the requester, the resolved policy, and the decision. It
+MUST NOT contain the derived key.
+
+## 7. References
+
+- [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [RFC 5869: HKDF](https://www.rfc-editor.org/rfc/rfc5869)
+- [RFC 8446: TLS 1.3](https://www.rfc-editor.org/rfc/rfc8446)
+- [NIST SP 800-56A: Key Establishment Using Discrete Logarithm Cryptography](https://csrc.nist.gov/pubs/sp/800/56/a/r3/final)

--- a/spec/nanotdf/v1alpha/nanotdf-kas.md
+++ b/spec/nanotdf/v1alpha/nanotdf-kas.md
@@ -18,7 +18,7 @@ there is no list, no alternative, and no quorum.
 
 The locator is a name, not a trust anchor. A client MUST resolve it through trusted local
 configuration and MUST NOT dispatch on the literal value or dereference it during parsing
-(NanoTDF-SEC §6).
+(NanoTDF-SEC §7).
 
 The KAS public key used to produce the object is not carried in the header and is not
 identified by any key identifier. Producer and KAS must therefore agree on which key is
@@ -83,10 +83,24 @@ under a default or fallback policy when the named policy is unavailable.
 Header parse failure, curve validation failure, binding verification failure, policy
 resolution failure, and authorization denial MUST be reported to the requester as one
 indistinguishable error class. Distinguishing them turns the KAS into an oracle for
-policy structure, key validity, and object well-formedness (NanoTDF-SEC §8).
+policy structure, key validity, and object well-formedness (NanoTDF-SEC §9).
 
 A KAS MUST NOT return the derived key, the shared secret, or decrypted policy content on
 any failure path, and MUST NOT log them.
+
+Indistinguishable errors limit what a failed request reveals; they do not limit how many
+failed requests a party may make. A KAS verifying a 64-bit GMAC policy binding is an
+online forgery oracle for that binding, bounded only by its own throughput
+(NanoTDF-SEC §3.6). A KAS therefore SHOULD count failed policy-binding verifications per
+ephemeral public key, rate-limit them, and stop verifying for that key once the count
+reaches the limit its deployment enforces under SP 800-38D Appendix C
+(NanoTDF-SEC §3.3). NanoTDF has no rekey: the derived key is a function of the object, so
+refusing further verification is the only response available.
+
+A KAS SHOULD also record the ephemeral public keys it has seen. A repeat identifies an
+object produced from a reused ephemeral key pair, which is the precondition for both the
+nonce-reuse and the volume hazards in NanoTDF-SEC §2.2 and §4, and which NanoTDF-KAO §2.1
+forbids. Rewrap is the only point at which a deployment can observe it.
 
 ## 6. Auditing
 
@@ -103,4 +117,5 @@ MUST NOT contain the derived key.
 - [BCP 14](https://www.rfc-editor.org/info/bcp14)
 - [RFC 5869: HKDF](https://www.rfc-editor.org/rfc/rfc5869)
 - [RFC 8446: TLS 1.3](https://www.rfc-editor.org/rfc/rfc8446)
+- [NIST SP 800-38D: GCM and GMAC](https://csrc.nist.gov/pubs/sp/800/38/d/final)
 - [NIST SP 800-56A: Key Establishment Using Discrete Logarithm Cryptography](https://csrc.nist.gov/pubs/sp/800/56/a/r3/final)

--- a/spec/nanotdf/v1alpha/nanotdf-loc.md
+++ b/spec/nanotdf/v1alpha/nanotdf-loc.md
@@ -73,7 +73,7 @@ parsing or validation action.
 - A consumer MUST resolve a locator through trusted local configuration — an allow-list,
   a catalog, or a service registry — rather than by dispatching on the literal body.
 - A consumer MUST NOT infer trust from a locator. Ownership of a name gives uniqueness,
-  not authority; an object may name any locator (NanoTDF-SEC §6).
+  not authority; an object may name any locator (NanoTDF-SEC §7).
 - A consumer MUST bound redirects, response size, and elapsed time, and MUST apply the
   same parser limits to fetched content as to the object itself (NanoTDF-SEC §1).
 

--- a/spec/nanotdf/v1alpha/nanotdf-loc.md
+++ b/spec/nanotdf/v1alpha/nanotdf-loc.md
@@ -1,0 +1,98 @@
+# NanoTDF-LOC: Resource Locators and Fetch Policy
+
+| | |
+|---|---|
+| Document | NanoTDF-LOC |
+| Version | 1 Alpha |
+| Source spec | nanotdf v1 |
+| Format version | 12 (`L1L`) |
+| Status | Draft |
+| Depends on | NanoTDF-SEC |
+| Referenced by | NanoTDF-PKG, NanoTDF-POL, NanoTDF-KAS, NanoTDF-CORE |
+
+## 1. Structure
+
+The Resource Locator is NanoTDF's single mechanism for naming something that lives
+outside the object. It is deliberately smaller than a general URL: the scheme is an
+enumerated byte rather than text, and the length is a single byte.
+
+| Field | Minimum (B) | Maximum (B) |
+|---|---:|---:|
+| Protocol Enum | 1 | 1 |
+| Body Length | 1 | 1 |
+| Body | 1 | 255 |
+| **Total** | **3** | **257** |
+
+A Resource Locator appears in three places: the KAS reference in the header
+(NanoTDF-KAS §1), the body of a remote policy (NanoTDF-POL §3), and the key reference
+inside Policy Key Access (NanoTDF-KAO §4).
+
+A body length of zero is invalid. A parser MUST reject a locator whose declared body
+length exceeds the remaining input.
+
+## 2. Protocol enumeration
+
+| Value | Protocol |
+|---|---|
+| `0x00` | `http` |
+| `0x01` | `https` |
+| `0x02` | unreserved |
+| `0xff` | Shared Resource Directory |
+
+Any value not listed is unreserved. A client encountering an unreserved value MUST treat
+the object as erroneous rather than guessing a scheme.
+
+For `http` and `https`, the Body is everything following `://` in the equivalent URL.
+The scheme, and the `://` separator, are not stored. A locator for
+`https://kas.example.com/policy` therefore carries protocol `0x01`, body length `0x1d`,
+and the 29 bytes `kas.example.com/policy`.
+
+`http` is retained for compatibility with constrained deployments that terminate TLS
+elsewhere. It SHOULD NOT be used: it exposes the KAS request, and with it the fact that a
+particular party holds a particular object, to any observer.
+
+### 2.1 Shared Resource Directory
+
+Protocol `0xff` indicates that the body names an entry in a directory shared between
+producer and consumer, rather than a network location. The intent is to shrink objects
+further by replacing a repeated hostname with a short key.
+
+The Shared Resource Directory is experimental. Version 1 defines no directory format, no
+resolution procedure, and no failure behaviour, so an implementation cannot interoperate
+on it. A client MUST reject protocol `0xff` unless the deployment has explicitly opted
+in and supplied the resolution rules out of band.
+
+## 3. Fetch policy
+
+Resolving a locator is a consumer action governed by deployment policy. It is never a
+parsing or validation action.
+
+- A parser MUST NOT dereference any locator while decoding or validating an object.
+  Doing so turns every malformed or hostile object into an outbound request, leaks the
+  fact and timing of validation, and makes validation depend on network reachability.
+- A consumer MUST resolve a locator through trusted local configuration — an allow-list,
+  a catalog, or a service registry — rather than by dispatching on the literal body.
+- A consumer MUST NOT infer trust from a locator. Ownership of a name gives uniqueness,
+  not authority; an object may name any locator (NanoTDF-SEC §6).
+- A consumer MUST bound redirects, response size, and elapsed time, and MUST apply the
+  same parser limits to fetched content as to the object itself (NanoTDF-SEC §1).
+
+## 4. Integrity of referenced content
+
+The object does not authenticate what a locator points at.
+
+For a remote policy, the policy binding covers the locator bytes, not the policy those
+bytes name (NanoTDF-BND §2). A party who can control what the locator resolves to can
+therefore change the effective policy without invalidating the binding. Remote policy
+SHOULD be used only where the resolver is as trusted as the KAS itself.
+
+Referenced content is mutable. Two consumers resolving the same object at different
+times may see different policy, and the object provides no way to detect it. Where that
+is unacceptable, use an embedded policy (NanoTDF-POL §4), whose bytes are covered by the
+binding directly.
+
+## 5. References
+
+- [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [RFC 3986: URI Generic Syntax](https://www.rfc-editor.org/rfc/rfc3986)
+- [RFC 9110: HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110)

--- a/spec/nanotdf/v1alpha/nanotdf-pay.md
+++ b/spec/nanotdf/v1alpha/nanotdf-pay.md
@@ -1,0 +1,104 @@
+# NanoTDF-PAY: Payload Carriage
+
+| | |
+|---|---|
+| Document | NanoTDF-PAY |
+| Version | 1 Alpha |
+| Source spec | nanotdf v1 |
+| Format version | 12 (`L1L`) |
+| Status | Draft |
+| Depends on | NanoTDF-SEC, NanoTDF-ALG, NanoTDF-PKG, NanoTDF-KAO |
+| Referenced by | NanoTDF-CORE, NanoTDF-EX |
+
+## 1. Scope
+
+This document defines the Payload section: how the ciphertext is framed, which IV and
+authentication tag accompany it, and when plaintext may be released. The key that
+protects it is derived in NanoTDF-KAO §2 and the cipher is selected in NanoTDF-ALG §2.
+
+## 2. Structure
+
+| Field | Minimum (B) | Maximum (B) |
+|---|---:|---:|
+| Length | 3 | 3 |
+| IV | 3 | 3 |
+| Ciphertext | 0 | 16,777,204 |
+| Payload MAC | 8 | 32 |
+| **Total** | **14** | **16,777,218** |
+
+Length is a three-byte unsigned integer giving the combined size of the IV, ciphertext,
+and MAC that follow. It does not include itself.
+
+Because Length caps those three fields together at 16,777,215 bytes, the ciphertext
+maximum above pairs with the 8-byte minimum MAC. With a 16-byte MAC the largest
+ciphertext is 16,777,196 bytes. In general:
+
+```text
+ciphertext length = Length - 3 - MAC length
+```
+
+The MAC length is not on the wire. It is implied by the Symmetric Cipher Enum
+(NanoTDF-ALG §2), so that byte MUST be parsed before the payload can be split into its
+parts.
+
+A zero-length ciphertext is legal. It yields a 14-byte payload section carrying an
+authenticated empty plaintext.
+
+## 3. IV
+
+The IV is three bytes, used as the AES-GCM nonce for the payload.
+
+- An IV MUST NOT repeat under one derived key. NanoTDF-SEC §2 explains why a three-byte
+  nonce space makes this a practical rather than theoretical constraint: a producer MUST
+  NOT encrypt many objects under one derived key.
+- The value `0x000000` is reserved for the encrypted policy (NanoTDF-POL §4) and MUST NOT
+  be used for a payload. A parser MUST reject a payload IV of `0x000000`.
+- An IV SHOULD be drawn from a cryptographically secure random source. A per-key counter
+  is acceptable where the producer can guarantee it cannot repeat or roll over.
+
+Because each object derives a fresh key from a fresh ephemeral key pair, the IV space is
+scoped to one object in normal use. Reusing an ephemeral key pair across objects collapses
+that scoping and reintroduces the reuse hazard.
+
+## 4. Ciphertext and MAC
+
+The ciphertext is the AES-256-GCM encryption of the plaintext under the derived key and
+the IV above. The Payload MAC is the GCM authentication tag, truncated to the length
+implied by the cipher selection.
+
+NanoTDF defines no associated data for the payload. The header is not authenticated by
+the payload tag; a modification to the KAS locator or the configuration bytes is detected
+only because it changes the derived key or the parse, and an object-wide integrity
+guarantee exists only when a creator signature is present (NanoTDF-BND §3).
+
+There is no segmentation, no per-segment integrity, and no Merkle layout. One payload is
+one AEAD operation.
+
+## 5. Release of plaintext
+
+The opener MUST verify the authentication tag over the complete ciphertext before
+releasing any plaintext. NanoTDF defines no incremental, prefix, or streaming release: a
+payload is authenticated whole or not at all.
+
+On authentication failure the opener MUST discard the plaintext, MUST NOT return partial
+output, and MUST report failure in the same error class as key derivation and
+authorization failure (NanoTDF-SEC §8).
+
+A verifier MUST NOT accept a tag shorter than the length implied by the declared cipher,
+and MUST NOT compare a prefix of a longer tag (NanoTDF-SEC §3).
+
+## 6. Size characteristics
+
+The payload adds a fixed 14 bytes to the plaintext at the smallest cipher setting: three
+for Length, three for the IV, and eight for the MAC. Selecting a 128-bit tag raises that
+to 22 bytes.
+
+The three-byte Length field caps a single NanoTDF payload at just under 16 MiB. A larger
+payload requires a different format; NanoTDF is designed for the case where the object
+must stay small, and BaseTDF covers large and streamed payloads.
+
+## 7. References
+
+- [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [FIPS 197: AES](https://csrc.nist.gov/pubs/fips/197/final)
+- [NIST SP 800-38D: GCM and GMAC](https://csrc.nist.gov/pubs/sp/800/38/d/final)

--- a/spec/nanotdf/v1alpha/nanotdf-pay.md
+++ b/spec/nanotdf/v1alpha/nanotdf-pay.md
@@ -48,13 +48,27 @@ authenticated empty plaintext.
 
 The IV is three bytes, used as the AES-GCM nonce for the payload.
 
+Those three bytes are the whole nonce. AES-GCM runs with a 24-bit IV, so the
+pre-counter block `J0` is derived by GHASH as SP 800-38D §7.1 Algorithm 4 step 2
+prescribes for any IV whose length is not 96 bits. The IV is not padded to twelve
+bytes on either side.
+
+The source specification does not state this, and the sentence above does not imply
+it: zero-padding the three bytes on the left or on the right also yields a usable
+nonce, and each of the three readings produces different ciphertext for the same key
+and plaintext. Both vectors in NanoTDF-EX decrypt to their stated plaintext and
+recorded tag under the 24-bit reading and under neither padded reading, which pins the
+mapping (NanoTDF-SEC §2.1, NanoTDF-CORE §6).
+
 - An IV MUST NOT repeat under one derived key. NanoTDF-SEC §2 explains why a three-byte
   nonce space makes this a practical rather than theoretical constraint: a producer MUST
   NOT encrypt many objects under one derived key.
 - The value `0x000000` is reserved for the encrypted policy (NanoTDF-POL §4) and MUST NOT
   be used for a payload. A parser MUST reject a payload IV of `0x000000`.
-- An IV SHOULD be drawn from a cryptographically secure random source. A per-key counter
-  is acceptable where the producer can guarantee it cannot repeat or roll over.
+- An IV SHOULD be drawn from a per-key counter that cannot repeat or roll over. This is
+  the deterministic construction SP 800-38D §8.2 requires below 96 bits, and it removes
+  the birthday term that a random 24-bit IV carries (NanoTDF-SEC §2.2). A
+  cryptographically secure random source is permitted where a counter cannot be kept.
 
 Because each object derives a fresh key from a fresh ephemeral key pair, the IV space is
 scoped to one object in normal use. Reusing an ephemeral key pair across objects collapses
@@ -64,7 +78,9 @@ that scoping and reintroduces the reuse hazard.
 
 The ciphertext is the AES-256-GCM encryption of the plaintext under the derived key and
 the IV above. The Payload MAC is the GCM authentication tag, truncated to the length
-implied by the cipher selection.
+implied by the cipher selection. Truncation keeps the leftmost bytes, as SP 800-38D §7.1
+Algorithm 4 step 6 specifies; the eight-byte MAC of the first vector in NanoTDF-EX is the
+leading eight bytes of the full 128-bit tag.
 
 NanoTDF defines no associated data for the payload. The header is not authenticated by
 the payload tag; a modification to the KAS locator or the configuration bytes is detected
@@ -82,10 +98,16 @@ payload is authenticated whole or not at all.
 
 On authentication failure the opener MUST discard the plaintext, MUST NOT return partial
 output, and MUST report failure in the same error class as key derivation and
-authorization failure (NanoTDF-SEC §8).
+authorization failure (NanoTDF-SEC §9).
 
 A verifier MUST NOT accept a tag shorter than the length implied by the declared cipher,
-and MUST NOT compare a prefix of a longer tag (NanoTDF-SEC §3).
+and MUST NOT compare a prefix of a longer tag (NanoTDF-SEC §3.5).
+
+An opener SHOULD count failed authentications per derived key and stop attempting them
+once the count reaches the limit its deployment enforces. At cipher `0x00` this is a
+requirement of SP 800-38D Appendix C rather than a refinement; NanoTDF-SEC §3.3
+tabulates the constraint and NanoTDF-SEC §3.1 gives the forgery advantage as a function
+of tag length and payload length.
 
 ## 6. Size characteristics
 
@@ -95,7 +117,8 @@ to 22 bytes.
 
 The three-byte Length field caps a single NanoTDF payload at just under 16 MiB. A larger
 payload requires a different format; NanoTDF is designed for the case where the object
-must stay small, and BaseTDF covers large and streamed payloads.
+must stay small, and BaseTDF covers large and streamed payloads. NanoTDF-CORE §1 gives
+the ceiling quantitatively and compares it with object-storage scale.
 
 ## 7. References
 

--- a/spec/nanotdf/v1alpha/nanotdf-pkg.md
+++ b/spec/nanotdf/v1alpha/nanotdf-pkg.md
@@ -1,0 +1,219 @@
+# NanoTDF-PKG: Binary Packaging Profile
+
+| | |
+|---|---|
+| Document | NanoTDF-PKG |
+| Version | 1 Alpha |
+| Source spec | nanotdf v1 |
+| Format version | 12 (`L1L`) |
+| Status | Draft |
+| Depends on | NanoTDF-SEC, NanoTDF-ALG, NanoTDF-LOC |
+| Referenced by | NanoTDF-KAO, NanoTDF-POL, NanoTDF-BND, NanoTDF-PAY, NanoTDF-CORE, NanoTDF-EX |
+
+## 1. Scope
+
+This document defines the physical serialization of one NanoTDF object. It owns the
+magic number, the version field, section ordering, the two bitfield configuration bytes,
+length fields, and outer parsing rules. The logical meaning of each section is defined by
+the component documents: NanoTDF-POL for the policy, NanoTDF-BND for the binding and
+signature, NanoTDF-KAO for the ephemeral key, and NanoTDF-PAY for the payload.
+
+All integers are unsigned and big-endian. Bit indices run from 7, the most significant
+bit, down to 0.
+
+Several field lengths are not on the wire. The ephemeral public key, the signature, and
+an ECDSA policy binding are all sized by a curve selected in a configuration byte, so
+those bytes MUST be parsed before the fields they govern can be located.
+
+## 2. Object structure
+
+A NanoTDF is three sections. The Signature is present if and only if `HAS_SIGNATURE` is
+set in the Symmetric and Payload Config byte.
+
+| Section | Minimum (B) | Maximum (B) |
+|---|---:|---:|
+| Header | 53 | 1,043 |
+| Payload | 14 | 16,777,218 |
+| Signature (optional) | 97 | 199 |
+| **Object** | **67** | **16,778,460** |
+
+```text
++-------------------------------------------------------+
+| Header                                                |
+|   +-----------------------------------------------+   |
+|   | Magic Number + Version           3 bytes      |   |
+|   | KAS Resource Locator             3 - 257      |   |
+|   | ECC and Binding Mode             1            |   |
+|   | Symmetric and Payload Config     1            |   |
+|   | Policy                           12 - 714     |   |
+|   | Ephemeral Public Key             33 - 67      |   |
+|   +-----------------------------------------------+   |
++-------------------------------------------------------+
+| Payload                                               |
+|   +-----------------------------------------------+   |
+|   | Length                           3 bytes      |   |
+|   | IV                               3            |   |
+|   | Ciphertext                       0 - 16777204 |   |
+|   | Payload MAC                      8 - 32       |   |
+|   +-----------------------------------------------+   |
++-------------------------------------------------------+
+| Signature      present iff HAS_SIGNATURE              |
+|   +-----------------------------------------------+   |
+|   | Creator Public Key               33 - 67      |   |
+|   | Signature (r || s)               64 - 132     |   |
+|   +-----------------------------------------------+   |
++-------------------------------------------------------+
+```
+
+The maxima above assume the largest legal value of every field independently. Some
+combinations cannot co-occur: the 16,777,204-byte ciphertext maximum pairs with the
+8-byte minimum MAC, because the three-byte Length field caps IV, ciphertext, and MAC
+together at 16,777,215 bytes.
+
+The Header is the unit transmitted to a KAS. It is self-delimiting: nothing in the
+Payload or Signature is required to parse it.
+
+## 3. Header
+
+### 3.1 Magic Number and Version
+
+Three bytes carry an 18-bit magic number followed by a 6-bit version. The `x` bits below
+are the version:
+
+```text
+0100 1100 0011 0001 01xx xxxx
+```
+
+The version count starts at 12. Every version below 12 is invalid by construction, and a
+parser MUST reject one. Version 12 is the first and, at the time of writing, only defined
+version; this suite refers to it as format version 12.
+
+Format version 12 serializes as `4c 31 4c`, which is ASCII `L1L` and base64 `TDFM`. Those
+three bytes are also the input to the HKDF salt in NanoTDF-ALG §3, so a version change
+domain-separates every derived key.
+
+A parser MUST reject an object whose first three bytes do not match a supported magic
+number and version.
+
+### 3.2 KAS Resource Locator
+
+A Resource Locator naming the Key Access Service for this object, encoded per
+NanoTDF-LOC §1. Its semantics are defined in NanoTDF-KAS §1.
+
+### 3.3 ECC and Binding Mode
+
+One byte selecting the ephemeral curve and the policy binding strategy.
+
+```text
+ bit   7   6   5   4   3   2   1   0
+     +---+---+---+---+---+---+---+---+
+     | E |     UNUSED    |   CURVE   |
+     +---+---+---+---+---+---+---+---+
+       |         |             |
+       |         |             +-- Ephemeral ECC Params Enum (3 bits, 2..0)
+       |         +-- reserved (4 bits, 6..3)
+       +-- USE_ECDSA_BINDING (1 bit, 7)
+```
+
+| Field | Bits | Width |
+|---|---|---:|
+| `USE_ECDSA_BINDING` | 7 | 1 |
+| Reserved | 6–3 | 4 |
+| Ephemeral ECC Params Enum | 2–0 | 3 |
+
+`USE_ECDSA_BINDING` selects the policy binding method: `0` for a 64-bit GMAC tag, `1` for
+an ECDSA signature. See NanoTDF-BND §2.
+
+The Ephemeral ECC Params Enum selects the curve from the registry in NanoTDF-ALG §1. It
+governs the length of the ephemeral public key in §3.5, the length of the Policy Key
+Access ephemeral key, and — when `USE_ECDSA_BINDING` is set — the length of the policy
+binding.
+
+The reserved bits MUST be zero when written. A parser SHOULD reject a non-zero reserved
+field rather than ignoring it, so that a later version can assign meaning to those bits
+without ambiguity.
+
+### 3.4 Symmetric and Payload Config
+
+One byte selecting the symmetric cipher and describing the optional signature. The
+selected cipher applies to both the payload and, where the policy is encrypted, the
+policy.
+
+```text
+ bit   7   6   5   4   3   2   1   0
+     +---+---+---+---+---+---+---+---+
+     | S | SIG CURVE |    CIPHER     |
+     +---+---+---+---+---+---+---+---+
+       |       |             |
+       |       |             +-- Symmetric Cipher Enum (4 bits, 3..0)
+       |       +-- Signature ECC Mode (3 bits, 6..4)
+       +-- HAS_SIGNATURE (1 bit, 7)
+```
+
+| Field | Bits | Width |
+|---|---|---:|
+| `HAS_SIGNATURE` | 7 | 1 |
+| Signature ECC Mode | 6–4 | 3 |
+| Symmetric Cipher Enum | 3–0 | 4 |
+
+`HAS_SIGNATURE` is `1` when a Signature section follows the payload and `0` otherwise.
+
+The Signature ECC Mode selects the curve of the creator signature from the registry in
+NanoTDF-ALG §1, and therefore the length of the Signature section. It has no meaning when
+`HAS_SIGNATURE` is `0`, and a parser MUST NOT reject an object because an unused
+Signature ECC Mode names a curve it would not otherwise accept.
+
+The Signature ECC Mode is independent of the Ephemeral ECC Params Enum. In particular, it
+does **not** size an ECDSA policy binding; that follows the ephemeral curve
+(NanoTDF-BND §2).
+
+The Symmetric Cipher Enum selects the cipher and tag length from the registry in
+NanoTDF-ALG §2, and therefore the length of the Payload MAC.
+
+### 3.5 Policy
+
+The Policy object, encoded per NanoTDF-POL §2. Its length depends on the policy type, the
+body, and the binding method selected in §3.3.
+
+### 3.6 Ephemeral Public Key
+
+The producer's ephemeral public key as an X9.62 compressed point, 33 to 67 bytes
+according to the curve selected in §3.3. Its use is defined in NanoTDF-KAO §2.
+
+## 4. Parsing
+
+A decoder MUST reject an object when:
+
+- the magic number is unrecognized, or the version is unsupported or below 12;
+- a Resource Locator declares a body length of zero, or one exceeding remaining input;
+- a declared section exceeds the remaining input;
+- offset or capacity arithmetic overflows;
+- the payload Length field does not accommodate the IV, the MAC implied by the cipher,
+  and a non-negative ciphertext length;
+- the payload IV is `0x000000`, which is reserved for the encrypted policy
+  (NanoTDF-SEC §2); or
+- bytes remain after the payload when `HAS_SIGNATURE` is `0`, or after the signature
+  when it is `1`.
+
+Parser limits from NanoTDF-SEC §1 apply before allocation, key derivation, or KAS
+contact.
+
+The exact policy body bytes are a cryptographic input to the binding. A decoder MUST
+retain them as received and MUST NOT re-serialize them (NanoTDF-BND §2).
+
+## 5. Versioning and conformance
+
+Changing section ordering, a length encoding, a bitfield layout, the meaning of an
+existing security-bearing field, or a cryptographic input construction requires a new
+format version, and therefore new magic-and-version bytes and a new HKDF salt.
+
+Adding a value to the curve or cipher registry does not require a new format version,
+because both are read from an enumerated field whose unlisted values are already rejected.
+
+NanoTDF-CORE §5 defines suite-wide conformance coverage.
+
+## 6. References
+
+- [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [RFC 4648: Base16 and Base64 Encodings](https://www.rfc-editor.org/rfc/rfc4648)
+- [SEC 1: Elliptic Curve Cryptography](https://www.secg.org/sec1-v2.pdf)

--- a/spec/nanotdf/v1alpha/nanotdf-pol.md
+++ b/spec/nanotdf/v1alpha/nanotdf-pol.md
@@ -1,0 +1,128 @@
+# NanoTDF-POL: Policy Object
+
+| | |
+|---|---|
+| Document | NanoTDF-POL |
+| Version | 1 Alpha |
+| Source spec | nanotdf v1 |
+| Format version | 12 (`L1L`) |
+| Status | Draft |
+| Depends on | NanoTDF-SEC, NanoTDF-ALG, NanoTDF-LOC, NanoTDF-PKG, NanoTDF-KAO |
+| Referenced by | NanoTDF-BND, NanoTDF-KAS, NanoTDF-CORE, NanoTDF-EX |
+
+## 1. Scope
+
+A NanoTDF carries exactly one policy. This document defines the policy object's
+structure and its four body types; the cryptographic binding that ties the policy to the
+payload is defined in NanoTDF-BND.
+
+NanoTDF does not define a policy *language*. The policy body is an opaque byte string
+whose interpretation belongs to the KAS and the deployment. A conforming parser reads its
+length and preserves its bytes; it does not parse its contents.
+
+## 2. Structure
+
+| Field | Minimum (B) | Maximum (B) |
+|---|---:|---:|
+| Type Enum | 1 | 1 |
+| Body | 3 | 581 |
+| Binding | 8 | 132 |
+| **Total** | **12** | **714** |
+
+The Binding length follows the binding method selected by `USE_ECDSA_BINDING`
+(NanoTDF-PKG §3.3): 8 bytes for a 64-bit GMAC tag, or 64 to 132 bytes for an ECDSA
+signature sized by the ephemeral curve.
+
+## 3. Type enumeration
+
+| Value | Body |
+|---|---|
+| `0x00` | Remote Policy |
+| `0x01` | Embedded Policy, plaintext |
+| `0x02` | Embedded Policy, encrypted |
+| `0x03` | Embedded Policy, encrypted, with Policy Key Access |
+
+Values outside this table are unreserved and MUST be rejected.
+
+### 3.1 Remote policy
+
+The body is a Resource Locator (NanoTDF-LOC §1) naming where the policy may be
+retrieved. This is the smallest option and the one used by both worked examples in
+NanoTDF-EX.
+
+The binding covers the locator bytes, not the policy those bytes name. A party who
+controls the resolution of that locator can change the effective policy without
+invalidating the binding, so remote policy SHOULD be used only where the resolver is as
+trusted as the KAS (NanoTDF-LOC §4).
+
+### 3.2 Embedded policy
+
+Types `0x01` through `0x03` carry the policy in the object.
+
+| Field | Minimum (B) | Maximum (B) |
+|---|---:|---:|
+| Content Length | 2 | 2 |
+| Plaintext or Ciphertext | 1 | 255 |
+| Policy Key Access (type `0x03` only) | 36 | 324 |
+
+Content Length is the length of the plaintext or ciphertext that follows. It is a
+two-byte field, but the policy content is limited to 255 bytes, so the high byte is zero
+for every legal value. A parser MUST reject a Content Length that exceeds 255 or that
+overruns the remaining input.
+
+Policy Key Access is present if and only if the type is `0x03`. Its structure and
+key-derivation rules are defined in NanoTDF-KAO §4.
+
+## 4. Policy encryption
+
+For types `0x02` and `0x03` the policy content is encrypted with the cipher selected in
+the Symmetric and Payload Config byte (NanoTDF-ALG §2) — the same cipher used for the
+payload.
+
+There is no IV field. To save three bytes, the encrypted policy always uses the reserved
+IV `0x000000`, which is why a payload IV of `0x000000` is invalid (NanoTDF-PKG §4).
+
+This makes key separation mandatory rather than advisory:
+
+- The key used to encrypt a policy MUST NOT be used to encrypt any payload, and MUST NOT
+  be used for any other policy. A fixed IV under a reused key repeats a nonce, which is
+  catastrophic for AES-GCM (NanoTDF-SEC §2).
+- Where a policy must be encrypted to a different party than the payload, use type
+  `0x03` and derive a separate policy key through Policy Key Access.
+
+The Content Length for an encrypted policy is the length of the ciphertext including its
+authentication tag.
+
+## 5. Choosing a policy type
+
+| Type | Size cost | Policy visible to holder | Policy fixed at creation |
+|---|---|---|---|
+| `0x00` Remote | Smallest | No | No |
+| `0x01` Embedded plaintext | Content plus 2 | Yes | Yes |
+| `0x02` Embedded encrypted | Content plus 2 | No | Yes |
+| `0x03` Embedded encrypted with PKA | Content plus 38 or more | No | Yes |
+
+An embedded plaintext policy is readable by anyone holding the object. Where attribute
+values are themselves sensitive — a compartment name, a project code — type `0x01`
+discloses them to every party that touches the object, including those who cannot decrypt
+the payload.
+
+An embedded policy is immutable once written, because its bytes are covered by the
+binding. Changing it requires producing a new object.
+
+## 6. Parsing requirements
+
+- The exact policy body bytes are a cryptographic input to the binding. A decoder MUST
+  retain them as received and MUST NOT re-serialize, canonicalize, or normalize them
+  (NanoTDF-BND §2).
+- A decoder MUST verify the binding before acting on the policy, and a KAS MUST verify it
+  before evaluating the policy (NanoTDF-KAS §2).
+- A decoder MUST NOT dereference a remote policy locator during parsing or validation
+  (NanoTDF-LOC §3).
+- An unlisted type value, a zero Content Length, or a Policy Key Access structure present
+  under a type other than `0x03` MUST be rejected.
+
+## 7. References
+
+- [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [NIST SP 800-38D: GCM and GMAC](https://csrc.nist.gov/pubs/sp/800/38/d/final)

--- a/spec/nanotdf/v1alpha/nanotdf-sec.md
+++ b/spec/nanotdf/v1alpha/nanotdf-sec.md
@@ -47,21 +47,335 @@ Each object derives its symmetric key from a fresh ephemeral key pair. Reusing a
 ephemeral key pair across objects defeats that separation and reintroduces the reuse
 hazard.
 
+### 2.1 How three bytes become a GCM nonce
+
+The source specification does not say how the three-byte IV is presented to AES-GCM,
+and until this revision no document in this suite said either. NanoTDF-PAY §3 stated
+only that the IV is used as the AES-GCM nonce. Three readings are consistent with that
+sentence, and they produce different ciphertext for the same key and plaintext:
+
+- the three bytes are the whole nonce, so GCM runs with a 24-bit nonce and derives the
+  pre-counter block `J0` through GHASH, as SP 800-38D §7.1 Algorithm 4 step 2 requires
+  for any IV whose length is not 96 bits;
+- the three bytes are right-aligned in a twelve-byte field zero-padded on the left; or
+- the three bytes are left-aligned in a twelve-byte field zero-padded on the right.
+
+Two implementations that chose differently would each produce objects the other could
+not open, with no diagnostic beyond an authentication failure.
+
+The two vectors in NanoTDF-EX settle it. Each carries the recipient private key, the
+ephemeral public key, the IV, the ciphertext, the tag, and the plaintext, so each
+reading can be tested by decryption. Only the first reproduces the recorded plaintext
+and the recorded tag; the other two fail authentication and yield unrelated bytes,
+under both vectors. NanoTDF-PAY §3 states that reading normatively and NanoTDF-CORE §6
+records the correction.
+
+This is an interoperability finding rather than a change of format: it names the one
+reading under which the suite's own vectors decrypt. An implementation that padded the
+IV to twelve bytes was never conforming, because it could not open either vector.
+
+Two things follow from the nonce being 24 bits rather than 96. The GHASH-derived `J0`
+costs one extra GHASH block per operation, which is immaterial at these sizes. More
+materially, SP 800-38D §8.2 requires that any IV shorter than 96 bits be built by the
+deterministic construction of §8.2.1 — a fixed field identifying the context,
+concatenated with an invocation field that increments — and the RBG-based construction
+of §8.2.2 is unavailable at this length, because it requires a random field of at
+least 96 bits. A randomly drawn 24-bit IV therefore inherits none of the uniqueness
+guarantees those two constructions exist to provide. SP 800-38D §5.2.1.1 recommends
+that implementations "restrict support to the length of 96 bits, to promote
+interoperability, efficiency, and simplicity of design"; NanoTDF trades all three for
+nine bytes per object.
+
+### 2.2 A 24-bit nonce space
+
+A three-byte IV admits 16,777,216 values, of which `0x000000` is reserved, leaving
+16,777,215 for payloads. Drawing them at random, the probability that some pair of
+objects encrypted under one derived key shares an IV is:
+
+| Objects under one derived key | P(at least one IV collision) |
+|---:|---:|
+| 100 | 0.03% |
+| 1,000 | 2.93% |
+| 2,048 | 11.75% |
+| 4,096 | 39.34% |
+| 4,823 | 50.00% |
+| 8,192 | 86.47% |
+| 16,384 | 99.97% |
+
+The even chance falls at 4,823 objects, and the risk is meaningful well below that
+whatever the objects weigh: 4,823 maximum-size objects are 75.4 GiB, and 4,823
+kilobyte objects are 4.7 MiB. The volume bound of §4 is far above either figure, which
+is why the nonce space and not the volume is NanoTDF's operative limit on the lifetime
+of a derived key.
+
+A per-key counter removes the birthday term outright and permits 16,777,215 objects
+before exhaustion, and it is also the construction SP 800-38D §8.2 requires at this IV
+length. It is the better choice rather than merely an acceptable one
+(NanoTDF-PAY §3). SP 800-38D §8.3 separately caps invocations under one key at 2^32
+for every IV length except a deterministically constructed 96-bit one; with 2^24
+usable IVs, NanoTDF exhausts its nonce space 256 times over before reaching that cap,
+so the cap never binds.
+
+None of this bites in normal use. The derived key is
+`HKDF(ECDH(ephemeral_private, kas_public))`, so a fresh ephemeral key pair yields a
+fresh derived key, and NanoTDF-KAO §2.1 requires one per object. Under that rule each
+object is the sole occupant of its own 24-bit nonce space and the table above is
+inert. The entire hazard is contingent on a producer reusing an ephemeral key pair.
+
+Version 1 cannot prevent that. Creation is offline, so no authority observes the
+second object at production time, and no field declares whether the ephemeral key was
+freshly generated. The ephemeral public key is on the wire, however, which gives a
+deployment one after-the-fact control: a KAS that records the ephemeral public keys it
+has seen can detect reuse across rewrap requests, and SHOULD treat a repeat as an
+anomaly rather than a routine request. This is the duplicate monitoring of SP 800-38D
+Appendix D applied to the key rather than to the IV. It detects; it does not prevent,
+and an opener holding a single object cannot tell at all.
+
+### 2.3 The policy and the payload share one key and one nonce space
+
+For policy types `0x02` and `0x03` without Policy Key Access, the encrypted policy is
+protected by the same derived key as the payload, under the fixed IV `0x000000`
+(NanoTDF-POL §4). Policy and payload are then two AES-GCM invocations under one key,
+and they MUST NOT collide. Reserving `0x000000` for the policy and rejecting it for
+the payload is what keeps them apart, and it is the one place in the format where
+version 1 defends itself against the narrow nonce space.
+
+That defence is scoped to a single object. Two objects that share a derived key — two
+objects produced from the same ephemeral key pair against the same KAS key — both
+encrypt their policy under the identical key with the identical nonce. This is not a
+birthday risk but a certainty on the first repeat, and it discloses the XOR of the two
+policy plaintexts, which for short and highly structured policy bodies is usually
+equivalent to disclosing both. Ephemeral key reuse is therefore strictly worse for the
+policy than for the payload: the payload still gets a fresh IV and the bound in §2.2,
+while the policy gets a guaranteed nonce collision.
+
 ## 3. Short authentication tags
 
 The Symmetric Cipher Enum admits authentication tags as short as 64 bits
-(NanoTDF-ALG §2). A 64-bit tag offers roughly 64 bits of forgery resistance, which is
-below contemporary guidance and degrades further as an attacker obtains more
-verification attempts against one key.
+(NanoTDF-ALG §2). The forgery resistance a tag delivers is not its length. It falls as
+the authenticated message grows, and again as an attacker obtains more verification
+attempts under one key. Version 1 coupled the two to nothing, so this section
+tabulates them.
+
+### 3.1 The integrity bound
+
+For `v` forgery attempts against a message of at most `l` sixteen-byte blocks under a
+`tau`-bit tag, from the analysis of Iwata, Ohashi and Minematsu as applied to TLS by
+Luykx and Paterson, and the same analysis from which RFC 8446 §5.5 derives the TLS 1.3
+record limits:
+
+```text
+Adv_INT-CTXT <= 2 * v * (l + 1) / 2^tau
+```
+
+The largest NanoTDF ciphertext is 16,777,204 bytes, which is 1,048,576 blocks, or
+2^20: the three-byte Length field caps IV, ciphertext, and MAC together at 16,777,215
+bytes, and 16,777,204 pairs with the eight-byte tag of cipher `0x00`
+(NanoTDF-PAY §2). At the longer tags the ciphertext maximum is a few bytes smaller and
+rounds to the same 2^20 blocks. NanoTDF defines no associated data for the payload, so
+`l` counts ciphertext blocks alone (NanoTDF-PAY §4).
+
+For one forgery attempt, rounded to a hundredth of a bit:
+
+| Cipher | Tag (bits) | 16 MiB, 2^20 blocks | 1 KiB, 64 blocks | 16 B, 1 block |
+|---|---:|---:|---:|---:|
+| `0x00` | 64 | 2^-43.00 | 2^-56.98 | 2^-62.00 |
+| `0x01` | 96 | 2^-75.00 | 2^-88.98 | 2^-94.00 |
+| `0x02` | 104 | 2^-83.00 | 2^-96.98 | 2^-102.00 |
+| `0x03` | 112 | 2^-91.00 | 2^-104.98 | 2^-110.00 |
+| `0x04` | 120 | 2^-99.00 | 2^-112.98 | 2^-118.00 |
+| `0x05` | 128 | 2^-107.00 | 2^-120.98 | 2^-126.00 |
+
+A 64-bit tag over a maximum-size payload is worth about 43 bits, not 64. The message
+length costs 21 bits of the 64, and that cost is identical at every tag length; only
+the short tag cannot absorb it.
+
+### 3.2 Attempts a tag absorbs
+
+Read the other way, the bound gives the number of forgery attempts a tag absorbs
+before the cumulative advantage reaches a chosen target. Taking 2^-32 as the target:
+
+| Cipher | Tag (bits) | Attempts at 2^20 blocks | Attempts at 64 blocks |
+|---|---:|---:|---:|
+| `0x00` | 64 | 2^11.00 — 2,048 | 2^24.98 |
+| `0x01` | 96 | 2^43.00 | 2^56.98 |
+| `0x02` | 104 | 2^51.00 | 2^64.98 |
+| `0x03` | 112 | 2^59.00 | 2^72.98 |
+| `0x04` | 120 | 2^67.00 | 2^80.98 |
+| `0x05` | 128 | 2^75.00 | 2^88.98 |
+
+One row in this table is reachable. Two thousand and forty-eight attempts is a few
+seconds of work against any service that will verify a tag on demand. Every other row
+is beyond any attacker, at any payload size NanoTDF can carry.
+
+### 3.3 What SP 800-38D Appendix C requires
+
+Appendix C of SP 800-38D is not advice. For 32-bit and 64-bit tags it states a
+requirement: "For any implementation that supports 32-bit or 64-bit tags, one of the
+rows in Table 1 or Table 2, respectively, shall be enforced." Each row pairs a maximum
+combined length of ciphertext and AAD in a single packet with a maximum number of
+invocations of the authenticated decryption function across all instances of GCM under
+that key, and the key must be changed before that number is exceeded. Table 2, for
+64-bit tags, is:
+
+| Max ciphertext and AAD in one packet (B) | Max authenticated-decryption invocations per key |
+|---:|---:|
+| 2^15 — 32,768 | 2^32 |
+| 2^17 — 131,072 | 2^29 |
+| 2^19 — 524,288 | 2^26 |
+| 2^21 — 2,097,152 | 2^23 |
+| 2^23 — 8,388,608 | 2^20 |
+| 2^25 — 33,554,432 | 2^17 |
+
+A maximum-size NanoTDF payload is 16,777,204 bytes, so the only row that admits it is
+the last: at most 2^17, or 131,072, authenticated-decryption invocations under that
+derived key. The rows are calibrated to comparable residual risk — spending a full row
+budget gives a cumulative advantage of 2^-20 at the first row falling to 2^-25 at the
+last — so a deployment buys length with attempts at a fixed exchange rate.
+
+Two further Appendix C items bear directly on cipher `0x00`.
+
+- Item 3 requires that "the substance or meaning of the overall message ... should not
+  be lost or compromised by the forgery of a single, arbitrary packet", and states that
+  "an individual packet should not carry a .txt or .doc file". A NanoTDF payload is
+  exactly one whole item of arbitrary content. Cipher `0x00` therefore falls outside
+  the circumstances Appendix C describes as appropriate for a 64-bit tag, for most of
+  what NanoTDF is used to protect. The tolerable case Appendix C has in mind — one
+  packet of a voice or video stream, where a forged packet costs a fraction of a
+  second of audio — has no analogue in a format whose payload is the whole object.
+- Item 1 requires that failing packets be discarded silently, that authentication
+  errors be logged internally in a way undetectable from side-channel information, and
+  that the connection be terminated or the user notified when the error rate exceeds
+  normal. §9 below and NanoTDF-KAS §5 already require indistinguishable errors, which
+  meets the first half. Version 1 required no counting; §3.5 does.
+
+Independently of tag length, SP 800-38D §5.2.1.1 caps one invocation at 2^39 − 256
+bits, 68,719,476,704 bytes. NanoTDF's frame cap is 4,096 times below that, so this
+limit is never reached.
+
+### 3.4 The tag is the only integrity mechanism
+
+Tag length matters more in NanoTDF than in a format with a second integrity layer,
+because there is no second layer. NanoTDF defines no segmentation, no Merkle layout,
+and no per-segment integrity; one payload is one AEAD operation (NanoTDF-PAY §4).
+There is no manifest digest, no assertion, and no metadata to cross-check. Undetected
+modification of the ciphertext is prevented by the payload tag and by nothing else.
+
+The one fallback is the optional creator signature, which covers the Header and the
+Payload — every byte of the object before the Signature section (NanoTDF-BND §3.2).
+Where it is present and the verifier requires it, a forged tag alone does not yield an
+object that verifies. Where it is absent, and it is absent by default and can be
+stripped from a signed object without trace (NanoTDF-BND §3.4), the tag stands alone.
+
+A successful GCM forgery is also not a one-off. Each success leaks information about
+the hash subkey `H` and raises the probability that the next targeted forgery
+succeeds; SP 800-38D Appendix B notes that `H` may eventually be recovered entirely,
+after which authentication assurance for that key is gone.
+
+### 3.5 Requirements and guidance
 
 - A 64-bit tag SHOULD be selected only where the size saving is decisive and the
   deployment bounds the number of forgery attempts.
+- A producer SHOULD NOT select cipher `0x00` for a payload whose ciphertext exceeds
+  32,768 bytes. That is the shortest row of SP 800-38D Table 2 and the only one leaving
+  a workable budget of 2^32 verification invocations; the eight bytes saved against
+  cipher `0x05` do not pay for the fourteen bits of forgery resistance given up between
+  a kilobyte and 16 MiB.
+- A producer SHOULD NOT select cipher `0x00` at all where the payload is a
+  self-contained document rather than one packet of a stream, per Appendix C item 3.
+- A deployment that permits cipher `0x00` MUST enforce one row of SP 800-38D Table 2.
+  Because the applicable row is chosen by the largest payload the deployment produces,
+  the practical form of this is a producer-side size cap together with a limit on the
+  failed authenticated-decryption attempts performed under one derived key. Both are
+  deployment controls: neither changes what a conforming parser accepts, and an opener
+  still parses and rejects exactly as NanoTDF-PKG §4 requires.
+- An opener or a KAS SHOULD count failed authentication and policy-binding
+  verifications per derived key, and SHOULD stop performing them once the count reaches
+  the limit of the enforced row (NanoTDF-KAS §5). NanoTDF cannot rekey — the derived
+  key is a function of the object — so refusing further verification is the only
+  response available where SP 800-38D would call for a new key.
 - A verifier MUST NOT accept a tag shorter than the length implied by the declared
   cipher, and MUST NOT truncate a longer tag to compare a prefix.
 - Deployments without a hard size constraint SHOULD use cipher `0x05`, AES-256-GCM
   with a 128-bit tag.
 
-## 4. Elliptic curve requirements
+### 3.6 The 64-bit GMAC policy binding
+
+When `USE_ECDSA_BINDING` is `0` the policy binding is a 64-bit GMAC tag over
+`SHA256(policy body)` (NanoTDF-BND §2). The authenticated message is a fixed 32 bytes,
+two blocks, so `l` is 2 and the bound is far kinder than for a payload:
+
+| Forgery attempts against one binding | Adv_INT-CTXT |
+|---:|---:|
+| 1 | 2^-61.42 |
+| 2^20 | 2^-41.42 |
+| 2^30 | 2^-31.42 |
+| 2^32 | 2^-29.42 |
+
+Reaching 2^-32 takes 715,827,883 attempts, about 2^29.42, against 2^11 for a
+maximum-size payload at the same tag length. The short fixed-length message does that
+work, and it is why the binding is not simply "a 64-bit tag" in the sense §3.1
+describes.
+
+The exposure differs in kind rather than in degree. A payload tag is verified by
+whoever already holds the object; a policy binding is verified by the KAS, on demand,
+for any header a requester chooses to submit. An attacker who keeps one object's
+ephemeral public key, which fixes the derived key, and varies the policy body and the
+eight binding bytes has an online forgery oracle whose only limit is how quickly the
+KAS answers. NanoTDF-KAS §5 requires the KAS's errors to be indistinguishable, which
+denies the attacker any signal about which stage rejected the request, but an
+indistinguishable rejection is still a rejection: it constrains what an attempt
+reveals, not how many attempts are possible.
+
+Two points sharpen this. The derived key protects the payload as well as the binding,
+so the Table 2 row a deployment must enforce is chosen by the payload and not by the
+32-byte binding message; a deployment carrying maximum-size payloads is held to 2^17
+invocations under that key, and binding verifications count against the same budget.
+And by §3.4 a successful forgery leaks hash-subkey material, so attempts against a
+binding are not independent trials.
+
+A KAS SHOULD therefore count failed policy-binding verifications per ephemeral public
+key, rate-limit them, and stop answering for that key once the count reaches the limit
+of the enforced row (NanoTDF-KAS §5). This is a deployment control and requires no
+change to the wire format or to what a conforming KAS accepts.
+
+## 4. Key usage volume
+
+The companion bound limits how much plaintext one key may protect. For `sigma` total
+sixteen-byte plaintext blocks and `q` encryption invocations under one key:
+
+```text
+Adv_IND-CPA <= (sigma + q + 1)^2 / 2^129
+```
+
+The sibling suites in this repository draw a single rule from it: a content-encryption
+key MUST NOT protect more than 2^40 bytes, one tebibyte, of plaintext. That is the
+volume at which the advantage reaches 2^-57, matching the margin RFC 8446 §5.5 targets
+for TLS 1.3 record limits. NanoTDF version 1 states no volume bound at all.
+
+One object cannot approach it. A maximum-size object gives `sigma = 1,048,576` and
+`q = 1`, or `q = 2` with an encrypted policy, for an advantage of 2^-89 — thirty-two
+bits of margin below the figure at 2^40 bytes. Reaching 2^40 bytes takes 65,537
+maximum-size objects.
+
+The bound is per key, and NanoTDF's derived key is per ephemeral key pair rather than
+per object. A producer that generates a fresh ephemeral key pair for each object, as
+NanoTDF-KAO §2.1 requires, accumulates nothing: each object is the whole lifetime of
+its key. Only a producer that reuses one ephemeral key pair across objects accumulates
+volume, and only such a producer can reach 2^40 bytes.
+
+It would exhaust its nonces long first. By §2.2 the chance of an IV collision under
+one derived key passes one half at 4,823 objects, which even at the maximum object
+size is 75.4 GiB — a factor of about 13.6 below the volume ceiling, and far below it
+at realistic NanoTDF sizes. The volume bound is worth stating because it is the bound
+a reader will look for and because version 1 is silent on it, but it is not the
+constraint that binds.
+
+- A producer MUST NOT protect more than 2^40 bytes of plaintext under one derived key.
+  Following NanoTDF-KAO §2.1 satisfies this automatically: a fresh ephemeral key pair
+  per object caps the volume under one derived key at 16,777,204 bytes.
+
+## 5. Elliptic curve requirements
 
 No curve below 256 bits is supported, and the curve registry is closed
 (NanoTDF-ALG §1). A parser MUST reject an unlisted curve value rather than substituting
@@ -74,7 +388,7 @@ admits invalid-curve attacks that recover the private key.
 The ephemeral private key MUST be generated from a cryptographically secure random
 source and MUST NOT be retained after the object is produced.
 
-## 5. Binding and signature semantics
+## 6. Binding and signature semantics
 
 The two binding modes protect different things, and the choice is visible on the wire.
 
@@ -97,7 +411,7 @@ A signature is optional and can be removed by re-encoding the object with
 `HAS_SIGNATURE` cleared. An application that requires provenance MUST reject an object
 whose signature is absent rather than treating absence as acceptable.
 
-## 6. Trust boundaries
+## 7. Trust boundaries
 
 The KAS Resource Locator is a name, not a trust anchor. Ownership of a URL gives
 uniqueness, not authority, and an object may name any locator.
@@ -112,7 +426,7 @@ uniqueness, not authority, and an object may name any locator.
   two retrievals, and is not authenticated by the object. The binding covers the policy
   body bytes, which for a remote policy are the locator, not the policy it names.
 
-## 7. Offline creation
+## 8. Offline creation
 
 NanoTDF is designed to be produced without contacting a KAS. That property has
 consequences a deployment must accept.
@@ -126,7 +440,7 @@ consequences a deployment must accept.
   or duplicated ephemeral key compromises the object with no server-side check that
   would detect it.
 
-## 8. Failure handling
+## 9. Failure handling
 
 Key derivation, binding verification, policy resolution, and authorization failures
 SHOULD be reported to the requester as one indistinguishable error class. Distinguishing
@@ -139,9 +453,12 @@ returned on failure. Implementations SHOULD clear transient key material when pr
 The opener MUST authenticate the payload under the declared cipher before releasing any
 plaintext. NanoTDF defines no incremental or streaming release.
 
-## 9. References
+## 10. References
 
 - [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [RFC 8446: TLS 1.3](https://www.rfc-editor.org/rfc/rfc8446)
 - [NIST SP 800-38D: GCM and GMAC](https://csrc.nist.gov/pubs/sp/800/38/d/final)
 - [NIST SP 800-56A: Key Establishment Using Discrete Logarithm Cryptography](https://csrc.nist.gov/pubs/sp/800/56/a/r3/final)
 - [SEC 1: Elliptic Curve Cryptography](https://www.secg.org/sec1-v2.pdf)
+- [Luykx and Paterson 2017: Limits on Authenticated Encryption Use in TLS](https://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf)
+- [Iwata, Ohashi, and Minematsu 2012: Breaking and Repairing GCM Security Proofs](https://eprint.iacr.org/2012/438)

--- a/spec/nanotdf/v1alpha/nanotdf-sec.md
+++ b/spec/nanotdf/v1alpha/nanotdf-sec.md
@@ -1,0 +1,147 @@
+# NanoTDF-SEC: Security Considerations
+
+| | |
+|---|---|
+| Document | NanoTDF-SEC |
+| Version | 1 Alpha |
+| Source spec | nanotdf v1 |
+| Format version | 12 (`L1L`) |
+| Status | Draft |
+| Depends on | None |
+| Referenced by | All NanoTDF components |
+
+## 1. Parser limits
+
+Every parser MUST enforce limits before allocation, key derivation, or authority
+contact. NanoTDF's length fields are narrow, so most bounds are structural rather than
+configurable.
+
+| Input | Required handling |
+|---|---|
+| Resource Locator body | Length is one byte; the body is at most 255 bytes |
+| Embedded policy content | At most 255 bytes, bounded by the Policy section maximum |
+| Payload length | Three bytes, at most 16,777,215; a framing bound, not an allocation instruction |
+| Ephemeral public key | Length is implied by the curve, never read from the wire |
+| Trailing bytes | Rejected; see NanoTDF-PKG §4 |
+
+A decoder MUST NOT allocate directly from a declared length before confirming that the
+remaining input can satisfy it. Offset and capacity arithmetic MUST be checked for
+overflow.
+
+## 2. Nonce and IV reuse
+
+AES-GCM nonce reuse under one key is catastrophic: it discloses the XOR of two
+plaintexts and permits authentication-tag forgery. NanoTDF makes this hazard sharper
+than most formats for three reasons.
+
+- The payload IV is only three bytes. A producer MUST NOT encrypt many objects under
+  one derived key, and MUST draw each IV from a cryptographically secure random source
+  or a per-key counter that cannot repeat.
+- The IV value `0x000000` is reserved for the encrypted policy and is never written to
+  the wire for that purpose. A payload IV of `0x000000` MUST be rejected.
+- Because the encrypted-policy IV is fixed, the key used to encrypt a policy MUST NOT
+  be used to encrypt any other policy or payload. Where a distinct policy key is
+  required, use Policy Key Access (NanoTDF-KAO §4).
+
+Each object derives its symmetric key from a fresh ephemeral key pair. Reusing an
+ephemeral key pair across objects defeats that separation and reintroduces the reuse
+hazard.
+
+## 3. Short authentication tags
+
+The Symmetric Cipher Enum admits authentication tags as short as 64 bits
+(NanoTDF-ALG §2). A 64-bit tag offers roughly 64 bits of forgery resistance, which is
+below contemporary guidance and degrades further as an attacker obtains more
+verification attempts against one key.
+
+- A 64-bit tag SHOULD be selected only where the size saving is decisive and the
+  deployment bounds the number of forgery attempts.
+- A verifier MUST NOT accept a tag shorter than the length implied by the declared
+  cipher, and MUST NOT truncate a longer tag to compare a prefix.
+- Deployments without a hard size constraint SHOULD use cipher `0x05`, AES-256-GCM
+  with a 128-bit tag.
+
+## 4. Elliptic curve requirements
+
+No curve below 256 bits is supported, and the curve registry is closed
+(NanoTDF-ALG §1). A parser MUST reject an unlisted curve value rather than substituting
+a default.
+
+An implementation MUST validate a received public key as a point on the declared curve
+before performing ECDH. Compressed point decoding that does not check curve membership
+admits invalid-curve attacks that recover the private key.
+
+The ephemeral private key MUST be generated from a cryptographically secure random
+source and MUST NOT be retained after the object is produced.
+
+## 5. Binding and signature semantics
+
+The two binding modes protect different things, and the choice is visible on the wire.
+
+- A 64-bit GMAC binding proves only that the binding was produced by a party holding
+  the derived symmetric key. Because the KAS can derive that key, a GMAC binding does
+  not attribute the policy to any particular producer.
+- An ECDSA binding is verifiable against the ephemeral public key in the header, and
+  ties the policy to the holder of the matching ephemeral private key at creation time.
+
+Neither mode authenticates the producer's identity. Only the optional creator signature
+(NanoTDF-BND §3) does that, and it does so with a persistent key that the format itself
+does not distribute or validate.
+
+Carriage is not endorsement. A valid signature proves that the named key signed the
+object; it does not establish that the signer is trusted, that the policy is correct, or
+that the key has not been revoked. Trust anchors, certificate handling, and revocation
+are deployment concerns.
+
+A signature is optional and can be removed by re-encoding the object with
+`HAS_SIGNATURE` cleared. An application that requires provenance MUST reject an object
+whose signature is absent rather than treating absence as acceptable.
+
+## 6. Trust boundaries
+
+The KAS Resource Locator is a name, not a trust anchor. Ownership of a URL gives
+uniqueness, not authority, and an object may name any locator.
+
+- A client MUST resolve the KAS locator through trusted local configuration — an
+  allow-list, a catalog, or a service registry — and MUST NOT dispatch on the literal
+  value.
+- A validator MUST NOT dereference any locator in an object. Doing so turns every
+  malformed or hostile object into an outbound request and leaks the fact and timing of
+  validation. See NanoTDF-LOC §3.
+- The remote-policy case means policy content may be unavailable, may change between
+  two retrievals, and is not authenticated by the object. The binding covers the policy
+  body bytes, which for a remote policy are the locator, not the policy it names.
+
+## 7. Offline creation
+
+NanoTDF is designed to be produced without contacting a KAS. That property has
+consequences a deployment must accept.
+
+- The producer cannot learn at creation time whether the KAS public key it holds has
+  been rotated or revoked. Objects produced against a retired key become
+  undecryptable.
+- No creation-time audit record exists at the KAS. The first evidence of an object's
+  existence is the rewrap request made when it is opened.
+- The strength of the object depends entirely on the producer's random source. A weak
+  or duplicated ephemeral key compromises the object with no server-side check that
+  would detect it.
+
+## 8. Failure handling
+
+Key derivation, binding verification, policy resolution, and authorization failures
+SHOULD be reported to the requester as one indistinguishable error class. Distinguishing
+them tells an attacker which stage rejected the request and turns the KAS into an oracle
+for policy structure and key validity.
+
+Plaintext, derived symmetric keys, and ephemeral private keys MUST NOT be logged or
+returned on failure. Implementations SHOULD clear transient key material when practical.
+
+The opener MUST authenticate the payload under the declared cipher before releasing any
+plaintext. NanoTDF defines no incremental or streaming release.
+
+## 9. References
+
+- [BCP 14](https://www.rfc-editor.org/info/bcp14)
+- [NIST SP 800-38D: GCM and GMAC](https://csrc.nist.gov/pubs/sp/800/38/d/final)
+- [NIST SP 800-56A: Key Establishment Using Discrete Logarithm Cryptography](https://csrc.nist.gov/pubs/sp/800/56/a/r3/final)
+- [SEC 1: Elliptic Curve Cryptography](https://www.secg.org/sec1-v2.pdf)


### PR DESCRIPTION
Stacked on #3907.

### Proposed Changes

* Reorganize the nanotdf version 1 specification into parallel BaseTDF-style components under `spec/nanotdf/v1alpha`.
* Preserve the wire format, algorithms, validation, and security semantics. The refactoring changes document ownership only.
* Cover the full normative surface: the three-section binary frame, the magic-and-version encoding, both configuration bitfields, the closed curve and cipher registries, HKDF derivation with its fixed salt, Resource Locators, all four policy types including Policy Key Access, both policy binding modes, the optional creator signature, and the KAS exchange.
* Normalize the source specification where it is internally inconsistent, and record every correction in an errata table in `NanoTDF-CORE` §6.
* Reproduce both worked examples in full in `NanoTDF-EX`, with byte-offset parsing tables.
* Add a row for the NanoTDF suite to `spec/README.md`.

### Module layout

| Layer | Documents |
|---|---|
| Foundation | SEC, ALG |
| Policy | POL |
| Operations | KAO, BND, PAY, KAS |
| Storage | LOC, PKG |
| Assembly | CORE |
| Examples | EX |

`NanoTDF-BND` owns both the policy binding and the creator signature, and covers the signature half of `BaseTDF-ASN`; in NanoTDF the binding is a load-bearing wire field sized by a header bitfield rather than a property of an assertion. `NanoTDF-PAY` exists because payload carriage has its own length field, reserved IV, and implied MAC length, which BaseTDF folds into `CORE` and `INT`.

Four BaseTDF modules are deliberately absent: `INT` (no segmentation and no per-segment integrity — one payload is one AEAD operation), `ASN` (no assertions), `MTD` (version 1 carries no metadata and no extension socket), and `SCH` (no external schema artifact — the byte tables in `NanoTDF-PKG` are the grammar). The suite README states these boundaries explicitly. There are no extension, profile, or migration documents, because NanoTDF version 1 defines no extension mechanism.

### Notes for reviewers

The source specification is internally inconsistent in several places. This suite states the corrected value and lists all eleven corrections in `NanoTDF-CORE` §6. The substantive ones are size ranges that do not follow from their own constituent fields:

| Field | Source | Corrected |
|---|---|---|
| Policy | 3–257 | 12–714 |
| Header | 43–584 | 53–1,043 |
| Signature | 97–133 | 97–199 |
| Policy Key Access | 36–136 | 36–324 |
| Policy Key Access ephemeral key | 33–133 | 33–67 |

The rest are editorial: the Ephemeral ECC Params Enum is called "7-bit" where its own table gives it 3 bits, the source does not say which curve sizes an ECDSA policy binding (it is the ephemeral curve, not the Signature ECC Mode), a cross-reference is left as the placeholder `[section X.X.X.X]()`, §3.4.2.2 is skipped, protocol `0xff` is described as experimental with no processing rules, and the §6.1.6 parsing breakdown omits the payload Length field.

One figure that looks wrong is correct and has been preserved: the Payload range of 14–16,777,218. The three-byte Length field caps IV + ciphertext + MAC at 16,777,215, and the source's 16,777,204-byte ciphertext maximum pairs with the *minimum* 8-byte MAC, so a naive max-plus-max sum overshoots. `NanoTDF-CORE` §6 carries a note explaining this so it is not "corrected" later.

The source's three SVG figures are redrawn as ASCII, since `spec/` contains no image assets.

### Checklist

- [ ] I have added or updated unit tests (not applicable: documentation only)
- [ ] I have added or updated integration tests (not applicable: documentation only)
- [x] I have added or updated documentation

### Testing Instructions

Documentation-only change. Both worked examples were decoded and verified rather than transcribed: each base64 object decodes to its stated length (258 and 197 bytes), every field offset in the `NanoTDF-EX` tables lands on a real field boundary, the per-section byte counts sum to the total, and both consume to zero remaining bytes. The per-field hex in `NanoTDF-EX` was generated from the decoded binaries. Example 2 has 173 bytes of overhead, which substantiates the format's sub-200-byte claim.

Also verified: the corrected size ranges each recompute from their constituent fields and are consistent across `PKG`, `POL`, `BND`, and `KAO`; the bitfield diagrams in `NanoTDF-PKG` decode the vectors' `0x80` and `0x35` configuration bytes correctly; all relative Markdown links resolve; every `NanoTDF-*` cross-reference names a real module and an existing section; and no source figure leaks into an owning module. No Go changes, so `make lint` and `make fmt` do not apply; the repository has no Markdown linter.