### PR TITLE
fix(cli): DSPX-4607 annotate deprecated Action.Value use in migration test

### DIFF
--- a/otdfctl/migrations/namespacedpolicy/resolved_test.go
+++ b/otdfctl/migrations/namespacedpolicy/resolved_test.go
@@ -338,8 +338,9 @@ func TestResolveExistingRoutesStandardActionsByEnumRegardlessOfName(t *testing.T
 			Actions: []*DerivedAction{
 				{
 					Source: &policy.Action{
-						Id:    "legacy",
-						Name:  "decrypt",
+						Id:   "legacy",
+						Name: "decrypt",
+						//nolint:staticcheck // deliberately exercises the deprecated Action.Value oneof to reach the legacy standard-action path
 						Value: &policy.Action_Standard{Standard: policy.Action_STANDARD_ACTION_DECRYPT},
 					},
 					Targets: []*policy.Namespace{namespace},


### PR DESCRIPTION
Part of the DSPX-4607 lint burndown, following the golangci-lint v2.13.2 bump (#3965, merged). Branched from `main`, independent of the other burndown PRs.

Best merged after #3968 (goconst tuning), which clears the other 133 `otdfctl` findings.

## What

golangci-lint v2.13.2 reports one `SA1019` in `otdfctl`:

```
otdfctl/migrations/namespacedpolicy/resolved_test.go:343:7: SA1019: (policy.Action).Value is deprecated: use 'name' instead (staticcheck)
```

`TestResolveExisting…` constructs a `policy.Action` whose `Id` is literally `"legacy"` and deliberately sets the deprecated `Value` oneof so the resolver takes the standard-action path — see the comment two blocks up: *"entirely on the proto Standard enum to reach the standard-action path"*. Migrating it to `Name` would delete the behaviour the test exists to cover, so it's annotated instead.

## Testing

```
$ cd otdfctl && golangci-lint run -c ../.golangci.yaml
0 issues.
$ go test ./migrations/...
ok  	github.com/opentdf/platform/otdfctl/migrations/namespacedpolicy	0.602s
```

(run against the tuned config from #3968; `otdfctl` goes from 134 findings to 0 across the two PRs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test clarity by documenting intentional coverage of a legacy action path.
  * Reformatted test data for consistency; test behavior and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- burndown-index -->
## DSPX-4607 burndown index

- #3965 — golangci-lint v2.13.2 bump (merged)
- #3968 — `.golangci.yaml` goconst tuning + `gomodguard_v2` migration (merged)
- Siblings: #3970 (`service/kas`), #3971 (`lib/fixtures`), #3973 (`sdk`), #3974 (`examples`), #3975 (`tests-bdd`), #3977 (`service/policy`), #3978 (`service` core)
