### PR TITLE
fix(otdfctl): stream TDF encryption

### DIFF
--- a/otdfctl/cmd/tdf/encrypt.go
+++ b/otdfctl/cmd/tdf/encrypt.go
@@ -1,8 +1,11 @@
 package tdf
 
 import (
+	"bufio"
+	"errors"
 	"io"
 	"log/slog"
+	"mime"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,8 +14,8 @@ import (
 	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/otdfctl/cmd/common"
 	"github.com/opentdf/platform/otdfctl/pkg/cli"
+	"github.com/opentdf/platform/otdfctl/pkg/handlers"
 	"github.com/opentdf/platform/otdfctl/pkg/man"
-	"github.com/opentdf/platform/otdfctl/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -23,6 +26,30 @@ var (
 	encryptDoc = man.Docs.GetCommand("encrypt", man.WithRun(encryptRun))
 	EncryptCmd = &encryptDoc.Command
 )
+
+// detectMimeType sniffs at most the first megabyte and returns a reader that
+// still yields the complete payload.
+func detectMimeType(in io.Reader, fileExt string) (string, io.Reader, error) {
+	buffered, ok := in.(*bufio.Reader)
+	if !ok {
+		buffered = bufio.NewReaderSize(in, Size1MB)
+		in = buffered
+	}
+
+	mimetype.SetLimit(Size1MB)
+	head, err := buffered.Peek(Size1MB)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, bufio.ErrBufferFull) {
+		return "", in, err
+	}
+
+	detected := mimetype.Detect(head).String()
+	if detected == "application/octet-stream" && fileExt != "" {
+		if byExtension := mime.TypeByExtension("." + strings.TrimPrefix(fileExt, ".")); byExtension != "" {
+			detected = byExtension
+		}
+	}
+	return detected, in, nil
+}
 
 func encryptRun(cmd *cobra.Command, args []string) {
 	c := cli.New(cmd, args, cli.WithPrintJSON())
@@ -57,13 +84,13 @@ func encryptRun(cmd *cobra.Command, args []string) {
 		wrappingKeyAlgorithm = ocrypto.RSA2048Key
 	}
 
-	piped := readPipedStdin()
+	piped, hasPiped := stdinReader()
 
 	inputCount := 0
 	if filePath != "" {
 		inputCount++
 	}
-	if len(piped) > 0 {
+	if hasPiped {
 		inputCount++
 	}
 
@@ -76,71 +103,78 @@ func encryptRun(cmd *cobra.Command, args []string) {
 		cliExit("ONLY ONE")
 	}
 
-	// prefer filepath argument over stdin input
-	bytesSlice := piped
-	var err error
+	var in io.Reader = piped
 	if filePath != "" {
-		bytesSlice, err = utils.ReadBytesFromFile(filePath, MaxFileSize)
+		file, err := os.Open(filePath)
 		if err != nil {
 			cli.ExitWithError("Failed to read file:", err)
 		}
+		defer file.Close()
+		fileInfo, err := file.Stat()
+		if err != nil {
+			cli.ExitWithError("Failed to read file:", err)
+		}
+		if fileInfo.Size() > MaxFileSize {
+			cli.ExitWithError("Failed to read file:", errors.New("file size exceeds the 10 GB limit"))
+		}
+		in = file
 	}
 
 	// auto-detect mime type if not provided
 	if fileMimeType == "" {
 		slog.Debug("detecting mime type of file")
-		// get the mime type of the file
-		mimetype.SetLimit(Size1MB) // limit to 1MB
-		m := mimetype.Detect(bytesSlice)
-		// default to application/octet-stream if no mime type is detected
-		fileMimeType = m.String()
-
-		if fileMimeType == "application/octet-stream" {
-			if fileExt != "" {
-				fileMimeType = mimetype.Lookup(fileExt).String()
-			}
+		var err error
+		fileMimeType, in, err = detectMimeType(in, fileExt)
+		if err != nil {
+			cli.ExitWithError("Failed to read file:", err)
 		}
 	}
 	slog.Debug("encrypting file",
-		slog.Int("file_len", len(bytesSlice)),
 		slog.String("mime_type", fileMimeType),
 	)
 
-	// Do the encryption
-	encrypted, err := h.EncryptBytes(
-		tdfType,
-		bytesSlice,
-		attrValues,
-		fileMimeType,
-		kasURLPath,
-		assertions,
-		wrappingKeyAlgorithm,
-		targetMode,
-	)
-	if err != nil {
-		cli.ExitWithError("Failed to encrypt", err)
-	}
-
-	// Find the destination as the output flag filename or stdout
-	var dest *os.File
+	var dest io.Writer
+	var tdfFile *outputFile
 	if out != "" {
 		// make sure output ends in .tdf extension
 		if !strings.HasSuffix(out, ".tdf") {
 			out += ".tdf"
 		}
-		tdfFile, err := os.Create(out)
+		var err error
+		tdfFile, err = newOutputFile(out)
 		if err != nil {
 			cli.ExitWithError("Failed to write encrypted file "+out, err)
 		}
-		defer tdfFile.Close()
+		defer tdfFile.Cleanup()
 		dest = tdfFile
 	} else {
 		dest = os.Stdout
 	}
 
-	_, e := io.Copy(dest, encrypted)
-	if e != nil {
-		cli.ExitWithError("Failed to write encrypted data to stdout", e)
+	fail := func(message string, err error) {
+		if tdfFile != nil {
+			tdfFile.Cleanup()
+		}
+		cli.ExitWithError(message, err)
+	}
+
+	err := h.Encrypt(c.Context(), dest, in, handlers.EncryptOptions{
+		TDFType:              tdfType,
+		Attributes:           attrValues,
+		MimeType:             fileMimeType,
+		KASURLPath:           kasURLPath,
+		Assertions:           assertions,
+		WrappingKeyAlgorithm: wrappingKeyAlgorithm,
+		TargetMode:           targetMode,
+	})
+	if err != nil {
+		fail("Failed to encrypt", err)
+	}
+
+	if tdfFile != nil {
+		if err := tdfFile.Commit(); err != nil {
+			fail("Failed to write encrypted file "+out, err)
+		}
 	}
 }
 

--- a/otdfctl/cmd/tdf/encrypt_test.go
+++ b/otdfctl/cmd/tdf/encrypt_test.go
@@ -1,0 +1,42 @@
+package tdf
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectMimeTypePreservesPayload(t *testing.T) {
+	payload := []byte("hello streaming world")
+	mimeType, reader, err := detectMimeType(bytes.NewReader(payload), "txt")
+	require.NoError(t, err)
+	assert.Equal(t, "text/plain; charset=utf-8", mimeType)
+
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}
+
+func TestDetectMimeTypePreservesPayloadLargerThanWindow(t *testing.T) {
+	payload := strings.Repeat("a", Size1MB+17)
+	_, reader, err := detectMimeType(strings.NewReader(payload), "")
+	require.NoError(t, err)
+
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(got))
+}
+
+func TestDetectMimeTypeFallsBackToKnownExtension(t *testing.T) {
+	mimeType, reader, err := detectMimeType(bytes.NewReader([]byte{0, 1, 2, 3}), "pdf")
+	require.NoError(t, err)
+	assert.Equal(t, "application/pdf", mimeType)
+
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0, 1, 2, 3}, got)
+}

