### PR TITLE
feat(policy): DSPX-3888 add maximum object count configuration

### DIFF
--- a/service/policy/config/config.go
+++ b/service/policy/config/config.go
@@ -17,13 +17,15 @@ type Config struct {
 	ListRequestLimitMax int `mapstructure:"list_request_limit_max" default:"2500"`
 	// Enable support for namespaced policies. If false, namespace fields are ignored and treated as null.
 	NamespacedPolicy bool `mapstructure:"namespaced_policy" default:"false"`
+	// Optional maximum policy object counts. A zero value disables an individual maximum.
+	MaxObjectCounts MaxObjectCounts `mapstructure:"max_object_counts"`
 }
 
 func (c Config) Validate() error {
 	if c.ListRequestLimitMax <= c.ListRequestLimitDefault {
 		return fmt.Errorf("policy svc config request limit maximum [%d] must be greater than request limit default [%d]", c.ListRequestLimitMax, c.ListRequestLimitDefault)
 	}
-	return nil
+	return c.MaxObjectCounts.Validate()
 }
 
 // GetSharedPolicyConfig retrieves the shared policy configuration, applying defaults and validating it.

--- a/service/policy/config/object_limits.go
+++ b/service/policy/config/object_limits.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	ObjectTypeNamespaces                          = "namespaces"
 	ObjectTypeAttributeDefinitionsPerNamespace    = "attribute definitions per namespace"
 	ObjectTypeAttributeValuesPerDefinition        = "attribute values per definition"
 	ObjectTypeResourceMappingGroupsPerNamespace   = "resource mapping groups per namespace"
