### PR TITLE
fix(ci): SonarCloud analysis scope and Postgres analysis 

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,6 +2,7 @@ name: SonarCloud
 on:
   schedule:
     - cron: "0 5 * * 2,4,6"
+  workflow_dispatch:
 #  pull_request:
 #    types:
 #      - opened
@@ -65,7 +66,7 @@ jobs:
           name: code-coverage-report
 
       - name: "SonarCloud Scan"
-        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 #v6.0.0
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,15 +2,15 @@ sonar.projectKey=opentdf_platform
 sonar.organization=opentdf
 
 sonar.sources=.
-sonar.exclusions=docs/**,protocol/**,.github/**,examples/**,**/*_test.go
+sonar.exclusions=docs/**,protocol/**,.github/**,examples/**,test/**,**/testdata/**,**/*_test.go,coverage.*
 
 sonar.tests=.
-sonar.test.inclusions=**/*_test.go 
+sonar.test.inclusions=**/*_test.go
 
 sonar.go.coverage.reportPaths=coverage.out
 sonar.go.tests.reportPaths=coverage.json
 
-# need to properly process coverage report file presented in the .gitignore
-sonar.scm.disabled=true
+sonar.plsql.file.suffixes=pks,pkb
+sonar.postgres.file.suffixes=sql,pgsql,psql
 
-sonar.log.level = INFO
+sonar.log.level=INFO


### PR DESCRIPTION
### Proposed Changes

SonarCloud's quality gate has been failing on `main`, so every commit gets a red X. The workflow itself is green — it's the gate check that fails. Most of what it was counting wasn't real.

**Every `.sql` file was being analyzed as Oracle PL/SQL.** `sonar.plsql.file.suffixes` defaults to `sql,pks,pkb`, while the PostgreSQL analyzer's default (`pgsql,psql`) matched nothing we have. Our SQL is Postgres, and Oracle's parser choked on 19 of our 48 migrations — which is why three were flagged as `DELETE` missing a `WHERE` when they actually rewrite a table from a temp table. This points `.sql` at the analyzer that can read it.

**Test fixtures were being scanned as production source.** Excluding `test/**` and `**/testdata/**` stops the recurring "leaked secret" findings from bats harnesses, a JWT that expired in 2019, and sample private keys — the ones we keep hand-triaging as *won't fix*.

**`sonar.scm.disabled` is gone.** It only existed because the gitignored coverage report was being indexed as source; excluding `coverage.*` removes the need. Sonar can date lines from git blame again.

Also bumps `sonarqube-scan-action` v6.0.0 → v8.2.1. We were two majors behind, and v6 runs node20, which GitHub is deprecating and already warns about in our logs.

### Validation

Verified by temporarily enabling `pull_request` and a branch-scoped `push` trigger, then reverting. Both runs succeeded:

* [PR scan](https://github.com/opentdf/platform/actions/runs/32748347992) — confirms the mechanics
* [Branch scan](https://github.com/opentdf/platform/actions/runs/32750230083) — confirms findings, since PR scans only see changed files

| | Before | After |
|---|---|---|
| SQL findings | 148 (PL/SQL) | **0** (PostgreSQL) |
| Migrations failing to parse | 19 of 48 | **0** of 62 |
| `coverage.json` indexed as source | yes | no |
| SCM | disabled | active |

**Worth knowing:** the PostgreSQL analyzer has 12 rules to PL/SQL's 186, so some of that 148 → 0 is lost breadth. Still the right trade — 131 of the 148 were one noise rule (duplicated string literals, mostly on sqlc query files) and 3 were BLOCKER bugs that were simply wrong. Notably `postgresdre:S2260` ("Postgres files should not have syntax errors") fired zero times, confirming all 62 files now parse cleanly.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

n/a — CI configuration only, no Go code changed.

### Testing Instructions

No Go changed, so `make lint` / `make test` don't apply. See the two runs linked above.

Once merged, `workflow_dispatch` makes on-demand scans possible (GitHub only exposes the trigger once it's on the default branch):

```bash
gh workflow run sonarcloud.yml --repo opentdf/platform
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * SonarCloud analysis can now be started manually.
  * Updated the SonarCloud scanning action for improved compatibility.
  * Refined code-quality analysis settings to exclude tests, test data, and coverage files.
  * Added support for analyzing PL/SQL and PostgreSQL files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->