### PR TITLE
fix(service): promote operational log levels

### DIFF
--- a/service/authorization/v2/authorization.go
+++ b/service/authorization/v2/authorization.go
@@ -81,7 +81,7 @@ func NewRegistration() *serviceregistry.Service[authzV2Connect.AuthorizationServ
 				l.Debug("authorization service config", slog.Any("config", authZCfg.LogValue()))
 
 				if !authZCfg.Cache.Enabled {
-					l.Debug("entitlement policy cache is disabled")
+					l.Info("entitlement policy cache is disabled")
 					return as, nil
 				}
 

--- a/service/authorization/v2/cache.go
+++ b/service/authorization/v2/cache.go
@@ -105,7 +105,9 @@ func NewEntitlementPolicyCache(
 	}
 
 	// Only set the instance if Start() succeeds
-	l.DebugContext(ctx, "initialized EntitlementPolicyCache and started periodic refresh")
+	l.InfoContext(ctx, "initialized entitlement policy cache",
+		slog.Duration("refresh_interval", cacheRefreshInterval),
+	)
 	return instance, nil
 }
 
@@ -119,7 +121,7 @@ func (c *EntitlementPolicyCache) IsReady(ctx context.Context) bool {
 	}
 	if !c.isCacheFilled {
 		if err := c.Refresh(ctx); err != nil {
-			c.logger.ErrorContext(ctx, "cache is not ready", slog.Any("error", err))
+			c.logger.WarnContext(ctx, "cache is not ready", slog.Any("error", err))
 			return false
 		}
 	}

