### PR TITLE
fix(kas): DSPX-4607 use snake_case slog key in rewrap test fake

### DIFF
--- a/service/kas/access/rewrap_test.go
+++ b/service/kas/access/rewrap_test.go
@@ -76,7 +76,7 @@ func (f *fakeKeyIndex) String() string {
 
 func (f *fakeKeyIndex) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("Indexer", f.String()),
+		slog.String("indexer", f.String()),
 	)
 }
 


### PR DESCRIPTION
Part of the DSPX-4607 lint burndown, following the golangci-lint v2.13.2 bump (#3965, merged). Branched from `main`, independent of the other burndown PRs.

## What

golangci-lint v2.13.2 enforces `sloglint`'s `key-naming-case: snake`, which was configured but not previously reachable. `service/kas` has exactly one violation:

```
service/kas/access/rewrap_test.go:79:15: keys should be written in snake_case (sloglint)
```

`"Indexer"` → `"indexer"` on the `fakeKeyIndex.LogValue` group. Test-only fake, no emitted-log contract.

The identical pattern in `service/trust/delegating_key_service_test.go:67` is renamed the same way in the `service` core PR — different CODEOWNER group, so it can't ride along here.

## Testing

```
$ cd service && golangci-lint run -c ../.golangci.yaml ./kas/...
0 issues.
$ go test ./kas/...
ok  	github.com/opentdf/platform/service/kas		0.511s
ok  	github.com/opentdf/platform/service/kas/access	0.761s
```

<!-- burndown-index -->
## DSPX-4607 burndown index

- #3965 — golangci-lint v2.13.2 bump (merged)
- #3968 — `.golangci.yaml` goconst tuning + `gomodguard_v2` migration (merged)
- Siblings: #3969 (`otdfctl`), #3971 (`lib/fixtures`), #3973 (`sdk`), #3974 (`examples`), #3975 (`tests-bdd`), #3977 (`service/policy`), #3978 (`service` core)
