### PR TITLE
fix(sdk): fill each segment with io.ReadFull and size the buffer to the input

### DIFF
--- a/sdk/tdf.go
+++ b/sdk/tdf.go
@@ -233,7 +233,10 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 
 	var readPos int64
 	var aggregateHashBuilder strings.Builder
-	readBuf := bytes.NewBuffer(make([]byte, 0, tdfConfig.defaultSegmentSize))
+	// Only as large as the payload actually needs: the segment size defaults to
+	// 2 MiB, so sizing on it alone would allocate that much to encrypt a
+	// handful of bytes.
+	readBuf := make([]byte, min(segmentSize, max(inputSize, 1)))
 	segmentIndex := 0
 	for totalSegments != 0 { // adjust read size
 		readSize := segmentSize
@@ -241,16 +244,14 @@ func (s SDK) CreateTDFContext(ctx context.Context, writer io.Writer, reader io.R
 			readSize = inputSize - readPos
 		}
 
-		n, err := reader.Read(readBuf.Bytes()[:readSize])
-		if err != nil {
+		// io.Reader.Read is free to return fewer bytes than asked for without
+		// erroring, so a bare Read would reject perfectly valid readers as a
+		// size mismatch. ReadFull retries until the segment is filled.
+		if _, err := io.ReadFull(reader, readBuf[:readSize]); err != nil {
 			return nil, fmt.Errorf("io.ReadSeeker.Read failed: %w", err)
 		}
 
-		if int64(n) != readSize {
-			return nil, errors.New("io.ReadSeeker.Read size mismatch")
-		}
-
-		cipherData, err := tdfObject.aesGcm.Encrypt(readBuf.Bytes()[:readSize])
+		cipherData, err := tdfObject.aesGcm.Encrypt(readBuf[:readSize])
 		if err != nil {
 			return nil, fmt.Errorf("io.ReadSeeker.Read failed: %w", err)
 		}

--- a/sdk/tdf_test.go
+++ b/sdk/tdf_test.go
@@ -1600,6 +1600,46 @@ func (s *TDFSuite) Test_TDFReader() { //nolint:gocognit // requires for testing 
 	}
 }
 
+// shortReadSeeker hands back at most maxRead bytes per Read, which io.Reader
+// explicitly permits. A *bytes.Reader never does this, so nothing else in the
+// suite covers it.
+type shortReadSeeker struct {
+	io.ReadSeeker
+	maxRead int
+}
+
+func (s *shortReadSeeker) Read(p []byte) (int, error) {
+	if len(p) > s.maxRead {
+		p = p[:s.maxRead]
+	}
+	return s.ReadSeeker.Read(p)
+}
+
+// Test_TDFCreateShortReads pins that CreateTDF fills each segment rather than
+// treating a short read as a fatal size mismatch.
+func (s *TDFSuite) Test_TDFCreateShortReads() {
+	kasInfoList := []KASInfo{
+		{URL: s.kasTestURLLookup["http://localhost:65432/"]},
+	}
+
+	tdfBuf := bytes.Buffer{}
+	_, err := s.sdk.CreateTDF(
+		io.Writer(&tdfBuf),
+		&shortReadSeeker{ReadSeeker: bytes.NewReader([]byte(payload)), maxRead: 3},
+		WithKasInformation(kasInfoList...),
+		WithSegmentSize(7),
+	)
+	s.Require().NoError(err)
+
+	r, err := s.sdk.LoadTDF(bytes.NewReader(tdfBuf.Bytes()))
+	s.Require().NoError(err)
+
+	var out bytes.Buffer
+	_, err = r.WriteTo(&out)
+	s.Require().NoError(err)
+	s.Equal(payload, out.String())
+}
+
 func (s *TDFSuite) Test_TDFReaderFail() {
 	kasInfoList := []KASInfo{
 		{


### PR DESCRIPTION
> **Part 07 of 20** in the DSPX-2604 re-cut. Base branch: `main`.
>
> This stack replaces #3782 / #3865 / #3921, which stay open and untouched
> until it lands. Nothing here is a rebase of those branches — the work was
> re-cut from the ticket so each PR stands on its own.

### Proposed Changes

Two problems in CreateTDFContext's encrypt loop.

io.Reader.Read is permitted to return fewer bytes than the caller asked
for without erroring, and the loop treated that as fatal:
"io.ReadSeeker.Read size mismatch". A *bytes.Reader or *os.File on a
local disk rarely returns short, which is why this has held up, but any
wrapping ReadSeeker -- a decompressor, a network-backed store, an
instrumented reader -- can trigger it and there is nothing wrong with
the input when it does. io.ReadFull retries until the segment is full,
so the manual size check goes away with it. The new
Test_TDFCreateShortReads fails on main with exactly that error message.

The read buffer was also sized on defaultSegmentSize alone, which is
2 MiB, so encrypting a twelve-byte payload allocated 2 MiB to hold it.
Size it to min(segmentSize, inputSize) instead; the max(inputSize, 1)
keeps the empty-payload case, which still emits one empty segment, from
asking for a zero-length buffer.

Peeled out of the DSPX-2604 stack.

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

```
cd sdk && go test ./... -race
```

`Test_TDFCreateShortReads` fails on `main` with
`io.ReadSeeker.Read size mismatch` and passes here.

<details>
<summary><b>The full DSPX-2604 stack — 20 PRs</b></summary>

| # | PR | Based on |
|---|----|----------|
| 01 | #3930 chore: bump go.work toolchain to go1.25.12 and simplify an rt_test condition | `main` |
| 02 | #3931 feat(sdk): make the zipstream clock injectable for deterministic ZIP output | `main` |
| 03 | #3932 fix(sdk): reject a zipstream write set that omits segment 0 | #3931 |
| 04 | #3933 fix(sdk): map ReadAt plaintext offsets from cumulative segment sizes | `main` |
| 05 | #3934 chore(sdk): extract integrityAlgorithmString, createPolicyBinding, signAssertions | `main` |
| 06 | #3935 chore(sdk): add direct tests for createKeyAccess, encryptMetadata and tdfSalt | `main` |
| 07 | #3936 fix(sdk): fill each segment with io.ReadFull and size the buffer to the input | `main` |
| 08 | #3937 chore(cli): move streaming IO helpers into pkg | `main` |
| 09 | #3938 fix(cli): stream encrypt instead of buffering the whole payload | #3937 |
| 10 | #3939 fix(cli): stream decrypt and inspect instead of buffering | #3938 |
| 11 | #3940 feat(sdk): add a chunked segment writer (experimental) | `dspx-2604-base-11` = #3932 + #3934 + #3935 |
| 12 | #3941 fix(sdk): stop GetManifest from splitting the key under the lock | #3940 |
| 13 | #3942 fix(sdk): reject a chunked split naming a KAS with no resolved public key | #3941 |
| 14 | #3943 chore(sdk): alias experimental/tdf manifest and assertion types | #3942 |
| 15 | #3944 fix(sdk): emit spec-compliant key access in experimental/tdf and delegate Writer | #3943 |
| 16 | #3945 feat(sdk): accept io.Reader in CreateTDF and drop the 64 GB payload cap | #3936 |
| 17 | #3946 chore(sdk): rewrite CreateTDF on top of the chunked writer | `dspx-2604-base-17` = #3944 + #3945 |
| 18 | #3947 chore(sdk): drop dead TDFConfig fields and deprecate the TDFFormat enum | #3946 |
| 19 | #3948 fix(cli): drop the encrypt-side stdin spool | `dspx-2604-base-19` = #3947 + #3939 |
| 20 | #3949 feat(sdk): graduate the chunked writer to stable API | #3948 |

**Reviewable in parallel right now**, since they sit directly on `main` and depend on
nothing else: 01, 02, 04, 05, 06, 07, 08.

**Why three PRs have a `dspx-2604-base-*` base.** A GitHub PR takes one base branch,
but 11, 17 and 19 each build on more than one parent. The `base-*` branches are empty
merge commits that exist only to join those parents so the PR diff shows exactly its
own change and nothing else. They contain no code, have no PR of their own, and go
away once their parents land — retarget the child onto `main` at that point.

**Wants a cross-SDK xtest run before merge:** 15, 17 (and therefore 20). They touch
the KAS wire format.

**Red checks you may see are network flakes, not this stack.** Four distinct ones hit
this batch and all clear on re-run: `golangci-lint config verify` timing out on
`https://golangci-lint.run/.../golangci.v2.8.jsonschema.json` (fails the whole `go
(<module>)` job and fail-fast cancels its siblings), the bats installer getting a 403,
Docker Hub timing out on `keycloak/keycloak:26.4`, and `buf` reporting "the server
hosted at that remote is unavailable" while the Java SDK generates sources. The
`govulncheck` step also emits `##[error]` annotations against the go1.25.11 stdlib, but
it is `continue-on-error: true` and never fails a job — 01 bumps the toolchain and
clears those annotations.

</details>
