### PR TITLE
feat(kas): Read kas registry from kao

### DIFF
--- a/service/internal/security/basic_manager_test.go
+++ b/service/internal/security/basic_manager_test.go
@@ -47,11 +47,6 @@ func (m *MockKeyDetails) ID() trust.KeyIdentifier {
 	return ""
 }
 
-func (m *MockKeyDetails) KASURI() string {
-	args := m.Called()
-	return args.String(0)
-}
-
 func (m *MockKeyDetails) Algorithm() ocrypto.KeyType {
 	args := m.Called()
 	return ocrypto.KeyType(args.String(0))

--- a/service/internal/security/basic_manager_test.go
+++ b/service/internal/security/basic_manager_test.go
@@ -47,6 +47,11 @@ func (m *MockKeyDetails) ID() trust.KeyIdentifier {
 	return ""
 }
 
+func (m *MockKeyDetails) KASURI() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 func (m *MockKeyDetails) Algorithm() ocrypto.KeyType {
 	args := m.Called()
 	return ocrypto.KeyType(args.String(0))

--- a/service/internal/security/in_process_provider.go
+++ b/service/internal/security/in_process_provider.go
@@ -62,10 +62,6 @@ func (k *KeyDetailsAdapter) ID() trust.KeyIdentifier {
 	return k.id
 }
 
-func (k *KeyDetailsAdapter) KASURI() string {
-	return ""
-}
-
 func (k *KeyDetailsAdapter) Algorithm() ocrypto.KeyType {
 	return k.algorithm
 }

--- a/service/internal/security/in_process_provider.go
+++ b/service/internal/security/in_process_provider.go
@@ -200,6 +200,10 @@ func (a *InProcessProvider) FindKeyByID(_ context.Context, id trust.KeyIdentifie
 	}, nil
 }
 
+func (a *InProcessProvider) FindKeyByIDWithKASURI(ctx context.Context, id trust.KeyIdentifier, _ string) (trust.KeyDetails, error) {
+	return a.FindKeyByID(ctx, id)
+}
+
 // ListKeys lists all available keys
 func (a *InProcessProvider) ListKeys(ctx context.Context) ([]trust.KeyDetails, error) {
 	return a.ListKeysWith(ctx, trust.ListKeyOptions{LegacyOnly: false})
@@ -236,6 +240,10 @@ func (a *InProcessProvider) ListKeysWith(ctx context.Context, opts trust.ListKey
 	}
 
 	return keys, nil
+}
+
+func (a *InProcessProvider) ListKeysWithKASURI(ctx context.Context, opts trust.ListKeyOptions, _ string) ([]trust.KeyDetails, error) {
+	return a.ListKeysWith(ctx, opts)
 }
 
 // Decrypt implements the unified decryption method for both RSA and EC

--- a/service/internal/security/in_process_provider.go
+++ b/service/internal/security/in_process_provider.go
@@ -62,6 +62,10 @@ func (k *KeyDetailsAdapter) ID() trust.KeyIdentifier {
 	return k.id
 }
 
+func (k *KeyDetailsAdapter) KASURI() string {
+	return ""
+}
+
 func (k *KeyDetailsAdapter) Algorithm() ocrypto.KeyType {
 	return k.algorithm
 }

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -46,6 +46,10 @@ func (m *MockKeyDetails) ID() trust.KeyIdentifier {
 	return m.id
 }
 
+func (m *MockKeyDetails) KASURI() string {
+	return ""
+}
+
 func (m *MockKeyDetails) Algorithm() ocrypto.KeyType {
 	return ocrypto.KeyType(m.algorithm)
 }

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -127,6 +127,10 @@ func (m *MockSecurityProvider) FindKeyByID(_ context.Context, id trust.KeyIdenti
 	return nil, security.ErrCertNotFound
 }
 
+func (m *MockSecurityProvider) FindKeyByIDWithKASURI(ctx context.Context, id trust.KeyIdentifier, _ string) (trust.KeyDetails, error) {
+	return m.FindKeyByID(ctx, id)
+}
+
 func (m *MockSecurityProvider) ListKeys(_ context.Context) ([]trust.KeyDetails, error) {
 	var keys []trust.KeyDetails
 	for _, key := range m.keys {
@@ -144,6 +148,10 @@ func (m *MockSecurityProvider) ListKeysWith(_ context.Context, opts trust.ListKe
 		keys = append(keys, key)
 	}
 	return keys, nil
+}
+
+func (m *MockSecurityProvider) ListKeysWithKASURI(ctx context.Context, opts trust.ListKeyOptions, _ string) ([]trust.KeyDetails, error) {
+	return m.ListKeysWith(ctx, opts)
 }
 
 func (m *MockSecurityProvider) Decrypt(_ context.Context, _ trust.KeyDetails, _, _ []byte) (ocrypto.ProtectedKey, error) {

--- a/service/kas/access/publicKey_test.go
+++ b/service/kas/access/publicKey_test.go
@@ -46,10 +46,6 @@ func (m *MockKeyDetails) ID() trust.KeyIdentifier {
 	return m.id
 }
 
-func (m *MockKeyDetails) KASURI() string {
-	return ""
-}
-
 func (m *MockKeyDetails) Algorithm() ocrypto.KeyType {
 	return ocrypto.KeyType(m.algorithm)
 }

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -709,6 +709,7 @@ func (p *Provider) verifyRewrapRequests(ctx context.Context, req *kaspb.Unsigned
 
 		var dek ocrypto.ProtectedKey
 		var err error
+		kasURI := kao.GetKeyAccessObject().GetKasUrl()
 		switch kao.GetKeyAccessObject().GetKeyType() {
 		case "ec-wrapped":
 
@@ -787,7 +788,7 @@ func (p *Provider) verifyRewrapRequests(ctx context.Context, req *kaspb.Unsigned
 			}
 
 			kid := trust.KeyIdentifier(kao.GetKeyAccessObject().GetKid())
-			dek, err = p.KeyDelegator.Decrypt(ctx, kid, kao.GetKeyAccessObject().GetWrappedKey(), compressedKey)
+			dek, err = p.KeyDelegator.Decrypt(ctx, kid, kasURI, kao.GetKeyAccessObject().GetWrappedKey(), compressedKey)
 			if err != nil {
 				p.Logger.WarnContext(ctx, "failed to decrypt EC key", slog.Any("error", err))
 				failedKAORewrap(results, kao, err400("bad request"))
@@ -801,7 +802,7 @@ func (p *Provider) verifyRewrapRequests(ctx context.Context, req *kaspb.Unsigned
 			}
 
 			kid := trust.KeyIdentifier(kao.GetKeyAccessObject().GetKid())
-			dek, err = p.KeyDelegator.Decrypt(ctx, kid, kao.GetKeyAccessObject().GetWrappedKey(), nil)
+			dek, err = p.KeyDelegator.Decrypt(ctx, kid, kasURI, kao.GetKeyAccessObject().GetWrappedKey(), nil)
 			if err != nil {
 				p.Logger.WarnContext(ctx, "failed to decrypt hybrid key", slog.Any("error", err))
 				failedKAORewrap(results, kao, err400("bad request"))
@@ -815,7 +816,7 @@ func (p *Provider) verifyRewrapRequests(ctx context.Context, req *kaspb.Unsigned
 			}
 
 			kid := trust.KeyIdentifier(kao.GetKeyAccessObject().GetKid())
-			dek, err = p.KeyDelegator.Decrypt(ctx, kid, kao.GetKeyAccessObject().GetWrappedKey(), nil)
+			dek, err = p.KeyDelegator.Decrypt(ctx, kid, kasURI, kao.GetKeyAccessObject().GetWrappedKey(), nil)
 			if err != nil {
 				p.Logger.WarnContext(ctx, "failed to decrypt ML-KEM key", slog.Any("error", err))
 				failedKAORewrap(results, kao, err400("bad request"))
@@ -827,7 +828,7 @@ func (p *Provider) verifyRewrapRequests(ctx context.Context, req *kaspb.Unsigned
 				kid := trust.KeyIdentifier(kao.GetKeyAccessObject().GetKid())
 				kidsToCheck = []trust.KeyIdentifier{kid}
 			} else {
-				kidsToCheck = p.listLegacyKeys(ctx)
+				kidsToCheck = p.listLegacyKeys(ctx, kasURI)
 				if len(kidsToCheck) == 0 {
 					p.Logger.WarnContext(ctx, "failure to find legacy kids for rsa")
 					failedKAORewrap(results, kao, err400("no legacy key IDs found"))
@@ -835,13 +836,13 @@ func (p *Provider) verifyRewrapRequests(ctx context.Context, req *kaspb.Unsigned
 				}
 			}
 
-			dek, err = p.KeyDelegator.Decrypt(ctx, kidsToCheck[0], kao.GetKeyAccessObject().GetWrappedKey(), nil)
+			dek, err = p.KeyDelegator.Decrypt(ctx, kidsToCheck[0], kasURI, kao.GetKeyAccessObject().GetWrappedKey(), nil)
 			for _, kid := range kidsToCheck[1:] {
 				p.Logger.WarnContext(ctx, "continue paging through legacy KIDs for kid free kao", slog.Any("error", err))
 				if err == nil {
 					break
 				}
-				dek, err = p.KeyDelegator.Decrypt(ctx, kid, kao.GetKeyAccessObject().GetWrappedKey(), nil)
+				dek, err = p.KeyDelegator.Decrypt(ctx, kid, kasURI, kao.GetKeyAccessObject().GetWrappedKey(), nil)
 			}
 		default:
 			// handle unsupported key types
@@ -911,7 +912,7 @@ func (p *Provider) verifyRewrapRequests(ctx context.Context, req *kaspb.Unsigned
 	return policy, results, nil
 }
 
-func (p *Provider) listLegacyKeys(ctx context.Context) []trust.KeyIdentifier {
+func (p *Provider) listLegacyKeys(ctx context.Context, kasURI string) []trust.KeyIdentifier {
 	var kidsToCheck []trust.KeyIdentifier
 	p.Logger.InfoContext(ctx, "kid free kao")
 	if len(p.Keyring) > 0 {
@@ -924,7 +925,7 @@ func (p *Provider) listLegacyKeys(ctx context.Context) []trust.KeyIdentifier {
 		return kidsToCheck
 	}
 
-	k, err := p.KeyDelegator.ListKeysWith(ctx, trust.ListKeyOptions{LegacyOnly: true})
+	k, err := p.KeyDelegator.ListKeysWithKASURI(ctx, trust.ListKeyOptions{LegacyOnly: true}, kasURI)
 	if err != nil {
 		p.Logger.WarnContext(ctx, "checkpoint KeyIndex.ListKeys failed", slog.Any("error", err))
 	} else {

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -48,7 +48,6 @@ type fakeKeyDetails struct {
 }
 
 func (f *fakeKeyDetails) ID() trust.KeyIdentifier { return f.id }
-func (f *fakeKeyDetails) KASURI() string          { return "" }
 func (f *fakeKeyDetails) Algorithm() ocrypto.KeyType {
 	return ocrypto.KeyType(f.algorithm)
 }

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -48,6 +48,7 @@ type fakeKeyDetails struct {
 }
 
 func (f *fakeKeyDetails) ID() trust.KeyIdentifier { return f.id }
+func (f *fakeKeyDetails) KASURI() string          { return "" }
 func (f *fakeKeyDetails) Algorithm() ocrypto.KeyType {
 	return ocrypto.KeyType(f.algorithm)
 }

--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -66,8 +66,9 @@ func (f *fakeKeyDetails) ProviderConfig() *policy.KeyProviderConfig {
 }
 
 type fakeKeyIndex struct {
-	keys []trust.KeyDetails
-	err  error
+	keys   []trust.KeyDetails
+	err    error
+	kasURI string
 }
 
 func (f *fakeKeyIndex) String() string {
@@ -88,6 +89,10 @@ func (f *fakeKeyIndex) FindKeyByID(context.Context, trust.KeyIdentifier) (trust.
 	return nil, errors.New("not implemented")
 }
 
+func (f *fakeKeyIndex) FindKeyByIDWithKASURI(context.Context, trust.KeyIdentifier, string) (trust.KeyDetails, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (f *fakeKeyIndex) ListKeys(context.Context) ([]trust.KeyDetails, error) {
 	return f.keys, f.err
 }
@@ -103,6 +108,11 @@ func (f *fakeKeyIndex) ListKeysWith(_ context.Context, opts trust.ListKeyOptions
 		return legacyKeys, f.err
 	}
 	return f.keys, f.err
+}
+
+func (f *fakeKeyIndex) ListKeysWithKASURI(ctx context.Context, opts trust.ListKeyOptions, kasURI string) ([]trust.KeyDetails, error) {
+	f.kasURI = kasURI
+	return f.ListKeysWith(ctx, opts)
 }
 
 func newBufferLogger() (*logger.Logger, *bytes.Buffer) {
@@ -156,7 +166,7 @@ func TestListLegacyKeys_KeyringPopulated(t *testing.T) {
 		},
 	}
 
-	kids := p.listLegacyKeys(t.Context())
+	kids := p.listLegacyKeys(t.Context(), "")
 	assert.ElementsMatch(t, []trust.KeyIdentifier{"legacy1", "legacy2"}, kids)
 }
 
@@ -168,15 +178,18 @@ func TestListLegacyKeys_KeyIndexPopulated(t *testing.T) {
 		&fakeKeyDetails{id: "id3", algorithm: "ec:secp256r1", legacy: true},
 		&fakeKeyDetails{id: "id4", algorithm: "rsa:2048", legacy: true},
 	}
-	delegator := trust.NewDelegatingKeyService(&fakeKeyIndex{
+	index := &fakeKeyIndex{
 		keys: fakeKeys,
-	}, logger.CreateTestLogger(), nil)
+	}
+	delegator := trust.NewDelegatingKeyService(index, logger.CreateTestLogger(), nil)
 	p := &Provider{
 		Logger:       testLogger,
 		KeyDelegator: delegator,
 	}
-	kids := p.listLegacyKeys(t.Context())
+	const kasURI = "https://request-kas.example.com"
+	kids := p.listLegacyKeys(t.Context(), kasURI)
 	assert.ElementsMatch(t, []trust.KeyIdentifier{"id1", "id4"}, kids)
+	assert.Equal(t, kasURI, index.kasURI)
 }
 
 func TestListLegacyKeys_Empty(t *testing.T) {
@@ -186,7 +199,7 @@ func TestListLegacyKeys_Empty(t *testing.T) {
 		Logger:       testLogger,
 		KeyDelegator: delegator,
 	}
-	kids := p.listLegacyKeys(t.Context())
+	kids := p.listLegacyKeys(t.Context(), "")
 	assert.Empty(t, kids)
 }
 
@@ -199,7 +212,7 @@ func TestListLegacyKeys_KeyIndexError(t *testing.T) {
 		Logger:       testLogger,
 		KeyDelegator: delegator,
 	}
-	kids := p.listLegacyKeys(t.Context())
+	kids := p.listLegacyKeys(t.Context(), "")
 	assert.Empty(t, kids)
 }
 

--- a/service/kas/kas_test.go
+++ b/service/kas/kas_test.go
@@ -152,8 +152,16 @@ func (stubKeyIndex) FindKeyByAlgorithm(_ context.Context, _ string, _ bool) (tru
 func (stubKeyIndex) FindKeyByID(_ context.Context, _ trust.KeyIdentifier) (trust.KeyDetails, error) {
 	return nil, errors.New("not implemented")
 }
+
+func (stubKeyIndex) FindKeyByIDWithKASURI(_ context.Context, _ trust.KeyIdentifier, _ string) (trust.KeyDetails, error) {
+	return nil, errors.New("not implemented")
+}
 func (stubKeyIndex) ListKeys(_ context.Context) ([]trust.KeyDetails, error) { return nil, nil }
 func (stubKeyIndex) ListKeysWith(_ context.Context, _ trust.ListKeyOptions) ([]trust.KeyDetails, error) {
+	return nil, nil
+}
+
+func (stubKeyIndex) ListKeysWithKASURI(_ context.Context, _ trust.ListKeyOptions, _ string) ([]trust.KeyDetails, error) {
 	return nil, nil
 }
 

--- a/service/kas/key_indexer.go
+++ b/service/kas/key_indexer.go
@@ -177,10 +177,6 @@ func (p *KeyAdapter) ID() trust.KeyIdentifier {
 	return trust.KeyIdentifier(p.key.GetKey().GetKeyId())
 }
 
-func (p *KeyAdapter) KASURI() string {
-	return p.key.GetKasUri()
-}
-
 // Might need to convert this to a standard format
 func (p *KeyAdapter) Algorithm() ocrypto.KeyType {
 	kt, err := sdk.PolicyAlgorithmToKeyType(p.key.GetKey().GetKeyAlgorithm())

--- a/service/kas/key_indexer.go
+++ b/service/kas/key_indexer.go
@@ -100,11 +100,17 @@ func (p *KeyIndexer) FindKeyByAlgorithm(ctx context.Context, algorithm string, i
 }
 
 func (p *KeyIndexer) FindKeyByID(ctx context.Context, id trust.KeyIdentifier) (trust.KeyDetails, error) {
+	return p.FindKeyByIDWithKASURI(ctx, id, "")
+}
+
+// FindKeyByIDWithKASURI returns a key from the specified KAS registration.
+// If kasURI is empty, the indexer's configured KAS URI is used.
+func (p *KeyIndexer) FindKeyByIDWithKASURI(ctx context.Context, id trust.KeyIdentifier, kasURI string) (trust.KeyDetails, error) {
 	req := &kasregistry.GetKeyRequest{
 		Identifier: &kasregistry.GetKeyRequest_Key{
 			Key: &kasregistry.KasKeyIdentifier{
 				Identifier: &kasregistry.KasKeyIdentifier_Uri{
-					Uri: p.kasURI,
+					Uri: p.kasURIOrDefault(kasURI),
 				},
 				Kid: string(id),
 			},
@@ -123,10 +129,16 @@ func (p *KeyIndexer) FindKeyByID(ctx context.Context, id trust.KeyIdentifier) (t
 }
 
 func (p *KeyIndexer) ListKeys(ctx context.Context) ([]trust.KeyDetails, error) {
-	return p.ListKeysWith(ctx, trust.ListKeyOptions{LegacyOnly: false})
+	return p.ListKeysWithKASURI(ctx, trust.ListKeyOptions{LegacyOnly: false}, "")
 }
 
 func (p *KeyIndexer) ListKeysWith(ctx context.Context, opts trust.ListKeyOptions) ([]trust.KeyDetails, error) {
+	return p.ListKeysWithKASURI(ctx, opts, "")
+}
+
+// ListKeysWithKASURI returns keys from the specified KAS registration.
+// If kasURI is empty, the indexer's configured KAS URI is used.
+func (p *KeyIndexer) ListKeysWithKASURI(ctx context.Context, opts trust.ListKeyOptions, kasURI string) ([]trust.KeyDetails, error) {
 	var legacyOnly *bool
 	if opts.LegacyOnly {
 		legacyOnly = &opts.LegacyOnly
@@ -134,7 +146,7 @@ func (p *KeyIndexer) ListKeysWith(ctx context.Context, opts trust.ListKeyOptions
 
 	req := &kasregistry.ListKeysRequest{
 		KasFilter: &kasregistry.ListKeysRequest_KasUri{
-			KasUri: p.kasURI,
+			KasUri: p.kasURIOrDefault(kasURI),
 		},
 		Legacy: legacyOnly,
 	}
@@ -152,6 +164,13 @@ func (p *KeyIndexer) ListKeysWith(ctx context.Context, opts trust.ListKeyOptions
 	}
 
 	return keys, nil
+}
+
+func (p *KeyIndexer) kasURIOrDefault(kasURI string) string {
+	if kasURI == "" {
+		return p.kasURI
+	}
+	return kasURI
 }
 
 func (p *KeyAdapter) ID() trust.KeyIdentifier {

--- a/service/kas/key_indexer.go
+++ b/service/kas/key_indexer.go
@@ -177,6 +177,10 @@ func (p *KeyAdapter) ID() trust.KeyIdentifier {
 	return trust.KeyIdentifier(p.key.GetKey().GetKeyId())
 }
 
+func (p *KeyAdapter) KASURI() string {
+	return p.key.GetKasUri()
+}
+
 // Might need to convert this to a standard format
 func (p *KeyAdapter) Algorithm() ocrypto.KeyType {
 	kt, err := sdk.PolicyAlgorithmToKeyType(p.key.GetKey().GetKeyAlgorithm())

--- a/service/kas/key_indexer_test.go
+++ b/service/kas/key_indexer_test.go
@@ -102,7 +102,8 @@ type KeyIndexTestSuite struct {
 func (s *KeyIndexTestSuite) SetupTest() {
 	s.rsaKey = &KeyAdapter{
 		key: &policy.KasKey{
-			KasId: "test-kas-id",
+			KasId:  "test-kas-id",
+			KasUri: "https://kas.example.com",
 			Key: &policy.AsymmetricKey{
 				Id:           "test-id",
 				KeyId:        "test-key-id",
@@ -126,6 +127,7 @@ func (s *KeyIndexTestSuite) TearDownTest() {}
 
 func (s *KeyIndexTestSuite) TestKeyDetails() {
 	s.Equal("test-key-id", string(s.rsaKey.ID()))
+	s.Equal("https://kas.example.com", s.rsaKey.KASURI())
 	s.Equal(ocrypto.RSA2048Key, s.rsaKey.Algorithm())
 	s.False(s.rsaKey.IsLegacy())
 	s.Equal("openbao", s.rsaKey.System())

--- a/service/kas/key_indexer_test.go
+++ b/service/kas/key_indexer_test.go
@@ -102,8 +102,7 @@ type KeyIndexTestSuite struct {
 func (s *KeyIndexTestSuite) SetupTest() {
 	s.rsaKey = &KeyAdapter{
 		key: &policy.KasKey{
-			KasId:  "test-kas-id",
-			KasUri: "https://kas.example.com",
+			KasId: "test-kas-id",
 			Key: &policy.AsymmetricKey{
 				Id:           "test-id",
 				KeyId:        "test-key-id",
@@ -127,7 +126,6 @@ func (s *KeyIndexTestSuite) TearDownTest() {}
 
 func (s *KeyIndexTestSuite) TestKeyDetails() {
 	s.Equal("test-key-id", string(s.rsaKey.ID()))
-	s.Equal("https://kas.example.com", s.rsaKey.KASURI())
 	s.Equal(ocrypto.RSA2048Key, s.rsaKey.Algorithm())
 	s.False(s.rsaKey.IsLegacy())
 	s.Equal("openbao", s.rsaKey.System())

--- a/service/kas/key_indexer_test.go
+++ b/service/kas/key_indexer_test.go
@@ -47,8 +47,17 @@ func (m *MockKeyAccessServerRegistryClient) CreateKey(context.Context, *kasregis
 	return nil, errors.New("not implemented")
 }
 
-func (m *MockKeyAccessServerRegistryClient) GetKey(context.Context, *kasregistry.GetKeyRequest) (*kasregistry.GetKeyResponse, error) {
-	return nil, errors.New("not implemented")
+func (m *MockKeyAccessServerRegistryClient) GetKey(ctx context.Context, req *kasregistry.GetKeyRequest) (*kasregistry.GetKeyResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	resp, ok := args.Get(0).(*kasregistry.GetKeyResponse)
+	if !ok {
+		return nil, args.Error(1)
+	}
+	return resp, args.Error(1)
 }
 
 func (m *MockKeyAccessServerRegistryClient) ListKeys(ctx context.Context, req *kasregistry.ListKeysRequest) (*kasregistry.ListKeysResponse, error) {
@@ -244,6 +253,77 @@ func (s *KeyIndexTestSuite) TestListKeys() {
 	s.Require().NoError(err)
 	s.Len(keys, 1)
 	s.Equal("test-key-id", string(keys[0].ID()))
+}
+
+func (s *KeyIndexTestSuite) TestFindKeyByIDWithKASURI() {
+	const (
+		defaultKASURI = "https://default-kas.example.com"
+		requestKASURI = "https://request-kas.example.com"
+	)
+
+	for _, test := range []struct {
+		name        string
+		kasURI      string
+		expectedURI string
+	}{
+		{name: "uses request KAS URI", kasURI: requestKASURI, expectedURI: requestKASURI},
+		{name: "defaults empty KAS URI", kasURI: "", expectedURI: defaultKASURI},
+	} {
+		s.Run(test.name, func() {
+			mockClient := new(MockKeyAccessServerRegistryClient)
+			keyIndexer := &KeyIndexer{
+				sdk:    &sdk.SDK{KeyAccessServerRegistry: mockClient},
+				kasURI: defaultKASURI,
+			}
+
+			mockClient.On("GetKey", mock.Anything, mock.MatchedBy(func(req *kasregistry.GetKeyRequest) bool {
+				return req.GetKey().GetUri() == test.expectedURI && req.GetKey().GetKid() == "test-key-id"
+			})).Return(&kasregistry.GetKeyResponse{KasKey: &policy.KasKey{
+				Key: &policy.AsymmetricKey{KeyId: "test-key-id"},
+			}}, nil).Once()
+
+			key, err := keyIndexer.FindKeyByIDWithKASURI(context.Background(), trust.KeyIdentifier("test-key-id"), test.kasURI)
+			s.Require().NoError(err)
+			s.Equal("test-key-id", string(key.ID()))
+			mockClient.AssertExpectations(s.T())
+		})
+	}
+}
+
+func (s *KeyIndexTestSuite) TestListKeysWithKASURI() {
+	const (
+		defaultKASURI = "https://default-kas.example.com"
+		requestKASURI = "https://request-kas.example.com"
+	)
+
+	for _, test := range []struct {
+		name        string
+		kasURI      string
+		expectedURI string
+	}{
+		{name: "uses request KAS URI", kasURI: requestKASURI, expectedURI: requestKASURI},
+		{name: "defaults empty KAS URI", kasURI: "", expectedURI: defaultKASURI},
+	} {
+		s.Run(test.name, func() {
+			mockClient := new(MockKeyAccessServerRegistryClient)
+			keyIndexer := &KeyIndexer{
+				sdk:    &sdk.SDK{KeyAccessServerRegistry: mockClient},
+				kasURI: defaultKASURI,
+			}
+
+			mockClient.On("ListKeys", mock.Anything, mock.MatchedBy(func(req *kasregistry.ListKeysRequest) bool {
+				return req.GetKasUri() == test.expectedURI && req.GetLegacy()
+			})).Return(&kasregistry.ListKeysResponse{KasKeys: []*policy.KasKey{
+				{Key: &policy.AsymmetricKey{KeyId: "test-key-id", Legacy: true}},
+			}}, nil).Once()
+
+			keys, err := keyIndexer.ListKeysWithKASURI(context.Background(), trust.ListKeyOptions{LegacyOnly: true}, test.kasURI)
+			s.Require().NoError(err)
+			s.Len(keys, 1)
+			s.Equal("test-key-id", string(keys[0].ID()))
+			mockClient.AssertExpectations(s.T())
+		})
+	}
 }
 
 func (s *KeyIndexTestSuite) TestFindKeyByAlgorithm() {

--- a/service/trust/delegating_key_service.go
+++ b/service/trust/delegating_key_service.go
@@ -121,11 +121,25 @@ func (d *DelegatingKeyService) FindKeyByID(ctx context.Context, id KeyIdentifier
 	return d.index.FindKeyByID(ctx, id)
 }
 
+func (d *DelegatingKeyService) FindKeyByIDWithKASURI(ctx context.Context, id KeyIdentifier, kasURI string) (KeyDetails, error) {
+	if scopedIndex, ok := d.index.(KASURIKeyIndex); ok {
+		return scopedIndex.FindKeyByIDWithKASURI(ctx, id, kasURI)
+	}
+	return d.index.FindKeyByID(ctx, id)
+}
+
 func (d *DelegatingKeyService) ListKeys(ctx context.Context) ([]KeyDetails, error) {
 	return d.index.ListKeys(ctx)
 }
 
 func (d *DelegatingKeyService) ListKeysWith(ctx context.Context, opts ListKeyOptions) ([]KeyDetails, error) {
+	return d.index.ListKeysWith(ctx, opts)
+}
+
+func (d *DelegatingKeyService) ListKeysWithKASURI(ctx context.Context, opts ListKeyOptions, kasURI string) ([]KeyDetails, error) {
+	if scopedIndex, ok := d.index.(KASURIKeyIndex); ok {
+		return scopedIndex.ListKeysWithKASURI(ctx, opts, kasURI)
+	}
 	return d.index.ListKeysWith(ctx, opts)
 }
 
@@ -159,8 +173,8 @@ func (d *DelegatingKeyService) Name() string {
 	return "DelegatingKeyService"
 }
 
-func (d *DelegatingKeyService) Decrypt(ctx context.Context, keyID KeyIdentifier, ciphertext []byte, ephemeralPublicKey []byte) (ocrypto.ProtectedKey, error) {
-	keyDetails, err := d.index.FindKeyByID(ctx, keyID)
+func (d *DelegatingKeyService) Decrypt(ctx context.Context, keyID KeyIdentifier, kasURI string, ciphertext []byte, ephemeralPublicKey []byte) (ocrypto.ProtectedKey, error) {
+	keyDetails, err := d.FindKeyByIDWithKASURI(ctx, keyID, kasURI)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt: unable to find key by ID '%s' within index %s: %w", keyID, d.index, err)
 	}

--- a/service/trust/delegating_key_service_test.go
+++ b/service/trust/delegating_key_service_test.go
@@ -129,6 +129,11 @@ func (m *MockKeyDetails) ID() KeyIdentifier {
 	return KeyIdentifier("unknown")
 }
 
+func (m *MockKeyDetails) KASURI() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 func (m *MockKeyDetails) Algorithm() ocrypto.KeyType {
 	args := m.Called()
 	return ocrypto.KeyType(args.String(0))

--- a/service/trust/delegating_key_service_test.go
+++ b/service/trust/delegating_key_service_test.go
@@ -129,11 +129,6 @@ func (m *MockKeyDetails) ID() KeyIdentifier {
 	return KeyIdentifier("unknown")
 }
 
-func (m *MockKeyDetails) KASURI() string {
-	args := m.Called()
-	return args.String(0)
-}
-
 func (m *MockKeyDetails) Algorithm() ocrypto.KeyType {
 	args := m.Called()
 	return ocrypto.KeyType(args.String(0))

--- a/service/trust/delegating_key_service_test.go
+++ b/service/trust/delegating_key_service_test.go
@@ -84,6 +84,14 @@ func (m *MockKeyIndex) FindKeyByID(ctx context.Context, id KeyIdentifier) (KeyDe
 	return &MockKeyDetails{}, args.Error(1)
 }
 
+func (m *MockKeyIndex) FindKeyByIDWithKASURI(ctx context.Context, id KeyIdentifier, kasURI string) (KeyDetails, error) {
+	args := m.Called(ctx, id, kasURI)
+	if a0, ok := args.Get(0).(KeyDetails); ok {
+		return a0, args.Error(1)
+	}
+	return &MockKeyDetails{}, args.Error(1)
+}
+
 func (m *MockKeyIndex) ListKeys(ctx context.Context) ([]KeyDetails, error) {
 	args := m.Called(ctx)
 	if a0, ok := args.Get(0).([]KeyDetails); ok {
@@ -94,6 +102,14 @@ func (m *MockKeyIndex) ListKeys(ctx context.Context) ([]KeyDetails, error) {
 
 func (m *MockKeyIndex) ListKeysWith(ctx context.Context, opts ListKeyOptions) ([]KeyDetails, error) {
 	args := m.Called(ctx, opts)
+	if a0, ok := args.Get(0).([]KeyDetails); ok {
+		return a0, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockKeyIndex) ListKeysWithKASURI(ctx context.Context, opts ListKeyOptions, kasURI string) ([]KeyDetails, error) {
+	args := m.Called(ctx, opts, kasURI)
 	if a0, ok := args.Get(0).([]KeyDetails); ok {
 		return a0, args.Error(1)
 	}
@@ -272,10 +288,11 @@ func (suite *DelegatingKeyServiceTestSuite) TestListKeysWith_Legacy() {
 }
 
 func (suite *DelegatingKeyServiceTestSuite) TestDecrypt() {
+	const kasURI = "https://request-kas.example.com"
 	mockKeyDetails := &MockKeyDetails{}
 	mockKeyDetails.On("ProviderConfig").Return(&policy.KeyProviderConfig{Manager: "mockManager", Name: "mock-01"})
 	mockKeyDetails.On("System").Return("mockManager")
-	suite.mockIndex.On("FindKeyByID", mock.Anything, KeyIdentifier("key1")).Return(mockKeyDetails, nil)
+	suite.mockIndex.On("FindKeyByIDWithKASURI", mock.Anything, KeyIdentifier("key1"), kasURI).Return(mockKeyDetails, nil)
 
 	mockProtectedKey := &MockProtectedKey{}
 	mockProtectedKey.On("DecryptAESGCM", mock.Anything, mock.Anything, mock.Anything).Return([]byte("decrypted"), nil)
@@ -285,7 +302,7 @@ func (suite *DelegatingKeyServiceTestSuite) TestDecrypt() {
 		return suite.mockManagerA, nil
 	})
 
-	protectedKey, err := suite.service.Decrypt(context.Background(), KeyIdentifier("key1"), []byte("ciphertext"), []byte("ephemeralKey"))
+	protectedKey, err := suite.service.Decrypt(context.Background(), KeyIdentifier("key1"), kasURI, []byte("ciphertext"), []byte("ephemeralKey"))
 	suite.Require().NoError(err)
 	suite.NotNil(protectedKey)
 }

--- a/service/trust/key_index.go
+++ b/service/trust/key_index.go
@@ -40,9 +40,6 @@ type KeyDetails interface {
 	// ID returns the unique identifier for the key
 	ID() KeyIdentifier
 
-	// KASURI returns the URI of the KAS registration associated with the key.
-	KASURI() string
-
 	// Algorithm returns the algorithm used by the key
 	Algorithm() ocrypto.KeyType
 

--- a/service/trust/key_index.go
+++ b/service/trust/key_index.go
@@ -40,6 +40,9 @@ type KeyDetails interface {
 	// ID returns the unique identifier for the key
 	ID() KeyIdentifier
 
+	// KASURI returns the URI of the KAS registration associated with the key.
+	KASURI() string
+
 	// Algorithm returns the algorithm used by the key
 	Algorithm() ocrypto.KeyType
 

--- a/service/trust/key_index.go
+++ b/service/trust/key_index.go
@@ -80,3 +80,13 @@ type KeyIndex interface {
 	// List keys with options
 	ListKeysWith(ctx context.Context, opts ListKeyOptions) ([]KeyDetails, error)
 }
+
+// KASURIKeyIndex optionally extends KeyIndex with KAS-registration-scoped
+// lookups. Callers must fall back to KeyIndex behavior when it is not
+// implemented so existing in-process and external indexes remain compatible.
+type KASURIKeyIndex interface {
+	// ListKeysWithKASURI lists keys from a KAS registration with options
+	ListKeysWithKASURI(ctx context.Context, opts ListKeyOptions, kasURI string) ([]KeyDetails, error)
+	// FindKeyByIDWithKASURI returns a key with the specified ID from a KAS registration
+	FindKeyByIDWithKASURI(ctx context.Context, id KeyIdentifier, kasURI string) (KeyDetails, error)
+}


### PR DESCRIPTION
### Summary

  Use the KAS URI from each rewrap KAO to scope registry key lookup and legacy-key listing, supporting multiple KAS registrations behind a shared endpoint.

  - Adds shared KeyOptions and FindKeyWith for URI-scoped lookups.
  - Uses the indexer’s configured default when no URI is supplied.
  - Keeps in-process key lookup behavior unchanged.
  - Adds table-driven tests covering URI selection and legacy filtering.

  No configuration flag or missing-key fallback is included. Custom KeyIndex implementations must implement the new FindKeyWith method.

  ### Testing

  Focused race tests and scoped lint pass. Full validation remains blocked by unavailable local Keycloak and unrelated existing lint issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Key lookup and listing now support a request-specific KAS URI.
  - Key access operations can select keys from the appropriate KAS endpoint when an override is provided.

- **Bug Fixes**
  - Rewrap and decrypt operations now consistently use the KAS URI associated with each key access request.
  - Requests without a specific KAS URI continue to use the configured default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->