### PR TITLE
chore(sdk): add direct tests for createKeyAccess, encryptMetadata and tdfSalt

### DIFF
--- a/sdk/key_access_test.go
+++ b/sdk/key_access_test.go
@@ -1,0 +1,191 @@
+package sdk
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/opentdf/platform/lib/ocrypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These cover createKeyAccess and its helpers directly, without going through
+// CreateTDF. TDFSuite exercises the same code but only asserts that a round
+// trip succeeds against its own fake KAS, so it cannot pin the KAO field shape
+// or the error paths, and encryptMetadata and tdfSalt have no direct coverage
+// at all.
+
+const (
+	testKAS1URL = "https://kas1.example.com/"
+
+	// A real RSA-2048 public key. Generating one per test run is slow enough
+	// to notice across this many subtests.
+	testRSAPublicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtQ2ZuyT/p32SFmWTj+wQ
+huQwR4IJSzlJ7CqZ4fOXw90rA2joK27dIGiHrtkQHGhS4SK1mvkYyJaREoppMFRc
+AyZWCgixbSdwYJS/KN0hjLIdhtkdBlZDaZN2ayTf2sZjWzOLL2cYzzVsAy9tGL8a
+bMqf91DEHv+l58fPxmbJ/i6YFFQoOEsyWnPhXdiExe6poQDCHJFYYOp6iu5kOPWr
+jKFj9eGXuFR/CJQ/uxTSM+8/7Ejmi8Oa52TQAUhMPH0U1CRFm/NuiFoFissa0jJC
+J3k6syxvf45mPrbtlhcELskXrquDtJOpIMQmEwfuV4j8iLNwVlsR2tAbClJi6UOy
+SQIDAQAB
+-----END PUBLIC KEY-----`
+
+	testMetadata = "test metadata content"
+)
+
+func testSymKey(t *testing.T) []byte {
+	t.Helper()
+	symKey := make([]byte, kKeySize)
+	_, err := rand.Read(symKey)
+	require.NoError(t, err)
+	return symKey
+}
+
+// TestCreateKeyAccessRSA pins the shape of the default (RSA) wrapping path:
+// which manifest fields are populated and which are deliberately left empty.
+func TestCreateKeyAccessRSA(t *testing.T) {
+	symKey := testSymKey(t)
+
+	kao, err := createKeyAccess(
+		KASInfo{URL: testKAS1URL, PublicKey: testRSAPublicKey, KID: "test-kid", Algorithm: "rsa:2048"},
+		symKey, PolicyBinding{Alg: "HS256", Hash: "test-binding"}, "encrypted-metadata", "split-1",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, kWrapped, kao.KeyType)
+	assert.Equal(t, testKAS1URL, kao.KasURL)
+	assert.Equal(t, "test-kid", kao.KID)
+	assert.Equal(t, kKasProtocol, kao.Protocol)
+	assert.Equal(t, "split-1", kao.SplitID)
+	assert.Equal(t, keyAccessSchemaVersion, kao.SchemaVersion)
+	assert.Equal(t, "encrypted-metadata", kao.EncryptedMetadata)
+	assert.NotEmpty(t, kao.WrappedKey)
+	assert.Empty(t, kao.EphemeralPublicKey, "RSA wrapping emits no ephemeral key")
+}
+
+func TestCreateKeyAccessRejectsBadPublicKey(t *testing.T) {
+	symKey := testSymKey(t)
+
+	for _, tc := range []struct{ name, pubKey string }{
+		{"empty", ""},
+		{"malformed", "invalid-pem-data"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := createKeyAccess(
+				KASInfo{URL: testKAS1URL, PublicKey: tc.pubKey, Algorithm: "rsa:2048"},
+				symKey, PolicyBinding{}, "", "split-1",
+			)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestCreateKeyAccessECUnwrap wraps a DEK to an EC KAS key and then unwraps it
+// exactly the way service/kas/access/rewrap.go does for "ec-wrapped".
+// Asserting only on KeyType would not catch the envelope being, say, a raw XOR
+// of the HKDF output instead of AES-GCM.
+func TestCreateKeyAccessECUnwrap(t *testing.T) {
+	symKey := testSymKey(t)
+
+	ecKeyPair, err := ocrypto.NewECKeyPair(ocrypto.ECCModeSecp256r1)
+	require.NoError(t, err)
+	kasPubPEM, err := ecKeyPair.PublicKeyInPemFormat()
+	require.NoError(t, err)
+	kasPrivPEM, err := ecKeyPair.PrivateKeyInPemFormat()
+	require.NoError(t, err)
+
+	kao, err := createKeyAccess(
+		KASInfo{URL: testKAS1URL, PublicKey: kasPubPEM, KID: "test-kid", Algorithm: "ec:secp256r1"},
+		symKey, PolicyBinding{}, "", "split-1",
+	)
+	require.NoError(t, err)
+	require.Equal(t, kECWrapped, kao.KeyType)
+	require.NotEmpty(t, kao.EphemeralPublicKey)
+	assert.True(t, strings.HasPrefix(kao.EphemeralPublicKey, "-----BEGIN PUBLIC KEY-----"))
+	assert.True(t, strings.HasSuffix(kao.EphemeralPublicKey, "-----END PUBLIC KEY-----\n"))
+
+	keySize, err := ocrypto.GetECKeySize([]byte(kao.EphemeralPublicKey))
+	require.NoError(t, err)
+	mode, err := ocrypto.ECSizeToMode(keySize)
+	require.NoError(t, err)
+
+	block, _ := pem.Decode([]byte(kao.EphemeralPublicKey))
+	require.NotNil(t, block)
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	require.NoError(t, err)
+	ecPub, ok := pub.(*ecdsa.PublicKey)
+	require.True(t, ok)
+	compressed, err := ocrypto.CompressedECPublicKey(mode, *ecPub)
+	require.NoError(t, err)
+
+	priv, err := ocrypto.ECPrivateKeyFromPem([]byte(kasPrivPEM))
+	require.NoError(t, err)
+	dec, err := ocrypto.NewSaltedECDecryptor(priv, tdfSalt(), nil)
+	require.NoError(t, err)
+
+	wrapped, err := ocrypto.Base64Decode([]byte(kao.WrappedKey))
+	require.NoError(t, err)
+	unwrapped, err := dec.DecryptWithEphemeralKey(wrapped, compressed)
+	require.NoError(t, err, "KAS must be able to unwrap the EC-wrapped DEK")
+	assert.Equal(t, symKey, unwrapped)
+}
+
+// The three hybrid KEM schemes are round-tripped in tdf_hybrid_test.go and are
+// deliberately not repeated here.
+
+func TestEncryptMetadata(t *testing.T) {
+	symKey := testSymKey(t)
+
+	t.Run("produces a base64 EncryptedMetadata envelope", func(t *testing.T) {
+		encrypted, err := encryptMetadata(symKey, testMetadata)
+		require.NoError(t, err)
+		require.NotEmpty(t, encrypted)
+
+		decodedJSON, err := ocrypto.Base64Decode([]byte(encrypted))
+		require.NoError(t, err)
+
+		var encMeta EncryptedMetadata
+		require.NoError(t, json.Unmarshal(decodedJSON, &encMeta))
+		require.NotEmpty(t, encMeta.Cipher)
+		require.NotEmpty(t, encMeta.Iv)
+
+		_, err = ocrypto.Base64Decode([]byte(encMeta.Iv))
+		require.NoError(t, err)
+		_, err = ocrypto.Base64Decode([]byte(encMeta.Cipher))
+		require.NoError(t, err)
+	})
+
+	t.Run("different keys produce different ciphertext", func(t *testing.T) {
+		otherKey := testSymKey(t)
+
+		a, err := encryptMetadata(symKey, testMetadata)
+		require.NoError(t, err)
+		b, err := encryptMetadata(otherKey, testMetadata)
+		require.NoError(t, err)
+		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("empty metadata still yields an envelope", func(t *testing.T) {
+		encrypted, err := encryptMetadata(symKey, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, encrypted)
+	})
+
+	t.Run("errors on an unusable key", func(t *testing.T) {
+		_, err := encryptMetadata([]byte{}, testMetadata)
+		require.Error(t, err)
+	})
+}
+
+func TestTdfSalt(t *testing.T) {
+	salt1 := tdfSalt()
+	salt2 := tdfSalt()
+
+	assert.Equal(t, salt1, salt2, "tdfSalt must be deterministic")
+	assert.Len(t, salt1, 32, "SHA-256 output")
+}

--- a/sdk/key_access_test.go
+++ b/sdk/key_access_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"strings"
@@ -183,9 +184,8 @@ func TestEncryptMetadata(t *testing.T) {
 }
 
 func TestTdfSalt(t *testing.T) {
-	salt1 := tdfSalt()
-	salt2 := tdfSalt()
-
-	assert.Equal(t, salt1, salt2, "tdfSalt must be deterministic")
-	assert.Len(t, salt1, 32, "SHA-256 output")
+	assert.Equal(t,
+		"aa17cf44585fe15fd634c27b9512d842b42af1bac6178d92161edb4e2abf8197",
+		hex.EncodeToString(tdfSalt()),
+	)
 }

--- a/sdk/key_access_test.go
+++ b/sdk/key_access_test.go
@@ -47,6 +47,29 @@ func testSymKey(t *testing.T) []byte {
 	return symKey
 }
 
+func decodeEncryptedMetadata(t *testing.T, encrypted string) []byte {
+	t.Helper()
+
+	decodedJSON, err := ocrypto.Base64Decode([]byte(encrypted))
+	require.NoError(t, err)
+
+	var encMeta EncryptedMetadata
+	require.NoError(t, json.Unmarshal(decodedJSON, &encMeta))
+	require.NotEmpty(t, encMeta.Cipher)
+	require.NotEmpty(t, encMeta.Iv)
+
+	iv, err := ocrypto.Base64Decode([]byte(encMeta.Iv))
+	require.NoError(t, err)
+	require.Len(t, iv, ocrypto.GcmStandardNonceSize)
+
+	ciphertext, err := ocrypto.Base64Decode([]byte(encMeta.Cipher))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(ciphertext), ocrypto.GcmStandardNonceSize)
+	assert.Equal(t, iv, ciphertext[:ocrypto.GcmStandardNonceSize])
+
+	return ciphertext
+}
+
 // TestCreateKeyAccessRSA pins the shape of the default (RSA) wrapping path:
 // which manifest fields are populated and which are deliberately left empty.
 func TestCreateKeyAccessRSA(t *testing.T) {
@@ -65,6 +88,7 @@ func TestCreateKeyAccessRSA(t *testing.T) {
 	assert.Equal(t, "split-1", kao.SplitID)
 	assert.Equal(t, keyAccessSchemaVersion, kao.SchemaVersion)
 	assert.Equal(t, "encrypted-metadata", kao.EncryptedMetadata)
+	assert.Equal(t, PolicyBinding{Alg: "HS256", Hash: "test-binding"}, kao.PolicyBinding)
 	assert.NotEmpty(t, kao.WrappedKey)
 	assert.Empty(t, kao.EphemeralPublicKey, "RSA wrapping emits no ephemeral key")
 }
@@ -142,39 +166,42 @@ func TestCreateKeyAccessECUnwrap(t *testing.T) {
 func TestEncryptMetadata(t *testing.T) {
 	symKey := testSymKey(t)
 
-	t.Run("produces a base64 EncryptedMetadata envelope", func(t *testing.T) {
+	t.Run("round trips a base64 EncryptedMetadata envelope", func(t *testing.T) {
 		encrypted, err := encryptMetadata(symKey, testMetadata)
 		require.NoError(t, err)
 		require.NotEmpty(t, encrypted)
 
-		decodedJSON, err := ocrypto.Base64Decode([]byte(encrypted))
+		ciphertext := decodeEncryptedMetadata(t, encrypted)
+		gcm, err := ocrypto.NewAESGcm(symKey)
 		require.NoError(t, err)
-
-		var encMeta EncryptedMetadata
-		require.NoError(t, json.Unmarshal(decodedJSON, &encMeta))
-		require.NotEmpty(t, encMeta.Cipher)
-		require.NotEmpty(t, encMeta.Iv)
-
-		_, err = ocrypto.Base64Decode([]byte(encMeta.Iv))
+		plaintext, err := gcm.Decrypt(ciphertext)
 		require.NoError(t, err)
-		_, err = ocrypto.Base64Decode([]byte(encMeta.Cipher))
-		require.NoError(t, err)
+		assert.Equal(t, testMetadata, string(plaintext))
 	})
 
-	t.Run("different keys produce different ciphertext", func(t *testing.T) {
+	t.Run("a different key cannot decrypt the ciphertext", func(t *testing.T) {
 		otherKey := testSymKey(t)
 
-		a, err := encryptMetadata(symKey, testMetadata)
+		encrypted, err := encryptMetadata(symKey, testMetadata)
 		require.NoError(t, err)
-		b, err := encryptMetadata(otherKey, testMetadata)
+		ciphertext := decodeEncryptedMetadata(t, encrypted)
+
+		gcm, err := ocrypto.NewAESGcm(otherKey)
 		require.NoError(t, err)
-		assert.NotEqual(t, a, b)
+		_, err = gcm.Decrypt(ciphertext)
+		require.Error(t, err)
 	})
 
-	t.Run("empty metadata still yields an envelope", func(t *testing.T) {
+	t.Run("empty metadata round trips through an envelope", func(t *testing.T) {
 		encrypted, err := encryptMetadata(symKey, "")
 		require.NoError(t, err)
-		assert.NotEmpty(t, encrypted)
+		ciphertext := decodeEncryptedMetadata(t, encrypted)
+
+		gcm, err := ocrypto.NewAESGcm(symKey)
+		require.NoError(t, err)
+		plaintext, err := gcm.Decrypt(ciphertext)
+		require.NoError(t, err)
+		assert.Empty(t, plaintext)
 	})
 
 	t.Run("errors on an unusable key", func(t *testing.T) {


### PR DESCRIPTION
> **Part 06 of 20** in the DSPX-2604 re-cut. Base branch: `main`.
>
> This stack replaces #3782 / #3865 / #3921, which stay open and untouched
> until it lands. Nothing here is a rebase of those branches — the work was
> re-cut from the ticket so each PR stands on its own.

### Proposed Changes

createKeyAccess builds the manifest key access object and picks the
wrapping scheme from the KAS key algorithm. Today the only thing
exercising it is TDFSuite, which asserts that a round trip against its
own fake KAS succeeds -- so it cannot pin which KAO fields are populated,
cannot catch an error path that silently returns a zero value, and says
nothing about encryptMetadata or tdfSalt, which have no direct coverage.

Adds, test-only:

  - the RSA KAO field shape, including the deliberately empty
    ephemeralPublicKey and the schemaVersion the KAS dispatches on
  - empty and malformed KAS public keys are rejected
  - an EC-wrapped DEK unwrapped the way service/kas/access/rewrap.go
    does it, so the envelope is checked to be AES-GCM over the HKDF
    output rather than merely tagged "ec-wrapped"
  - encryptMetadata's envelope shape, key sensitivity, empty input, and
    unusable key
  - tdfSalt determinism and length

The three hybrid KEM schemes already round-trip in tdf_hybrid_test.go
and are not repeated.

Landing this ahead of the DSPX-2604 work that deletes the duplicate
key-wrapping implementation in sdk/experimental/tdf makes that deletion
checkable as a de-duplication rather than a coverage loss.

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

```
cd sdk && go test ./... -race
```

<details>
<summary><b>The full DSPX-2604 stack — 20 PRs</b></summary>

| # | PR | Based on |
|---|----|----------|
| 01 | #3930 chore: bump go.work toolchain to go1.25.12 and simplify an rt_test condition | `main` |
| 02 | #3931 feat(sdk): make the zipstream clock injectable for deterministic ZIP output | `main` |
| 03 | #3932 fix(sdk): reject a zipstream write set that omits segment 0 | #3931 |
| 04 | #3933 fix(sdk): map ReadAt plaintext offsets from cumulative segment sizes | `main` |
| 05 | #3934 chore(sdk): extract integrityAlgorithmString, createPolicyBinding, signAssertions | `main` |
| 06 | #3935 chore(sdk): add direct tests for createKeyAccess, encryptMetadata and tdfSalt | `main` |
| 07 | #3936 fix(sdk): fill each segment with io.ReadFull and size the buffer to the input | `main` |
| 08 | #3937 chore(cli): move streaming IO helpers into pkg | `main` |
| 09 | #3938 fix(cli): stream encrypt instead of buffering the whole payload | #3937 |
| 10 | #3939 fix(cli): stream decrypt and inspect instead of buffering | #3938 |
| 11 | #3940 feat(sdk): add a chunked segment writer (experimental) | `dspx-2604-base-11` = #3932 + #3934 + #3935 |
| 12 | #3941 fix(sdk): stop GetManifest from splitting the key under the lock | #3940 |
| 13 | #3942 fix(sdk): reject a chunked split naming a KAS with no resolved public key | #3941 |
| 14 | #3943 chore(sdk): alias experimental/tdf manifest and assertion types | #3942 |
| 15 | #3944 fix(sdk): emit spec-compliant key access in experimental/tdf and delegate Writer | #3943 |
| 16 | #3945 feat(sdk): accept io.Reader in CreateTDF and drop the 64 GB payload cap | #3936 |
| 17 | #3946 chore(sdk): rewrite CreateTDF on top of the chunked writer | `dspx-2604-base-17` = #3944 + #3945 |
| 18 | #3947 chore(sdk): drop dead TDFConfig fields and deprecate the TDFFormat enum | #3946 |
| 19 | #3948 fix(cli): drop the encrypt-side stdin spool | `dspx-2604-base-19` = #3947 + #3939 |
| 20 | #3949 feat(sdk): graduate the chunked writer to stable API | #3948 |

**Reviewable in parallel right now**, since they sit directly on `main` and depend on
nothing else: 01, 02, 04, 05, 06, 07, 08.

**Why three PRs have a `dspx-2604-base-*` base.** A GitHub PR takes one base branch,
but 11, 17 and 19 each build on more than one parent. The `base-*` branches are empty
merge commits that exist only to join those parents so the PR diff shows exactly its
own change and nothing else. They contain no code, have no PR of their own, and go
away once their parents land — retarget the child onto `main` at that point.

**Wants a cross-SDK xtest run before merge:** 15, 17 (and therefore 20). They touch
the KAS wire format.

**Red checks you may see are network flakes, not this stack.** Four distinct ones hit
this batch and all clear on re-run: `golangci-lint config verify` timing out on
`https://golangci-lint.run/.../golangci.v2.8.jsonschema.json` (fails the whole `go
(<module>)` job and fail-fast cancels its siblings), the bats installer getting a 403,
Docker Hub timing out on `keycloak/keycloak:26.4`, and `buf` reporting "the server
hosted at that remote is unavailable" while the Java SDK generates sources. The
`govulncheck` step also emits `##[error]` annotations against the go1.25.11 stdlib, but
it is `continue-on-error: true` and never fails a job — 01 bumps the toolchain and
clears those annotations.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for RSA and EC key-access creation.
  * Added validation for invalid or unusable public keys and incorrect decryption keys.
  * Added tests for metadata encryption and decryption, including empty metadata.
  * Added coverage for encrypted metadata structure and EC interoperability.
  * Added deterministic TDF salt generation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->