### PR TITLE
chore(ci): DSPX-4607 linter cfg: tune goconst; schema updates

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,7 +28,7 @@ linters:
     # - gochecknoinits
     - goconst
     - gocritic
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - govet
@@ -79,27 +79,30 @@ linters:
       check:
         - switch
         - map
+    goconst:
+      # Map/composite-literal keys repeat by nature (log attribute names, test
+      # tables); they are not extractable constants.
+      ignore-map-keys: true
     gocritic:
       settings:
         captLocal:
           paramsOnly: false
         underef:
           skipRecvDeref: false
-    gomodguard:
+    gomodguard_v2:
       blocked:
-        modules:
-          - github.com/golang/protobuf:
-              recommendations:
-                - google.golang.org/protobuf
-              reason: see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules
-          - github.com/satori/go.uuid:
-              recommendations:
-                - github.com/google/uuid
-              reason: satori's package is not maintained
-          - github.com/gofrs/uuid:
-              recommendations:
-                - github.com/google/uuid
-              reason: gofrs' package is not go module
+        - module: github.com/golang/protobuf
+          recommendations:
+            - google.golang.org/protobuf
+          reason: see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules
+        - module: github.com/satori/go.uuid
+          recommendations:
+            - github.com/google/uuid
+          reason: satori's package is not maintained
+        - module: github.com/gofrs/uuid
+          recommendations:
+            - github.com/google/uuid
+          reason: gofrs' package is not go module
     gosec:
       excludes:
         - G115
@@ -207,6 +210,15 @@ linters:
         linters:
           - nolintlint
         text: "exhaustive"
+      # goconst: CLI table-column headers and other presentation strings
+      - path: otdfctl/
+        linters:
+          - goconst
+      # goconst: integration-test fixtures that escape the _test.go rule above
+      # only because of their filenames
+      - path: service/entityresolution/integration/
+        linters:
+          - goconst
     paths:
       - .*\.pb\.go
       - .*\.pb\.gw.go


### PR DESCRIPTION
Follows the golangci-lint v2.13.2 bump (#3965, merged). Rebased onto it; CI now runs a version that understands these config keys.

## Context

The v2.13.2 bump surfaces **351 pre-existing findings** that v2.8.0 never reported, and deprecates `gomodguard`. The findings didn't block #3965 (CI uses `only-new-issues: true`) but they will block any future PR that touches an affected line, so they're being burned down.

`goconst` alone accounts for 219 of the 351. This PR tunes it rather than extracting 219 constants; the residue is fixed in per-CODEOWNER follow-up PRs.

Tracked by DSPX-4607.

## goconst

Three levers, measured against the actual findings:

| lever | remaining |
| --- | --- |
| (start) | 219 |
| `+ exclude otdfctl/` | 86 |
| `+ exclude service/entityresolution/integration/` | 59 |
| `+ ignore-map-keys: true` | 29 |

- **`otdfctl/`** — the findings are CLI table-column headers (`"Name"` ×35, `"Namespace"` ×22, `"Value"` ×14) in `cmd/policy/*.go`. Presentation strings, not domain constants. `.golangci.yaml` already carries an `# otdfctl: defer refactoring-level lint fixes to follow-up` block for exactly this class.
- **`service/entityresolution/integration/`** — an integration-test package whose `internal/` helpers (`contract_tests.go`, `container_helpers.go`, `flexible_assertions.go`) are pure test fixtures. They only escape the existing `path: _test\.go` goconst exclusion because of their filenames.
- **`ignore-map-keys`** — 115 of the 219 sites are map/composite-literal keys (log attribute names, test tables). Those repeat by nature and aren't extractable constants.

Raising `min-occurrences` was considered and rejected: clearing the noise that way needs a threshold of ≥36, which effectively disables the linter repo-wide.

## gomodguard_v2

Same blocked module list, new schema shape (a list of `{module, recommendations, reason}` instead of a list of single-key maps). This is copied verbatim from the migration golangci-lint's own deprecation warning emits.

## Testing

```
$ golangci-lint config verify -c .golangci.yaml    # rc=0
$ make go-lint
```

Findings drop **351 → 164**, and the `gomodguard` deprecation warning is gone from the output.

Per-module residue, each addressed in an independent follow-up PR branched from `main` and grouped by CODEOWNER:

| module | findings | PR |
| --- | --- | --- |
| `service` (core) | 60 | pending |
| `service/policy` | 48 | pending |
| `lib/fixtures` | 26 | #3971 |
| `sdk` | 12 | #3973 |
| `examples` | 9 | pending |
| `tests-bdd` | 7 | pending |
| `otdfctl` | 1 | #3969 |
| `service/kas` | 1 | #3970 |

**Merge this one first.** The follow-ups don't touch `.golangci.yaml`, but until the goconst tuning lands, any of them that edits a line carrying a goconst finding turns it into a "new issue" under `only-new-issues`.

No Go code changes, so no test impact.

## Follow-up

The `otdfctl/` and `service/entityresolution/integration/` exclusions are deferrals, not fixes — noted on DSPX-4607 so the CLI table-header constants can be extracted later if @opentdf/cli wants them.