--- a/otdfctl/cmd/tdf/tdf.go
+++ b/otdfctl/cmd/tdf/tdf.go
@@ -1,8 +1,11 @@
 package tdf
 
 import (
+	"bufio"
+	"errors"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/opentdf/platform/otdfctl/pkg/cli"
 )
@@ -28,4 +31,74 @@ func readPipedStdin() []byte {
 		return buf
 	}
 	return nil
+}
+
+// stdinReader reports whether stdin is a non-empty pipe or redirect and
+// returns it without consuming the first byte.
+func stdinReader() (*bufio.Reader, bool) {
+	r, ok, err := pipeReader(os.Stdin)
+	if err != nil {
+		cli.ExitWithError("failed to scan bytes from stdin", err)
+	}
+	return r, ok
+}
+
+func pipeReader(in *os.File) (*bufio.Reader, bool, error) {
+	stat, err := in.Stat()
+	if err != nil {
+		return nil, false, err
+	}
+	if (stat.Mode() & os.ModeCharDevice) != 0 {
+		return nil, false, nil
+	}
+
+	r := bufio.NewReaderSize(in, Size1MB)
+	if _, err := r.Peek(1); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return r, true, nil
+}
+
+// outputFile stages output next to its destination and renames it into place
+// only after encryption succeeds.
+type outputFile struct {
+	f         *os.File
+	path      string
+	committed bool
+}
+
+func newOutputFile(path string) (*outputFile, error) {
+	f, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return nil, err
+	}
+	return &outputFile{f: f, path: path}, nil
+}
+
+func (o *outputFile) Write(p []byte) (int, error) {
+	return o.f.Write(p)
+}
+
+func (o *outputFile) Commit() error {
+	if err := o.f.Close(); err != nil {
+		_ = os.Remove(o.f.Name())
+		return err
+	}
+	if err := os.Rename(o.f.Name(), o.path); err != nil {
+		_ = os.Remove(o.f.Name())
+		return err
+	}
+	o.committed = true
+	return nil
+}
+
+func (o *outputFile) Cleanup() {
+	if o == nil || o.committed {
+		return
+	}
+	_ = o.f.Close()
+	_ = os.Remove(o.f.Name())
 }

--- a/otdfctl/cmd/tdf/tdf_test.go
+++ b/otdfctl/cmd/tdf/tdf_test.go
@@ -1,0 +1,137 @@
+package tdf
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutputFileCommitRenamesIntoPlace(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.tdf")
+
+	o, err := newOutputFile(dest)
+	require.NoError(t, err)
+	_, err = o.Write([]byte("payload"))
+	require.NoError(t, err)
+
+	_, err = os.Stat(dest)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.NoError(t, o.Commit())
+
+	got, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(got))
+	assert.Empty(t, tempSiblings(t, dir, "out.tdf"))
+}
+
+func TestOutputFileCleanupLeavesNoPartialOutput(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.tdf")
+
+	o, err := newOutputFile(dest)
+	require.NoError(t, err)
+	_, err = o.Write([]byte("partial"))
+	require.NoError(t, err)
+	o.Cleanup()
+
+	_, err = os.Stat(dest)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	assert.Empty(t, tempSiblings(t, dir, "out.tdf"))
+}
+
+func TestOutputFileCleanupAfterCommitIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.tdf")
+
+	o, err := newOutputFile(dest)
+	require.NoError(t, err)
+	_, err = o.Write([]byte("payload"))
+	require.NoError(t, err)
+	require.NoError(t, o.Commit())
+	o.Cleanup()
+	o.Cleanup()
+
+	got, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(got))
+}
+
+func TestOutputFileTempIsSiblingOfDestination(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.tdf")
+
+	o, err := newOutputFile(dest)
+	require.NoError(t, err)
+	defer o.Cleanup()
+	assert.Equal(t, dir, filepath.Dir(o.f.Name()))
+}
+
+func TestPipeReader(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		wantOK  bool
+	}{
+		{name: "with data", content: "hello world", wantOK: true},
+		{name: "empty pipe reports absent", content: "", wantOK: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, w, err := os.Pipe()
+			require.NoError(t, err)
+			defer r.Close()
+
+			go func() {
+				defer w.Close()
+				_, _ = io.WriteString(w, tc.content)
+			}()
+
+			got, ok, err := pipeReader(r)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantOK, ok)
+			if ok {
+				all, err := io.ReadAll(got)
+				require.NoError(t, err)
+				assert.Equal(t, tc.content, string(all))
+			}
+		})
+	}
+}
+
+func TestPipeReaderPreservesPayloadLargerThanBuffer(t *testing.T) {
+	content := strings.Repeat("a", Size1MB*2+7)
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer r.Close()
+
+	go func() {
+		defer w.Close()
+		_, _ = io.WriteString(w, content)
+	}()
+
+	got, ok, err := pipeReader(r)
+	require.NoError(t, err)
+	require.True(t, ok)
+	all, err := io.ReadAll(got)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(all))
+}
+
+func tempSiblings(t *testing.T, dir, dest string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var found []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "."+dest+".tmp-") {
+			found = append(found, entry.Name())
+		}
+	}
+	return found
+}

