### PR TITLE
feat(sdk): make the zipstream clock injectable for deterministic ZIP output

### DIFF
--- a/sdk/internal/zipstream/segment_writer.go
+++ b/sdk/internal/zipstream/segment_writer.go
@@ -10,7 +10,6 @@ import (
 	"hash/crc32"
 	"sort"
 	"sync"
-	"time"
 )
 
 // segmentWriter implements the SegmentWriter interface for out-of-order segment writing
@@ -36,12 +35,12 @@ func NewSegmentTDFWriter(expectedSegments int, opts ...Option) SegmentWriter {
 
 	return &segmentWriter{
 		baseWriter: base,
-		metadata:   NewSegmentMetadata(expectedSegments),
+		metadata:   NewSegmentMetadata(expectedSegments, cfg.Now),
 		centralDir: NewCentralDirectory(),
 		payloadEntry: &FileEntry{
 			Name:        TDFPayloadFileName,
 			Offset:      0,
-			ModTime:     time.Now(),
+			ModTime:     cfg.Now(),
 			IsStreaming: true, // Use data descriptor pattern
 		},
 		finalized: false,
@@ -191,7 +190,7 @@ func (sw *segmentWriter) Finalize(ctx context.Context, manifest []byte) ([]byte,
 		Size:           uint64(len(manifest)),
 		CompressedSize: uint64(len(manifest)),
 		CRC32:          crc32.ChecksumIEEE(manifest),
-		ModTime:        time.Now(),
+		ModTime:        sw.config.Now(),
 		IsStreaming:    false,
 	}
 
@@ -264,7 +263,7 @@ func (sw *segmentWriter) writeDataDescriptor(buf *bytes.Buffer, zip64 bool) erro
 
 // writeManifestFile writes the manifest as a complete file entry
 func (sw *segmentWriter) writeManifestFile(buf *bytes.Buffer, manifest []byte, entry FileEntry) error {
-	fileTime, fileDate := sw.getTimeDateInMSDosFormat(entry.ModTime)
+	fileTime, fileDate := msDosTimeDate(entry.ModTime)
 
 	// Write local file header for manifest
 	header := LocalFileHeader{
@@ -298,19 +297,9 @@ func (sw *segmentWriter) writeManifestFile(buf *bytes.Buffer, manifest []byte, e
 	return nil
 }
 
-// getTimeDateInMSDosFormat converts time to MS-DOS format
-func (sw *segmentWriter) getTimeDateInMSDosFormat(t time.Time) (uint16, uint16) {
-	const monthShift = 5
-
-	timeInDos := t.Hour()<<11 | t.Minute()<<5 | t.Second()>>1
-	dateInDos := (t.Year()-zipBaseYear)<<9 | int((t.Month())<<monthShift) | t.Day()
-
-	return uint16(timeInDos), uint16(dateInDos)
-}
-
 // writeLocalFileHeader writes the ZIP local file header for the payload
 func (sw *segmentWriter) writeLocalFileHeader(buf *bytes.Buffer) error {
-	fileTime, fileDate := sw.getTimeDateInMSDosFormat(sw.payloadEntry.ModTime)
+	fileTime, fileDate := msDosTimeDate(sw.payloadEntry.ModTime)
 
 	header := LocalFileHeader{
 		Signature:             fileHeaderSignature,

--- a/sdk/internal/zipstream/segment_writer_test.go
+++ b/sdk/internal/zipstream/segment_writer_test.go
@@ -10,6 +10,7 @@ import (
 	"hash/crc32"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -517,4 +518,111 @@ func benchmarkSegmentWriter(b *testing.B, name string, writeOrder []int) {
 			writer.Close()
 		}
 	})
+}
+
+// TestApplyOptionsRestoresNilClock covers an option clearing Config.Now.
+// Now is exported on an exported Config and Option is a bare
+// func(*Config), so nothing stops an option from doing this; without a
+// restore the first header stamp panics in NewSegmentTDFWriter.
+func TestApplyOptionsRestoresNilClock(t *testing.T) {
+	clearClock := func(c *Config) { c.Now = nil }
+
+	cfg := applyOptions([]Option{clearClock})
+	require.NotNil(t, cfg.Now)
+	assert.False(t, cfg.Now().IsZero())
+
+	assert.NotPanics(t, func() {
+		NewSegmentTDFWriter(1, clearClock)
+	})
+}
+
+// TestMSDosTimeDateClampsOutOfRangeYears pins the clamping behaviour for
+// years the MS-DOS date cannot hold. The "wraps to" column is what the
+// unclamped encoder produced, and is the reason clamping exists: every
+// one of those is a silently wrong date, not a failure.
+func TestMSDosTimeDateClampsOutOfRangeYears(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		in      time.Time
+		want    time.Time
+		wrapsTo string
+	}{
+		{
+			name:    "unix epoch",
+			in:      time.Unix(0, 0).UTC(),
+			want:    time.Date(zipBaseYear, time.January, 1, 0, 0, 0, 0, time.UTC),
+			wrapsTo: "2098-01-01",
+		},
+		{
+			name:    "zero time",
+			in:      time.Time{},
+			want:    time.Date(zipBaseYear, time.January, 1, 0, 0, 0, 0, time.UTC),
+			wrapsTo: "2049-01-01",
+		},
+		{
+			name: "one second before the base year",
+			in:   time.Date(zipBaseYear-1, time.December, 31, 23, 59, 59, 0, time.UTC),
+			want: time.Date(zipBaseYear, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "past the last representable year",
+			in:   time.Date(zipMaxYear+1, time.January, 1, 0, 0, 0, 0, time.UTC),
+			want: time.Date(zipMaxYear, time.December, 31, 23, 59, 58, 0, time.UTC),
+		},
+		{
+			name: "in range is untouched",
+			in:   time.Date(2024, time.June, 1, 12, 30, 8, 0, time.UTC),
+			want: time.Date(2024, time.June, 1, 12, 30, 8, 0, time.UTC),
+		},
+		{
+			name: "first representable instant",
+			in:   time.Date(zipBaseYear, time.January, 1, 0, 0, 0, 0, time.UTC),
+			want: time.Date(zipBaseYear, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dosTime, dosDate := msDosTimeDate(tc.in)
+
+			wantTime, wantDate := encodeMSDos(tc.want)
+			assert.Equal(t, wantDate, dosDate, "date; unclamped this wrapped to %s", tc.wrapsTo)
+			assert.Equal(t, wantTime, dosTime, "time")
+		})
+	}
+}
+
+// encodeMSDos packs t without any clamping, so the expectations above are
+// derived independently of the code under test.
+func encodeMSDos(t time.Time) (uint16, uint16) {
+	dosTime := t.Hour()<<11 | t.Minute()<<5 | t.Second()>>1
+	dosDate := (t.Year()-zipBaseYear)<<9 | int(t.Month())<<5 | t.Day()
+	return uint16(dosTime), uint16(dosDate)
+}
+
+// TestWriterClampsOutOfRangeClock drives a full archive with an epoch
+// clock and reads the timestamps back through archive/zip, covering the
+// WithClock -> local header -> central directory path end to end.
+func TestWriterClampsOutOfRangeClock(t *testing.T) {
+	ctx := t.Context()
+	writer := NewSegmentTDFWriter(1, WithClock(func() time.Time { return time.Unix(0, 0).UTC() }))
+
+	payload := []byte("payload")
+	segmentBytes, err := writer.WriteSegment(ctx, 0, uint64(len(payload)), crc32.ChecksumIEEE(payload))
+	require.NoError(t, err)
+
+	var allBytes []byte
+	allBytes = append(allBytes, segmentBytes...)
+	allBytes = append(allBytes, payload...)
+
+	finalBytes, err := writer.Finalize(ctx, []byte(`{"manifest":true}`))
+	require.NoError(t, err)
+	allBytes = append(allBytes, finalBytes...)
+
+	zipReader, err := zip.NewReader(bytes.NewReader(allBytes), int64(len(allBytes)))
+	require.NoError(t, err, "epoch clock should still produce a readable ZIP")
+	require.Len(t, zipReader.File, 2)
+
+	for _, f := range zipReader.File {
+		assert.Equal(t, zipBaseYear, f.Modified.Year(),
+			"%s should be clamped to the base year, not wrapped into the future", f.Name)
+	}
 }

--- a/sdk/internal/zipstream/writer.go
+++ b/sdk/internal/zipstream/writer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 )
 
 const (
@@ -60,6 +61,10 @@ type Config struct {
 	Zip64         Zip64Mode
 	MaxSegments   int
 	EnableLogging bool
+	// Now returns the current time for header/metadata timestamps.
+	// Defaults to time.Now; tests inject a pinned clock for
+	// deterministic ZIP output.
+	Now func() time.Time
 }
 
 // Option is a functional option for configuring writers
@@ -100,12 +105,24 @@ func WithLogging() Option {
 	}
 }
 
+// WithClock overrides the time source used to stamp ZIP headers and
+// segment metadata. Tests inject a pinned clock to make output byte-
+// for-byte deterministic.
+func WithClock(now func() time.Time) Option {
+	return func(c *Config) {
+		if now != nil {
+			c.Now = now
+		}
+	}
+}
+
 // defaultConfig returns default configuration
 func defaultConfig() *Config {
 	return &Config{
 		Zip64:         Zip64Auto,
 		MaxSegments:   defaultMaxSegments,
 		EnableLogging: false,
+		Now:           time.Now,
 	}
 }
 
@@ -114,6 +131,14 @@ func applyOptions(opts []Option) *Config {
 	cfg := defaultConfig()
 	for _, opt := range opts {
 		opt(cfg)
+	}
+	// Now is an exported field on an exported Config and Option is a
+	// bare func(*Config), so an option is free to clear it even though
+	// WithClock will not. Restore the default rather than let the
+	// writers panic on the first header stamp; NewSegmentMetadata
+	// already defends the same way.
+	if cfg.Now == nil {
+		cfg.Now = time.Now
 	}
 	return cfg
 }

--- a/sdk/internal/zipstream/zip_headers.go
+++ b/sdk/internal/zipstream/zip_headers.go
@@ -22,6 +22,9 @@ const (
 
 const (
 	zipBaseYear = 1980 // ZIP file format base year for date calculations
+	// zipMaxYear is the newest year an MS-DOS date can hold: the year is a
+	// 7-bit offset from zipBaseYear.
+	zipMaxYear = zipBaseYear + 127
 )
 
 const (

--- a/sdk/internal/zipstream/zip_primitives.go
+++ b/sdk/internal/zipstream/zip_primitives.go
@@ -42,15 +42,23 @@ type SegmentMetadata struct {
 	// Order, when set, defines the exact logical order of segments for
 	// completeness checks and CRC computation. Indices may be sparse.
 	Order []int
+	// now is the injected time source used to stamp SegmentEntry.Written.
+	now func() time.Time
 }
 
-// NewSegmentMetadata creates metadata for tracking segments using combine-based CRC.
-func NewSegmentMetadata(expectedCount int) *SegmentMetadata {
+// NewSegmentMetadata creates metadata for tracking segments using
+// combine-based CRC. now stamps SegmentEntry.Written; pass time.Now
+// for production or a pinned clock for deterministic tests.
+func NewSegmentMetadata(expectedCount int, now func() time.Time) *SegmentMetadata {
+	if now == nil {
+		now = time.Now
+	}
 	return &SegmentMetadata{
 		ExpectedCount: expectedCount,
 		Segments:      make(map[int]*SegmentEntry),
 		presentCount:  0,
 		TotalCRC32:    0,
+		now:           now,
 	}
 }
 
@@ -69,7 +77,7 @@ func (sm *SegmentMetadata) AddSegment(index int, originalSize uint64, originalCR
 		Index:   index,
 		Size:    originalSize,
 		CRC32:   originalCRC32,
-		Written: time.Now(),
+		Written: sm.now(),
 	}
 
 	sm.TotalSize += originalSize
@@ -234,16 +242,49 @@ func (cd *CentralDirectory) GenerateBytes(isZip64 bool) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// msDosTimeDate encodes t as the (time, date) pair ZIP headers carry.
+//
+// The date packs the year as a 7-bit offset from zipBaseYear, so only
+// zipBaseYear..zipMaxYear is representable. An out-of-range year would
+// wrap through the uint16 conversion into a plausible but wrong date --
+// the zero time.Time lands on 2049-01-01 and the Unix epoch on
+// 2098-01-01 -- so clamp to the endpoints instead. time.Now is always in
+// range; a clock injected via WithClock is the only way to get here.
+func msDosTimeDate(t time.Time) (uint16, uint16) {
+	const (
+		hourShift   = 11
+		minuteShift = 5
+		monthShift  = 5
+		yearShift   = 9
+	)
+
+	// Compare on calendar fields, not instants: DOS timestamps are local
+	// wall-clock with no zone, and those fields are what get encoded.
+	switch {
+	case t.Year() < zipBaseYear:
+		t = time.Date(zipBaseYear, time.January, 1, 0, 0, 0, 0, t.Location())
+	case t.Year() > zipMaxYear:
+		t = time.Date(zipMaxYear, time.December, 31, 23, 59, 58, 0, t.Location())
+	}
+
+	timeInDos := t.Hour()<<hourShift | t.Minute()<<minuteShift | t.Second()>>1
+	dateInDos := (t.Year()-zipBaseYear)<<yearShift | int(t.Month())<<monthShift | t.Day()
+
+	return uint16(timeInDos), uint16(dateInDos)
+}
+
 // writeCDFileHeader writes a central directory file header
 func (cd *CentralDirectory) writeCDFileHeader(buf *bytes.Buffer, entry FileEntry, isZip64 bool) error {
+	lastModifiedTime, lastModifiedDate := msDosTimeDate(entry.ModTime)
+
 	header := CDFileHeader{
 		Signature:              centralDirectoryHeaderSignature,
 		VersionCreated:         zipVersion,
 		VersionNeeded:          zipVersion,
 		GeneralPurposeBitFlag:  0,
 		CompressionMethod:      0, // No compression
-		LastModifiedTime:       uint16(entry.ModTime.Hour()<<11 | entry.ModTime.Minute()<<5 | entry.ModTime.Second()>>1),
-		LastModifiedDate:       uint16((entry.ModTime.Year()-zipBaseYear)<<9 | int(entry.ModTime.Month())<<5 | entry.ModTime.Day()),
+		LastModifiedTime:       lastModifiedTime,
+		LastModifiedDate:       lastModifiedDate,
 		Crc32:                  entry.CRC32,
 		CompressedSize:         uint32(entry.CompressedSize),
 		UncompressedSize:       uint32(entry.Size),


### PR DESCRIPTION
> **Part 02 of 20** in the DSPX-2604 re-cut. Base branch: `main`.
>
> This stack replaces #3782 / #3865 / #3921, which stay open and untouched
> until it lands. Nothing here is a rebase of those branches — the work was
> re-cut from the ticket so each PR stands on its own.

### Proposed Changes

zipstream stamped ZIP header and segment-metadata timestamps straight
from time.Now, so archive bytes could never be compared byte-for-byte
across runs. Config gains a Now func() time.Time, defaulted to time.Now
and overridable via WithClock; NewSegmentMetadata takes the time source
explicitly and SegmentEntry.Written stamps from it.

Now is an exported field on an exported Config and Option is a bare
func(*Config), so an option is free to nil it out even though WithClock
will not. applyOptions restores the default rather than letting the
first header stamp panic.

No behavior change for existing callers: sdk/tdf.go constructs the
writer without WithClock and keeps time.Now.

Also drops a redundant paren pair in dosDateTime flagged by the linter.

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

```
cd sdk && go test ./internal/zipstream/... -race
```

<details>
<summary><b>The full DSPX-2604 stack — 20 PRs</b></summary>

| # | PR | Based on |
|---|----|----------|
| 01 | #3930 chore: bump go.work toolchain to go1.25.12 and simplify an rt_test condition | `main` |
| 02 | #3931 feat(sdk): make the zipstream clock injectable for deterministic ZIP output | `main` |
| 03 | #3932 fix(sdk): reject a zipstream write set that omits segment 0 | #3931 |
| 04 | #3933 fix(sdk): map ReadAt plaintext offsets from cumulative segment sizes | `main` |
| 05 | #3934 chore(sdk): extract integrityAlgorithmString, createPolicyBinding, signAssertions | `main` |
| 06 | #3935 chore(sdk): add direct tests for createKeyAccess, encryptMetadata and tdfSalt | `main` |
| 07 | #3936 fix(sdk): fill each segment with io.ReadFull and size the buffer to the input | `main` |
| 08 | #3937 chore(cli): move streaming IO helpers into pkg | `main` |
| 09 | #3938 fix(cli): stream encrypt instead of buffering the whole payload | #3937 |
| 10 | #3939 fix(cli): stream decrypt and inspect instead of buffering | #3938 |
| 11 | #3940 feat(sdk): add a chunked segment writer (experimental) | `dspx-2604-base-11` = #3932 + #3934 + #3935 |
| 12 | #3941 fix(sdk): stop GetManifest from splitting the key under the lock | #3940 |
| 13 | #3942 fix(sdk): reject a chunked split naming a KAS with no resolved public key | #3941 |
| 14 | #3943 chore(sdk): alias experimental/tdf manifest and assertion types | #3942 |
| 15 | #3944 fix(sdk): emit spec-compliant key access in experimental/tdf and delegate Writer | #3943 |
| 16 | #3945 feat(sdk): accept io.Reader in CreateTDF and drop the 64 GB payload cap | #3936 |
| 17 | #3946 chore(sdk): rewrite CreateTDF on top of the chunked writer | `dspx-2604-base-17` = #3944 + #3945 |
| 18 | #3947 chore(sdk): drop dead TDFConfig fields and deprecate the TDFFormat enum | #3946 |
| 19 | #3948 fix(cli): drop the encrypt-side stdin spool | `dspx-2604-base-19` = #3947 + #3939 |
| 20 | #3949 feat(sdk): graduate the chunked writer to stable API | #3948 |

**Reviewable in parallel right now**, since they sit directly on `main` and depend on
nothing else: 01, 02, 04, 05, 06, 07, 08.

**Why three PRs have a `dspx-2604-base-*` base.** A GitHub PR takes one base branch,
but 11, 17 and 19 each build on more than one parent. The `base-*` branches are empty
merge commits that exist only to join those parents so the PR diff shows exactly its
own change and nothing else. They contain no code, have no PR of their own, and go
away once their parents land — retarget the child onto `main` at that point.

**Wants a cross-SDK xtest run before merge:** 15, 17 (and therefore 20). They touch
the KAS wire format.

**Red checks you may see are network flakes, not this stack.** Four distinct ones hit
this batch and all clear on re-run: `golangci-lint config verify` timing out on
`https://golangci-lint.run/.../golangci.v2.8.jsonschema.json` (fails the whole `go
(<module>)` job and fail-fast cancels its siblings), the bats installer getting a 403,
Docker Hub timing out on `keycloak/keycloak:26.4`, and `buf` reporting "the server
hosted at that remote is unavailable" while the Java SDK generates sources. The
`govulncheck` step also emits `##[error]` annotations against the go1.25.11 stdlib, but
it is `continue-on-error: true` and never fails a job — 01 bumps the toolchain and
clears those annotations.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ZIP archives now use a consistent configured timestamp for metadata and entries.
  - Archive timestamps outside the ZIP format’s supported range are safely clamped, improving compatibility with archive readers.
  - Archive creation remains stable when no custom clock is provided.

- **Testing**
  - Added coverage for timestamp configuration, boundary-year handling, and archive readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->