### PR TITLE
feat(ci): publish protobuf schemas to BSR

### DIFF
--- a/.github/workflows/buf-push.yaml
+++ b/.github/workflows/buf-push.yaml
@@ -41,3 +41,5 @@ jobs:
             exit 1
           fi
           buf push --git-metadata
+      - name: Verify published module
+        run: buf build "buf.build/opentdf/platform:${GITHUB_REF_NAME}"

--- a/.github/workflows/buf-push.yaml
+++ b/.github/workflows/buf-push.yaml
@@ -1,0 +1,43 @@
+name: Publish Protobufs to the Buf Schema Registry
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+    paths:
+      - ".github/workflows/buf-push.yaml"
+      - "buf.lock"
+      - "buf.yaml"
+      - "service/**/*.proto"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: buf-push-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  push:
+    name: Publish buf.build/opentdf/platform
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
+        with:
+          github_token: ${{ github.token }}
+          version: "1.70.0"
+      - name: Publish module
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+        run: |
+          if [[ -z "${BUF_TOKEN}" ]]; then
+            echo "BUF_TOKEN repository secret is not configured" >&2
+            exit 1
+          fi
+          buf push --git-metadata

--- a/.github/workflows/buf-push.yaml
+++ b/.github/workflows/buf-push.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "v*"
+      - "protocol/go/v*"
     paths:
       - ".github/workflows/buf-push.yaml"
       - "buf.lock"
@@ -40,6 +40,9 @@ jobs:
             echo "BUF_TOKEN repository secret is not configured" >&2
             exit 1
           fi
-          buf push --git-metadata
+          label="${GITHUB_REF_NAME##*/}"
+          buf push \
+            --label "${label}" \
+            --source-control-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
       - name: Verify published module
-        run: buf build "buf.build/opentdf/platform:${GITHUB_REF_NAME}"
+        run: buf build "buf.build/opentdf/platform:${GITHUB_REF_NAME##*/}"

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,6 +1,7 @@
 version: v2
 modules:
   - path: service
+    name: buf.build/opentdf/platform
     excludes:
       - service/logger/audit
 deps:


### PR DESCRIPTION
### Why

OpenTDF Platform's protobuf definitions currently live only in this GitHub repository. Publishing them to the public Buf Schema Registry gives developers a standard, discoverable place to browse and consume the API schemas:

https://buf.build/opentdf/platform

The BSR module already exists, but it does not contain any published schemas yet.

### What this changes

This PR:

* Connects the existing `service/` protobuf module to `buf.build/opentdf/platform`.
* Adds a GitHub Actions workflow that publishes the schemas after relevant changes merge to `main`.
* Publishes version-tagged schemas when an OpenTDF Platform `protocol/go/v*` tag is pushed.
* Uses the existing protocol release version (for example, `v0.33.1`) as the BSR label.
* Records the source commit's GitHub URL with each BSR publication.
* Builds the module back from the BSR after publishing to verify that developers can resolve and consume it.

The first workflow run after merge will publish the current schemas and establish the BSR `main` label.

### What this does not change

This is an additive distribution change. It does not:

* Modify any protobuf definitions.
* Change protobuf package or import paths.
* Change generated Go code or package paths.
* Change how the SDK or other existing consumers obtain protobuf code.
* Remove generated code from this repository.

Moving code generation or downstream consumers to the BSR can be evaluated separately after this publishing path is established.

### Validation

The following checks pass locally:

```console
buf lint
buf build
actionlint .github/workflows/buf-push.yaml
git diff --check
```

The post-publish smoke test cannot run until the first BSR commit exists. After merge, the workflow will run `buf build` against the published `main` label. On version tags, it will verify the corresponding tag label instead.

### Risk and rollback

Risk is low because existing generation and consumption paths remain unchanged. If BSR publishing fails, the current GitHub-based workflow continues to work. The publishing workflow can be disabled or reverted without affecting the protobuf API or generated packages.

### Checklist

- [ ] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Protobuf definitions are now published to the Buf Schema Registry.
  - Published schemas are automatically validated to help ensure reliable access for integrations and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->