### PR TITLE
fix(policy): GetAttrVal only expose connected obligations.

### DIFF
--- a/service/integration/attribute_values_test.go
+++ b/service/integration/attribute_values_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opentdf/platform/service/internal/fixtures"
 	"github.com/opentdf/platform/service/pkg/db"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
 )
 
 var absentAttributeValueUUID = "78909865-8888-9999-9999-000000000000"
@@ -1019,10 +1020,12 @@ func (s *AttributeValuesSuite) Test_GetAttributeValue_ScopesObligationsToRequest
 	secondSharedTrigger := triggerForAttributeValue(secondAttrValue)
 
 	assertScopedObligations := func(attributeValue *policy.Value, firstExpected, secondExpected *policy.ObligationValue) {
-		firstObligation.Values = []*policy.ObligationValue{firstExpected}
-		secondObligation.Values = []*policy.ObligationValue{secondExpected}
+		obligationOne := proto.CloneOf(firstObligation)
+		obligationTwo := proto.CloneOf(secondObligation)
+		obligationOne.Values = []*policy.ObligationValue{firstExpected}
+		obligationTwo.Values = []*policy.ObligationValue{secondExpected}
 		s.assertObligations(
-			[]*policy.Obligation{firstObligation, secondObligation},
+			[]*policy.Obligation{obligationOne, obligationTwo},
 			attributeValue.GetObligations(),
 		)
 	}

--- a/service/integration/attribute_values_test.go
+++ b/service/integration/attribute_values_test.go
@@ -985,6 +985,7 @@ func (s *AttributeValuesSuite) Test_GetAttributeValue_ScopesObligationsToRequest
 	s.obligations = append(s.obligations, secondObligation)
 
 	readAction := s.getActionByNameInNamespace("read", attributeNamespace.GetId())