--- a/otdfctl/e2e/encrypt-decrypt.bats
+++ b/otdfctl/e2e/encrypt-decrypt.bats
@@ -103,6 +103,32 @@ teardown_file(){
   ./otdfctl decrypt --host $HOST --tls-no-verify $DEBUG_LEVEL $WITH_CREDS $OUTFILE_TXT | grep "$SECRET_TEXT"
 }
 
+@test "roundtrip TDF3, no attributes, file to stdout" {
+  ./otdfctl encrypt --host $HOST --tls-no-verify $DEBUG_LEVEL $WITH_CREDS $INFILE_GO_MOD > $OUTFILE_GO_MOD
+  ./otdfctl decrypt -o $RESULTFILE_GO_MOD --host $HOST --tls-no-verify $DEBUG_LEVEL $WITH_CREDS $OUTFILE_GO_MOD
+  diff $INFILE_GO_MOD $RESULTFILE_GO_MOD
+}
+
+@test "roundtrip TDF3, stdin to stdout, fully piped" {
+  run bash -c "echo '$SECRET_TEXT' | ./otdfctl encrypt --host $HOST --tls-no-verify $WITH_CREDS | ./otdfctl decrypt --host $HOST --tls-no-verify $WITH_CREDS"
+  assert_success
+  assert_output --partial "$SECRET_TEXT"
+}
+
+@test "encrypt rejects empty stdin" {
+  run bash -c "./otdfctl encrypt --host $HOST --tls-no-verify $WITH_CREDS < /dev/null"
+  assert_failure
+}
+
+@test "encrypt leaves no output behind when it fails" {
+  rm -f $OUTFILE_TXT .$OUTFILE_TXT.tmp-*
+  run bash -c "echo '$SECRET_TEXT' | ./otdfctl encrypt -o $OUT_TXT --host $HOST --tls-no-verify $WITH_CREDS -a 'https://testing-enc-dec.io/attr/attr1/value/does-not-exist'"
+  assert_failure
+  [ ! -f "$OUTFILE_TXT" ]
+  run bash -c "ls .$OUTFILE_TXT.tmp-* 2>/dev/null | wc -l"
+  assert_output "0"
+}
+
 @test "allow traversal with mapped key uses definition when value missing" {
   local attr_name="attr-allow-traversal-${RANDOM}"
   local kas_name="kas-allow-traversal-${RANDOM}"

--- a/otdfctl/pkg/handlers/tdf.go
+++ b/otdfctl/pkg/handlers/tdf.go
@@ -13,10 +13,15 @@ import (
 	"log/slog"
 	"strings"
 
+	"connectrpc.com/connect"
 	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/otdfctl/pkg/tdf"
 	"github.com/opentdf/platform/otdfctl/pkg/utils"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/attributes"
 	"github.com/opentdf/platform/sdk"
+	experimentaltdf "github.com/opentdf/platform/sdk/experimental/tdf"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -30,6 +35,7 @@ var (
 
 const (
 	MaxAssertionsFileSize = int64(5 * 1024 * 1024) // 5MB
+	encryptSegmentSize    = 2 * 1024 * 1024        // 2MB
 )
 
 type TDFInspect struct {
@@ -38,67 +44,351 @@ type TDFInspect struct {
 	UnencryptedMetadata []byte
 }
 
-func (h Handler) EncryptBytes(
-	tdfType string,
-	unencrypted []byte,
-	attrValues []string,
-	mimeType string,
-	kasURLPath string,
-	assertions string,
-	wrappingKeyAlgorithm ocrypto.KeyType,
-	targetMode string,
-) (*bytes.Buffer, error) {
-	var encrypted []byte
-	enc := bytes.NewBuffer(encrypted)
+// EncryptOptions carries the non-stream inputs to Encrypt.
+type EncryptOptions struct {
+	TDFType              string
+	Attributes           []string
+	MimeType             string
+	KASURLPath           string
+	Assertions           string
+	WrappingKeyAlgorithm ocrypto.KeyType
+	TargetMode           string
+}
 
-	switch tdfType {
+// Encrypt streams plaintext from in into a TDF written to out. Memory use is
+// bounded by one plaintext segment and the manifest, rather than payload size.
+func (h Handler) Encrypt(ctx context.Context, out io.Writer, in io.Reader, o EncryptOptions) error {
+	switch o.TDFType {
 	// Encrypt the data as a ZTDF
 	case "", tdf.TypeTDF3, tdf.TypeZTDF:
-		opts := []sdk.TDFOption{
-			sdk.WithDataAttributes(attrValues...),
-			sdk.WithKasInformation(sdk.KASInfo{
-				URL: h.platformEndpoint + kasURLPath,
-			}),
-			sdk.WithMimeType(mimeType),
-			sdk.WithWrappingKeyAlg(wrappingKeyAlgorithm), //nolint:staticcheck // SDK option is deprecated but no replacement is available in this SDK version.
+		attributeValues, err := h.resolveTDFAttributeValues(ctx, o.Attributes, o.WrappingKeyAlgorithm)
+		if err != nil {
+			return err
 		}
 
-		var assertionConfigs []sdk.AssertionConfig
-		//nolint:nestif // nested its mainly for error catching and handling case of string vs file
-		if assertions != "" {
-			err := json.Unmarshal([]byte(assertions), &assertionConfigs)
+		var defaultKAS *policy.SimpleKasKey
+		if attributesNeedDefaultKAS(attributeValues) {
+			defaultKAS, err = h.resolveDefaultKAS(ctx, o.KASURLPath)
 			if err != nil {
-				// if unable to marshal to json, interpret as file string and try to read from file
-				assertionBytes, err := utils.ReadBytesFromFile(assertions, MaxAssertionsFileSize)
-				if err != nil {
-					return nil, fmt.Errorf("unable to read assertions file: %w", err)
-				}
-				err = json.Unmarshal(assertionBytes, &assertionConfigs)
-				if err != nil {
-					return nil, fmt.Errorf("unable to unmarshal assertions json: %w", err)
+				return err
+			}
+			for _, value := range attributeValues {
+				if !hasUsableKAS(value) {
+					value.KasKeys = append(value.KasKeys, defaultKAS)
 				}
 			}
-			for i, config := range assertionConfigs {
-				if !config.SigningKey.IsEmpty() {
-					correctedKey, err := correctKeyType(config.SigningKey, false)
-					if err != nil {
-						return nil, fmt.Errorf("error with assertion signing key: %w", err)
-					}
-					assertionConfigs[i].SigningKey.Key = correctedKey
-				}
-			}
-			opts = append(opts, sdk.WithAssertions(assertionConfigs...))
 		}
 
-		if targetMode != "" {
-			opts = append(opts, sdk.WithTargetMode(targetMode))
+		assertionConfigs, err := parseExperimentalAssertions(o.Assertions)
+		if err != nil {
+			return err
 		}
 
-		_, err := h.sdk.CreateTDF(enc, bytes.NewReader(unencrypted), opts...)
-		return enc, err
+		writer, err := experimentaltdf.NewWriter(ctx,
+			experimentaltdf.WithIntegrityAlgorithm(experimentaltdf.HS256),
+			experimentaltdf.WithSegmentIntegrityAlgorithm(experimentaltdf.GMAC),
+			experimentaltdf.WithTargetMode(o.TargetMode),
+		)
+		if err != nil {
+			return err
+		}
+
+		if err := writeTDFSegments(ctx, writer, out, in); err != nil {
+			return err
+		}
+
+		finalizeOptions := []experimentaltdf.Option[*experimentaltdf.WriterFinalizeConfig]{
+			experimentaltdf.WithAttributeValues(attributeValues),
+		}
+		if o.MimeType != "" {
+			finalizeOptions = append(finalizeOptions, experimentaltdf.WithPayloadMimeType(o.MimeType))
+		}
+		if defaultKAS != nil {
+			finalizeOptions = append(finalizeOptions, experimentaltdf.WithDefaultKAS(defaultKAS))
+		}
+		if len(assertionConfigs) > 0 {
+			finalizeOptions = append(finalizeOptions, experimentaltdf.WithAssertions(assertionConfigs...))
+		}
+
+		finalized, err := writer.Finalize(ctx, finalizeOptions...)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, bytes.NewReader(finalized.Data)); err != nil {
+			return fmt.Errorf("writing finalized TDF: %w", err)
+		}
+		return nil
 	default:
-		return nil, errors.New("unknown TDF type")
+		return errors.New("unknown TDF type")
 	}
+}
+
+func writeTDFSegments(ctx context.Context, writer *experimentaltdf.Writer, out io.Writer, in io.Reader) error {
+	buffer := make([]byte, encryptSegmentSize)
+	segmentIndex := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		n, readErr := io.ReadFull(in, buffer)
+		if errors.Is(readErr, io.EOF) && segmentIndex > 0 {
+			break
+		}
+		if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
+			return fmt.Errorf("reading plaintext segment: %w", readErr)
+		}
+
+		segment, err := writer.WriteSegment(ctx, segmentIndex, buffer[:n])
+		if err != nil {
+			return fmt.Errorf("encrypting segment %d: %w", segmentIndex, err)
+		}
+		if _, err := io.Copy(out, segment.TDFData); err != nil {
+			return fmt.Errorf("writing encrypted segment %d: %w", segmentIndex, err)
+		}
+		segmentIndex++
+
+		if errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF) {
+			break
+		}
+	}
+	return nil
+}
+
+func (h Handler) resolveDefaultKAS(ctx context.Context, kasURLPath string) (*policy.SimpleKasKey, error) {
+	kas, err := h.sdk.GetBaseKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving default KAS: %w", err)
+	}
+	if kas == nil || kas.GetPublicKey() == nil {
+		return nil, errors.New("resolving default KAS: base key is empty")
+	}
+	if kasURLPath != "" {
+		clonedKAS, ok := proto.Clone(kas).(*policy.SimpleKasKey)
+		if !ok {
+			return nil, errors.New("resolving default KAS: invalid base key type")
+		}
+		kas = clonedKAS
+		kas.KasUri = h.platformEndpoint + kasURLPath
+	}
+	return kas, nil
+}
+
+func (h Handler) resolveTDFAttributeValues(ctx context.Context, fqns []string, wrappingKeyAlgorithm ocrypto.KeyType) ([]*policy.Value, error) {
+	if len(fqns) == 0 {
+		return nil, nil
+	}
+
+	for _, fqn := range fqns {
+		if _, err := sdk.NewAttributeValueFQN(fqn); err != nil {
+			return nil, err
+		}
+	}
+
+	resolved := make(map[string]*policy.Value, len(fqns))
+	fallback := append([]string(nil), fqns...)
+	mappings, err := h.sdk.Attributes.GetKeyMappingsByFqns(ctx, &attributes.GetKeyMappingsByFqnsRequest{Fqns: fqns})
+	if err == nil {
+		fallback = fallback[:0]
+		for _, requestedFQN := range fqns {
+			mapping := mappings.GetFqnKeyMappings()[strings.ToLower(requestedFQN)]
+			if mapping == nil {
+				mapping = mappings.GetFqnKeyMappings()[requestedFQN]
+			}
+			keys := selectKASKeys(mapping.GetKeys(), wrappingKeyAlgorithm)
+			if len(keys) == 0 {
+				fallback = append(fallback, requestedFQN)
+				continue
+			}
+			valueFQN, _ := sdk.NewAttributeValueFQN(requestedFQN)
+			resolved[strings.ToLower(requestedFQN)] = &policy.Value{
+				Fqn:     requestedFQN,
+				KasKeys: keys,
+				Attribute: &policy.Attribute{
+					Fqn:  valueFQN.Prefix().String(),
+					Rule: mapping.GetRule(),
+				},
+			}
+		}
+	} else if connect.CodeOf(err) != connect.CodeUnimplemented {
+		return nil, fmt.Errorf("resolving attribute KAS mappings: %w", err)
+	}
+
+	if err := h.resolveFallbackAttributeValues(ctx, fallback, wrappingKeyAlgorithm, resolved); err != nil {
+		return nil, err
+	}
+
+	values := make([]*policy.Value, 0, len(fqns))
+	for _, fqn := range fqns {
+		value := resolved[strings.ToLower(fqn)]
+		if value == nil {
+			return nil, fmt.Errorf("attribute value not found: %s", fqn)
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func (h Handler) resolveFallbackAttributeValues(
+	ctx context.Context,
+	fqns []string,
+	wrappingKeyAlgorithm ocrypto.KeyType,
+	resolved map[string]*policy.Value,
+) error {
+	if len(fqns) == 0 {
+		return nil
+	}
+	response, err := h.sdk.Attributes.GetAttributeValuesByFqns(ctx, &attributes.GetAttributeValuesByFqnsRequest{Fqns: fqns})
+	if err != nil {
+		return fmt.Errorf("resolving attribute values: %w", err)
+	}
+	for _, requestedFQN := range fqns {
+		pair := response.GetFqnAttributeValues()[requestedFQN]
+		if pair == nil {
+			pair = response.GetFqnAttributeValues()[strings.ToLower(requestedFQN)]
+		}
+		if pair == nil || pair.GetAttribute() == nil {
+			return fmt.Errorf("attribute value not found: %s", requestedFQN)
+		}
+
+		value := &policy.Value{Fqn: requestedFQN}
+		if pair.GetValue() != nil {
+			clonedValue, ok := proto.Clone(pair.GetValue()).(*policy.Value)
+			if !ok {
+				return fmt.Errorf("invalid attribute value type: %s", requestedFQN)
+			}
+			value = clonedValue
+		}
+		clonedAttribute, ok := proto.Clone(pair.GetAttribute()).(*policy.Attribute)
+		if !ok {
+			return fmt.Errorf("invalid attribute type: %s", requestedFQN)
+		}
+		value.Fqn = requestedFQN
+		value.Attribute = clonedAttribute
+		filterAttributeKASKeys(value, wrappingKeyAlgorithm)
+		resolved[strings.ToLower(requestedFQN)] = value
+	}
+	return nil
+}
+
+func selectKASKeys(keys []*policy.SimpleKasKey, algorithm ocrypto.KeyType) []*policy.SimpleKasKey {
+	if algorithm == "" {
+		return keys
+	}
+	policyAlgorithm, err := sdk.KeyTypeToPolicyAlgorithm(algorithm)
+	if err != nil {
+		return nil
+	}
+	selected := make([]*policy.SimpleKasKey, 0, len(keys))
+	for _, key := range keys {
+		if key.GetPublicKey().GetAlgorithm() == policyAlgorithm {
+			selected = append(selected, key)
+		}
+	}
+	return selected
+}
+
+func filterAttributeKASKeys(value *policy.Value, algorithm ocrypto.KeyType) {
+	value.KasKeys = selectKASKeys(value.GetKasKeys(), algorithm)
+	attribute := value.GetAttribute()
+	if attribute == nil {
+		return
+	}
+	attribute.KasKeys = selectKASKeys(attribute.GetKasKeys(), algorithm)
+	if namespace := attribute.GetNamespace(); namespace != nil {
+		namespace.KasKeys = selectKASKeys(namespace.GetKasKeys(), algorithm)
+	}
+}
+
+func attributesNeedDefaultKAS(values []*policy.Value) bool {
+	if len(values) == 0 {
+		return true
+	}
+	for _, value := range values {
+		if !hasUsableKAS(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasUsableKAS(value *policy.Value) bool {
+	if value == nil {
+		return false
+	}
+	if hasUsableSimpleKAS(value.GetKasKeys()) || hasUsableGrantKAS(value.GetGrants()) {
+		return true
+	}
+	attribute := value.GetAttribute()
+	if attribute == nil {
+		return false
+	}
+	if hasUsableSimpleKAS(attribute.GetKasKeys()) || hasUsableGrantKAS(attribute.GetGrants()) {
+		return true
+	}
+	namespace := attribute.GetNamespace()
+	return namespace != nil && (hasUsableSimpleKAS(namespace.GetKasKeys()) || hasUsableGrantKAS(namespace.GetGrants()))
+}
+
+func hasUsableSimpleKAS(keys []*policy.SimpleKasKey) bool {
+	for _, key := range keys {
+		publicKey := key.GetPublicKey()
+		if key.GetKasUri() != "" && publicKey.GetKid() != "" && publicKey.GetPem() != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasUsableGrantKAS(grants []*policy.KeyAccessServer) bool {
+	for _, grant := range grants {
+		if grant.GetUri() == "" {
+			continue
+		}
+		if hasUsableSimpleKAS(grant.GetKasKeys()) {
+			return true
+		}
+		for _, key := range grant.GetPublicKey().GetCached().GetKeys() {
+			if key.GetKid() != "" && key.GetPem() != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func parseExperimentalAssertions(assertionsJSON string) ([]experimentaltdf.AssertionConfig, error) {
+	if assertionsJSON == "" {
+		return nil, nil
+	}
+
+	assertionBytes := []byte(assertionsJSON)
+	var assertionConfigs []experimentaltdf.AssertionConfig
+	if err := json.Unmarshal(assertionBytes, &assertionConfigs); err != nil {
+		var readErr error
+		assertionBytes, readErr = utils.ReadBytesFromFile(assertionsJSON, MaxAssertionsFileSize)
+		if readErr != nil {
+			return nil, fmt.Errorf("unable to read assertions file: %w", readErr)
+		}
+		if err := json.Unmarshal(assertionBytes, &assertionConfigs); err != nil {
+			return nil, fmt.Errorf("unable to unmarshal assertions json: %w", err)
+		}
+	}
+
+	for i, config := range assertionConfigs {
+		if config.SigningKey.IsEmpty() {
+			continue
+		}
+		correctedKey, err := correctKeyType(sdk.AssertionKey{
+			Alg: sdk.AssertionKeyAlg(config.SigningKey.Alg),
+			Key: config.SigningKey.Key,
+		}, false)
+		if err != nil {
+			return nil, fmt.Errorf("error with assertion signing key: %w", err)
+		}
+		assertionConfigs[i].SigningKey.Key = correctedKey
+	}
+	return assertionConfigs, nil
 }
 
 func (h Handler) DecryptBytes(

--- a/otdfctl/pkg/handlers/tdf_stream_test.go
+++ b/otdfctl/pkg/handlers/tdf_stream_test.go
@@ -1,0 +1,201 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/opentdf/platform/lib/ocrypto"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/protocol/go/policy/attributes"
+	"github.com/opentdf/platform/sdk"
+	experimentaltdf "github.com/opentdf/platform/sdk/experimental/tdf"
+	"github.com/opentdf/platform/sdk/sdkconnect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteTDFSegmentsUsesBoundedReads(t *testing.T) {
+	reader := &countingReader{remaining: encryptSegmentSize*2 + 7}
+	writer, err := experimentaltdf.NewWriter(t.Context())
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	require.NoError(t, writeTDFSegments(t.Context(), writer, &output, reader))
+	assert.LessOrEqual(t, reader.maxRead, encryptSegmentSize)
+	assert.Positive(t, output.Len())
+}
+
+func TestWriteTDFSegmentsWritesEmptyPayload(t *testing.T) {
+	writer, err := experimentaltdf.NewWriter(t.Context())
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	require.NoError(t, writeTDFSegments(t.Context(), writer, &output, strings.NewReader("")))
+	assert.Positive(t, output.Len())
+}
+
+func TestWriteTDFSegmentsPropagatesOutputFailure(t *testing.T) {
+	writer, err := experimentaltdf.NewWriter(t.Context())
+	require.NoError(t, err)
+
+	err = writeTDFSegments(t.Context(), writer, errorWriter{}, strings.NewReader("payload"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "writing encrypted segment 0")
+}
+
+func TestEncryptStreamsBeforeReadingEntirePayload(t *testing.T) {
+	fqn := "https://example.com/attr/classification/value/secret"
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	publicKey, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+	require.NoError(t, err)
+
+	kasKey := simpleKASKey("rsa", policy.Algorithm_ALGORITHM_RSA_2048)
+	kasKey.PublicKey.Pem = string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicKey}))
+	client := &attributeResolutionClient{
+		mappings: &attributes.GetKeyMappingsByFqnsResponse{
+			FqnKeyMappings: map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping{
+				fqn: {
+					Rule: policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF,
+					Keys: []*policy.SimpleKasKey{kasKey},
+				},
+			},
+		},
+	}
+	handler := Handler{sdk: &sdk.SDK{Attributes: client}}
+	reader := &countingReader{remaining: encryptSegmentSize + 7}
+	output := &observingWriter{reader: reader}
+
+	err = handler.Encrypt(t.Context(), output, reader, EncryptOptions{
+		Attributes:           []string{fqn},
+		MimeType:             "application/octet-stream",
+		WrappingKeyAlgorithm: ocrypto.RSA2048Key,
+	})
+	require.NoError(t, err)
+	assert.True(t, output.wroteBeforeEOF)
+	assert.Equal(t, sdk.Standard, sdk.GetTdfType(bytes.NewReader(output.Bytes())))
+}
+
+func TestResolveTDFAttributeValuesUsesEffectiveKeyMappings(t *testing.T) {
+	fqn := "https://Example.com/attr/Classification/value/Secret"
+	rsaKey := simpleKASKey("rsa", policy.Algorithm_ALGORITHM_RSA_2048)
+	ecKey := simpleKASKey("ec", policy.Algorithm_ALGORITHM_EC_P256)
+	client := &attributeResolutionClient{
+		mappings: &attributes.GetKeyMappingsByFqnsResponse{
+			FqnKeyMappings: map[string]*attributes.GetKeyMappingsByFqnsResponse_AttributeKeyMapping{
+				strings.ToLower(fqn): {
+					Rule: policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF,
+					Keys: []*policy.SimpleKasKey{ecKey, rsaKey},
+				},
+			},
+		},
+	}
+	handler := Handler{sdk: &sdk.SDK{Attributes: client}}
+
+	values, err := handler.resolveTDFAttributeValues(t.Context(), []string{fqn}, ocrypto.RSA2048Key)
+	require.NoError(t, err)
+	require.Len(t, values, 1)
+	assert.Equal(t, fqn, values[0].GetFqn())
+	assert.Equal(t, "https://Example.com/attr/Classification", values[0].GetAttribute().GetFqn())
+	require.Len(t, values[0].GetKasKeys(), 1)
+	assert.Equal(t, "rsa", values[0].GetKasKeys()[0].GetPublicKey().GetKid())
+}
+
+func TestResolveTDFAttributeValuesFallsBackForOlderPlatforms(t *testing.T) {
+	fqn := "https://example.com/attr/classification/value/secret"
+	definition := &policy.Attribute{
+		Fqn:  "https://example.com/attr/classification",
+		Rule: policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY,
+		KasKeys: []*policy.SimpleKasKey{
+			simpleKASKey("definition", policy.Algorithm_ALGORITHM_RSA_2048),
+		},
+	}
+	client := &attributeResolutionClient{
+		mappingErr: connect.NewError(connect.CodeUnimplemented, errors.New("not implemented")),
+		values: &attributes.GetAttributeValuesByFqnsResponse{
+			FqnAttributeValues: map[string]*attributes.GetAttributeValuesByFqnsResponse_AttributeAndValue{
+				fqn: {Attribute: definition},
+			},
+		},
+	}
+	handler := Handler{sdk: &sdk.SDK{Attributes: client}}
+
+	values, err := handler.resolveTDFAttributeValues(t.Context(), []string{fqn}, ocrypto.RSA2048Key)
+	require.NoError(t, err)
+	require.Len(t, values, 1)
+	assert.Equal(t, fqn, values[0].GetFqn())
+	assert.Equal(t, definition.GetFqn(), values[0].GetAttribute().GetFqn())
+}
+
+type countingReader struct {
+	remaining int
+	maxRead   int
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	if len(p) > r.maxRead {
+		r.maxRead = len(p)
+	}
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := min(len(p), r.remaining)
+	clear(p[:n])
+	r.remaining -= n
+	return n, nil
+}
+
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+type observingWriter struct {
+	bytes.Buffer
+	reader         *countingReader
+	wroteBeforeEOF bool
+}
+
+func (w *observingWriter) Write(p []byte) (int, error) {
+	if w.reader.remaining > 0 {
+		w.wroteBeforeEOF = true
+	}
+	return w.Buffer.Write(p)
+}
+
+type attributeResolutionClient struct {
+	sdkconnect.AttributesServiceClient
+	mappings   *attributes.GetKeyMappingsByFqnsResponse
+	mappingErr error
+	values     *attributes.GetAttributeValuesByFqnsResponse
+	valuesErr  error
+}
+
+func (c *attributeResolutionClient) GetKeyMappingsByFqns(context.Context, *attributes.GetKeyMappingsByFqnsRequest) (*attributes.GetKeyMappingsByFqnsResponse, error) {
+	return c.mappings, c.mappingErr
+}
+
+func (c *attributeResolutionClient) GetAttributeValuesByFqns(context.Context, *attributes.GetAttributeValuesByFqnsRequest) (*attributes.GetAttributeValuesByFqnsResponse, error) {
+	return c.values, c.valuesErr
+}
+
+func simpleKASKey(kid string, algorithm policy.Algorithm) *policy.SimpleKasKey {
+	return &policy.SimpleKasKey{
+		KasUri: "https://kas.example.com",
+		PublicKey: &policy.SimpleKasPublicKey{
+			Kid:       kid,
+			Algorithm: algorithm,
+			Pem:       "public key",
+		},
+	}
+}

--- a/sdk/experimental/tdf/options.go
+++ b/sdk/experimental/tdf/options.go
@@ -2,7 +2,14 @@
 
 package tdf
 
-import "github.com/opentdf/platform/protocol/go/policy"
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/opentdf/platform/protocol/go/policy"
+)
+
+const legacySignatureThreshold = "4.3.0"
 
 // IntegrityAlgorithm specifies the cryptographic algorithm used for integrity verification.
 //
@@ -60,6 +67,13 @@ type WriterConfig struct {
 	// initialDefaultKAS allows callers to provide a default KAS at writer creation time.
 	// This will be used during Finalize() if no default KAS is provided there.
 	initialDefaultKAS *policy.SimpleKasKey
+
+	// useHex selects the legacy pre-4.3 signature representation.
+	useHex bool
+	// excludeVersionFromManifest omits schemaVersion for legacy TDFs.
+	excludeVersionFromManifest bool
+	// targetModeError defers option validation until NewWriter can return it.
+	targetModeError error
 }
 
 // ReaderConfig contains configuration options for TDF Reader creation.
@@ -141,6 +155,32 @@ func WithInitialAttributes(values []*policy.Value) Option[*WriterConfig] {
 func WithDefaultKASForWriter(kas *policy.SimpleKasKey) Option[*WriterConfig] {
 	return func(c *WriterConfig) {
 		c.initialDefaultKAS = kas
+	}
+}
+
+// WithTargetMode configures compatibility with a target TDF schema version.
+// Versions older than 4.3.0 use hex-encoded integrity signatures and omit the
+// schemaVersion field, matching the stable SDK's legacy behavior.
+func WithTargetMode(mode string) Option[*WriterConfig] {
+	return func(c *WriterConfig) {
+		if mode == "" {
+			c.useHex = false
+			c.excludeVersionFromManifest = false
+			return
+		}
+
+		version, err := semver.NewVersion(mode)
+		if err != nil {
+			c.targetModeError = fmt.Errorf("semver.NewVersion failed for version %s: %w", mode, err)
+			return
+		}
+		threshold, err := semver.NewVersion(legacySignatureThreshold)
+		if err != nil {
+			c.targetModeError = err
+			return
+		}
+		c.useHex = version.LessThan(threshold)
+		c.excludeVersionFromManifest = c.useHex
 	}
 }
 

--- a/sdk/experimental/tdf/writer.go
+++ b/sdk/experimental/tdf/writer.go
@@ -163,6 +163,9 @@ func NewWriter(_ context.Context, opts ...Option[*WriterConfig]) (*Writer, error
 	for _, opt := range opts {
 		opt(config)
 	}
+	if config.targetModeError != nil {
+		return nil, config.targetModeError
+	}
 
 	// Initialize archive writer - start with 1 segment and expand dynamically
 	archiveWriter := zipstream.NewSegmentTDFWriter(1, zipstream.WithZip64())
@@ -264,7 +267,7 @@ func (w *Writer) WriteSegment(ctx context.Context, index int, data []byte) (*Seg
 	if err != nil {
 		return nil, err
 	}
-	segmentSig, err := calculateSignature(segmentCipher, w.dek, w.segmentIntegrityAlgorithm, false) // Don't ever hex encode new tdf's
+	segmentSig, err := calculateSignature(segmentCipher, w.dek, w.segmentIntegrityAlgorithm, w.useHex)
 	if err != nil {
 		return nil, err
 	}
@@ -457,7 +460,6 @@ func (w *Writer) getManifest(ctx context.Context, cfg *WriterFinalizeConfig) (*M
 	}
 
 	manifest := &Manifest{
-		TDFVersion: TDFSpecVersion,
 		Payload: Payload{
 			MimeType:    cfg.payloadMimeType,
 			Protocol:    tdfAsZip,
@@ -465,6 +467,9 @@ func (w *Writer) getManifest(ctx context.Context, cfg *WriterFinalizeConfig) (*M
 			URL:         zipstream.TDFPayloadFileName,
 			IsEncrypted: true,
 		},
+	}
+	if !w.excludeVersionFromManifest {
+		manifest.TDFVersion = TDFSpecVersion
 	}
 	// Determine finalize order by collecting all present segment indices and sorting.
 	// This densifies sparse indices automatically and ignores any gaps.
@@ -562,7 +567,7 @@ func (w *Writer) getManifest(ctx context.Context, cfg *WriterFinalizeConfig) (*M
 		return nil, 0, 0, errors.New("empty segment hash")
 	}
 
-	rootSignature, err := calculateSignature(aggregateHash.Bytes(), w.dek, w.integrityAlgorithm, false)
+	rootSignature, err := calculateSignature(aggregateHash.Bytes(), w.dek, w.integrityAlgorithm, w.useHex)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -656,7 +661,11 @@ func (w *Writer) buildAssertions(aggregateHash []byte, assertions []AssertionCon
 
 		var completeHashBuilder bytes.Buffer
 		completeHashBuilder.Write(aggregateHash)
-		completeHashBuilder.Write(hashOfAssertion)
+		if w.useHex {
+			completeHashBuilder.Write(hashOfAssertionAsHex)
+		} else {
+			completeHashBuilder.Write(hashOfAssertion)
+		}
 
 		encoded := ocrypto.Base64Encode(completeHashBuilder.Bytes())
 

--- a/sdk/experimental/tdf/writer_test.go
+++ b/sdk/experimental/tdf/writer_test.go
@@ -5,6 +5,7 @@ package tdf
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -68,6 +69,64 @@ func TestWriterEndToEnd(t *testing.T) {
 			tc.test(t)
 		})
 	}
+}
+
+func TestWriterTargetMode(t *testing.T) {
+	t.Run("legacy mode omits schema version and uses hex signatures", func(t *testing.T) {
+		writer, err := NewWriter(t.Context(), WithTargetMode("v4.2.2"))
+		require.NoError(t, err)
+
+		_, err = writer.WriteSegment(t.Context(), 0, []byte("legacy payload"))
+		require.NoError(t, err)
+
+		kas := &policy.SimpleKasKey{
+			KasUri: testKAS1,
+			PublicKey: &policy.SimpleKasPublicKey{
+				Algorithm: policy.Algorithm_ALGORITHM_RSA_2048,
+				Kid:       "kid1",
+				Pem:       mockRSAPublicKey1,
+			},
+		}
+		result, err := writer.Finalize(t.Context(), WithDefaultKAS(kas))
+		require.NoError(t, err)
+		assert.Empty(t, result.Manifest.TDFVersion)
+
+		segmentHash, err := ocrypto.Base64Decode([]byte(result.Manifest.Segments[0].Hash))
+		require.NoError(t, err)
+		assert.Len(t, segmentHash, 64)
+		_, err = hex.DecodeString(string(segmentHash))
+		require.NoError(t, err)
+
+		rootHash, err := ocrypto.Base64Decode([]byte(result.Manifest.Signature))
+		require.NoError(t, err)
+		assert.Len(t, rootHash, 64)
+		_, err = hex.DecodeString(string(rootHash))
+		require.NoError(t, err)
+	})
+
+	t.Run("current mode includes schema version", func(t *testing.T) {
+		writer, err := NewWriter(t.Context(), WithTargetMode("4.3.0"))
+		require.NoError(t, err)
+		_, err = writer.WriteSegment(t.Context(), 0, []byte("current payload"))
+		require.NoError(t, err)
+
+		kas := &policy.SimpleKasKey{
+			KasUri: testKAS1,
+			PublicKey: &policy.SimpleKasPublicKey{
+				Algorithm: policy.Algorithm_ALGORITHM_RSA_2048,
+				Kid:       "kid1",
+				Pem:       mockRSAPublicKey1,
+			},
+		}
+		result, err := writer.Finalize(t.Context(), WithDefaultKAS(kas))
+		require.NoError(t, err)
+		assert.Equal(t, TDFSpecVersion, result.Manifest.TDFVersion)
+	})
+
+	t.Run("invalid mode fails construction", func(t *testing.T) {
+		_, err := NewWriter(t.Context(), WithTargetMode("not-semver"))
+		require.Error(t, err)
+	})
 }
 
 // testFinalizeWithSegmentsContiguousPrefix validates successful finalize when


### PR DESCRIPTION
### Proposed Changes

* Stream `otdfctl encrypt` input through `sdk/experimental/tdf.Writer` in bounded 2 MiB segments instead of buffering the plaintext and ciphertext in memory.
* Resolve attribute values and effective KAS keys before output, while preserving wrapping-key selection, assertions, MIME metadata, default KAS behavior, and legacy target modes.
* Stage named outputs in a sibling temporary file and atomically rename on success so failures do not leave partial TDFs.
* Add unit coverage for streaming-before-EOF, MIME sniffing without consumption, stdin handling, attribute/KAS resolution, target-mode signatures, and output cleanup; add file/stdin/stdout BATS cases.

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

Passing checks:

```shell
cd sdk && go test ./... -race
cd otdfctl && go test ./... -race
cd sdk && go test -run TestREADMECodeBlocks
# golangci-lint for changed SDK and otdfctl code: 0 issues
```

Repository-wide commands were also attempted. `make test` stops in the unchanged `lib/fixtures` module because `TestTokenManager_InitialLogin` and `TestTokenManager_CustomTokenBuffer` expect a 120s/60s buffer but receive 30s. `make lint` reports existing baseline findings across unchanged modules; changed-line lint for this PR reports 0 issues.