### PR TITLE
chore(ci): DSPX-4607 bump golangci-lint to v2.13.2

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -101,8 +101,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          # v2.12.0+ embeds the config JSONSchema in the binary; earlier versions fetch it
-          # from golangci-lint.run with a 2s timeout, which flakes `config verify` in CI.
           version: v2.13.2
           working-directory: ${{ matrix.directory }}
           skip-cache: true

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -101,7 +101,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.8.0
+          # v2.12.0+ embeds the config JSONSchema in the binary; earlier versions fetch it
+          # from golangci-lint.run with a 2s timeout, which flakes `config verify` in CI.
+          version: v2.13.2
           working-directory: ${{ matrix.directory }}
           skip-cache: true
           only-new-issues: true
@@ -619,7 +621,7 @@ jobs:
       - run: cd service && go get github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
       - run: cd service && go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
       - run: cd service && go install github.com/sudorandom/protoc-gen-connect-openapi@v0.25.6
-      - run: cd service && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
+      - run: cd service && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2
       - run: make proto-generate
       - name: generate connect wrappers
         run: make connect-wrapper-generate

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ all: toolcheck clean build lint license test
 toolcheck:
 	@echo "Checking for required tools..."
 	@$(MAKE) --no-print-directory buf-check
-	@which golangci-lint > /dev/null || (echo "golangci-lint not found, run  'go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0'" && exit 1)
+	@which golangci-lint > /dev/null || (echo "golangci-lint not found, run  'go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2'" && exit 1)
 	@which protoc-gen-doc > /dev/null || (echo "protoc-gen-doc not found, run 'go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1'" && exit 1)
 	@which protoc-gen-connect-openapi > /dev/null || (echo "protoc-gen-connect-openapi not found, run 'go install github.com/sudorandom/protoc-gen-connect-openapi@v0.18.0'" && exit 1)
-	@required_golangci_lint_version="2.8.0"; \
+	@required_golangci_lint_version="2.13.2"; \
 	current_version=$$(golangci-lint --version | grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^v//' | head -n 1); \
 	[ "$$(printf '%s\n' "$$required_golangci_lint_version" "$$current_version" | sort -V | head -n1)" = "$$required_golangci_lint_version" ] || \
 		(echo "golangci-lint version must be v$$required_golangci_lint_version or later [found: $$current_version]" && exit 1)


### PR DESCRIPTION
### Proposed Changes

Fixes flaky lint failures in CI that are a network error, not a real lint finding:

```
[../../.golangci.yaml] validate: compile schema: failing loading
"https://golangci-lint.run/jsonschema/golangci.v2.8.jsonschema.json":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Error: Command failed: /home/runner/golangci-lint-2.8.0-linux-amd64/golangci-lint config verify
```

**Root cause:** `golangci/golangci-lint-action` defaults `verify: true`, which runs `golangci-lint config verify`. In golangci-lint **v2.8.0** (what we pinned), `config verify` downloads the config JSONSchema over HTTPS with a **2-second client timeout**, so any slow response from `golangci-lint.run` fails the job. Known upstream complaint: golangci/golangci-lint#4864

**Upstream fix landed in v2.12.0:** `pkg/commands/config_verify.go` switched from an HTTP loader to `jsonsch.NewEmbedLoader()`, so the schema is compiled into the binary via `go:embed`.

| version | schema source |
| --- | --- |
| v2.8.0 | remote URL, 2s timeout |
| v2.9.0, v2.11.0 | remote URL |
| **v2.12.0+** | **embedded** |

This bumps all three `2.8.0` pins to `2.13.2` (current latest):

- `.github/workflows/checks.yaml` — `golangci-lint-action` `version:` in the `go` matrix job
- `.github/workflows/checks.yaml` — `go install ...golangci-lint@v2.13.2` in the proto-generate job
- `Makefile` — `toolcheck` install hint and `required_golangci_lint_version` (still a minimum, not an exact pin)

The action's `verify` input stays at its `true` default. Bumping already removes the network call, so disabling verification would needlessly give up validation of `.golangci.yaml`. No `.golangci.yaml` changes are needed — the existing config validates cleanly under v2.13.2.

Ticket: [DSPX-4607](https://virtru.atlassian.net/browse/DSPX-4607)

#### Notes for reviewers

- `make lint` is never invoked in CI — the only lint gate is the `golangci-lint-action` step in the `go` matrix, which uses `only-new-issues: true`.
- v2.13.x surfaces **351 pre-existing findings** repo-wide that v2.8.0 did not (lib/fixtures 26, sdk 10, service 163, examples 9, otdfctl 134, tests-bdd 9). These are deliberately **out of scope** here; `only-new-issues: true` means they only block a PR that touches those lines. Follow-up work is enumerated in DSPX-4607, grouped by fix type (unused `//nolint:sloglint` directives, `sloglint` snake_case keys, `goconst`, `canonicalheader` on DPoP headers, `staticcheck` QF1012/SA1019, and a `gomodguard` → `gomodguard_v2` migration).
- v2.12.0 deprecated `gomodguard` in favor of `gomodguard_v2`. It emits a warning and still runs, so it is not a blocker.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

CI-only change; no product code touched, so no test or doc updates apply.

### Testing Instructions

**Local**

```sh
make toolcheck                                        # passes with v2.13.2

golangci-lint config verify -c .golangci.yaml         # exit 0

# the exact CI failure mode -- blackhole outbound HTTP
HTTPS_PROXY=http://127.0.0.1:9 HTTP_PROXY=http://127.0.0.1:9 \
  golangci-lint config verify -c .golangci.yaml       # exit 0 on v2.13.2; fails on v2.8.0
```

**CI**

Verified ahead of this PR with a `workflow_dispatch` run of `checks.yaml` on this branch: https://github.com/opentdf/platform/actions/runs/33771514702

```
Installed golangci-lint into /home/runner/golangci-lint-2.13.2-linux-amd64/golangci-lint in 650ms
Running [.../golangci-lint config verify] in [.../lib/fixtures] ...
Running [.../golangci-lint run --path-mode=abs] in [.../lib/fixtures] ...
```

`config verify` completed with no schema fetch and no error. That dispatch run did then fail `lib/fixtures` on the pre-existing findings, but only because the log shows `Not fetching patch for showing only new issues because it's not a pull request context: event name is workflow_dispatch` — `only-new-issues` was inert so everything got reported. On this PR it filters to changed lines, and since no Go code changes here, the `go` matrix should be clean.


[DSPX-4607]: https://virtru.atlassian.net/browse/DSPX-4607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the required golangci-lint version to 2.13.2 across automated checks and local tooling.
  - Improved lint configuration verification reliability by using a version that embeds the configuration schema.
  - Updated installation guidance and minimum-version validation accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->