+	updateAction := s.getActionByNameInNamespace("update", attributeNamespace.GetId())
 	createObligationValue := func(obligation *policy.Obligation, value string, attributeValues ...*policy.Value) *policy.ObligationValue {
 		triggers := make([]*obligations.ValueTriggerRequest, 0, len(attributeValues))
 		for _, attributeValue := range attributeValues {
@@ -1004,20 +1005,39 @@ func (s *AttributeValuesSuite) Test_GetAttributeValue_ScopesObligationsToRequest
 
 	firstObligationFirstValue := createObligationValue(firstObligation, "first", firstAttrValue)
 	firstObligationSecondValue := createObligationValue(firstObligation, "second", secondAttrValue)
-	secondObligationSharedValue := createObligationValue(secondObligation, "shared", firstAttrValue, secondAttrValue)
+	secondObligationSharedValue, err := s.db.PolicyClient.CreateObligationValue(s.ctx, &obligations.CreateObligationValueRequest{
+		ObligationId: secondObligation.GetId(),
+		Value:        "shared",
+		Triggers: []*obligations.ValueTriggerRequest{
+			{
+				Action:         &common.IdNameIdentifier{Id: readAction.GetId()},
+				AttributeValue: &common.IdFqnIdentifier{Id: firstAttrValue.GetId()},
+			},
+			{
+				Action:         &common.IdNameIdentifier{Id: updateAction.GetId()},
+				AttributeValue: &common.IdFqnIdentifier{Id: firstAttrValue.GetId()},
+			},
+			{
+				Action:         &common.IdNameIdentifier{Id: readAction.GetId()},
+				AttributeValue: &common.IdFqnIdentifier{Id: secondAttrValue.GetId()},
+			},
+		},
+	})
+	s.Require().NoError(err)
 	createObligationValue(secondObligation, "untriggered")
 
-	triggerForAttributeValue := func(attributeValue *policy.Value) *policy.ObligationTrigger {
+	triggerForAttributeValueAndAction := func(attributeValue *policy.Value, action *policy.Action) *policy.ObligationTrigger {
 		for _, trigger := range secondObligationSharedValue.GetTriggers() {
-			if trigger.GetAttributeValue().GetId() == attributeValue.GetId() {
+			if trigger.GetAttributeValue().GetId() == attributeValue.GetId() && trigger.GetAction().GetId() == action.GetId() {
 				return trigger
 			}
 		}
 		s.FailNow("shared obligation value is missing an expected trigger")
 		return nil
 	}
-	firstSharedTrigger := triggerForAttributeValue(firstAttrValue)
-	secondSharedTrigger := triggerForAttributeValue(secondAttrValue)
+	firstSharedReadTrigger := triggerForAttributeValueAndAction(firstAttrValue, readAction)
+	firstSharedUpdateTrigger := triggerForAttributeValueAndAction(firstAttrValue, updateAction)
+	secondSharedTrigger := triggerForAttributeValueAndAction(secondAttrValue, readAction)
 
 	assertScopedObligations := func(attributeValue *policy.Value, firstExpected, secondExpected *policy.ObligationValue) {
 		obligationOne := proto.CloneOf(firstObligation)
@@ -1043,7 +1063,7 @@ func (s *AttributeValuesSuite) Test_GetAttributeValue_ScopesObligationsToRequest
 	})
 	s.Require().NoError(err)
 	assertAttributeValue(firstAttrValue, retrievedFirstValue)
-	secondObligationSharedValue.Triggers = []*policy.ObligationTrigger{firstSharedTrigger}
+	secondObligationSharedValue.Triggers = []*policy.ObligationTrigger{firstSharedReadTrigger, firstSharedUpdateTrigger}
 	assertScopedObligations(retrievedFirstValue, firstObligationFirstValue, secondObligationSharedValue)
 
 	retrievedSecondValue, err := s.db.PolicyClient.GetAttributeValue(s.ctx, secondAttrValue.GetId())

--- a/service/integration/attribute_values_test.go
+++ b/service/integration/attribute_values_test.go
@@ -118,6 +118,27 @@ func (s *AttributeValuesSuite) Test_GetAttributeValue() {
 	}
 }
 
+func (s *AttributeValuesSuite) Test_GetAttributeValue_WithoutObligationTriggers() {
+	namespace, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{
+		Name: "test-attribute-value-without-obligation-triggers.com",
+	})
+	s.Require().NoError(err)
+	s.namespaces = append(s.namespaces, namespace)
+
+	attribute, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+		Name:        "without-obligation-triggers",
+		NamespaceId: namespace.GetId(),
+		Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF,
+		Values:      []string{"value"},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(attribute.GetValues(), 1)
+
+	value, err := s.db.PolicyClient.GetAttributeValue(s.ctx, attribute.GetValues()[0].GetId())
+	s.Require().NoError(err)
+	s.Empty(value.GetObligations())
+}
+
 func (s *AttributeValuesSuite) Test_GetAttributeValue_NotFound() {
 	testCases := []struct {
 		name           string
@@ -925,123 +946,108 @@ func (s *AttributeValuesSuite) Test_RemovePublicKeyFromAttributeValue_Not_Found_
 	s.NotNil(resp)
 }
 
-func (s *AttributeValuesSuite) Test_GetAttributeValue_With_Two_Obligations_Success() {
-	// Create a namespace
-	ns, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{
-		Name: "test-obligations.com",
+func (s *AttributeValuesSuite) Test_GetAttributeValue_ScopesObligationsToRequestedAttributeValue() {
+	attributeNamespace, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{
+		Name: "test-scoped-attribute-values.com",
 	})
 	s.Require().NoError(err)
-	s.NotNil(ns)
-	s.namespaces = append(s.namespaces, ns)
+	s.namespaces = append(s.namespaces, attributeNamespace)
 
-	// Create an attribute definition
-	attrDef, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
-		Name:        "test-attr-for-obligations",
-		NamespaceId: ns.GetId(),
+	attribute, err := s.db.PolicyClient.CreateAttribute(s.ctx, &attributes.CreateAttributeRequest{
+		Name:        "test-scoped-obligations",
+		NamespaceId: attributeNamespace.GetId(),
 		Rule:        policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF,
+		Values:      []string{"first", "second"},
 	})
 	s.Require().NoError(err)
-	s.NotNil(attrDef)
+	s.Require().Len(attribute.GetValues(), 2)
+	firstAttrValue, secondAttrValue := attribute.GetValues()[0], attribute.GetValues()[1]
 
-	// Create a test attribute value that will have obligations triggered by it
-	req := &attributes.CreateAttributeValueRequest{
-		Value: "test_value_with_obligations",
+	obligationNamespace, err := s.db.PolicyClient.CreateNamespace(s.ctx, &namespaces.CreateNamespaceRequest{
+		Name: "test-scoped-obligations.com",
+	})
+	s.Require().NoError(err)
+	s.namespaces = append(s.namespaces, obligationNamespace)
+
+	firstObligation, err := s.db.PolicyClient.CreateObligation(s.ctx, &obligations.CreateObligationRequest{
+		NamespaceId: obligationNamespace.GetId(),
+		Name:        "first_scoped_obligation",
+	})
+	s.Require().NoError(err)
+	s.obligations = append(s.obligations, firstObligation)
+
+	secondObligation, err := s.db.PolicyClient.CreateObligation(s.ctx, &obligations.CreateObligationRequest{
+		NamespaceId: obligationNamespace.GetId(),
+		Name:        "second_scoped_obligation",
+	})
+	s.Require().NoError(err)
+	s.obligations = append(s.obligations, secondObligation)
+
+	readAction := s.getActionByNameInNamespace("read", attributeNamespace.GetId())
+	createObligationValue := func(obligation *policy.Obligation, value string, attributeValues ...*policy.Value) *policy.ObligationValue {
+		triggers := make([]*obligations.ValueTriggerRequest, 0, len(attributeValues))
+		for _, attributeValue := range attributeValues {
+			triggers = append(triggers, &obligations.ValueTriggerRequest{
+				Action:         &common.IdNameIdentifier{Id: readAction.GetId()},
+				AttributeValue: &common.IdFqnIdentifier{Id: attributeValue.GetId()},
+			})
+		}
+		created, err := s.db.PolicyClient.CreateObligationValue(s.ctx, &obligations.CreateObligationValueRequest{
+			ObligationId: obligation.GetId(),
+			Value:        value,
+			Triggers:     triggers,
+		})
+		s.Require().NoError(err)
+		return created
 	}
-	createdValue, err := s.db.PolicyClient.CreateAttributeValue(s.ctx, attrDef.GetId(), req)
-	s.Require().NoError(err)
-	s.NotNil(createdValue)
 
-	// Create first obligation with two obligation values
-	obl1, err := s.db.PolicyClient.CreateObligation(s.ctx, &obligations.CreateObligationRequest{
-		NamespaceId: ns.GetId(),
-		Name:        "test_obligation_1",
+	firstObligationFirstValue := createObligationValue(firstObligation, "first", firstAttrValue)
+	firstObligationSecondValue := createObligationValue(firstObligation, "second", secondAttrValue)
+	secondObligationSharedValue := createObligationValue(secondObligation, "shared", firstAttrValue, secondAttrValue)
+	createObligationValue(secondObligation, "untriggered")
+
+	triggerForAttributeValue := func(attributeValue *policy.Value) *policy.ObligationTrigger {
+		for _, trigger := range secondObligationSharedValue.GetTriggers() {
+			if trigger.GetAttributeValue().GetId() == attributeValue.GetId() {
+				return trigger
+			}
+		}
+		s.FailNow("shared obligation value is missing an expected trigger")
+		return nil
+	}
+	firstSharedTrigger := triggerForAttributeValue(firstAttrValue)
+	secondSharedTrigger := triggerForAttributeValue(secondAttrValue)
+
+	assertScopedObligations := func(attributeValue *policy.Value, firstExpected, secondExpected *policy.ObligationValue) {
+		firstObligation.Values = []*policy.ObligationValue{firstExpected}
+		secondObligation.Values = []*policy.ObligationValue{secondExpected}
+		s.assertObligations(
+			[]*policy.Obligation{firstObligation, secondObligation},
+			attributeValue.GetObligations(),
+		)
+	}
+	assertAttributeValue := func(expected, actual *policy.Value) {
+		s.Require().NotNil(actual)
+		s.Equal(expected.GetId(), actual.GetId())
+		s.Equal(expected.GetValue(), actual.GetValue())
+		s.Equal(expected.GetFqn(), actual.GetFqn())
+		s.Equal(attribute.GetId(), actual.GetAttribute().GetId())
+		s.Require().NotNil(actual.GetMetadata())
+	}
+
+	retrievedFirstValue, err := s.db.PolicyClient.GetAttributeValue(s.ctx, &attributes.GetAttributeValueRequest_Fqn{
+		Fqn: firstAttrValue.GetFqn(),
 	})
 	s.Require().NoError(err)
-	s.obligations = append(s.obligations, obl1)
+	assertAttributeValue(firstAttrValue, retrievedFirstValue)
+	secondObligationSharedValue.Triggers = []*policy.ObligationTrigger{firstSharedTrigger}
+	assertScopedObligations(retrievedFirstValue, firstObligationFirstValue, secondObligationSharedValue)
 
-	// Create first obligation value with two triggers
-	readAction := s.getActionByNameInNamespace("read", ns.GetId())
-	updateAction := s.getActionByNameInNamespace("update", ns.GetId())
-
-	obl1Val1, err := s.db.PolicyClient.CreateObligationValue(s.ctx, &obligations.CreateObligationValueRequest{
-		ObligationId: obl1.GetId(),
-		Value:        "obligation_value_1",
-		Triggers: []*obligations.ValueTriggerRequest{
-			{
-				Action:         &common.IdNameIdentifier{Id: readAction.GetId()},
-				AttributeValue: &common.IdFqnIdentifier{Id: createdValue.GetId()},
-				Context: &policy.RequestContext{
-					Pep: &policy.PolicyEnforcementPoint{
-						ClientId: "test-client-1",
-					},
-				},
-			},
-			{
-				Action:         &common.IdNameIdentifier{Id: updateAction.GetId()},
-				AttributeValue: &common.IdFqnIdentifier{Id: createdValue.GetId()},
-				Context: &policy.RequestContext{
-					Pep: &policy.PolicyEnforcementPoint{
-						ClientId: "test-client-2",
-					},
-				},
-			},
-		},
-	})
+	retrievedSecondValue, err := s.db.PolicyClient.GetAttributeValue(s.ctx, secondAttrValue.GetId())
 	s.Require().NoError(err)
-
-	// Create second obligation value with two triggers
-	obl1Val2, err := s.db.PolicyClient.CreateObligationValue(s.ctx, &obligations.CreateObligationValueRequest{
-		ObligationId: obl1.GetId(),
-		Value:        "obligation_value_2",
-		Triggers: []*obligations.ValueTriggerRequest{
-			{
-				Action:         &common.IdNameIdentifier{Id: readAction.GetId()},
-				AttributeValue: &common.IdFqnIdentifier{Id: createdValue.GetId()},
-				Context: &policy.RequestContext{
-					Pep: &policy.PolicyEnforcementPoint{
-						ClientId: "test-client-3",
-					},
-				},
-			},
-		},
-	})
-	s.Require().NoError(err)
-
-	// Create second obligation with one obligation value
-	obl2, err := s.db.PolicyClient.CreateObligation(s.ctx, &obligations.CreateObligationRequest{
-		NamespaceId: ns.GetId(),
-		Name:        "test_obligation_2",
-	})
-	s.Require().NoError(err)
-	s.obligations = append(s.obligations, obl2)
-
-	// Create obligation value with one trigger
-	obl2Val1, err := s.db.PolicyClient.CreateObligationValue(s.ctx, &obligations.CreateObligationValueRequest{
-		ObligationId: obl2.GetId(),
-		Value:        "obligation_value_3",
-		Triggers: []*obligations.ValueTriggerRequest{
-			{
-				Action:         &common.IdNameIdentifier{Id: updateAction.GetId()},
-				AttributeValue: &common.IdFqnIdentifier{Id: createdValue.GetId()},
-				Context: &policy.RequestContext{
-					Pep: &policy.PolicyEnforcementPoint{
-						ClientId: "test-client-5",
-					},
-				},
-			},
-		},
-	})
-	s.Require().NoError(err)
-
-	// Test GetAttributeValue and verify obligations are returned
-	retrievedValue, err := s.db.PolicyClient.GetAttributeValue(s.ctx, createdValue.GetId())
-	s.Require().NoError(err)
-	s.NotNil(retrievedValue)
-	s.Require().Len(retrievedValue.GetObligations(), 2)
-
-	obl1.Values = append(obl1.Values, obl1Val1, obl1Val2)
-	obl2.Values = append(obl2.Values, obl2Val1)
-	s.assertObligations([]*policy.Obligation{obl1, obl2}, retrievedValue.GetObligations())
+	assertAttributeValue(secondAttrValue, retrievedSecondValue)
+	secondObligationSharedValue.Triggers = []*policy.ObligationTrigger{secondSharedTrigger}
+	assertScopedObligations(retrievedSecondValue, firstObligationSecondValue, secondObligationSharedValue)
 }
 
 func (s *AttributeValuesSuite) Test_CreateAttributeValue_WithObligationTriggers_Succeeds() {
@@ -1513,8 +1519,11 @@ func (s *AttributeValuesSuite) assertObligations(expected, actual []*policy.Obli
 		expObl, foundObl := expectedMap[actObl.GetId()]
 		s.Require().True(foundObl, "unexpected obligation with ID %s", actObl.GetId())
 		s.Equal(expObl.GetName(), actObl.GetName(), "obligation name mismatch for ID %s", actObl.GetId())
+		s.Require().NotNil(actObl.GetNamespace())
+		s.Equal(expObl.GetNamespace().GetId(), actObl.GetNamespace().GetId(), "obligation namespace ID mismatch for ID %s", actObl.GetId())
+		s.Equal(expObl.GetNamespace().GetFqn(), actObl.GetNamespace().GetFqn(), "obligation namespace FQN mismatch for ID %s", actObl.GetId())
 		s.Require().Len(actObl.GetValues(), len(expObl.GetValues()), "number of obligation values does not match for obligation ID %s", actObl.GetId())
-		s.Require().Equal(expObl.GetFqn(), actObl.GetFqn(), "obligation namespace FQN mismatch for obligation ID %s", actObl.GetId())
+		s.Require().Equal(expObl.GetFqn(), actObl.GetFqn(), "obligation FQN mismatch for obligation ID %s", actObl.GetId())
 
 		expValuesMap := make(map[string]*policy.ObligationValue)
 		for _, val := range expObl.GetValues() {
@@ -1548,7 +1557,12 @@ func (s *AttributeValuesSuite) assertObligations(expected, actual []*policy.Obli
 						s.Require().Equal(expContextMap[ctx.GetPep().GetClientId()], ctx, "trigger context mismatch for actual trigger %s", actTrig.GetId())
 					}
 				}
+				s.Require().NotNil(expTrig.GetNamespace())
+				s.Require().NotNil(actTrig.GetNamespace())
+				s.Require().Equal(expTrig.GetNamespace().GetId(), actTrig.GetNamespace().GetId(), "trigger namespace ID mismatch for actual trigger %s", actTrig.GetId())
+				s.Require().Equal(expTrig.GetNamespace().GetFqn(), actTrig.GetNamespace().GetFqn(), "trigger namespace FQN mismatch for actual trigger %s", actTrig.GetId())
 				s.Require().Equal(expTrig.GetAttributeValue().GetId(), actTrig.GetAttributeValue().GetId(), "trigger attribute value ID mismatch for actual trigger %s", actTrig.GetId())
+				s.Require().Equal(expTrig.GetAttributeValue().GetFqn(), actTrig.GetAttributeValue().GetFqn(), "trigger attribute value FQN mismatch for actual trigger %s", actTrig.GetId())
 			}
 		}
 	}

--- a/service/policy/db/attribute_values.sql.go
+++ b/service/policy/db/attribute_values.sql.go
@@ -75,8 +75,22 @@ func (q *Queries) deleteAttributeValue(ctx context.Context, id string) (int64, e
 
 const getAttributeValue = `-- name: getAttributeValue :one
 
-WITH obligation_triggers_agg AS (
+WITH target_attribute_value AS (
     SELECT
+        av.id,
+        fqns.fqn,
+        ns.id AS namespace_id,
+        ns.name AS namespace_name
+    FROM attribute_values av
+    JOIN attribute_definitions ad ON av.attribute_definition_id = ad.id
+    JOIN attribute_namespaces ns ON ad.namespace_id = ns.id
+    LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+    WHERE ($1::uuid IS NULL OR av.id = $1::uuid)
+      AND ($2::text IS NULL OR REGEXP_REPLACE(fqns.fqn, '^https://', '') = REGEXP_REPLACE($2::text, '^https://', ''))
+),
+matched_obligation_triggers AS (
+    SELECT
+        ot.attribute_value_id,
         ot.obligation_value_id,
         JSONB_AGG(
             DISTINCT JSONB_BUILD_OBJECT(
@@ -86,13 +100,13 @@ WITH obligation_triggers_agg AS (
                     'name', a.name
                 ),
                 'attribute_value', JSONB_BUILD_OBJECT(
-                    'id', av.id,
-                    'fqn', av_fqns.fqn
+                    'id', tav.id,
+                    'fqn', tav.fqn
                 ),
                 'namespace', JSONB_BUILD_OBJECT(
-                    'id', trigger_ns.id,
-                    'name', trigger_ns.name,
-                    'fqn', CONCAT('https://', trigger_ns.name)
+                    'id', tav.namespace_id,
+                    'name', tav.namespace_name,
+                    'fqn', CONCAT('https://', tav.namespace_name)
                 ),
                 'context', CASE
                     WHEN ot.client_id IS NOT NULL THEN JSONB_BUILD_ARRAY(
@@ -107,34 +121,32 @@ WITH obligation_triggers_agg AS (
             )
         ) AS triggers
     FROM obligation_triggers ot
+    JOIN target_attribute_value tav ON ot.attribute_value_id = tav.id
     JOIN actions a ON ot.action_id = a.id
-    JOIN attribute_values av ON ot.attribute_value_id = av.id
-    JOIN attribute_definitions ad ON av.attribute_definition_id = ad.id
-    JOIN attribute_namespaces trigger_ns ON ad.namespace_id = trigger_ns.id
-    LEFT JOIN attribute_fqns av_fqns ON av.id = av_fqns.value_id
-    GROUP BY ot.obligation_value_id
+    GROUP BY ot.attribute_value_id, ot.obligation_value_id
 ),
-obligation_values_agg AS (
+matched_obligation_values AS (
     SELECT
+        ota.attribute_value_id,
         ov.obligation_definition_id,
         JSONB_AGG(
             DISTINCT JSONB_BUILD_OBJECT(
                 'id', ov.id,
                 'value', ov.value,
                 'fqn', ns_fqns.fqn || '/obl/' || od.name || '/value/' || ov.value,
-                'triggers', COALESCE(ota.triggers, '[]'::JSONB)
+                'triggers', ota.triggers
             )
         ) AS values
-    FROM obligation_values_standard ov
-    LEFT JOIN obligation_triggers_agg ota ON ov.id = ota.obligation_value_id
+    FROM matched_obligation_triggers ota
+    JOIN obligation_values_standard ov ON ota.obligation_value_id = ov.id
     JOIN obligation_definitions od ON ov.obligation_definition_id = od.id
     JOIN attribute_namespaces n ON od.namespace_id = n.id
     LEFT JOIN attribute_fqns ns_fqns ON n.id = ns_fqns.namespace_id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-    GROUP BY ov.obligation_definition_id
+    GROUP BY ota.attribute_value_id, ov.obligation_definition_id
 ),
-attribute_obligations AS (
+matched_obligations AS (
     SELECT
-        ot.attribute_value_id,
+        ova.attribute_value_id,
         JSONB_AGG(
             DISTINCT JSONB_BUILD_OBJECT(
                 'id', od.id,
@@ -145,16 +157,14 @@ attribute_obligations AS (
                     'name', n.name,
                     'fqn', ns_fqns.fqn
                 ),
-                'values', COALESCE(ova.values, '[]'::JSONB)
+                'values', ova.values
             )
         ) AS obligations
-    FROM obligation_triggers ot
-    JOIN obligation_values_standard ov ON ot.obligation_value_id = ov.id
-    JOIN obligation_definitions od ON ov.obligation_definition_id = od.id
+    FROM matched_obligation_values ova
+    JOIN obligation_definitions od ON ova.obligation_definition_id = od.id
     JOIN attribute_namespaces n ON od.namespace_id = n.id
     LEFT JOIN attribute_fqns ns_fqns ON n.id = ns_fqns.namespace_id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-    LEFT JOIN obligation_values_agg ova ON od.id = ova.obligation_definition_id
-    GROUP BY ot.attribute_value_id
+    GROUP BY ova.attribute_value_id
 )
 SELECT
     av.id,
@@ -162,7 +172,7 @@ SELECT
     av.active,
     JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', av.metadata -> 'labels', 'created_at', av.created_at, 'updated_at', av.updated_at)) as metadata,
     av.attribute_definition_id,
-    fqns.fqn,
+    tav.fqn,
     JSONB_AGG(
         DISTINCT JSONB_BUILD_OBJECT(
             'id', kas.id,
@@ -175,7 +185,7 @@ SELECT
     ao.obligations,
     asm.subject_mappings
 FROM attribute_values av
-LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+JOIN target_attribute_value tav ON av.id = tav.id
 LEFT JOIN attribute_value_key_access_grants avkag ON av.id = avkag.attribute_value_id
 LEFT JOIN key_access_servers kas ON avkag.key_access_server_id = kas.id
 LEFT JOIN (
@@ -197,7 +207,7 @@ LEFT JOIN (
     INNER JOIN key_access_servers kas ON kas.id = kask.key_access_server_id
     GROUP BY k.value_id
 ) value_keys ON av.id = value_keys.value_id
-LEFT JOIN attribute_obligations ao ON av.id = ao.attribute_value_id
+LEFT JOIN matched_obligations ao ON av.id = ao.attribute_value_id
 LEFT JOIN LATERAL (
     SELECT
         JSONB_AGG(
@@ -216,7 +226,7 @@ LEFT JOIN LATERAL (
                     'id', av.id,
                     'value', av.value,
                     'active', av.active,
-                    'fqn', fqns.fqn
+                    'fqn', tav.fqn
                 ),
                 'namespace', CASE
                     WHEN sm.namespace_id IS NULL THEN NULL
@@ -251,9 +261,7 @@ LEFT JOIN LATERAL (
     LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
     WHERE sm.attribute_value_id = av.id
 ) asm ON TRUE
-WHERE ($1::uuid IS NULL OR av.id = $1::uuid)
-  AND ($2::text IS NULL OR REGEXP_REPLACE(fqns.fqn, '^https://', '') = REGEXP_REPLACE($2::text, '^https://', ''))
-GROUP BY av.id, fqns.fqn, value_keys.keys, ao.obligations, asm.subject_mappings
+GROUP BY av.id, tav.fqn, value_keys.keys, ao.obligations, asm.subject_mappings
 `
 
 type getAttributeValueParams struct {
@@ -278,8 +286,22 @@ type getAttributeValueRow struct {
 // ATTRIBUTE VALUES
 // --------------------------------------------------------------
 //
-//	WITH obligation_triggers_agg AS (
+//	WITH target_attribute_value AS (
 //	    SELECT
+//	        av.id,
+//	        fqns.fqn,
+//	        ns.id AS namespace_id,
+//	        ns.name AS namespace_name
+//	    FROM attribute_values av
+//	    JOIN attribute_definitions ad ON av.attribute_definition_id = ad.id
+//	    JOIN attribute_namespaces ns ON ad.namespace_id = ns.id
+//	    LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+//	    WHERE ($1::uuid IS NULL OR av.id = $1::uuid)
+//	      AND ($2::text IS NULL OR REGEXP_REPLACE(fqns.fqn, '^https://', '') = REGEXP_REPLACE($2::text, '^https://', ''))
+//	),
+//	matched_obligation_triggers AS (
+//	    SELECT
+//	        ot.attribute_value_id,
 //	        ot.obligation_value_id,
 //	        JSONB_AGG(
 //	            DISTINCT JSONB_BUILD_OBJECT(
@@ -289,13 +311,13 @@ type getAttributeValueRow struct {
 //	                    'name', a.name
 //	                ),
 //	                'attribute_value', JSONB_BUILD_OBJECT(
-//	                    'id', av.id,
-//	                    'fqn', av_fqns.fqn
+//	                    'id', tav.id,
+//	                    'fqn', tav.fqn
 //	                ),
 //	                'namespace', JSONB_BUILD_OBJECT(
-//	                    'id', trigger_ns.id,
-//	                    'name', trigger_ns.name,
-//	                    'fqn', CONCAT('https://', trigger_ns.name)
+//	                    'id', tav.namespace_id,
+//	                    'name', tav.namespace_name,
+//	                    'fqn', CONCAT('https://', tav.namespace_name)
 //	                ),
 //	                'context', CASE
 //	                    WHEN ot.client_id IS NOT NULL THEN JSONB_BUILD_ARRAY(
@@ -310,34 +332,32 @@ type getAttributeValueRow struct {
 //	            )
 //	        ) AS triggers
 //	    FROM obligation_triggers ot
+//	    JOIN target_attribute_value tav ON ot.attribute_value_id = tav.id
 //	    JOIN actions a ON ot.action_id = a.id
-//	    JOIN attribute_values av ON ot.attribute_value_id = av.id
-//	    JOIN attribute_definitions ad ON av.attribute_definition_id = ad.id
-//	    JOIN attribute_namespaces trigger_ns ON ad.namespace_id = trigger_ns.id
-//	    LEFT JOIN attribute_fqns av_fqns ON av.id = av_fqns.value_id
-//	    GROUP BY ot.obligation_value_id
+//	    GROUP BY ot.attribute_value_id, ot.obligation_value_id
 //	),
-//	obligation_values_agg AS (
+//	matched_obligation_values AS (
 //	    SELECT
+//	        ota.attribute_value_id,
 //	        ov.obligation_definition_id,
 //	        JSONB_AGG(
 //	            DISTINCT JSONB_BUILD_OBJECT(
 //	                'id', ov.id,
 //	                'value', ov.value,
 //	                'fqn', ns_fqns.fqn || '/obl/' || od.name || '/value/' || ov.value,
-//	                'triggers', COALESCE(ota.triggers, '[]'::JSONB)
+//	                'triggers', ota.triggers
 //	            )
 //	        ) AS values
-//	    FROM obligation_values_standard ov
-//	    LEFT JOIN obligation_triggers_agg ota ON ov.id = ota.obligation_value_id
+//	    FROM matched_obligation_triggers ota
+//	    JOIN obligation_values_standard ov ON ota.obligation_value_id = ov.id
 //	    JOIN obligation_definitions od ON ov.obligation_definition_id = od.id
 //	    JOIN attribute_namespaces n ON od.namespace_id = n.id
 //	    LEFT JOIN attribute_fqns ns_fqns ON n.id = ns_fqns.namespace_id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-//	    GROUP BY ov.obligation_definition_id
+//	    GROUP BY ota.attribute_value_id, ov.obligation_definition_id
 //	),
-//	attribute_obligations AS (
+//	matched_obligations AS (
 //	    SELECT
-//	        ot.attribute_value_id,
+//	        ova.attribute_value_id,
 //	        JSONB_AGG(
 //	            DISTINCT JSONB_BUILD_OBJECT(
 //	                'id', od.id,
@@ -348,16 +368,14 @@ type getAttributeValueRow struct {
 //	                    'name', n.name,
 //	                    'fqn', ns_fqns.fqn
 //	                ),
-//	                'values', COALESCE(ova.values, '[]'::JSONB)
+//	                'values', ova.values
 //	            )
 //	        ) AS obligations
-//	    FROM obligation_triggers ot
-//	    JOIN obligation_values_standard ov ON ot.obligation_value_id = ov.id
-//	    JOIN obligation_definitions od ON ov.obligation_definition_id = od.id
+//	    FROM matched_obligation_values ova
+//	    JOIN obligation_definitions od ON ova.obligation_definition_id = od.id
 //	    JOIN attribute_namespaces n ON od.namespace_id = n.id
 //	    LEFT JOIN attribute_fqns ns_fqns ON n.id = ns_fqns.namespace_id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-//	    LEFT JOIN obligation_values_agg ova ON od.id = ova.obligation_definition_id
-//	    GROUP BY ot.attribute_value_id
+//	    GROUP BY ova.attribute_value_id
 //	)
 //	SELECT
 //	    av.id,
@@ -365,7 +383,7 @@ type getAttributeValueRow struct {
 //	    av.active,
 //	    JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', av.metadata -> 'labels', 'created_at', av.created_at, 'updated_at', av.updated_at)) as metadata,
 //	    av.attribute_definition_id,
-//	    fqns.fqn,
+//	    tav.fqn,
 //	    JSONB_AGG(
 //	        DISTINCT JSONB_BUILD_OBJECT(
 //	            'id', kas.id,
@@ -378,7 +396,7 @@ type getAttributeValueRow struct {
 //	    ao.obligations,
 //	    asm.subject_mappings
 //	FROM attribute_values av
-//	LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+//	JOIN target_attribute_value tav ON av.id = tav.id
 //	LEFT JOIN attribute_value_key_access_grants avkag ON av.id = avkag.attribute_value_id
 //	LEFT JOIN key_access_servers kas ON avkag.key_access_server_id = kas.id
 //	LEFT JOIN (
@@ -400,7 +418,7 @@ type getAttributeValueRow struct {
 //	    INNER JOIN key_access_servers kas ON kas.id = kask.key_access_server_id
 //	    GROUP BY k.value_id
 //	) value_keys ON av.id = value_keys.value_id
-//	LEFT JOIN attribute_obligations ao ON av.id = ao.attribute_value_id
+//	LEFT JOIN matched_obligations ao ON av.id = ao.attribute_value_id
 //	LEFT JOIN LATERAL (
 //	    SELECT
 //	        JSONB_AGG(
@@ -419,7 +437,7 @@ type getAttributeValueRow struct {
 //	                    'id', av.id,
 //	                    'value', av.value,
 //	                    'active', av.active,
-//	                    'fqn', fqns.fqn
+//	                    'fqn', tav.fqn
 //	                ),
 //	                'namespace', CASE
 //	                    WHEN sm.namespace_id IS NULL THEN NULL
@@ -454,9 +472,7 @@ type getAttributeValueRow struct {
 //	    LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
 //	    WHERE sm.attribute_value_id = av.id
 //	) asm ON TRUE
-//	WHERE ($1::uuid IS NULL OR av.id = $1::uuid)
-//	  AND ($2::text IS NULL OR REGEXP_REPLACE(fqns.fqn, '^https://', '') = REGEXP_REPLACE($2::text, '^https://', ''))
-//	GROUP BY av.id, fqns.fqn, value_keys.keys, ao.obligations, asm.subject_mappings
+//	GROUP BY av.id, tav.fqn, value_keys.keys, ao.obligations, asm.subject_mappings
 func (q *Queries) getAttributeValue(ctx context.Context, arg getAttributeValueParams) (getAttributeValueRow, error) {
 	row := q.db.QueryRow(ctx, getAttributeValue, arg.ID, arg.Fqn)
 	var i getAttributeValueRow

--- a/service/policy/db/attribute_values.sql.go
+++ b/service/policy/db/attribute_values.sql.go
@@ -80,11 +80,13 @@ WITH target_attribute_value AS (
         av.id,
         fqns.fqn,
         ns.id AS namespace_id,
-        ns.name AS namespace_name
+        ns.name AS namespace_name,
+        ns_fqns.fqn AS namespace_fqn
     FROM attribute_values av
     JOIN attribute_definitions ad ON av.attribute_definition_id = ad.id
     JOIN attribute_namespaces ns ON ad.namespace_id = ns.id
     LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+    LEFT JOIN attribute_fqns ns_fqns ON ns.id = ns_fqns.namespace_id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
     WHERE ($1::uuid IS NULL OR av.id = $1::uuid)
       AND ($2::text IS NULL OR REGEXP_REPLACE(fqns.fqn, '^https://', '') = REGEXP_REPLACE($2::text, '^https://', ''))
 ),
@@ -106,7 +108,7 @@ matched_obligation_triggers AS (
                 'namespace', JSONB_BUILD_OBJECT(
                     'id', tav.namespace_id,
                     'name', tav.namespace_name,
-                    'fqn', CONCAT('https://', tav.namespace_name)
+                    'fqn', tav.namespace_fqn
                 ),
                 'context', CASE
                     WHEN ot.client_id IS NOT NULL THEN JSONB_BUILD_ARRAY(
@@ -291,11 +293,13 @@ type getAttributeValueRow struct {
 //	        av.id,
 //	        fqns.fqn,
 //	        ns.id AS namespace_id,
-//	        ns.name AS namespace_name
+//	        ns.name AS namespace_name,
+//	        ns_fqns.fqn AS namespace_fqn
 //	    FROM attribute_values av
 //	    JOIN attribute_definitions ad ON av.attribute_definition_id = ad.id
 //	    JOIN attribute_namespaces ns ON ad.namespace_id = ns.id
 //	    LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+//	    LEFT JOIN attribute_fqns ns_fqns ON ns.id = ns_fqns.namespace_id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
 //	    WHERE ($1::uuid IS NULL OR av.id = $1::uuid)
 //	      AND ($2::text IS NULL OR REGEXP_REPLACE(fqns.fqn, '^https://', '') = REGEXP_REPLACE($2::text, '^https://', ''))
 //	),
@@ -317,7 +321,7 @@ type getAttributeValueRow struct {
 //	                'namespace', JSONB_BUILD_OBJECT(
 //	                    'id', tav.namespace_id,
 //	                    'name', tav.namespace_name,
-//	                    'fqn', CONCAT('https://', tav.namespace_name)
+//	                    'fqn', tav.namespace_fqn
 //	                ),
 //	                'context', CASE
 //	                    WHEN ot.client_id IS NOT NULL THEN JSONB_BUILD_ARRAY(

--- a/service/policy/db/queries/attribute_values.sql
+++ b/service/policy/db/queries/attribute_values.sql
@@ -3,8 +3,22 @@
 ----------------------------------------------------------------
 
 -- name: getAttributeValue :one
-WITH obligation_triggers_agg AS (
+WITH target_attribute_value AS (
     SELECT
+        av.id,
+        fqns.fqn,
+        ns.id AS namespace_id,
+        ns.name AS namespace_name
+    FROM attribute_values av
+    JOIN attribute_definitions ad ON av.attribute_definition_id = ad.id
+    JOIN attribute_namespaces ns ON ad.namespace_id = ns.id
+    LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+    WHERE (sqlc.narg('id')::uuid IS NULL OR av.id = sqlc.narg('id')::uuid)
+      AND (sqlc.narg('fqn')::text IS NULL OR REGEXP_REPLACE(fqns.fqn, '^https://', '') = REGEXP_REPLACE(sqlc.narg('fqn')::text, '^https://', ''))
+),
+matched_obligation_triggers AS (
+    SELECT
+        ot.attribute_value_id,
         ot.obligation_value_id,
         JSONB_AGG(
             DISTINCT JSONB_BUILD_OBJECT(
@@ -14,13 +28,13 @@ WITH obligation_triggers_agg AS (
                     'name', a.name
                 ),
                 'attribute_value', JSONB_BUILD_OBJECT(
-                    'id', av.id,
-                    'fqn', av_fqns.fqn
+                    'id', tav.id,
+                    'fqn', tav.fqn
                 ),
                 'namespace', JSONB_BUILD_OBJECT(
-                    'id', trigger_ns.id,
-                    'name', trigger_ns.name,
-                    'fqn', CONCAT('https://', trigger_ns.name)
+                    'id', tav.namespace_id,
+                    'name', tav.namespace_name,
+                    'fqn', CONCAT('https://', tav.namespace_name)
                 ),
                 'context', CASE
                     WHEN ot.client_id IS NOT NULL THEN JSONB_BUILD_ARRAY(
@@ -35,34 +49,32 @@ WITH obligation_triggers_agg AS (
             )
         ) AS triggers
     FROM obligation_triggers ot
+    JOIN target_attribute_value tav ON ot.attribute_value_id = tav.id
     JOIN actions a ON ot.action_id = a.id
-    JOIN attribute_values av ON ot.attribute_value_id = av.id
-    JOIN attribute_definitions ad ON av.attribute_definition_id = ad.id
-    JOIN attribute_namespaces trigger_ns ON ad.namespace_id = trigger_ns.id
-    LEFT JOIN attribute_fqns av_fqns ON av.id = av_fqns.value_id
-    GROUP BY ot.obligation_value_id
+    GROUP BY ot.attribute_value_id, ot.obligation_value_id
 ),
-obligation_values_agg AS (
+matched_obligation_values AS (
     SELECT
+        ota.attribute_value_id,
         ov.obligation_definition_id,
         JSONB_AGG(
             DISTINCT JSONB_BUILD_OBJECT(
                 'id', ov.id,
                 'value', ov.value,
                 'fqn', ns_fqns.fqn || '/obl/' || od.name || '/value/' || ov.value,
-                'triggers', COALESCE(ota.triggers, '[]'::JSONB)
+                'triggers', ota.triggers
             )
         ) AS values
-    FROM obligation_values_standard ov
-    LEFT JOIN obligation_triggers_agg ota ON ov.id = ota.obligation_value_id
+    FROM matched_obligation_triggers ota
+    JOIN obligation_values_standard ov ON ota.obligation_value_id = ov.id
     JOIN obligation_definitions od ON ov.obligation_definition_id = od.id
     JOIN attribute_namespaces n ON od.namespace_id = n.id
     LEFT JOIN attribute_fqns ns_fqns ON n.id = ns_fqns.namespace_id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-    GROUP BY ov.obligation_definition_id
+    GROUP BY ota.attribute_value_id, ov.obligation_definition_id
 ),
-attribute_obligations AS (
+matched_obligations AS (
     SELECT
-        ot.attribute_value_id,
+        ova.attribute_value_id,
         JSONB_AGG(
             DISTINCT JSONB_BUILD_OBJECT(
                 'id', od.id,
@@ -73,16 +85,14 @@ attribute_obligations AS (
                     'name', n.name,
                     'fqn', ns_fqns.fqn
                 ),
-                'values', COALESCE(ova.values, '[]'::JSONB)
+                'values', ova.values
             )
         ) AS obligations
-    FROM obligation_triggers ot
-    JOIN obligation_values_standard ov ON ot.obligation_value_id = ov.id
-    JOIN obligation_definitions od ON ov.obligation_definition_id = od.id
+    FROM matched_obligation_values ova
+    JOIN obligation_definitions od ON ova.obligation_definition_id = od.id
     JOIN attribute_namespaces n ON od.namespace_id = n.id
     LEFT JOIN attribute_fqns ns_fqns ON n.id = ns_fqns.namespace_id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
-    LEFT JOIN obligation_values_agg ova ON od.id = ova.obligation_definition_id
-    GROUP BY ot.attribute_value_id
+    GROUP BY ova.attribute_value_id
 )
 SELECT
     av.id,
@@ -90,7 +100,7 @@ SELECT
     av.active,
     JSON_STRIP_NULLS(JSON_BUILD_OBJECT('labels', av.metadata -> 'labels', 'created_at', av.created_at, 'updated_at', av.updated_at)) as metadata,
     av.attribute_definition_id,
-    fqns.fqn,
+    tav.fqn,
     JSONB_AGG(
         DISTINCT JSONB_BUILD_OBJECT(
             'id', kas.id,
@@ -103,7 +113,7 @@ SELECT
     ao.obligations,
     asm.subject_mappings
 FROM attribute_values av
-LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+JOIN target_attribute_value tav ON av.id = tav.id
 LEFT JOIN attribute_value_key_access_grants avkag ON av.id = avkag.attribute_value_id
 LEFT JOIN key_access_servers kas ON avkag.key_access_server_id = kas.id
 LEFT JOIN (
@@ -125,7 +135,7 @@ LEFT JOIN (
     INNER JOIN key_access_servers kas ON kas.id = kask.key_access_server_id
     GROUP BY k.value_id
 ) value_keys ON av.id = value_keys.value_id
-LEFT JOIN attribute_obligations ao ON av.id = ao.attribute_value_id
+LEFT JOIN matched_obligations ao ON av.id = ao.attribute_value_id
 LEFT JOIN LATERAL (
     SELECT
         JSONB_AGG(
@@ -144,7 +154,7 @@ LEFT JOIN LATERAL (
                     'id', av.id,
                     'value', av.value,
                     'active', av.active,
-                    'fqn', fqns.fqn
+                    'fqn', tav.fqn
                 ),
                 'namespace', CASE
                     WHEN sm.namespace_id IS NULL THEN NULL
@@ -179,9 +189,7 @@ LEFT JOIN LATERAL (
     LEFT JOIN attribute_fqns sm_ns_fqns ON sm_ns_fqns.namespace_id = sm_ns.id AND sm_ns_fqns.attribute_id IS NULL AND sm_ns_fqns.value_id IS NULL
     WHERE sm.attribute_value_id = av.id
 ) asm ON TRUE
-WHERE (sqlc.narg('id')::uuid IS NULL OR av.id = sqlc.narg('id')::uuid)
-  AND (sqlc.narg('fqn')::text IS NULL OR REGEXP_REPLACE(fqns.fqn, '^https://', '') = REGEXP_REPLACE(sqlc.narg('fqn')::text, '^https://', ''))
-GROUP BY av.id, fqns.fqn, value_keys.keys, ao.obligations, asm.subject_mappings;
+GROUP BY av.id, tav.fqn, value_keys.keys, ao.obligations, asm.subject_mappings;
 
 -- name: createAttributeValue :one
 INSERT INTO attribute_values (attribute_definition_id, value, metadata)

--- a/service/policy/db/queries/attribute_values.sql
+++ b/service/policy/db/queries/attribute_values.sql
@@ -9,10 +9,12 @@ WITH target_attribute_value AS (
         fqns.fqn,
         ns.id AS namespace_id,
         ns.name AS namespace_name
+        ns_fqns.fqn AS namespace_fqn
     FROM attribute_values av
     JOIN attribute_definitions ad ON av.attribute_definition_id = ad.id
     JOIN attribute_namespaces ns ON ad.namespace_id = ns.id
     LEFT JOIN attribute_fqns fqns ON av.id = fqns.value_id
+    LEFT JOIN attribute_fqns ns_fqns ON ns.id = ns_fqns.namespace_id AND ns_fqns.attribute_id IS NULL AND ns_fqns.value_id IS NULL
     WHERE (sqlc.narg('id')::uuid IS NULL OR av.id = sqlc.narg('id')::uuid)
       AND (sqlc.narg('fqn')::text IS NULL OR REGEXP_REPLACE(fqns.fqn, '^https://', '') = REGEXP_REPLACE(sqlc.narg('fqn')::text, '^https://', ''))
 ),
@@ -34,7 +36,7 @@ matched_obligation_triggers AS (
                 'namespace', JSONB_BUILD_OBJECT(
                     'id', tav.namespace_id,
                     'name', tav.namespace_name,
-                    'fqn', CONCAT('https://', tav.namespace_name)
+                    'fqn', tav.namespace_fqn
                 ),
                 'context', CASE
                     WHEN ot.client_id IS NOT NULL THEN JSONB_BUILD_ARRAY(

--- a/service/policy/db/queries/attribute_values.sql
+++ b/service/policy/db/queries/attribute_values.sql
@@ -8,7 +8,7 @@ WITH target_attribute_value AS (
         av.id,
         fqns.fqn,
         ns.id AS namespace_id,
-        ns.name AS namespace_name
+        ns.name AS namespace_name,
         ns_fqns.fqn AS namespace_fqn
     FROM attribute_values av
     JOIN attribute_definitions ad ON av.attribute_definition_id = ad.id


### PR DESCRIPTION
### Proposed Changes

1.) Only show obligation information that is tied to the attribute value.
 - Meaning we will filter out additional obligation triggers and obligation values that are not directly tied to the attribute via an obligation trigger.

### What previously happened
- Previously when calling GetAttributeValue we would find the Obligation that is tied to the Attribute Value via the Obligation Trigger. In doing that, we also would return all the Obligation Values under that Obligation and all the Triggers under each Value. This is a bug, and we should only be populating Obligation Values / Triggers that are directly connected to the attribute value itself.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected attribute value retrieval so obligations are limited to the requested attribute value.
  * Prevented unrelated obligations and triggerless obligation values from appearing in results.
  * Improved returned attribute and namespace details for retrieved values.
  * Ensured shared obligation values are correctly scoped to the selected attribute value.
* **Tests**
  * Added coverage for attribute values without obligation triggers.
  * Expanded validation for value-specific obligation and trigger information, including namespace and fully qualified name details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->