### PR TITLE
fix(ci): DSPX-4607 clear tests-bdd goconst, gosec, nestif and sloglint findings

### DIFF
--- a/tests-bdd/cukes/glue_platform.go
+++ b/tests-bdd/cukes/glue_platform.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"log/slog"
 	"net"
@@ -337,8 +338,8 @@ func (l *LocalDevPlatformGlue) Shutdown(platformCukesContext *PlatformTestSuiteC
 	if platformCukesContext.HasFailures || preserveTestDirectory {
 		platformCukesContext.Logger.Warn("preserving cukes directory for debugging",
 			slog.String("directory", l.Options.CukesDir),
-			slog.Bool("hasFailures", platformCukesContext.HasFailures),
-			slog.Bool("preserveOnFailure", preserveTestDirectory))
+			slog.Bool("has_failures", platformCukesContext.HasFailures),
+			slog.Bool("preserve_on_failure", preserveTestDirectory))
 		return nil
 	}
 
@@ -347,20 +348,49 @@ func (l *LocalDevPlatformGlue) Shutdown(platformCukesContext *PlatformTestSuiteC
 	return err
 }
 
+// changePermissions chmods every file below dirPath. The walk is scoped to an
+// os.Root so a symlink planted mid-walk cannot redirect the chmod outside dirPath.
 func changePermissions(dirPath string, mode os.FileMode) error {
-	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+	root, err := os.OpenRoot(dirPath)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	return fs.WalkDir(root.FS(), ".", func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() {
-			err = os.Chmod(path, mode)
-			if err != nil {
-				return err
-			}
+		if entry.IsDir() {
+			return nil
 		}
+		return root.Chmod(path, mode)
+	})
+}
+
+// logKeyFiles dumps the generated PEM files so container startup failures can be
+// diagnosed from the test output. Scoped to an os.Root for the same reason as above.
+func logKeyFiles(keysDir string, logger *slog.Logger) error {
+	root, err := os.OpenRoot(keysDir)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	return fs.WalkDir(root.FS(), ".", func(path string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !strings.HasSuffix(path, ".pem") {
+			return nil
+		}
+		content, err := root.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		logger.Warn("keys content",
+			slog.String("path", filepath.Join(keysDir, path)),
+			slog.String("content", string(content)))
 		return nil
 	})
-	return err
 }
 
 // Setup local platform including cert/key generation and platform and keycloak configuration setup.
@@ -396,7 +426,6 @@ func (l *LocalDevPlatformGlue) Setup(platformCukesContext *PlatformTestSuiteCont
 		return err
 	}
 
-	//nolint:nestif // refactor later - compose is private *dockercompose
 	if err := compose.WithEnv(map[string]string{
 		"POSTGRES_EXPOSE_PORT": strconv.Itoa(l.Options.postgresPort),
 		"KC_EXPOSE_PORT_HTTP":  strconv.Itoa(l.Options.keycloakPort), // Use HTTP port for BDD tests
@@ -405,22 +434,7 @@ func (l *LocalDevPlatformGlue) Setup(platformCukesContext *PlatformTestSuiteCont
 	}).Up(ctx, tc.Wait(true)); err != nil {
 		logger.Error("error standing up containers", slog.String("error", err.Error()))
 		// log key data
-		err := filepath.WalkDir(l.Options.KeysDir, func(path string, _ os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if strings.HasSuffix(path, ".pem") {
-				content, err := os.ReadFile(path)
-				if err != nil {
-					return err
-				}
-				logger.Warn("keys content",
-					slog.String("path", path),
-					slog.String("content", string(content)))
-			}
-			return nil
-		})
-		if err != nil {
+		if err := logKeyFiles(l.Options.KeysDir, logger); err != nil {
 			logger.Error("error dumping keys", slog.String("error", err.Error()))
 		}
 		LogComposeServices(compose, logger)

--- a/tests-bdd/cukes/glue_platform_test.go
+++ b/tests-bdd/cukes/glue_platform_test.go
@@ -1,0 +1,99 @@
+package cukes
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// recordingHandler captures records so tests can assert on emitted attributes.
+type recordingHandler struct {
+	records *[]slog.Record
+}
+
+func (recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.records = append(*h.records, r)
+	return nil
+}
+
+func (h recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h recordingHandler) WithGroup(string) slog.Handler { return h }
+
+func TestChangePermissions_RecursesFilesButNotDirs(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "sub", "deeper")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	files := []string{
+		filepath.Join(root, "top.pem"),
+		filepath.Join(root, "sub", "mid.pem"),
+		filepath.Join(nested, "leaf.pem"),
+	}
+	for _, f := range files {
+		if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := changePermissions(root, 0o644); err != nil {
+		t.Fatalf("changePermissions: %v", err)
+	}
+
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o644 {
+			t.Errorf("%s: got mode %o, want 644", f, got)
+		}
+	}
+	// Directories are skipped, so the 0700 created above must survive.
+	info, err := os.Stat(nested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Errorf("%s: directory mode changed to %o, want 700", nested, got)
+	}
+}
+
+func TestLogKeyFiles_OnlyReadsPEMs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sub", "kas.pem"), []byte("PEMBODY"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "notes.txt"), []byte("ignored"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var logged []slog.Record
+	handler := recordingHandler{records: &logged}
+	if err := logKeyFiles(root, slog.New(handler)); err != nil {
+		t.Fatalf("logKeyFiles: %v", err)
+	}
+
+	if len(logged) != 1 {
+		t.Fatalf("got %d records, want 1 (only the .pem)", len(logged))
+	}
+	attrs := map[string]string{}
+	logged[0].Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.String()
+		return true
+	})
+	if want := filepath.Join(root, "sub", "kas.pem"); attrs["path"] != want {
+		t.Errorf("path attr = %q, want %q", attrs["path"], want)
+	}
+	if attrs["content"] != "PEMBODY" {
+		t.Errorf("content attr = %q, want %q", attrs["content"], "PEMBODY")
+	}
+}