--- a/service/health/health.go
+++ b/service/health/health.go
@@ -32,7 +32,7 @@ func NewRegistration() *serviceregistry.Service[grpchealth.Checker] {
 					"endpoint": "/healthz",
 				})
 				if err != nil {
-					srp.Logger.Error("failed to set well-known config", slog.String("error", err.Error()))
+					srp.Logger.Warn("failed to set well-known config", slog.String("error", err.Error()))
 				}
 				hs := HealthService{logger: srp.Logger}
 				return hs, func(_ context.Context, mux *http.ServeMux) error {
@@ -76,7 +76,7 @@ func (s HealthService) Check(ctx context.Context, req *grpchealth.CheckRequest) 
 	case "all":
 		for service, check := range serviceHealthChecks {
 			if err := check(ctx); err != nil {
-				s.logger.ErrorContext(ctx,
+				s.logger.WarnContext(ctx,
 					"service is not ready",
 					slog.String("service", service),
 					slog.Any("error", err),
@@ -89,7 +89,7 @@ func (s HealthService) Check(ctx context.Context, req *grpchealth.CheckRequest) 
 	default:
 		if check, ok := serviceHealthChecks[req.Service]; ok {
 			if err := check(ctx); err != nil {
-				s.logger.ErrorContext(ctx,
+				s.logger.WarnContext(ctx,
 					"service is not ready",
 					slog.String("service", req.Service),
 					slog.Any("error", err),

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"net/http/pprof"
 	"net/textproto"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -274,7 +275,7 @@ func NewOpenTDFServer(config Config, logger *logger.Logger, cacheManager *cache.
 		if err != nil {
 			return nil, fmt.Errorf("failed to create authentication interceptor: %w", err)
 		}
-		logger.Debug("authentication interceptor enabled")
+		logger.Info("authentication interceptor enabled")
 	} else {
 		logger.Warn("disabling authentication. this is deprecated and will be removed. if you are using an IdP without DPoP set `server.auth.dpop.enforce = false`")
 	}
@@ -349,7 +350,7 @@ func newHTTPServer(c Config, connectRPC http.Handler, extraHTTP http.Handler, a 
 	if c.Auth.Enabled {
 		httpHandler = a.MuxHandler(httpHandler)
 	} else {
-		l.Error("disabling authentication. this is deprecated and will be removed. if you are using an IdP without DPoP set `server.auth.dpop.enforce = false`")
+		l.Warn("disabling authentication. this is deprecated and will be removed. if you are using an IdP without DPoP set `server.auth.dpop.enforce = false`")
 	}
 
 	// CORS
@@ -359,14 +360,18 @@ func newHTTPServer(c Config, connectRPC http.Handler, extraHTTP http.Handler, a 
 		effectiveHeaders := c.CORS.EffectiveHeaders()
 		effectiveExposed := c.CORS.EffectiveExposedHeaders()
 
-		// Log effective CORS config for operator visibility
-		l.Info(
-			"CORS middleware enabled",
+		corsLogFields := []any{
 			slog.Any("allowed_origins", c.CORS.AllowedOrigins),
 			slog.Any("effective_methods", effectiveMethods),
 			slog.Any("effective_headers", effectiveHeaders),
 			slog.Any("effective_exposed_headers", effectiveExposed),
-		)
+			slog.Bool("allow_credentials", c.CORS.AllowCredentials),
+		}
+		if slices.Contains(c.CORS.AllowedOrigins, "*") {
+			l.Warn("CORS middleware enabled with wildcard origin", corsLogFields...)
+		} else {
+			l.Info("CORS middleware enabled", corsLogFields...)
+		}
 
 		corsHandler := cors.New(cors.Options{
 			AllowOriginFunc: func(_ *http.Request, origin string) bool {
@@ -483,7 +488,7 @@ func newConnectRPC(c Config, authInts []connect.Interceptor, ints []connect.Inte
 		}
 		interceptors = append(interceptors, connect.WithInterceptors(authInts...))
 	} else {
-		logger.Error("disabling authentication. this is deprecated and will be removed. if you are using an IdP without DPoP you can set `enforceDpop = false`")
+		logger.Warn("disabling authentication. this is deprecated and will be removed. if you are using an IdP without DPoP you can set `enforceDpop = false`")
 	}
 
 	// Add protovalidate interceptor
@@ -553,7 +558,7 @@ func (s inProcessServer) Conn() *sdk.ConnectRPCConnection {
 
 	// OTel tracing and metrics for outbound IPC Connect RPCs
 	if clientTraceInt, err := tracing.ConnectClientTraceInterceptor(); err != nil {
-		s.logger.Error("failed to create IPC client trace interceptor", slog.String("error", err.Error()))
+		s.logger.Warn("failed to create IPC client trace interceptor", slog.String("error", err.Error()))
 	} else {
 		clientInterceptors = append(clientInterceptors, clientTraceInt)
 	}

--- a/service/kas/access/accessPdp.go
+++ b/service/kas/access/accessPdp.go
@@ -137,7 +137,7 @@ func (p *Provider) checkAttributes(ctx context.Context, resources []*authzV2.Res
 		dr, err := p.SDK.AuthorizationV2.GetDecision(ctx, req)
 		if err != nil {
 			category, _ := classifyAccessError(ctx, err)
-			p.Logger.InfoContext(
+			p.Logger.WarnContext(
 				ctx,
 				"get decision failed",
 				slog.String("category", category),
@@ -170,7 +170,7 @@ func (p *Provider) checkAttributes(ctx context.Context, resources []*authzV2.Res
 	dr, err := p.SDK.AuthorizationV2.GetDecisionMultiResource(ctx, req)
 	if err != nil {
 		category, _ := classifyAccessError(ctx, err)
-		p.Logger.InfoContext(
+		p.Logger.WarnContext(
 			ctx,
 			"get multi-resource decision failed",
 			slog.String("category", category),

--- a/service/kas/access/rewrap.go
+++ b/service/kas/access/rewrap.go
@@ -981,14 +981,17 @@ func (p *Provider) tdf3Rewrap(ctx context.Context, requests []*kaspb.UnsignedRew
 		category, isInternal := classifyAccessError(ctx, accessErr)
 		// Terse, sensitive-payload-free line for the routine-denial flood case.
 		// Floods read as floods, not as a forest of stack traces.
-		p.Logger.InfoContext(
-			ctx,
-			"tdf3rewrap: access evaluation failed",
+		accessLogFields := []any{
 			slog.String("category", category),
 			slog.Bool("internal", isInternal),
 			slog.Int("policies", len(policies)),
 			slog.Int("requests", len(requests)),
-		)
+		}
+		if isInternal {
+			p.Logger.WarnContext(ctx, "tdf3rewrap: access evaluation failed", accessLogFields...)
+		} else {
+			p.Logger.InfoContext(ctx, "tdf3rewrap: access evaluation failed", accessLogFields...)
+		}
 		// Verbose / sensitive: only read when investigating one specific request.
 		p.Logger.DebugContext(
 			ctx,

--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -72,7 +72,7 @@ func NewRegistration() *serviceregistry.Service[kasconnect.AccessServiceHandler]
 						panic(fmt.Errorf("failed to determine KAS URL: %w", err))
 					}
 
-					srp.Logger.Debug("determined KAS URL", slog.String("kas_url", kasURL.String()))
+					srp.Logger.Info("determined KAS URL", slog.String("kas_url", kasURL.String()))
 
 					// Configure new delegation service
 					p.KeyDelegator = trust.NewDelegatingKeyService(NewPlatformKeyIndexer(srp.SDK, kasURL.String(), srp.Logger), srp.Logger, cacheClient)

--- a/service/pkg/server/start.go
+++ b/service/pkg/server/start.go
@@ -161,13 +161,13 @@ func Start(f ...StartOptions) error {
 
 	// Set allowed public routes when platform is being extended
 	if len(startConfig.PublicRoutes) > 0 {
-		logger.Info("additional public routes added", slog.Any("routes", startConfig.PublicRoutes))
+		logger.Warn("additional public routes added", slog.Any("routes", startConfig.PublicRoutes))
 		cfg.Server.Auth.PublicRoutes = startConfig.PublicRoutes
 	}
 
 	// Set IPC reauthorization routes when platform is being extended
 	if len(startConfig.IPCReauthRoutes) > 0 {
-		logger.Info("additional IPC reauthorization routes added", slog.Any("routes", startConfig.IPCReauthRoutes))
+		logger.Warn("additional IPC reauthorization routes added", slog.Any("routes", startConfig.IPCReauthRoutes))
 		cfg.Server.Auth.IPCReauthRoutes = startConfig.IPCReauthRoutes
 	}
 
@@ -446,7 +446,7 @@ func setupERSConnection(cfg *config.Config, oidcconfig *auth.OIDCConfiguration, 
 
 	// OTel tracing and metrics for outbound ERS Connect RPCs (outermost interceptor)
 	if ersTraceInt, err := tracing.ConnectClientTraceInterceptor(); err != nil {
-		logger.Error("failed to create ERS trace interceptor", slog.String("error", err.Error()))
+		logger.Warn("failed to create ERS trace interceptor", slog.String("error", err.Error()))
 	} else {
 		ersConnectRPCConn.Options = append(ersConnectRPCConn.Options, connect.WithInterceptors(ersTraceInt))
 	}

--- a/service/pkg/serviceregistry/serviceregistry.go
+++ b/service/pkg/serviceregistry/serviceregistry.go
@@ -403,7 +403,7 @@ func (reg *Registry) RegisterServicesFromConfiguration(modes []string, configura
 	for _, config := range configurations {
 		// Check if this service is explicitly excluded
 		if slices.Contains(excludedServices, config.Name.String()) {
-			slog.Debug("skipping excluded service", slog.String("service", config.Name.String()))
+			slog.Info("skipping excluded service", slog.String("service", config.Name.String()))
 			continue
 		}
 

--- a/service/policy/db/key_access_server_registry.go
+++ b/service/policy/db/key_access_server_registry.go
@@ -591,7 +591,10 @@ func (c PolicyDBClient) UnsafeUpdateKey(ctx context.Context, existing *policy.Ka
 	if count == 0 {
 		return nil, db.ErrNotFound
 	} else if count > 1 {
-		c.logger.Warn("unsafeUpdateKey updated more than one row", slog.Int64("count", count))
+		c.logger.ErrorContext(ctx, "unsafeUpdateKey updated more than one row",
+			slog.String("key_id", id),
+			slog.Int64("count", count),
+		)
 	}
 
 	return c.GetKey(ctx, &kasregistry.GetKeyRequest_Id{
@@ -1055,7 +1058,10 @@ func (c PolicyDBClient) updateKeyInternal(ctx context.Context, params updateKeyP
 	if count == 0 {
 		return nil, db.ErrNotFound
 	} else if count > 1 {
-		c.logger.Warn("updateKey updated more than one row", slog.Int64("count", count))
+		c.logger.ErrorContext(ctx, "updateKey updated more than one row",
+			slog.Any("key_id", params.ID),
+			slog.Int64("count", count),
+		)
 	}
 
 	return c.GetKey(ctx, &kasregistry.GetKeyRequest_Id{

--- a/service/policy/db/key_management.go
+++ b/service/policy/db/key_management.go
@@ -186,7 +186,10 @@ func (c PolicyDBClient) UpdateProviderConfig(ctx context.Context, r *keymanageme
 	if count == 0 {
 		return nil, db.ErrNotFound
 	} else if count > 1 {
-		c.logger.Warn("updateProviderConfig updated more than one row", slog.Int64("count", count))
+		c.logger.ErrorContext(ctx, "updateProviderConfig updated more than one row",
+			slog.String("provider_config_id", id),
+			slog.Int64("count", count),
+		)
 	}
 
 	return c.GetProviderConfig(ctx, &keymanagement.GetProviderConfigRequest{

--- a/service/trust/delegating_key_service.go
+++ b/service/trust/delegating_key_service.go
@@ -294,7 +294,7 @@ func (d *DelegatingKeyService) getKeyManager(ctx context.Context, cfg *policy.Ke
 	// Factory for 'name' not found.
 	// If 'name' was the defaultMode, _defKM will error if its factory is also missing.
 	// If 'name' was not the defaultMode, we fall back to the default manager.
-	d.l.Debug(
+	d.l.WarnContext(ctx,
 		"key manager factory not found for name, attempting to use/load default",
 		slog.Any("key_managers", allManagers),
 		slog.Any("requested_name", designation),


### PR DESCRIPTION
## Summary

- promote operator-visible service and cache state from debug to info
- downgrade recoverable degraded states from error to warning
- warn on authorization dependencies, trust-boundary changes, and permissive CORS
- promote impossible multi-row policy updates to error