@@ -29,6 +30,7 @@ var ErrObjectLimitExceeded = errors.New("policy object limit exceeded")
 // MaxObjectCounts configures maximum policy object counts. Zero disables an
 // individual maximum so existing OpenTDF deployments remain unlimited by default.
 type MaxObjectCounts struct {
+	Namespaces                          int64 `mapstructure:"namespaces" default:"0"`
 	AttributeDefinitionsPerNamespace    int64 `mapstructure:"attribute_definitions_per_namespace" default:"0"`
 	AttributeValuesPerDefinition        int64 `mapstructure:"attribute_values_per_definition" default:"0"`
 	ResourceMappingGroupsPerNamespace   int64 `mapstructure:"resource_mapping_groups_per_namespace" default:"0"`
@@ -43,6 +45,7 @@ type MaxObjectCounts struct {
 
 func (l MaxObjectCounts) Validate() error {
 	limits := map[string]int64{
+		"namespaces":                              l.Namespaces,
 		"attribute_definitions_per_namespace":     l.AttributeDefinitionsPerNamespace,
 		"attribute_values_per_definition":         l.AttributeValuesPerDefinition,
 		"resource_mapping_groups_per_namespace":   l.ResourceMappingGroupsPerNamespace,

--- a/service/policy/config/object_limits.go
+++ b/service/policy/config/object_limits.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"github.com/opentdf/platform/service/logger"
+)
+
+const (
+	ObjectTypeAttributeDefinitionsPerNamespace    = "attribute definitions per namespace"
+	ObjectTypeAttributeValuesPerDefinition        = "attribute values per definition"
+	ObjectTypeResourceMappingGroupsPerNamespace   = "resource mapping groups per namespace"
+	ObjectTypeResourceMappingsPerAttributeValue   = "resource mappings per attribute value"
+	ObjectTypeSubjectMappingsPerAttributeValue    = "subject mappings per attribute value"
+	ObjectTypeSubjectConditionSetsPerNamespace    = "subject condition sets per namespace"
+	ObjectTypeObligationDefinitionsPerNamespace   = "obligation definitions per namespace"
+	ObjectTypeObligationValuesPerDefinition       = "obligation values per definition"
+	ObjectTypeObligationTriggersPerAttributeValue = "obligation triggers per attribute value"
+	ObjectTypeActionsPerNamespace                 = "actions per namespace"
+)
+
+// ErrObjectLimitExceeded identifies a create rejected by a configured object limit.
+var ErrObjectLimitExceeded = errors.New("policy object limit exceeded")
+
+// MaxObjectCounts configures maximum policy object counts. Zero disables an
+// individual maximum so existing OpenTDF deployments remain unlimited by default.
+type MaxObjectCounts struct {
+	AttributeDefinitionsPerNamespace    int64 `mapstructure:"attribute_definitions_per_namespace" default:"0"`
+	AttributeValuesPerDefinition        int64 `mapstructure:"attribute_values_per_definition" default:"0"`
+	ResourceMappingGroupsPerNamespace   int64 `mapstructure:"resource_mapping_groups_per_namespace" default:"0"`
+	ResourceMappingsPerAttributeValue   int64 `mapstructure:"resource_mappings_per_attribute_value" default:"0"`
+	SubjectMappingsPerAttributeValue    int64 `mapstructure:"subject_mappings_per_attribute_value" default:"0"`
+	SubjectConditionSetsPerNamespace    int64 `mapstructure:"subject_condition_sets_per_namespace" default:"0"`
+	ObligationDefinitionsPerNamespace   int64 `mapstructure:"obligation_definitions_per_namespace" default:"0"`
+	ObligationValuesPerDefinition       int64 `mapstructure:"obligation_values_per_definition" default:"0"`
+	ObligationTriggersPerAttributeValue int64 `mapstructure:"obligation_triggers_per_attribute_value" default:"0"`
+	ActionsPerNamespace                 int64 `mapstructure:"actions_per_namespace" default:"0"`
+}
+
+func (l MaxObjectCounts) Validate() error {
+	limits := map[string]int64{
+		"attribute_definitions_per_namespace":     l.AttributeDefinitionsPerNamespace,
+		"attribute_values_per_definition":         l.AttributeValuesPerDefinition,
+		"resource_mapping_groups_per_namespace":   l.ResourceMappingGroupsPerNamespace,
+		"resource_mappings_per_attribute_value":   l.ResourceMappingsPerAttributeValue,
+		"subject_mappings_per_attribute_value":    l.SubjectMappingsPerAttributeValue,
+		"subject_condition_sets_per_namespace":    l.SubjectConditionSetsPerNamespace,
+		"obligation_definitions_per_namespace":    l.ObligationDefinitionsPerNamespace,
+		"obligation_values_per_definition":        l.ObligationValuesPerDefinition,
+		"obligation_triggers_per_attribute_value": l.ObligationTriggersPerAttributeValue,
+		"actions_per_namespace":                   l.ActionsPerNamespace,
+	}
+	for name, limit := range limits {
+		if limit < 0 {
+			return fmt.Errorf("policy object limit [%s] must be zero or positive", name)
+		}
+	}
+	return nil
+}
+
+// ObjectLimitError describes which configured object limit rejected an addition.
+type ObjectLimitError struct {
+	ObjectType string
+	Limit      int64
+	Current    int64
+	Added      int64
+}
+
+func (e *ObjectLimitError) Error() string {
+	return fmt.Sprintf("policy object limit reached for %s (maximum %d); contact your administrator to request a higher limit", e.ObjectType, e.Limit)
+}
+
+func (e *ObjectLimitError) Unwrap() error {
+	return ErrObjectLimitExceeded
+}
+
+// EnforceObjectLimit rejects an addition that would exceed a nonzero limit.
+func EnforceObjectLimit(objectType string, limit, current int64, added int) error {
+	if limit == 0 || added == 0 {
+		return nil
+	}
+	if current+int64(added) > limit {
+		return &ObjectLimitError{
+			ObjectType: objectType,
+			Limit:      limit,
+			Current:    current,
+			Added:      int64(added),
+		}
+	}
+	return nil
+}
+
+// ObjectLimitConnectError translates a configured limit error for the public
+// service boundary and logs rejected mutations. Unrelated errors are left to
+// the service's normal path.
+func ObjectLimitConnectError(ctx context.Context, log *logger.Logger, operation string, err error) error {
+	var limitErr *ObjectLimitError
+	if !errors.As(err, &limitErr) {
+		return nil
+	}
+
+	log.WarnContext(ctx, "policy object limit reached; rejected mutation",
+		slog.String("operation", operation),
+		slog.String("object_type", limitErr.ObjectType),
+		slog.Int64("current_count", limitErr.Current),
+		slog.Int64("configured_maximum", limitErr.Limit),
+		slog.Int64("attempted_addition", limitErr.Added),
+		slog.Bool("configured_maximum_below_current_count", limitErr.Limit < limitErr.Current),
+	)
+	return connect.NewError(connect.CodeResourceExhausted, err)
+}

--- a/service/policy/config/object_limits_test.go
+++ b/service/policy/config/object_limits_test.go
@@ -1,13 +1,8 @@
 package config
 
 import (
-	"bytes"
-	"encoding/json"
-	"log/slog"
 	"testing"
 
-	"connectrpc.com/connect"
-	"github.com/opentdf/platform/service/logger"
 	serviceconfig "github.com/opentdf/platform/service/pkg/config"
 	"github.com/stretchr/testify/require"
 )
@@ -49,48 +44,6 @@ func Test_MaxObjectCounts_ValidateNegativeLimit_Fails(t *testing.T) {
 
 	err := (MaxObjectCounts{AttributeDefinitionsPerNamespace: -1}).Validate()
 	require.EqualError(t, err, "policy object limit [attribute_definitions_per_namespace] must be zero or positive")
-}
-
-func Test_EnforceObjectLimit_AtLimit_Fails(t *testing.T) {
-	t.Parallel()
-
-	err := EnforceObjectLimit(ObjectTypeAttributeDefinitionsPerNamespace, 10, 10, 1)
-	require.ErrorIs(t, err, ErrObjectLimitExceeded)
-
-	var logs bytes.Buffer
-	testLogger := &logger.Logger{Logger: slog.New(slog.NewJSONHandler(&logs, nil))}
-	connectErr := ObjectLimitConnectError(t.Context(), testLogger, "create", err)
-	require.Error(t, connectErr)
-	require.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(connectErr))
-	require.Contains(t, connectErr.Error(), "maximum 10")
-
-	var entry map[string]any
-	require.NoError(t, json.Unmarshal(logs.Bytes(), &entry))
-	require.Equal(t, "policy object limit reached; rejected mutation", entry["msg"])
-	require.Equal(t, "create", entry["operation"])
-	require.Equal(t, "attribute definitions per namespace", entry["object_type"])
-	require.EqualValues(t, 10, entry["current_count"])
-	require.EqualValues(t, 10, entry["configured_maximum"])
-	require.EqualValues(t, 1, entry["attempted_addition"])
-	require.Equal(t, false, entry["configured_maximum_below_current_count"])
-}
-
-func Test_ObjectLimitConnectError_LimitBelowCurrentCount_LogsWhenMutationRejected(t *testing.T) {
-	t.Parallel()
-
-	var logs bytes.Buffer
-	testLogger := &logger.Logger{Logger: slog.New(slog.NewJSONHandler(&logs, nil))}
-	err := EnforceObjectLimit(ObjectTypeAttributeDefinitionsPerNamespace, 4, 5, 1)
-
-	require.Error(t, ObjectLimitConnectError(t.Context(), testLogger, "update", err))
-
-	var entry map[string]any
-	require.NoError(t, json.Unmarshal(logs.Bytes(), &entry))
-	require.Equal(t, "policy object limit reached; rejected mutation", entry["msg"])
-	require.Equal(t, "update", entry["operation"])
-	require.EqualValues(t, 5, entry["current_count"])
-	require.EqualValues(t, 4, entry["configured_maximum"])
-	require.Equal(t, true, entry["configured_maximum_below_current_count"])
 }
 
 func Test_EnforceObjectLimit_ZeroLimit_Succeeds(t *testing.T) {

--- a/service/policy/config/object_limits_test.go
+++ b/service/policy/config/object_limits_test.go
@@ -12,6 +12,7 @@ func Test_GetSharedPolicyConfig_MaxObjectCountsDecode(t *testing.T) {
 
 	cfg, err := GetSharedPolicyConfig(serviceconfig.ServiceConfig{
 		"max_object_counts": map[string]any{
+			"namespaces":                              11,
 			"attribute_definitions_per_namespace":     1,
 			"attribute_values_per_definition":         2,
 			"resource_mapping_groups_per_namespace":   3,
@@ -26,6 +27,7 @@ func Test_GetSharedPolicyConfig_MaxObjectCountsDecode(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, MaxObjectCounts{
+		Namespaces:                          11,
 		AttributeDefinitionsPerNamespace:    1,
 		AttributeValuesPerDefinition:        2,
 		ResourceMappingGroupsPerNamespace:   3,

--- a/service/policy/config/object_limits_test.go
+++ b/service/policy/config/object_limits_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/opentdf/platform/service/logger"
+	serviceconfig "github.com/opentdf/platform/service/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetSharedPolicyConfig_MaxObjectCountsDecode(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := GetSharedPolicyConfig(serviceconfig.ServiceConfig{
+		"max_object_counts": map[string]any{
+			"attribute_definitions_per_namespace":     1,
+			"attribute_values_per_definition":         2,
+			"resource_mapping_groups_per_namespace":   3,
+			"resource_mappings_per_attribute_value":   4,
+			"subject_mappings_per_attribute_value":    5,
+			"subject_condition_sets_per_namespace":    6,
+			"obligation_definitions_per_namespace":    7,
+			"obligation_values_per_definition":        8,
+			"obligation_triggers_per_attribute_value": 9,
+			"actions_per_namespace":                   10,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, MaxObjectCounts{
+		AttributeDefinitionsPerNamespace:    1,
+		AttributeValuesPerDefinition:        2,
+		ResourceMappingGroupsPerNamespace:   3,
+		ResourceMappingsPerAttributeValue:   4,
+		SubjectMappingsPerAttributeValue:    5,
+		SubjectConditionSetsPerNamespace:    6,
+		ObligationDefinitionsPerNamespace:   7,
+		ObligationValuesPerDefinition:       8,
+		ObligationTriggersPerAttributeValue: 9,
+		ActionsPerNamespace:                 10,
+	}, cfg.MaxObjectCounts)
+}
+
+func Test_MaxObjectCounts_ValidateNegativeLimit_Fails(t *testing.T) {
+	t.Parallel()
+
+	err := (MaxObjectCounts{AttributeDefinitionsPerNamespace: -1}).Validate()
+	require.EqualError(t, err, "policy object limit [attribute_definitions_per_namespace] must be zero or positive")
+}
+
+func Test_EnforceObjectLimit_AtLimit_Fails(t *testing.T) {
+	t.Parallel()
+
+	err := EnforceObjectLimit(ObjectTypeAttributeDefinitionsPerNamespace, 10, 10, 1)
+	require.ErrorIs(t, err, ErrObjectLimitExceeded)
+
+	var logs bytes.Buffer
+	testLogger := &logger.Logger{Logger: slog.New(slog.NewJSONHandler(&logs, nil))}
+	connectErr := ObjectLimitConnectError(t.Context(), testLogger, "create", err)
+	require.Error(t, connectErr)
+	require.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(connectErr))
+	require.Contains(t, connectErr.Error(), "maximum 10")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(logs.Bytes(), &entry))
+	require.Equal(t, "policy object limit reached; rejected mutation", entry["msg"])
+	require.Equal(t, "create", entry["operation"])
+	require.Equal(t, "attribute definitions per namespace", entry["object_type"])
+	require.EqualValues(t, 10, entry["current_count"])
+	require.EqualValues(t, 10, entry["configured_maximum"])
+	require.EqualValues(t, 1, entry["attempted_addition"])
+	require.Equal(t, false, entry["configured_maximum_below_current_count"])
+}
+
+func Test_ObjectLimitConnectError_LimitBelowCurrentCount_LogsWhenMutationRejected(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	testLogger := &logger.Logger{Logger: slog.New(slog.NewJSONHandler(&logs, nil))}
+	err := EnforceObjectLimit(ObjectTypeAttributeDefinitionsPerNamespace, 4, 5, 1)
+
+	require.Error(t, ObjectLimitConnectError(t.Context(), testLogger, "update", err))
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(logs.Bytes(), &entry))
+	require.Equal(t, "policy object limit reached; rejected mutation", entry["msg"])
+	require.Equal(t, "update", entry["operation"])
+	require.EqualValues(t, 5, entry["current_count"])
+	require.EqualValues(t, 4, entry["configured_maximum"])
+	require.Equal(t, true, entry["configured_maximum_below_current_count"])
+}
+
+func Test_EnforceObjectLimit_ZeroLimit_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, EnforceObjectLimit(ObjectTypeAttributeDefinitionsPerNamespace, 0, 100, 1))
+}

--- a/service/policy/db/namespaces.go
+++ b/service/policy/db/namespaces.go
@@ -174,6 +174,10 @@ func (c PolicyDBClient) ListAllNamespaces(ctx context.Context) ([]*policy.Namesp
 	return nsList, nil
 }
 
+func (c PolicyDBClient) CountNamespaces(ctx context.Context) (int64, error) {
+	return c.queries.countNamespaces(ctx)
+}
+
 func (c PolicyDBClient) CreateNamespace(ctx context.Context, r *namespaces.CreateNamespaceRequest) (*policy.Namespace, error) {
 	name := strings.ToLower(r.GetName())
 	metadataJSON, _, err := db.MarshalCreateMetadata(r.GetMetadata())

--- a/service/policy/db/namespaces.sql.go
+++ b/service/policy/db/namespaces.sql.go
@@ -34,6 +34,22 @@ func (q *Queries) assignPublicKeyToNamespace(ctx context.Context, arg assignPubl
 	return i, err
 }
 
+const countNamespaces = `-- name: countNamespaces :one
+SELECT COUNT(*)
+FROM attribute_namespaces
+`
+
+// countNamespaces
+//
+//	SELECT COUNT(*)
+//	FROM attribute_namespaces
+func (q *Queries) countNamespaces(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, countNamespaces)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createNamespace = `-- name: createNamespace :one
 INSERT INTO attribute_namespaces (name, metadata)
 VALUES ($1, $2)

--- a/service/policy/db/queries/namespaces.sql
+++ b/service/policy/db/queries/namespaces.sql
@@ -39,6 +39,10 @@ ORDER BY
 LIMIT @limit_
 OFFSET @offset_;
 
+-- name: countNamespaces :one
+SELECT COUNT(*)
+FROM attribute_namespaces;
+
 -- name: getNamespace :one
 SELECT
     ns.id,

--- a/service/policy/namespaces/namespaces.go
+++ b/service/policy/namespaces/namespaces.go
@@ -133,6 +133,15 @@ func (ns NamespacesService) CreateNamespace(ctx context.Context, req *connect.Re
 	rsp := &namespaces.CreateNamespaceResponse{}
 
 	err := ns.dbClient.RunInTx(ctx, func(txClient *policydb.PolicyDBClient) error {
+		if limit := ns.config.MaxObjectCounts.Namespaces; limit > 0 {
+			count, err := txClient.CountNamespaces(ctx)
+			if err != nil {
+				return err
+			}
+			if err := policyconfig.EnforceObjectLimit(policyconfig.ObjectTypeNamespaces, limit, count, 1); err != nil {
+				return err
+			}
+		}
 		n, err := txClient.CreateNamespace(ctx, req.Msg)
 		if err != nil {
 			ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
@@ -149,6 +158,9 @@ func (ns NamespacesService) CreateNamespace(ctx context.Context, req *connect.Re
 		return nil
 	})
 	if err != nil {
+		if limitErr := policyconfig.ObjectLimitConnectError(ctx, ns.logger, "create", err); limitErr != nil {
+			return nil, limitErr
+		}
 		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextCreationFailed, slog.String("namespace", req.Msg.String()))
 	}
 


### PR DESCRIPTION
## Summary

- add max_object_counts policy configuration for namespace- and parent-scoped limits
- reject negative limits while treating zero as disabled
- provide shared RESOURCE_EXHAUSTED error and rejection logging behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum counts for policy objects, including attributes, mappings, subjects, obligations, triggers, actions, and namespaces.
  * Limits can be set independently by object type; a value of zero leaves that limit disabled.
  * Requests that exceed configured limits now receive a resource-exhausted error.

* **Bug Fixes**
  * Invalid negative object limits are rejected during configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->