--- a/tests-bdd/cukes/steps_authorization.go
+++ b/tests-bdd/cukes/steps_authorization.go
@@ -21,6 +21,9 @@ type AuthorizationServiceStepDefinitions struct{}
 
 const (
 	decisionResponse = "decisionResponse"
+	// singleResourceEphemeralID labels the lone resource in single-resource
+	// decision requests; the response is correlated back by this id.
+	singleResourceEphemeralID = "resource1"
 )
 
 func ConvertInterfaceToAny(jsonData []byte) (*anypb.Any, error) {
@@ -293,7 +296,7 @@ func (s *AuthorizationServiceStepDefinitions) sendDecisionRequestV2WithFulfillab
 			Name: strings.ToLower(action),
 		},
 		Resource: &authzV2.Resource{
-			EphemeralId: "resource1",
+			EphemeralId: singleResourceEphemeralID,
 			Resource: &authzV2.Resource_AttributeValues_{
 				AttributeValues: &authzV2.Resource_AttributeValues{
 					Fqns: resourceFQNs,
@@ -350,7 +353,7 @@ func (s *AuthorizationServiceStepDefinitions) iSendADecisionRequestForTokenForAc
 		},
 		Action: &policy.Action{Name: strings.ToLower(action)},
 		Resource: &authzV2.Resource{
-			EphemeralId: "resource1",
+			EphemeralId: singleResourceEphemeralID,
 			Resource: &authzV2.Resource_AttributeValues_{
 				AttributeValues: &authzV2.Resource_AttributeValues{Fqns: resourceFQNs},
 			},

--- a/tests-bdd/cukes/steps_localplatform.go
+++ b/tests-bdd/cukes/steps_localplatform.go
@@ -114,33 +114,39 @@ func (s *LocalPlatformStepDefinitions) aUser(ctx context.Context, username strin
 	return ctx, nil
 }
 
+// reattachSharedPlatform prepares a scenario that reuses a platform an earlier
+// @stateless scenario already stood up. Each godog scenario gets its own
+// PlatformScenarioContext with a nil SDK, so the SDK has to be re-attached to the
+// shared endpoint before step definitions (and the Background) can use it.
+func reattachSharedPlatform(ctx context.Context, scenarioContext *PlatformScenarioContext, options *platformStartOptions) error {
+	if scenarioContext.SDK == nil {
+		//nolint:contextcheck // otdf.New takes no context parameter
+		platformSDK, err := otdf.New(
+			scenarioContext.ScenarioOptions.PlatformEndpoint,
+			otdf.WithInsecureSkipVerifyConn(),
+			otdf.WithClientCredentials(clientID, platformClientSecret, nil),
+		)
+		if err != nil {
+			return err
+		}
+		scenarioContext.SDK = platformSDK
+	}
+	dbName := scenarioContext.ScenarioOptions.DatabaseName
+	if options.provisionDefaultPolicy && !scenarioContext.TestSuiteContext.defaultPolicyDBs[dbName] {
+		if err := provisionDefaultPolicy(ctx, scenarioContext.SDK); err != nil {
+			return fmt.Errorf("provision default policy: %w", err)
+		}
+		scenarioContext.TestSuiteContext.defaultPolicyDBs[dbName] = true
+	}
+	return nil
+}
+
 func (s *LocalPlatformStepDefinitions) commonLocalPlatform(ctx context.Context, options *platformStartOptions) (context.Context, error) {
 	scenarioContext := GetPlatformScenarioContext(ctx)
 	logger := scenarioContext.TestSuiteContext.Logger
 	if !scenarioContext.FirstScenario && scenarioContext.Stateless {
-		// Platform is already up (shared across @stateless scenarios), but
-		// each godog scenario gets its own PlatformScenarioContext with a
-		// nil SDK. Re-attach the SDK to the shared endpoint so step
-		// definitions (and the Background) keep working.
-		if scenarioContext.SDK == nil {
-			platformSDK, err := otdf.New(
-				scenarioContext.ScenarioOptions.PlatformEndpoint,
-				otdf.WithInsecureSkipVerifyConn(),
-				otdf.WithClientCredentials(clientID, platformClientSecret, nil),
-			)
-			if err != nil {
-				return ctx, err
-			}
-			scenarioContext.SDK = platformSDK
-		}
-		dbName := scenarioContext.ScenarioOptions.DatabaseName
-		if options.provisionDefaultPolicy && !scenarioContext.TestSuiteContext.defaultPolicyDBs[dbName] {
-			if err := provisionDefaultPolicy(ctx, scenarioContext.SDK); err != nil {
-				return ctx, fmt.Errorf("provision default policy: %w", err)
-			}
-			scenarioContext.TestSuiteContext.defaultPolicyDBs[dbName] = true
-		}
-		return ctx, nil
+		// Platform is already up (shared across @stateless scenarios).
+		return ctx, reattachSharedPlatform(ctx, scenarioContext, options)
 	}
 	localPlatformGlue, ok := (*scenarioContext.TestSuiteContext.PlatformGlue).(*LocalDevPlatformGlue)
 	if !ok {

--- a/tests-bdd/cukes/steps_registeredresources.go
+++ b/tests-bdd/cukes/steps_registeredresources.go
@@ -199,7 +199,7 @@ func (s *RegisteredResourcesStepDefinitions) iSendADecisionRequestForEntityChain
 		},
 		Action: &policy.Action{Name: strings.ToLower(action)},
 		Resource: &authzV2.Resource{
-			EphemeralId: "resource1",
+			EphemeralId: singleResourceEphemeralID,
 			Resource: &authzV2.Resource_RegisteredResourceValueFqn{
 				RegisteredResourceValueFqn: resourceValueFQN,
 			},
@@ -238,7 +238,7 @@ func (s *RegisteredResourcesStepDefinitions) iSendADecisionRequestForRegisteredR
 		},
 		Action: &policy.Action{Name: strings.ToLower(action)},
 		Resource: &authzV2.Resource{
-			EphemeralId: "resource1",
+			EphemeralId: singleResourceEphemeralID,
 			Resource: &authzV2.Resource_AttributeValues_{
 				AttributeValues: &authzV2.Resource_AttributeValues{
 					Fqns: resourceFQNs,
@@ -278,7 +278,7 @@ func (s *RegisteredResourcesStepDefinitions) iSendADecisionRequestForRegisteredR
 		},
 		Action: &policy.Action{Name: strings.ToLower(action)},
 		Resource: &authzV2.Resource{
-			EphemeralId: "resource1",
+			EphemeralId: singleResourceEphemeralID,
 			Resource: &authzV2.Resource_RegisteredResourceValueFqn{
 				RegisteredResourceValueFqn: resourceFQN,
 			},


### PR DESCRIPTION
Part of the [DSPX-4607](https://virtru.atlassian.net/browse/DSPX-4607) lint burndown. golangci-lint v2.13.2 (#3965) surfaced 351 pre-existing findings across the repo; they're being cleared as independent PRs grouped by CODEOWNER. This one covers **`tests-bdd/` — 7 findings**.

## Changes

**`gosec` G122 ×2 — `cukes/glue_platform.go`.** Two `filepath.Walk`/`WalkDir` callbacks performed filesystem operations on the callback-supplied path, which is symlink-TOCTOU-prone. Both are now scoped to an `os.Root` (Go 1.24/1.25 `Root.Chmod` and `Root.ReadFile`), so a symlink planted mid-walk can't redirect the operation outside the target directory. This is a real fix rather than a suppression:

- `changePermissions` walks `root.FS()` and chmods via `root.Chmod`.
- The compose-failure key dump is extracted into a new `logKeyFiles` helper using `root.ReadFile`. The logged `path` is re-joined with `keysDir` so the log output is unchanged.

**Incidental bug fix.** Extracting `logKeyFiles` also fixes a shadowing bug in the compose-startup error path. The old code was:

```go
if err := compose.WithEnv(...).Up(ctx, tc.Wait(true)); err != nil {
    logger.Error("error standing up containers", ...)
    err := filepath.WalkDir(...)   // shadows the if-scoped err
    ...
    return err                     // returned the WalkDir result, not the compose error
}
```

so a compose failure returned `nil` whenever the key dump succeeded, and `Setup` reported success against a platform that never came up. The new `if err := logKeyFiles(...); err != nil` confines the shadow to the `if`, and `return err` now yields the compose error.

**`nestif` ×1 — `cukes/steps_localplatform.go`.** The stateless-reuse branch of `commonLocalPlatform` is extracted into `reattachSharedPlatform`. Same logic, same order; the caller is now a two-line early return. The `otdf.New` call picks up a `//nolint:contextcheck` because `otdf.New` has no context parameter.

**`sloglint` ×2 — `cukes/glue_platform.go`.** `hasFailures` → `has_failures`, `preserveOnFailure` → `preserve_on_failure`. Debug-only log keys, not a consumed contract.

**`goconst` ×2.** `"resource1"` (5 uses across `steps_authorization.go` and `steps_registeredresources.go`) is now `singleResourceEphemeralID`.

**Stale directive removed.** `//nolint:nestif // refactor later - compose is private *dockercompose` in `glue_platform.go` became unused once the `WalkDir` closure moved out of that block, so `nolintlint` flagged it.

## Testing

- `golangci-lint run` over `tests-bdd/` → `0 issues.` under the tuned config from #3968.
- Under the *current* `.golangci.yaml` two pre-existing `goconst` findings for `"password"` remain (`steps_encryption.go:179`, `steps_localplatform.go:106`). Those are map entries on lines this PR doesn't touch, so `only-new-issues` won't surface them; #3968's `goconst.ignore-map-keys` clears them.
- `golangci-lint fmt ./...` clean; `go build ./...` and `go vet ./...` pass.
- **New unit tests** — `cukes/glue_platform_test.go` covers both rewritten helpers directly, since the BDD suite only exercises them incidentally:
  - `TestChangePermissions_RecursesFilesButNotDirs` — asserts files under the root become `0644` while directories keep `0700` (the walk skips dirs).
  - `TestLogKeyFiles_OnlyReadsPEMs` — asserts only the `.pem` file is logged, that the emitted `path` attr is the full `filepath.Join(root, "sub", "kas.pem")`, and that `content` is the file body.
- **Full BDD suite** — `docker build -t platform-cukes .` then `go test ./tests-bdd -tags=cukes`. Note the suite is behind a `cukes` build tag, so a plain `go test ./...` compiles but runs no scenarios.
  - 104 scenarios, 100 passed. The 4 failures were host-port contention from parallel execution (3× `failed to bind host port ... address already in use`, 1× container exit) — re-running those features with `--godog.concurrency=1` passes, so they're environmental flakes, not regressions.

## Related

- #3965 — the linter bump that surfaced these (merged)
- #3968 — `.golangci.yaml` goconst tuning + `gomodguard_v2` migration
- #3969 (`otdfctl`), #3970 (`service/kas`), #3971 (`lib/fixtures`), #3973 (`sdk`), #3974 (`examples`), #3977 (`service/policy`), #3978 (`service` core) — sibling burndown PRs

[DSPX-4607]: https://virtru.atlassian.net/browse/DSPX-4607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostics when container startup fails by recording relevant PEM key file details.
  - File permission handling now updates files recursively without changing directory permissions.

- **Tests**
  - Added coverage for recursive file permission updates and PEM-only logging.
  - Improved authorization scenario consistency and shared-platform test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- burndown-index -->
## DSPX-4607 burndown index

- #3965 — golangci-lint v2.13.2 bump (merged)
- #3968 — `.golangci.yaml` goconst tuning + `gomodguard_v2` migration (merged)
- Siblings: #3969 (`otdfctl`), #3970 (`service/kas`), #3971 (`lib/fixtures`), #3973 (`sdk`), #3974 (`examples`), #3977 (`service/policy`), #3978 (`service` core)
