### PR TITLE
fix(policy): DSPX-4607 clear sloglint and SA1019 lint findings

### DIFF
--- a/service/policy/attributes/attributes_test.go
+++ b/service/policy/attributes/attributes_test.go
@@ -248,6 +248,7 @@ func Test_GetAttributeRequest(t *testing.T) {
 		{
 			name: "Valid Deprecated Id",
 			req: &attributes.GetAttributeRequest{
+				//nolint:staticcheck // these cases exist to validate the deprecated Id field, so they must set it
 				Id: validUUID,
 			},
 			expectError: false,
@@ -255,6 +256,7 @@ func Test_GetAttributeRequest(t *testing.T) {
 		{
 			name: "Invalid Deprecated Id (empty string)",
 			req: &attributes.GetAttributeRequest{
+				//nolint:staticcheck // these cases exist to validate the deprecated Id field, so they must set it
 				Id: "",
 			},
 			expectError:  true,
@@ -301,6 +303,7 @@ func Test_GetAttributeRequest(t *testing.T) {
 		{
 			name: "Invalid can't have both Id and Identifier",
 			req: &attributes.GetAttributeRequest{
+				//nolint:staticcheck // these cases exist to validate the deprecated Id field, so they must set it
 				Id: validUUID,
 				Identifier: &attributes.GetAttributeRequest_Fqn{
 					Fqn: "https://example.com/valid_fqn",
@@ -806,6 +809,7 @@ func Test_GetAttributeValueRequest(t *testing.T) {
 		{
 			name: "Valid Deprecated Id",
 			req: &attributes.GetAttributeValueRequest{
+				//nolint:staticcheck // these cases exist to validate the deprecated Id field, so they must set it
 				Id: validUUID,
 			},
 			expectError: false,
@@ -813,6 +817,7 @@ func Test_GetAttributeValueRequest(t *testing.T) {
 		{
 			name: "Invalid Deprecated Id (empty string)",
 			req: &attributes.GetAttributeValueRequest{
+				//nolint:staticcheck // these cases exist to validate the deprecated Id field, so they must set it
 				Id: "",
 			},
 			expectError:  true,
@@ -859,6 +864,7 @@ func Test_GetAttributeValueRequest(t *testing.T) {
 		{
 			name: "Invalid can't have both Id and Identifier",
 			req: &attributes.GetAttributeValueRequest{
+				//nolint:staticcheck // these cases exist to validate the deprecated Id field, so they must set it
 				Id: validUUID,
 				Identifier: &attributes.GetAttributeValueRequest_Fqn{
 					Fqn: "https://example.com/valid_fqn_value",

--- a/service/policy/db/attribute_fqn_test.go
+++ b/service/policy/db/attribute_fqn_test.go
@@ -67,6 +67,7 @@ func TestResolveEffectiveKasKeys(t *testing.T) {
 		return &policy.KeyAccessServer{
 			Uri: uri,
 			Id:  id,
+			//nolint:staticcheck // fixture mirrors stored grants, which still carry the deprecated PublicKey
 			PublicKey: &policy.PublicKey{
 				PublicKey: &policy.PublicKey_Cached{
 					Cached: &policy.KasPublicKeySet{Keys: []*policy.KasPublicKey{

--- a/service/policy/db/grant_mappings.go
+++ b/service/policy/db/grant_mappings.go
@@ -96,6 +96,7 @@ func mapKasKeysToGrants(keys []*policy.SimpleKasKey, existingGrants []*policy.Ke
 			grant := &policy.KeyAccessServer{
 				Uri: key.GetKasUri(),
 				Id:  key.GetKasId(),
+				//nolint:staticcheck // grants are mapped back onto the deprecated PublicKey field for clients that have not moved to multiple key pairs
 				PublicKey: &policy.PublicKey{
 					PublicKey: &policy.PublicKey_Cached{
 						Cached: &policy.KasPublicKeySet{Keys: []*policy.KasPublicKey{newKasPublicKey}},

--- a/service/policy/db/key_access_server_registry.go
+++ b/service/policy/db/key_access_server_registry.go
@@ -172,8 +172,9 @@ func (c PolicyDBClient) GetKeyAccessServer(ctx context.Context, identifier any) 
 	}
 
 	return &policy.KeyAccessServer{
-		Id:         kas.ID,
-		Uri:        kas.Uri,
+		Id:  kas.ID,
+		Uri: kas.Uri,
+		//nolint:staticcheck // responses still populate the deprecated PublicKey for clients that have not moved to multiple key pairs
 		PublicKey:  publicKey,
 		Name:       kas.Name.String,
 		Metadata:   metadata,
@@ -210,8 +211,9 @@ func (c PolicyDBClient) CreateKeyAccessServer(ctx context.Context, r *kasregistr
 	}
 
 	return &policy.KeyAccessServer{
-		Id:         createdID,
-		Uri:        uri,
+		Id:  createdID,
+		Uri: uri,
+		//nolint:staticcheck // responses still populate the deprecated PublicKey for clients that have not moved to multiple key pairs
 		PublicKey:  publicKey,
 		Name:       name,
 		Metadata:   metadata,
@@ -277,9 +279,10 @@ func (c PolicyDBClient) UpdateKeyAccessServer(ctx context.Context, id string, r 
 	}
 
 	return &policy.KeyAccessServer{
-		Id:         id,
-		Uri:        uri,
-		Name:       name,
+		Id:   id,
+		Uri:  uri,
+		Name: name,
+		//nolint:staticcheck // responses still populate the deprecated PublicKey for clients that have not moved to multiple key pairs
 		PublicKey:  publicKey,
 		Metadata:   metadata,
 		SourceType: r.GetSourceType(),
@@ -327,8 +330,9 @@ func (c PolicyDBClient) ListKeyAccessServerGrants(ctx context.Context, r *kasreg
 			return nil, fmt.Errorf("failed to unmarshal KAS public key: %w", err)
 		}
 		kas := &policy.KeyAccessServer{
-			Id:        grant.KasID,
-			Uri:       grant.KasUri,
+			Id:  grant.KasID,
+			Uri: grant.KasUri,
+			//nolint:staticcheck // responses still populate the deprecated PublicKey for clients that have not moved to multiple key pairs
 			PublicKey: pubKey,
 			Name:      grant.KasName.String,
 		}
@@ -358,6 +362,7 @@ func (c PolicyDBClient) ListKeyAccessServerGrants(ctx context.Context, r *kasreg
 		nextOffset = getNextOffset(offset, limit, total)
 	}
 	return &kasregistry.ListKeyAccessServerGrantsResponse{ //nolint:staticcheck // Compatibility path for deprecated RPC.
+		//nolint:staticcheck // compatibility path for the deprecated ListKeyAccessServerGrants RPC
 		Grants: grants,
 		Pagination: &policy.PageResponse{
 			CurrentOffset: params.Offset,

--- a/service/policy/dynamicvaluemapping/dynamic_value_mapping.go
+++ b/service/policy/dynamicvaluemapping/dynamic_value_mapping.go
@@ -102,7 +102,7 @@ func (s DynamicValueMappingService) CreateDynamicValueMapping(ctx context.Contex
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("dynamicValueMapping", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("dynamic_value_mapping", req.Msg.String()))
 	}
 	return connect.NewResponse(rsp), nil
 }
@@ -167,7 +167,7 @@ func (s DynamicValueMappingService) UpdateDynamicValueMapping(ctx context.Contex
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", id), slog.String("dynamicValueMapping", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", id), slog.String("dynamic_value_mapping", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil

--- a/service/policy/kasregistry/key_access_server_registry_test.go
+++ b/service/policy/kasregistry/key_access_server_registry_test.go
@@ -174,6 +174,7 @@ func Test_GetKeyAccessServerRequest(t *testing.T) {
 				Identifier: &kasregistry.GetKeyAccessServerRequest_Name{
 					Name: "kas-name",
 				},
+				//nolint:staticcheck // asserts that setting both the deprecated Id and an Identifier is rejected
 				Id: validUUID,
 			},
 			expectError:  true,

--- a/service/policy/keymanagement/key_management.go
+++ b/service/policy/keymanagement/key_management.go
@@ -141,7 +141,7 @@ func (ksvc Service) CreateProviderConfig(ctx context.Context, req *connect.Reque
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextCreationFailed, slog.String("keyManagementService", req.Msg.GetName()))
+		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextCreationFailed, slog.String("key_management_service", req.Msg.GetName()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -154,7 +154,7 @@ func (ksvc Service) GetProviderConfig(ctx context.Context, req *connect.Request[
 
 	pc, err := ksvc.dbClient.GetProviderConfig(ctx, req.Msg)
 	if err != nil {
-		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextGetRetrievalFailed, slog.String("keyManagementService", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextGetRetrievalFailed, slog.String("key_management_service", req.Msg.String()))
 	}
 
 	rsp.ProviderConfig = pc
@@ -166,7 +166,7 @@ func (ksvc Service) ListProviderConfigs(ctx context.Context, req *connect.Reques
 
 	resp, err := ksvc.dbClient.ListProviderConfigs(ctx, req.Msg.GetPagination())
 	if err != nil {
-		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextGetRetrievalFailed, slog.String("keyManagementService", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextGetRetrievalFailed, slog.String("key_management_service", req.Msg.String()))
 	}
 
 	return connect.NewResponse(resp), nil
@@ -227,7 +227,7 @@ func (ksvc Service) UpdateProviderConfig(ctx context.Context, req *connect.Reque
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextUpdateFailed, slog.String("keyManagementService", req.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextUpdateFailed, slog.String("key_management_service", req.Msg.GetId()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -246,7 +246,7 @@ func (ksvc Service) DeleteProviderConfig(ctx context.Context, req *connect.Reque
 	pc, err := ksvc.dbClient.DeleteProviderConfig(ctx, req.Msg.GetId())
 	if err != nil {
 		ksvc.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextDeletionFailed, slog.String("keyManagementService", req.Msg.GetId()))
+		return nil, db.StatusifyError(ctx, ksvc.logger, err, db.ErrTextDeletionFailed, slog.String("key_management_service", req.Msg.GetId()))
 	}
 
 	auditParams.ObjectID = pc.GetId()

--- a/service/policy/keymanagement/key_management_test.go
+++ b/service/policy/keymanagement/key_management_test.go
@@ -123,6 +123,7 @@ func Test_GetProviderConfigRequest(t *testing.T) {
 			name: "Invalid Name (empty) identifier",
 			req: &keymanagement.GetProviderConfigRequest{
 				Identifier: &keymanagement.GetProviderConfigRequest_Name{
+					//nolint:staticcheck // exercises the deprecated Name identifier, which must keep validating until it is removed
 					Name: "",
 				},
 			},
@@ -142,6 +143,7 @@ func Test_GetProviderConfigRequest(t *testing.T) {
 			name: "Valid Name Identifier",
 			req: &keymanagement.GetProviderConfigRequest{
 				Identifier: &keymanagement.GetProviderConfigRequest_Name{
+					//nolint:staticcheck // exercises the deprecated Name identifier, which must keep validating until it is removed
 					Name: validName,
 				},
 			},

--- a/service/policy/namespaces/namespaces.go
+++ b/service/policy/namespaces/namespaces.go
@@ -251,7 +251,7 @@ func (ns NamespacesService) RemoveKeyAccessServerFromNamespace(ctx context.Conte
 	namespaceKas, err := ns.dbClient.RemoveKeyAccessServerFromNamespace(ctx, grant)
 	if err != nil {
 		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextDeletionFailed, slog.String("namespaceKas", grant.String()))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextDeletionFailed, slog.String("namespace_kas", grant.String()))
 	}
 	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
 
@@ -273,7 +273,7 @@ func (ns NamespacesService) AssignPublicKeyToNamespace(ctx context.Context, r *c
 	namespaceKey, err := ns.dbClient.AssignPublicKeyToNamespace(ctx, key)
 	if err != nil {
 		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextCreationFailed, slog.String("namespaceKey", key.String()))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextCreationFailed, slog.String("namespace_key", key.String()))
 	}
 	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
 
@@ -295,7 +295,7 @@ func (ns NamespacesService) RemovePublicKeyFromNamespace(ctx context.Context, r 
 	_, err := ns.dbClient.RemovePublicKeyFromNamespace(ctx, key)
 	if err != nil {
 		ns.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextDeletionFailed, slog.String("namespaceKey", key.String()))
+		return nil, db.StatusifyError(ctx, ns.logger, err, db.ErrTextDeletionFailed, slog.String("namespace_key", key.String()))
 	}
 	ns.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
 

--- a/service/policy/namespaces/namespaces_test.go
+++ b/service/policy/namespaces/namespaces_test.go
@@ -161,6 +161,7 @@ func Test_GetNamespaceRequest(t *testing.T) {
 		{
 			name: "Valid Deprecated Id",
 			req: &namespaces.GetNamespaceRequest{
+				//nolint:staticcheck // these cases exist to validate the deprecated Id field, so they must set it
 				Id: validUUID,
 			},
 			expectError: false,
@@ -168,6 +169,7 @@ func Test_GetNamespaceRequest(t *testing.T) {
 		{
 			name: "Invalid Deprecated Id (empty string)",
 			req: &namespaces.GetNamespaceRequest{
+				//nolint:staticcheck // these cases exist to validate the deprecated Id field, so they must set it
 				Id: "",
 			},
 			expectError:  true,
@@ -176,6 +178,7 @@ func Test_GetNamespaceRequest(t *testing.T) {
 		{
 			name: "Invalid Deprecated Id (invalid UUID)",
 			req: &namespaces.GetNamespaceRequest{
+				//nolint:staticcheck // these cases exist to validate the deprecated Id field, so they must set it
 				Id: "invalid-uuid",
 			},
 			expectError:  true,
@@ -223,6 +226,7 @@ func Test_GetNamespaceRequest(t *testing.T) {
 		{
 			name: "Invalid can't have both Id and Identifier",
 			req: &namespaces.GetNamespaceRequest{
+				//nolint:staticcheck // these cases exist to validate the deprecated Id field, so they must set it
 				Id: validUUID,
 				Identifier: &namespaces.GetNamespaceRequest_Fqn{
 					Fqn: "https://namespace.org",

--- a/service/policy/obligations/obligations.go
+++ b/service/policy/obligations/obligations.go
@@ -244,7 +244,7 @@ func (s *Service) CreateObligationValue(ctx context.Context, req *connect.Reques
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("obligation value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("obligation_value", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -311,7 +311,7 @@ func (s *Service) UpdateObligationValue(ctx context.Context, req *connect.Reques
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("obligation value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("obligation_value", req.Msg.String()))
 	}
 	return connect.NewResponse(rsp), nil
 }
@@ -330,7 +330,7 @@ func (s *Service) DeleteObligationValue(ctx context.Context, req *connect.Reques
 	deleted, err := s.dbClient.DeleteObligationValue(ctx, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("obligation value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("obligation_value", req.Msg.String()))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
@@ -399,7 +399,7 @@ func (s *Service) AddObligationTrigger(ctx context.Context, req *connect.Request
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("obligation trigger", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("obligation_trigger", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -419,7 +419,7 @@ func (s *Service) RemoveObligationTrigger(ctx context.Context, req *connect.Requ
 	deleted, err := s.dbClient.DeleteObligationTrigger(ctx, req.Msg)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("obligation trigger", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("obligation_trigger", req.Msg.String()))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)

--- a/service/policy/registeredresources/registered_resources.go
+++ b/service/policy/registeredresources/registered_resources.go
@@ -119,7 +119,7 @@ func (s *RegisteredResourcesService) CreateRegisteredResource(ctx context.Contex
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("registered resource", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("registered_resource", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -187,7 +187,7 @@ func (s *RegisteredResourcesService) UpdateRegisteredResource(ctx context.Contex
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("registered resource", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("registered_resource", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -209,7 +209,7 @@ func (s *RegisteredResourcesService) DeleteRegisteredResource(ctx context.Contex
 	deleted, err := s.dbClient.DeleteRegisteredResource(ctx, resourceID)
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("registered resource", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("registered_resource", req.Msg.String()))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)
@@ -246,7 +246,7 @@ func (s *RegisteredResourcesService) CreateRegisteredResourceValue(ctx context.C
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("registered resource value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("registered_resource_value", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -331,7 +331,7 @@ func (s *RegisteredResourcesService) UpdateRegisteredResourceValue(ctx context.C
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("registered resource value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("registered_resource_value", req.Msg.String()))
 	}
 
 	return connect.NewResponse(rsp), nil
@@ -358,7 +358,7 @@ func (s *RegisteredResourcesService) DeleteRegisteredResourceValue(ctx context.C
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("registered resource value", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextDeletionFailed, slog.String("registered_resource_value", req.Msg.String()))
 	}
 
 	s.logger.Audit.PolicyCRUDSuccess(ctx, auditParams)

--- a/service/policy/resourcemapping/resource_mapping.go
+++ b/service/policy/resourcemapping/resource_mapping.go
@@ -123,7 +123,7 @@ func (s ResourceMappingService) CreateResourceMappingGroup(ctx context.Context, 
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("resourceMappingGroup", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("resource_mapping_group", req.Msg.String()))
 	}
 
 	auditParams.ObjectID = rmGroup.GetId()
@@ -285,7 +285,7 @@ func (s ResourceMappingService) CreateResourceMapping(ctx context.Context,
 	})
 	if err != nil {
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("resourceMapping", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("resource_mapping", req.Msg.String()))
 	}
 
 	auditParams.ObjectID = rm.GetId()
@@ -330,7 +330,7 @@ func (s ResourceMappingService) UpdateResourceMapping(ctx context.Context,
 		s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
 		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed,
 			slog.String("id", req.Msg.GetId()),
-			slog.String("resourceMapping", req.Msg.String()),
+			slog.String("resource_mapping", req.Msg.String()),
 		)
 	}
 

--- a/service/policy/subjectmapping/subject_mapping.go
+++ b/service/policy/subjectmapping/subject_mapping.go
@@ -112,7 +112,7 @@ func (s SubjectMappingService) CreateSubjectMapping(ctx context.Context,
 		return nil
 	})
 	if err != nil {
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("subjectMapping", req.Msg.String()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("subject_mapping", req.Msg.String()))
 	}
 	return connect.NewResponse(rsp), nil
 }
@@ -223,7 +223,7 @@ func (s SubjectMappingService) MatchSubjectMappings(ctx context.Context,
 
 	smList, err := s.dbClient.GetMatchedSubjectMappings(ctx, req.Msg.GetSubjectProperties())
 	if err != nil {
-		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.Any("subjectProperties", req.Msg.GetSubjectProperties()))
+		return nil, db.StatusifyError(ctx, s.logger, err, db.ErrTextGetRetrievalFailed, slog.Any("subject_properties", req.Msg.GetSubjectProperties()))
 	}
 
 	rsp.SubjectMappings = smList
@@ -281,7 +281,7 @@ func (s SubjectMappingService) CreateSubjectConditionSet(ctx context.Context,
 		cs, err := txClient.CreateSubjectConditionSet(ctx, req.Msg.GetSubjectConditionSet(), req.Msg.GetNamespaceId(), req.Msg.GetNamespaceFqn())
 		if err != nil {
 			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-			return db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("subjectConditionSet", req.Msg.String()))
+			return db.StatusifyError(ctx, s.logger, err, db.ErrTextCreationFailed, slog.String("subject_condition_set", req.Msg.String()))
 		}
 
 		conditionSet = cs
@@ -324,7 +324,7 @@ func (s SubjectMappingService) UpdateSubjectConditionSet(ctx context.Context,
 		upd, err := txClient.UpdateSubjectConditionSet(ctx, req.Msg)
 		if err != nil {
 			s.logger.Audit.PolicyCRUDFailure(ctx, auditParams)
-			return db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", req.Msg.GetId()), slog.String("subjectConditionSet fields", req.Msg.String()))
+			return db.StatusifyError(ctx, s.logger, err, db.ErrTextUpdateFailed, slog.String("id", req.Msg.GetId()), slog.String("subject_condition_set_fields", req.Msg.String()))
 		}
 
 		original = orig


### PR DESCRIPTION
Part of the [DSPX-4607](https://virtru.atlassian.net/browse/DSPX-4607) burndown of the 351 pre-existing findings that golangci-lint v2.13.2 (#3965) surfaced and v2.8.0 never reported. They don't fail CI today — the lint step runs with `only-new-issues: true` — but any future PR touching one of these lines would trip on them.

This PR covers the `service/policy` slice (48 findings). It is independent of the other DSPX-4607 PRs: no file overlap, and it does not touch `.golangci.yaml`.

## Changes

**sloglint (28)** — operational log keys renamed to snake_case, matching the linter's configured `key-naming-case`:

| package | before → after |
| --- | --- |
| `dynamicvaluemapping` | `dynamicValueMapping` → `dynamic_value_mapping` |
| `keymanagement` | `keyManagementService` → `key_management_service` (×5) |
| `namespaces` | `namespaceKas` → `namespace_kas`, `namespaceKey` → `namespace_key` |
| `obligations` | `obligation value` → `obligation_value`, `obligation trigger` → `obligation_trigger` |
| `registeredresources` | `registered resource` → `registered_resource`, `registered resource value` → `registered_resource_value` |
| `resourcemapping` | `resourceMappingGroup` → `resource_mapping_group`, `resourceMapping` → `resource_mapping` |
| `subjectmapping` | `subjectMapping` → `subject_mapping`, `subjectProperties` → `subject_properties`, `subjectConditionSet` → `subject_condition_set`, `subjectConditionSet fields` → `subject_condition_set_fields` |

These are all diagnostic keys — none is an audit event field (those live in `service/logger/audit` and are deliberately left alone, see the core PR) and no test asserts on any of these strings.

**staticcheck SA1019 (20)** — `//nolint:staticcheck` with a per-site reason rather than migrating off the deprecated proto fields, so this PR stays a lint-only change:

- `db/grant_mappings.go`, `db/key_access_server_registry.go` — responses still populate the deprecated `PublicKey` for clients that have not moved to multiple key pairs, plus the compatibility path for the deprecated `ListKeyAccessServerGrants` RPC.
- `attributes/attributes_test.go`, `namespaces/namespaces_test.go`, `kasregistry/key_access_server_registry_test.go`, `keymanagement/key_management_test.go` — these cases exist specifically to validate the deprecated `Id` / `Name` identifiers, so they have to keep setting them.

## Testing

- `golangci-lint run` over `service/policy/...` — 0 findings, verified under both the tuned config from #3968 and `main`'s config, so merge order doesn't matter.
- `make fmt`
- `cd service && go test ./policy/... -race` — pass.

## Related

#3965 (linter bump) · #3968 (config tuning) · #3969 · #3970 · #3971 · #3973 · #3974 · #3975


[DSPX-4607]: https://virtru.atlassian.net/browse/DSPX-4607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- burndown-index -->
## DSPX-4607 burndown index

- #3965 — golangci-lint v2.13.2 bump (merged)
- #3968 — `.golangci.yaml` goconst tuning + `gomodguard_v2` migration (merged)
- Siblings: #3969 (`otdfctl`), #3970 (`service/kas`), #3971 (`lib/fixtures`), #3973 (`sdk`), #3974 (`examples`), #3975 (`tests-bdd`), #3978 (`service` core)
