### PR TITLE
chore: bump go.work toolchain to go1.25.14

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.25.5
 
-toolchain go1.25.11
+toolchain go1.25.14
 
 use (
 	./examples

--- a/service/rttests/rt_test.go
+++ b/service/rttests/rt_test.go
@@ -396,7 +396,7 @@ func decrypt(client *sdk.SDK, tdfFile string, plaintext string) error {
 
 	buf := new(strings.Builder)
 	_, err = io.Copy(buf, tdfreader)
-	if err != nil && !(errors.Is(err, io.EOF)) {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}
 


### PR DESCRIPTION
> **Part 01 of 20** in the DSPX-2604 re-cut. Base branch: `main`.
>
> This stack replaces #3782 / #3865 / #3921, which stay open and untouched
> until it lands. Nothing here is a rebase of those branches — the work was
> re-cut from the ticket so each PR stands on its own.

### Proposed Changes

Two unrelated one-line cleanups peeled out of the DSPX-2604 stack so they
stop inflating a feature diff.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

```
make build && make test
```

<details>
<summary><b>The full DSPX-2604 stack — 20 PRs</b></summary>

| # | PR | Based on |
|---|----|----------|
| 01 | #3930 chore: bump go.work toolchain to go1.25.12 and simplify an rt_test condition | `main` |
| 02 | #3931 feat(sdk): make the zipstream clock injectable for deterministic ZIP output | `main` |
| 03 | #3932 fix(sdk): reject a zipstream write set that omits segment 0 | #3931 |
| 04 | #3933 fix(sdk): map ReadAt plaintext offsets from cumulative segment sizes | `main` |
| 05 | #3934 chore(sdk): extract integrityAlgorithmString, createPolicyBinding, signAssertions | `main` |
| 06 | #3935 chore(sdk): add direct tests for createKeyAccess, encryptMetadata and tdfSalt | `main` |
| 07 | #3936 fix(sdk): fill each segment with io.ReadFull and size the buffer to the input | `main` |
| 08 | #3937 chore(cli): move streaming IO helpers into pkg | `main` |
| 09 | #3938 fix(cli): stream encrypt instead of buffering the whole payload | #3937 |
| 10 | #3939 fix(cli): stream decrypt and inspect instead of buffering | #3938 |
| 11 | #3940 feat(sdk): add a chunked segment writer (experimental) | `dspx-2604-base-11` = #3932 + #3934 + #3935 |
| 12 | #3941 fix(sdk): stop GetManifest from splitting the key under the lock | #3940 |
| 13 | #3942 fix(sdk): reject a chunked split naming a KAS with no resolved public key | #3941 |
| 14 | #3943 chore(sdk): alias experimental/tdf manifest and assertion types | #3942 |
| 15 | #3944 fix(sdk): emit spec-compliant key access in experimental/tdf and delegate Writer | #3943 |
| 16 | #3945 feat(sdk): accept io.Reader in CreateTDF and drop the 64 GB payload cap | #3936 |
| 17 | #3946 chore(sdk): rewrite CreateTDF on top of the chunked writer | `dspx-2604-base-17` = #3944 + #3945 |
| 18 | #3947 chore(sdk): drop dead TDFConfig fields and deprecate the TDFFormat enum | #3946 |
| 19 | #3948 fix(cli): drop the encrypt-side stdin spool | `dspx-2604-base-19` = #3947 + #3939 |
| 20 | #3949 feat(sdk): graduate the chunked writer to stable API | #3948 |

**Reviewable in parallel right now**, since they sit directly on `main` and depend on
nothing else: 01, 02, 04, 05, 06, 07, 08.

**Why three PRs have a `dspx-2604-base-*` base.** A GitHub PR takes one base branch,
but 11, 17 and 19 each build on more than one parent. The `base-*` branches are empty
merge commits that exist only to join those parents so the PR diff shows exactly its
own change and nothing else. They contain no code, have no PR of their own, and go
away once their parents land — retarget the child onto `main` at that point.

**Wants a cross-SDK xtest run before merge:** 15, 17 (and therefore 20). They touch
the KAS wire format.

**Red checks you may see are network flakes, not this stack.** Four distinct ones hit
this batch and all clear on re-run: `golangci-lint config verify` timing out on
`https://golangci-lint.run/.../golangci.v2.8.jsonschema.json` (fails the whole `go
(<module>)` job and fail-fast cancels its siblings), the bats installer getting a 403,
Docker Hub timing out on `keycloak/keycloak:26.4`, and `buf` reporting "the server
hosted at that remote is unavailable" while the Java SDK generates sources. The
`govulncheck` step also emits `##[error]` annotations against the go1.25.11 stdlib, but
it is `continue-on-error: true` and never fails a job — 01 bumps the toolchain and
clears those annotations.

</details>
