### PR TITLE
fix(examples): DSPX-4607 clear goconst and SA1019 lint findings

### DIFF
--- a/examples/cmd/attributes.go
+++ b/examples/cmd/attributes.go
@@ -173,7 +173,11 @@ func attruuid(ctx context.Context, s *sdk.SDK, nsu, fqn string) (string, error) 
 }
 
 func avuuid(ctx context.Context, s *sdk.SDK, auuid, vs string) (string, error) {
-	resp, err := s.Attributes.GetAttribute(ctx, &attributes.GetAttributeRequest{Id: auuid})
+	req := &attributes.GetAttributeRequest{
+		//nolint:staticcheck // the deprecated Id field is kept here deliberately; migrating to the identifier oneof is tracked separately
+		Id: auuid,
+	}
+	resp, err := s.Attributes.GetAttribute(ctx, req)
 	if err != nil {
 		slog.Error("failed to GetAttribute", slog.Any("error", err))
 		return "", errors.Join(err, ErrInvalidArgument)

--- a/examples/cmd/benchmark.go
+++ b/examples/cmd/benchmark.go
@@ -34,7 +34,7 @@ var config BenchmarkConfig
 func init() {
 	benchmarkCmd := &cobra.Command{
 		Use:   "benchmark",
-		Short: "OpenTDF benchmark tool",
+		Short: benchmarkCmdShort,
 		Long:  `A OpenTDF benchmark tool to measure throughput and latency with configurable concurrency.`,
 		RunE:  runBenchmark,
 	}
@@ -68,7 +68,7 @@ func runBenchmark(cmd *cobra.Command, _ []string) error {
 		}
 	}()
 
-	dataAttributes := []string{"https://example.com/attr/attr1/value/value1"}
+	dataAttributes := []string{exampleAttrValueFQN}
 	opts := []sdk.TDFOption{sdk.WithDataAttributes(dataAttributes...), sdk.WithAutoconfigure(false)}
 	if insecurePlaintextConn || strings.HasPrefix(platformEndpoint, "http://") {
 		opts = append(opts, sdk.WithKasInformation(

--- a/examples/cmd/benchmark_bulk.go
+++ b/examples/cmd/benchmark_bulk.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	benchmarkCmd := &cobra.Command{
 		Use:   "benchmark-bulk",
-		Short: "OpenTDF benchmark tool",
+		Short: benchmarkCmdShort,
 		Long:  `A OpenTDF benchmark tool to measure Bulk Rewrap.`,
 		RunE:  runBenchmarkBulk,
 	}
@@ -49,7 +49,7 @@ func runBenchmarkBulk(cmd *cobra.Command, _ []string) error {
 		}
 	}()
 
-	dataAttributes := []string{"https://example.com/attr/attr1/value/value1"}
+	dataAttributes := []string{exampleAttrValueFQN}
 	opts := []sdk.TDFOption{sdk.WithDataAttributes(dataAttributes...), sdk.WithAutoconfigure(false)}
 	if insecurePlaintextConn || strings.HasPrefix(platformEndpoint, "http://") {
 		opts = append(opts, sdk.WithKasInformation(

--- a/examples/cmd/benchmark_decision.go
+++ b/examples/cmd/benchmark_decision.go
@@ -14,7 +14,7 @@ import (
 func init() {
 	benchmarkCmd := &cobra.Command{
 		Use:   "benchmark-decision",
-		Short: "OpenTDF benchmark tool",
+		Short: benchmarkCmdShort,
 		Long:  `A OpenTDF benchmark tool to measure throughput and latency with configurable concurrency.`,
 		RunE:  runDecisionBenchmark,
 	}
@@ -31,7 +31,7 @@ func runDecisionBenchmark(_ *cobra.Command, _ []string) error {
 
 	ras := []*authorization.ResourceAttribute{}
 	for i := 0; i < config.RequestCount; i++ {
-		ras = append(ras, &authorization.ResourceAttribute{AttributeValueFqns: []string{"https://example.com/attr/attr1/value/value1"}})
+		ras = append(ras, &authorization.ResourceAttribute{AttributeValueFqns: []string{exampleAttrValueFQN}})
 	}
 
 	start := time.Now()

--- a/examples/cmd/benchmark_decision_v2.go
+++ b/examples/cmd/benchmark_decision_v2.go
@@ -32,14 +32,13 @@ func runDecisionBenchmarkV2(_ *cobra.Command, _ []string) error {
 	}
 
 	var resources []*authzV2.Resource
-	attrValueFQN := "https://example.com/attr/attr1/value/value1"
 
 	for i := range config.RequestCount {
 		r := &authzV2.Resource{
 			EphemeralId: "resource-%d" + strconv.Itoa(i),
 			Resource: &authzV2.Resource_AttributeValues_{
 				AttributeValues: &authzV2.Resource_AttributeValues{
-					Fqns: []string{attrValueFQN},
+					Fqns: []string{exampleAttrValueFQN},
 				},
 			},
 		}

--- a/examples/cmd/benchmark_experimental.go
+++ b/examples/cmd/benchmark_experimental.go
@@ -22,7 +22,6 @@ import (
 var (
 	payloadSize  int
 	segmentChunk int
-	testAttr     = "https://example.com/attr/attr1/value/value1"
 )
 
 func init() {
@@ -65,7 +64,7 @@ func runExperimentalWriterBenchmark(_ *cobra.Command, _ []string) error {
 		},
 	}
 
-	attrs = append(attrs, &policy.Value{Fqn: testAttr, KasKeys: []*policy.SimpleKasKey{simpleyKey}, Attribute: &policy.Attribute{Namespace: &policy.Namespace{Name: "example.com"}, Fqn: testAttr}})
+	attrs = append(attrs, &policy.Value{Fqn: exampleAttrValueFQN, KasKeys: []*policy.SimpleKasKey{simpleyKey}, Attribute: &policy.Attribute{Namespace: &policy.Namespace{Name: "example.com"}, Fqn: exampleAttrValueFQN}})
 	writer, err := tdf.NewWriter(context.Background(), tdf.WithDefaultKASForWriter(simpleyKey), tdf.WithInitialAttributes(attrs), tdf.WithSegmentIntegrityAlgorithm(tdf.HS256))
 	if err != nil {
 		return fmt.Errorf("failed to create writer: %w", err)

--- a/examples/cmd/encrypt.go
+++ b/examples/cmd/encrypt.go
@@ -25,7 +25,7 @@ func init() {
 		RunE:  encrypt,
 		Args:  cobra.MinimumNArgs(1),
 	}
-	encryptCmd.Flags().StringSliceVarP(&dataAttributes, "data-attributes", "a", []string{"https://example.com/attr/attr1/value/value1"}, "space separated list of data attributes")
+	encryptCmd.Flags().StringSliceVarP(&dataAttributes, "data-attributes", "a", []string{exampleAttrValueFQN}, "space separated list of data attributes")
 	encryptCmd.Flags().BoolVar(&autoconfigure, "autoconfigure", true, "Use attribute grants to select kases")
 	encryptCmd.Flags().BoolVar(&noKIDInKAO, "no-kid-in-kao", false, "[deprecated] Disable storing key identifiers in TDF KAOs")
 	encryptCmd.Flags().StringVarP(&outputName, "output", "o", "sensitive.txt.tdf", "name or path of output file; - for stdout")

--- a/examples/cmd/examples.go
+++ b/examples/cmd/examples.go
@@ -11,6 +11,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	// benchmarkCmdShort is the one-line description shared by the benchmark subcommands.
+	benchmarkCmdShort = "OpenTDF benchmark tool"
+	// exampleAttrValueFQN is the attribute value FQN the examples default to.
+	exampleAttrValueFQN = "https://example.com/attr/attr1/value/value1"
+)
+
 var (
 	platformEndpoint      string
 	clientCredentials     string


### PR DESCRIPTION
Part of the [DSPX-4607](https://virtru.atlassian.net/browse/DSPX-4607) lint burndown. golangci-lint v2.13.2 (#3965) surfaced 351 pre-existing findings across the repo; they're being cleared as independent PRs grouped by CODEOWNER. This one covers **`examples/` — 9 findings** (8 `goconst`, 1 `staticcheck` SA1019).

## Changes

**`goconst` (8)** — two strings repeated across the benchmark subcommands are now package constants in `cmd/examples.go`:

- `benchmarkCmdShort = "OpenTDF benchmark tool"` (3 uses)
- `exampleAttrValueFQN = "https://example.com/attr/attr1/value/value1"` (5 uses)

Two redundant aliases folded into the new constant while I was there: the `testAttr` package var in `benchmark_experimental.go` and the `attrValueFQN` local in `benchmark_decision_v2.go` both held the same literal.

**`staticcheck` SA1019 (1)** — `cmd/attributes.go` sets the deprecated `GetAttributeRequest.Id`. Annotated with `//nolint:staticcheck` per the agreed strategy for this burndown (annotate, don't migrate off deprecated proto fields).

> Worth a follow-up: `GetAttributeRequest` does have a non-deprecated `attribute_id` in its `identifier` oneof, and this is *example* code — showing the deprecated path is arguably the wrong thing to demonstrate. Left as-is here to keep the burndown mechanical; happy to migrate it in this PR if reviewers prefer.

No behavior change.

## Testing

- `golangci-lint run` over `examples/` → `0 issues.`, under both the current `.golangci.yaml` and the tuned config from #3968 (so this PR is independent of merge order).
- `golangci-lint fmt ./...` clean.
- `go build ./...` and `go test ./...` pass.

## Related

- #3965 — the linter bump that surfaced these (merged)
- #3968 — `.golangci.yaml` goconst tuning + `gomodguard_v2` migration
- #3969 (`otdfctl`), #3970 (`service/kas`), #3971 (`lib/fixtures`), #3973 (`sdk`) — sibling burndown PRs

[DSPX-4607]: https://virtru.atlassian.net/browse/DSPX-4607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- burndown-index -->
## DSPX-4607 burndown index

- #3965 — golangci-lint v2.13.2 bump (merged)
- #3968 — `.golangci.yaml` goconst tuning + `gomodguard_v2` migration (merged)
- Siblings: #3969 (`otdfctl`), #3970 (`service/kas`), #3971 (`lib/fixtures`), #3973 (`sdk`), #3975 (`tests-bdd`), #3977 (`service/policy`), #3978 (`service` core)
