### PR TITLE
fix(core): DSPX-4607 clear sloglint, goconst, nolintlint and SA1019 findings

### DIFF
--- a/service/authorization/authorization.go
+++ b/service/authorization/authorization.go
@@ -605,6 +605,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 						Decision:      authorization.DecisionResponse_DECISION_DENY,
 						EntityChainId: ec.GetId(),
 						Action: &policy.Action{
+							//nolint:staticcheck // the v1 authorization API still returns the deprecated Action.Value oneof for clients that have not moved to Action.Name
 							Value: &policy.Action_Standard{
 								Standard: policy.Action_STANDARD_ACTION_TRANSMIT,
 							},
@@ -769,6 +770,7 @@ func (as *AuthorizationService) getDecisions(ctx context.Context, dr *authorizat
 				Decision:      decision,
 				EntityChainId: ec.GetId(),
 				Action: &policy.Action{
+					//nolint:staticcheck // the v1 authorization API still returns the deprecated Action.Value oneof for clients that have not moved to Action.Name
 					Value: &policy.Action_Standard{
 						Standard: policy.Action_STANDARD_ACTION_TRANSMIT,
 					},

--- a/service/entityresolution/keycloak/v2/entity_resolution.go
+++ b/service/entityresolution/keycloak/v2/entity_resolution.go
@@ -373,7 +373,7 @@ func expandGroup(ctx context.Context, groupID string, kcConnector *Connector, kc
 			logger.DebugContext(ctx,
 				"adding members",
 				slog.Int("amount", len(grpMembers)),
-				slog.String("from group", *grp.Name),
+				slog.String("from_group", *grp.Name),
 			)
 			for i := 0; i < len(grpMembers); i++ {
 				user := grpMembers[i]

--- a/service/entityresolution/multi-strategy/mapper.go
+++ b/service/entityresolution/multi-strategy/mapper.go
@@ -8,6 +8,15 @@ import (
 	"github.com/opentdf/platform/service/entityresolution/multi-strategy/types"
 )
 
+// Names of the value transformations shared by the mappers in this package.
+const (
+	transformationCSVToArray = "csv_to_array"
+	transformationArray      = "array"
+	transformationString     = "string"
+	transformationLowercase  = "lowercase"
+	transformationUppercase  = "uppercase"
+)
+
 // BaseMapper provides common functionality for all mapper implementations
 type BaseMapper struct {
 	providerType string
@@ -70,7 +79,7 @@ func (m *BaseMapper) ApplyTransformation(value interface{}, transformation strin
 	}
 
 	switch transformation {
-	case "csv_to_array":
+	case transformationCSVToArray:
 		if str, ok := value.(string); ok {
 			if str == "" {
 				return []string{}, nil
@@ -83,7 +92,7 @@ func (m *BaseMapper) ApplyTransformation(value interface{}, transformation strin
 		}
 		return nil, fmt.Errorf("csv_to_array transformation requires string input, got %T", value)
 
-	case "array":
+	case transformationArray:
 		// Ensure value is an array
 		if arr, ok := value.([]interface{}); ok {
 			return arr, nil
@@ -97,16 +106,16 @@ func (m *BaseMapper) ApplyTransformation(value interface{}, transformation strin
 		}
 		return []interface{}{value}, nil
 
-	case "string":
+	case transformationString:
 		return fmt.Sprintf("%v", value), nil
 
-	case "lowercase":
+	case transformationLowercase:
 		if str, ok := value.(string); ok {
 			return strings.ToLower(str), nil
 		}
 		return strings.ToLower(fmt.Sprintf("%v", value)), nil
 
-	case "uppercase":
+	case transformationUppercase:
 		if str, ok := value.(string); ok {
 			return strings.ToUpper(str), nil
 		}
@@ -120,10 +129,10 @@ func (m *BaseMapper) ApplyTransformation(value interface{}, transformation strin
 // GetCommonTransformations returns transformations supported by all mappers
 func (m *BaseMapper) GetCommonTransformations() []string {
 	return []string{
-		"csv_to_array",
-		"array",
-		"string",
-		"lowercase",
-		"uppercase",
+		transformationCSVToArray,
+		transformationArray,
+		transformationString,
+		transformationLowercase,
+		transformationUppercase,
 	}
 }

--- a/service/entityresolution/multi-strategy/output_mapper.go
+++ b/service/entityresolution/multi-strategy/output_mapper.go
@@ -141,19 +141,19 @@ func (om *OutputMapper) applyTransformation(value interface{}, transformation st
 	}
 
 	switch strings.ToLower(transformation) {
-	case "array":
+	case transformationArray:
 		return om.transformToArray(value)
 
-	case "csv_to_array":
+	case transformationCSVToArray:
 		return om.transformCSVToArray(value)
 
 	case "ldap_dn_to_cn_array":
 		return om.transformLDAPDNToCNArray(value)
 
-	case "lowercase":
+	case transformationLowercase:
 		return om.transformToLowercase(value)
 
-	case "uppercase":
+	case transformationUppercase:
 		return om.transformToUppercase(value)
 
 	case "trim":

--- a/service/entityresolution/multi-strategy/providers/claims/claims_mapper.go
+++ b/service/entityresolution/multi-strategy/providers/claims/claims_mapper.go
@@ -19,7 +19,7 @@ var _ types.Mapper = (*Mapper)(nil)
 // NewMapper creates a new Claims mapper
 func NewMapper() *Mapper {
 	return &Mapper{
-		providerType: "claims",
+		providerType: providerTypeClaims,
 	}
 }
 
@@ -115,10 +115,10 @@ func (m *Mapper) GetSupportedTransformations() []string {
 
 // ApplyTransformation applies Claims-specific transformations
 func (m *Mapper) ApplyTransformation(value interface{}, transformationName string) (interface{}, error) {
-	return transformation.DefaultRegistry.ApplyTransformation(value, transformationName, "claims")
+	return transformation.DefaultRegistry.ApplyTransformation(value, transformationName, providerTypeClaims)
 }
 
 // isTransformationSupported checks if a transformation is supported by Claims mapper
 func (m *Mapper) isTransformationSupported(transformationName string) bool {
-	return transformation.IsSupportedByProvider(transformationName, "claims")
+	return transformation.IsSupportedByProvider(transformationName, providerTypeClaims)
 }

--- a/service/entityresolution/multi-strategy/providers/claims/claims_provider.go
+++ b/service/entityresolution/multi-strategy/providers/claims/claims_provider.go
@@ -6,6 +6,9 @@ import (
 	"github.com/opentdf/platform/service/entityresolution/multi-strategy/types"
 )
 
+// providerTypeClaims is the registry name for this entity-resolution provider.
+const providerTypeClaims = "claims"
+
 // Provider implements the Provider interface for JWT claims
 type Provider struct {
 	name   string
@@ -29,7 +32,7 @@ func (p *Provider) Name() string {
 
 // Type returns the provider type
 func (p *Provider) Type() string {
-	return "claims"
+	return providerTypeClaims
 }
 
 // ResolveEntity extracts claims directly from JWT (passed via context)
@@ -55,7 +58,7 @@ func (p *Provider) ResolveEntity(ctx context.Context, strategy types.MappingStra
 	}
 
 	// Add metadata about the source
-	result.Metadata["provider_type"] = "claims"
+	result.Metadata["provider_type"] = providerTypeClaims
 	result.Metadata["provider_name"] = p.name
 	result.Metadata["source"] = "jwt_claims"
 	result.Metadata["claim_count"] = len(claims)

--- a/service/entityresolution/multi-strategy/providers/ldap/ldap_mapper.go
+++ b/service/entityresolution/multi-strategy/providers/ldap/ldap_mapper.go
@@ -19,7 +19,7 @@ var _ types.Mapper = (*Mapper)(nil)
 // NewMapper creates a new LDAP mapper
 func NewMapper() *Mapper {
 	return &Mapper{
-		providerType: "ldap",
+		providerType: providerTypeLDAP,
 	}
 }
 
@@ -123,7 +123,7 @@ func (m *Mapper) GetSupportedTransformations() []string {
 
 // ApplyTransformation applies LDAP-specific transformations
 func (m *Mapper) ApplyTransformation(value interface{}, transformationName string) (interface{}, error) {
-	return transformation.DefaultRegistry.ApplyTransformation(value, transformationName, "ldap")
+	return transformation.DefaultRegistry.ApplyTransformation(value, transformationName, providerTypeLDAP)
 }
 
 // escapeLDAPFilter escapes special characters in LDAP filter values
@@ -177,7 +177,7 @@ func isValidLDAPAttribute(name string) bool {
 
 // isTransformationSupported checks if a transformation is supported by LDAP mapper
 func (m *Mapper) isTransformationSupported(transformationName string) bool {
-	return transformation.IsSupportedByProvider(transformationName, "ldap")
+	return transformation.IsSupportedByProvider(transformationName, providerTypeLDAP)
 }
 
 func isASCIIAlpha(char byte) bool {

--- a/service/entityresolution/multi-strategy/providers/ldap/ldap_provider.go
+++ b/service/entityresolution/multi-strategy/providers/ldap/ldap_provider.go
@@ -9,6 +9,9 @@ import (
 	"github.com/opentdf/platform/service/entityresolution/multi-strategy/types"
 )
 
+// providerTypeLDAP is the registry name for this entity-resolution provider.
+const providerTypeLDAP = "ldap"
+
 // Provider implements the Provider interface for LDAP directories
 type Provider struct {
 	name    string
@@ -61,7 +64,7 @@ func (p *Provider) Name() string {
 
 // Type returns the provider type
 func (p *Provider) Type() string {
-	return "ldap"
+	return providerTypeLDAP
 }
 
 // ResolveEntity executes LDAP search to resolve entity information
@@ -194,7 +197,7 @@ func (p *Provider) ResolveEntity(ctx context.Context, strategy types.MappingStra
 	}
 
 	// Add metadata
-	result.Metadata["provider_type"] = "ldap"
+	result.Metadata["provider_type"] = providerTypeLDAP
 	result.Metadata["provider_name"] = p.name
 	result.Metadata["base_dn"] = strategy.LDAPSearch.BaseDN
 	result.Metadata["search_filter"] = searchFilter

--- a/service/entityresolution/multi-strategy/providers/sql/sql_mapper.go
+++ b/service/entityresolution/multi-strategy/providers/sql/sql_mapper.go
@@ -20,7 +20,7 @@ var _ types.Mapper = (*Mapper)(nil)
 // NewMapper creates a new SQL mapper
 func NewMapper() *Mapper {
 	return &Mapper{
-		providerType: "sql",
+		providerType: providerTypeSQL,
 	}
 }
 
@@ -135,7 +135,7 @@ func (m *Mapper) GetSupportedTransformations() []string {
 
 // ApplyTransformation applies SQL-specific transformations
 func (m *Mapper) ApplyTransformation(value interface{}, transformationName string) (interface{}, error) {
-	return transformation.DefaultRegistry.ApplyTransformation(value, transformationName, "sql")
+	return transformation.DefaultRegistry.ApplyTransformation(value, transformationName, providerTypeSQL)
 }
 
 // sanitizeParameterValue ensures parameter values are safe for SQL queries
@@ -172,5 +172,5 @@ func isValidSQLIdentifier(name string) bool {
 
 // isTransformationSupported checks if a transformation is supported by SQL mapper
 func (m *Mapper) isTransformationSupported(transformationName string) bool {
-	return transformation.IsSupportedByProvider(transformationName, "sql")
+	return transformation.IsSupportedByProvider(transformationName, providerTypeSQL)
 }

--- a/service/entityresolution/multi-strategy/providers/sql/sql_provider.go
+++ b/service/entityresolution/multi-strategy/providers/sql/sql_provider.go
@@ -11,6 +11,9 @@ import (
 	"github.com/opentdf/platform/service/entityresolution/multi-strategy/types"
 )
 
+// providerTypeSQL is the registry name for this entity-resolution provider.
+const providerTypeSQL = "sql"
+
 func normalizeDriverName(driver string) string {
 	driver = strings.ToLower(strings.TrimSpace(driver))
 	switch driver {
@@ -104,7 +107,7 @@ func (p *Provider) Name() string {
 
 // Type returns the provider type
 func (p *Provider) Type() string {
-	return "sql"
+	return providerTypeSQL
 }
 
 // ResolveEntity executes SQL query to resolve entity information
@@ -199,7 +202,7 @@ func (p *Provider) ResolveEntity(ctx context.Context, strategy types.MappingStra
 	}
 
 	// Add metadata
-	result.Metadata["provider_type"] = "sql"
+	result.Metadata["provider_type"] = providerTypeSQL
 	result.Metadata["provider_name"] = p.name
 	result.Metadata["query"] = strategy.Query
 	result.Metadata["column_count"] = len(columns)

--- a/service/integration/keymanagement_test.go
+++ b/service/integration/keymanagement_test.go
@@ -140,6 +140,7 @@ func (s *KeyManagementSuite) Test_GetProviderConfig_WithId_DeprecatedManager_Suc
 		Identifier: &keymanagement.GetProviderConfigRequest_Id{
 			Id: pc.GetId(),
 		},
+		//nolint:staticcheck // exercises the deprecated Manager field, which must keep validating until it is removed
 		Manager: pc.GetManager(),
 	})
 	s.Require().NoError(err)
@@ -160,6 +161,7 @@ func (s *KeyManagementSuite) Test_GetProviderConfig_WithNameOnlyIdentifier_Fails
 
 	_, err := s.db.PolicyClient.GetProviderConfig(s.ctx, &keymanagement.GetProviderConfigRequest{
 		Identifier: &keymanagement.GetProviderConfigRequest_Name{
+			//nolint:staticcheck // exercises the deprecated Name identifier, which must keep validating until it is removed
 			Name: s.testProvider,
 		},
 	})
@@ -169,6 +171,7 @@ func (s *KeyManagementSuite) Test_GetProviderConfig_WithNameOnlyIdentifier_Fails
 
 func (s *KeyManagementSuite) Test_GetProviderConfig_WithManagerOnly_Fails() {
 	_, err := s.db.PolicyClient.GetProviderConfig(s.ctx, &keymanagement.GetProviderConfigRequest{
+		//nolint:staticcheck // exercises the deprecated Manager field, which must keep validating until it is removed
 		Manager: basicManager,
 	})
 	s.Require().Error(err)

--- a/service/integration/main_test.go
+++ b/service/integration/main_test.go
@@ -97,7 +97,6 @@ func TestMain(m *testing.M) {
 		Started: true,
 	}
 
-	//nolint:sloglint // emoji
 	slog.Info("📀 starting postgres container")
 	postgres, err := tc.GenericContainer(context.Background(), req)
 	if err != nil {
@@ -125,7 +124,6 @@ func TestMain(m *testing.M) {
 
 	conf.DB.Port = int(port.Num())
 
-	//nolint:sloglint // emoji
 	slog.Info("🏠 loading fixtures")
 	fixtures.LoadFixtureData("../internal/fixtures/policy_fixtures.yaml")
 

--- a/service/internal/access/v2/evaluate.go
+++ b/service/internal/access/v2/evaluate.go
@@ -415,11 +415,11 @@ func hierarchyRule(
 				if isRequestedActionMatch(ctx, l, action, requiredNamespaceFQN, entitledAction, namespacedPolicy) {
 					l.DebugContext(ctx, "hierarchy rule satisfied",
 						slog.Group("entitled_by_value",
-							slog.String("FQN", entitlementFQN),
+							slog.String("fqn", entitlementFQN),
 							slog.Int("index", idx),
 						),
 						slog.Group("resource_highest_hierarchy_value",
-							slog.String("FQN", attrValues[lowestValueFQNIndex].GetFqn()),
+							slog.String("fqn", attrValues[lowestValueFQNIndex].GetFqn()),
 							slog.Int("index", lowestValueFQNIndex),
 						),
 					)

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -491,7 +491,9 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 			return
 		}
 
-		dp := r.Header.Values("Dpop")
+		// The proofs are attacker-controlled request headers, so only their count is
+		// ever logged; logging the values verbatim trips CodeQL go/clear-text-logging.
+		dp := r.Header.Values("DPoP")
 		log := a.logger
 
 		// Verify the token
@@ -536,7 +538,7 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 					ctxWithAuthX,
 					"unauthenticated",
 					slog.Any("error", err),
-					slog.Any("dpop", dp),
+					slog.Int("dpop_proof_count", len(dp)),
 				)
 				http.Error(w, "unauthenticated", http.StatusUnauthorized)
 				return
@@ -545,7 +547,7 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 				ctxWithAuthX,
 				"unauthenticated",
 				slog.Any("error", err),
-				slog.Any("dpop", dp),
+				slog.Int("dpop_proof_count", len(dp)),
 			)
 			http.Error(w, "unauthenticated", http.StatusUnauthorized)
 			return

--- a/service/internal/auth/authz/casbin/v1/authorizer.go
+++ b/service/internal/auth/authz/casbin/v1/authorizer.go
@@ -40,7 +40,7 @@ func NewAuthorizer(cfg authz.CasbinV1Config, log *logger.Logger) (*Authorizer, e
 	log.Info(
 		"casbin authorizer initialized",
 		slog.String("version", authorizer.Version()),
-		slog.Bool("supportsResourceAuth", authorizer.SupportsResourceAuthorization()),
+		slog.Bool("supports_resource_auth", authorizer.SupportsResourceAuthorization()),
 	)
 
 	return authorizer, nil

--- a/service/internal/auth/authz/casbin/v1/enforcer.go
+++ b/service/internal/auth/authz/casbin/v1/enforcer.go
@@ -106,10 +106,10 @@ func newCasbinEnforcer(c casbinConfig, logger *logger.Logger) (*Enforcer, error)
 	logger.Debug(
 		"creating casbin enforcer",
 		slog.Any("config", c),
-		slog.Bool("isDefaultModel", isDefaultModel),
-		slog.Bool("isBuiltinPolicy", isDefaultPolicy),
-		slog.Bool("isPolicyExtended", isPolicyExtended),
-		slog.Bool("isDefaultAdapter", isDefaultAdapter),
+		slog.Bool("is_default_model", isDefaultModel),
+		slog.Bool("is_builtin_policy", isDefaultPolicy),
+		slog.Bool("is_policy_extended", isPolicyExtended),
+		slog.Bool("is_default_adapter", isDefaultAdapter),
 	)
 
 	m, err := casbinModel.NewModelFromString(c.Model)

--- a/service/internal/auth/authz/casbin/v2/authorizer.go
+++ b/service/internal/auth/authz/casbin/v2/authorizer.go
@@ -98,7 +98,7 @@ func NewAuthorizer(cfg authz.CasbinV2Config, log *logger.Logger) (*Authorizer, e
 	log.Info(
 		"casbin authorizer initialized",
 		slog.String("version", authorizer.Version()),
-		slog.Bool("supportsResourceAuth", authorizer.SupportsResourceAuthorization()),
+		slog.Bool("supports_resource_auth", authorizer.SupportsResourceAuthorization()),
 	)
 
 	return authorizer, nil

--- a/service/internal/fixtures/fixtures.go
+++ b/service/internal/fixtures/fixtures.go
@@ -423,7 +423,6 @@ func (f *Fixtures) GetRegisteredResourceValueKey(key string) FixtureDataRegister
 	return rv
 }
 
-//nolint:sloglint // preserve emoji usage
 func (f *Fixtures) Provision(ctx context.Context) {
 	slog.Info("📦 running migrations in schema", slog.String("schema", f.db.Schema))
 	_, err := f.db.Client.RunMigrations(ctx, policy.Migrations)
@@ -492,7 +491,6 @@ func (f *Fixtures) Provision(ctx context.Context) {
 	slog.Info("📚 successfully indexed FQNs")
 }
 
-//nolint:sloglint // preserve emoji usage
 func (f *Fixtures) TearDown(ctx context.Context) {
 	slog.Info("🗑  dropping schema", slog.String("schema", f.db.Schema))
 	if err := f.db.DropSchema(ctx); err != nil {
@@ -542,7 +540,6 @@ func (f *Fixtures) provisionAttributeValues(ctx context.Context) int64 {
 	return f.provision(ctx, fixtureData.AttributeValues.Metadata.TableName, fixtureData.AttributeValues.Metadata.Columns, values)
 }
 
-//nolint:sloglint // preserve emoji usage
 func (f *Fixtures) provisionSubjectConditionSet(ctx context.Context) int64 {
 	values := make([][]any, 0, len(fixtureData.SubjectConditionSet.Data))
 	for _, d := range fixtureData.SubjectConditionSet.Data {
@@ -628,7 +625,6 @@ func (f *Fixtures) provisionResourceMappings(ctx context.Context) int64 {
 	return f.provision(ctx, fixtureData.ResourceMappings.Metadata.TableName, fixtureData.ResourceMappings.Metadata.Columns, values)
 }
 
-//nolint:sloglint // preserve emoji usage
 func (f *Fixtures) provisionKasRegistry(ctx context.Context) int64 {
 	values := make([][]any, 0, len(fixtureData.KasRegistries.Data))
 	for _, d := range fixtureData.KasRegistries.Data {
@@ -670,7 +666,6 @@ func (f *Fixtures) provisionAttributeValueKeyAccessServer(ctx context.Context) i
 	return f.provision(ctx, "attribute_value_key_access_grants", []string{"attribute_value_id", "key_access_server_id"}, values)
 }
 
-//nolint:sloglint // preserve emoji usage
 func (f *Fixtures) provisionProviderConfigs(ctx context.Context) int64 {
 	values := make([][]any, 0, len(fixtureData.ProviderConfigs.Data))
 	for _, d := range fixtureData.ProviderConfigs.Data {
@@ -690,7 +685,6 @@ func (f *Fixtures) provisionProviderConfigs(ctx context.Context) int64 {
 	return f.provision(ctx, fixtureData.ProviderConfigs.Metadata.TableName, fixtureData.ProviderConfigs.Metadata.Columns, values)
 }
 
-//nolint:sloglint // preserve emoji usage
 func (f *Fixtures) provisionKasRegistryKeys(ctx context.Context) int64 {
 	values := make([][]any, 0, len(fixtureData.KasRegistryKeys.Data))
 	for _, d := range fixtureData.KasRegistryKeys.Data {
@@ -769,19 +763,25 @@ func (f *Fixtures) provisionRegisteredResourceActionAttributeValues(ctx context.
 	return f.provision(ctx, fixtureData.RegisteredResourceActionAttributeValues.Metadata.TableName, fixtureData.RegisteredResourceActionAttributeValues.Metadata.Columns, values)
 }
 
-//nolint:sloglint // preserve emoji usage
 func (f *Fixtures) provision(ctx context.Context, t string, c []string, v [][]any) int64 {
 	rows, err := f.db.ExecInsert(ctx, t, c, v...)
 	if err != nil {
-		slog.Error("⛔️ 📦 issue with insert into table - check policy_fixtures.yaml for issues", slog.String("table", t), slog.Any("err", err))
+		slog.Error("⛔️ 📦 issue with insert into table - check policy_fixtures.yaml for issues",
+			slog.String("table", t),
+			slog.Any("err", err))
 		panic("issue with insert into table")
 	}
 	if rows == 0 {
-		slog.Error("⛔️ 📦 no rows provisioned - check policy_fixtures.yaml for issues", slog.String("table", t), slog.Int("expected", len(v)))
+		slog.Error("⛔️ 📦 no rows provisioned - check policy_fixtures.yaml for issues",
+			slog.String("table", t),
+			slog.Int("expected", len(v)))
 		panic("no rows provisioned")
 	}
 	if rows != int64(len(v)) {
-		slog.Error("⛔️ 📦 incorrect number of rows provisioned - check policy_fixtures.yaml for issues", slog.String("table", t), slog.Int("expected", len(v)), slog.Int64("actual", rows))
+		slog.Error("⛔️ 📦 incorrect number of rows provisioned - check policy_fixtures.yaml for issues",
+			slog.String("table", t),
+			slog.Int("expected", len(v)),
+			slog.Int64("actual", rows))
 		panic("incorrect number of rows provisioned")
 	}
 	return rows

--- a/service/internal/security/basic_manager.go
+++ b/service/internal/security/basic_manager.go
@@ -150,7 +150,7 @@ func (b *BasicManager) DeriveKey(ctx context.Context, keyDetails trust.KeyDetail
 		return nil, fmt.Errorf("failed to marshal ECDSA public key: %w", err)
 	}
 	pemBlock := &pem.Block{
-		Type:  "PUBLIC KEY",
+		Type:  pemTypePublicKey,
 		Bytes: derBytes,
 	}
 	ephemeralECDSAPublicKeyPEM := pem.EncodeToMemory(pemBlock)

--- a/service/internal/security/in_process_provider.go
+++ b/service/internal/security/in_process_provider.go
@@ -319,7 +319,7 @@ func (a *InProcessProvider) DeriveKey(_ context.Context, keyDetails trust.KeyDet
 		return nil, fmt.Errorf("failed to marshal ECDSA public key: %w", err)
 	}
 	ephemeralECDSAPublicKeyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "PUBLIC KEY",
+		Type:  pemTypePublicKey,
 		Bytes: derBytes,
 	})
 

--- a/service/internal/security/standard_crypto.go
+++ b/service/internal/security/standard_crypto.go
@@ -18,6 +18,9 @@ import (
 	"github.com/opentdf/platform/service/trust"
 )
 
+// pemTypePublicKey is the PEM block type for SubjectPublicKeyInfo-encoded keys.
+const pemTypePublicKey = "PUBLIC KEY"
+
 type StandardConfig struct {
 	Keys []KeyPairInfo `mapstructure:"keys" json:"keys"`
 	// Deprecated
@@ -264,7 +267,7 @@ func loadDeprecatedKeys(rsaKeys map[string]StandardKeyInfo, ecKeys map[string]St
 		slog.Info(
 			"cfg.ECKeys",
 			slog.String("id", id),
-			slog.Any("kasInfo", kasInfo),
+			slog.Any("kas_info", kasInfo),
 		)
 		// private and public EC KAS key
 		privatePemData, err := os.ReadFile(kasInfo.PrivateKeyPath)
@@ -358,7 +361,7 @@ func (s StandardCrypto) ECPublicKey(kid string) (string, error) {
 	}
 
 	pemBlock := &pem.Block{
-		Type:  "PUBLIC KEY",
+		Type:  pemTypePublicKey,
 		Bytes: derBytes,
 	}
 	pemBytes := pem.EncodeToMemory(pemBlock)

--- a/service/internal/server/memhttp/memhttp.go
+++ b/service/internal/server/memhttp/memhttp.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"golang.org/x/net/http2"
+	//nolint:staticcheck // h2c is deprecated in favour of http.Server.Protocols, but that requires a Go 1.24+ server rework tracked separately
 	"golang.org/x/net/http2/h2c"
 )
 
@@ -41,6 +42,7 @@ func New(handler http.Handler, opts ...Option) *Server {
 
 	http2Server := &http2.Server{}
 
+	//nolint:staticcheck // h2c.NewHandler is deprecated in favour of http.Server.Protocols; migration tracked separately
 	handler = h2c.NewHandler(handler, http2Server)
 
 	server := &http.Server{

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opentdf/platform/service/pkg/cache"
 	"github.com/opentdf/platform/service/tracing"
 	"golang.org/x/net/http2"
+	//nolint:staticcheck // h2c is deprecated in favour of http.Server.Protocols, but that requires a Go 1.24+ server rework tracked separately
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 )
@@ -404,6 +405,7 @@ func newHTTPServer(c Config, connectRPC http.Handler, extraHTTP http.Handler, a 
 
 	var handler http.Handler
 	if !c.TLS.Enabled {
+		//nolint:staticcheck // h2c.NewHandler is deprecated in favour of http.Server.Protocols; migration tracked separately
 		handler = h2c.NewHandler(routeConnectRPCRequests(connectRPC, httpHandler), &http2.Server{})
 	} else {
 		tc, err = loadTLSConfig(c.TLS)

--- a/service/logger/audit/utils.go
+++ b/service/logger/audit/utils.go
@@ -176,6 +176,7 @@ type eventClientInfo struct {
 	EventClientInfo
 }
 
+//nolint:sloglint // audit event field names are a published contract enforced as reserved paths in schema.go; renaming them would break downstream SIEM consumers
 func (e eventClientInfo) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("userAgent", e.UserAgent),
@@ -190,6 +191,7 @@ type ContextData struct {
 	ActorID   string
 }
 
+//nolint:sloglint // audit event field names are a published contract enforced as reserved paths in schema.go; renaming them would break downstream SIEM consumers
 func (c ContextData) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("requestID", c.RequestID.String()),

--- a/service/pkg/config/config.go
+++ b/service/pkg/config/config.go
@@ -326,13 +326,13 @@ func (c *Config) Reload(ctx context.Context) error {
 func (c SDKConfig) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.Group("core",
-			"endpoint", c.CorePlatformConnection.Endpoint,
-			"plaintext", c.CorePlatformConnection.Plaintext,
-			"insecure", c.CorePlatformConnection.Insecure),
+			slog.String("endpoint", c.CorePlatformConnection.Endpoint),
+			slog.Bool("plaintext", c.CorePlatformConnection.Plaintext),
+			slog.Bool("insecure", c.CorePlatformConnection.Insecure)),
 		slog.Group("entityresolution",
-			"endpoint", c.EntityResolutionConnection.Endpoint,
-			"plaintext", c.EntityResolutionConnection.Plaintext,
-			"insecure", c.EntityResolutionConnection.Insecure),
+			slog.String("endpoint", c.EntityResolutionConnection.Endpoint),
+			slog.Bool("plaintext", c.EntityResolutionConnection.Plaintext),
+			slog.Bool("insecure", c.EntityResolutionConnection.Insecure)),
 		slog.String("client_id", c.ClientID),
 		slog.String("client_secret", "[REDACTED]"),
 	)

--- a/service/pkg/db/db.go
+++ b/service/pkg/db/db.go
@@ -124,8 +124,8 @@ func (c Config) LogValue() slog.Value {
 			slog.Int("max_connection_idle_seconds", c.Pool.MaxConnIdleTime),
 			slog.Int("health_check_period_seconds", c.Pool.HealthCheckPeriod),
 		),
-		slog.Bool("runMigrations", c.RunMigrations),
-		slog.Bool("verifyConnection", c.VerifyConnection),
+		slog.Bool("run_migrations", c.RunMigrations),
+		slog.Bool("verify_connection", c.VerifyConnection),
 	)
 }
 

--- a/service/tracing/otel.go
+++ b/service/tracing/otel.go
@@ -305,10 +305,10 @@ func createFileExporter(cfg *FileConfig) (sdktrace.SpanExporter, io.Closer, erro
 
 	logger.Info("configuring file trace exporter",
 		slog.String("path", cfg.Path),
-		slog.Bool("prettyPrint", cfg.PrettyPrint),
-		slog.Int("maxSizeMB", maxSize),
-		slog.Int("maxBackups", maxBackups),
-		slog.Int("maxAgeDays", maxAge),
+		slog.Bool("pretty_print", cfg.PrettyPrint),
+		slog.Int("max_size_mb", maxSize),
+		slog.Int("max_backups", maxBackups),
+		slog.Int("max_age_days", maxAge),
 		slog.Bool("compress", cfg.Compress),
 	)
 

--- a/service/trust/delegating_key_service_test.go
+++ b/service/trust/delegating_key_service_test.go
@@ -64,7 +64,7 @@ func (m *MockKeyIndex) String() string {
 
 func (m *MockKeyIndex) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("Indexer", m.String()),
+		slog.String("indexer", m.String()),
 	)
 }
 


### PR DESCRIPTION
Part of the [DSPX-4607](https://virtru.atlassian.net/browse/DSPX-4607) burndown of the 351 pre-existing findings that golangci-lint v2.13.2 (#3965) surfaced and v2.8.0 never reported. They don't fail CI today — the lint step runs with `only-new-issues: true` — but any future PR touching one of these lines would trip on them.

This PR covers the `service` core slice (60 findings) — everything under `service/` that isn't `service/policy` (#3977) or `service/kas` (#3970). It is independent of the other DSPX-4607 PRs: no file overlap, and it does not touch `.golangci.yaml`.

## Changes

**sloglint (25)**

*Audit event keys are suppressed, not renamed (6).* `service/logger/audit/utils.go` emits `userAgent`, `requestIP`, `requestID` and `actorID`. Those names are a published contract: they're asserted as golden JSON in `logger_test.go` and enforced as reserved paths by `schema.go`, and renaming them would break downstream SIEM consumers. Each `LogValue` gets one function-level `//nolint:sloglint` carrying that rationale.

*The other 17 are ordinary operational keys*, renamed to snake_case: `from group` → `from_group` (entityresolution), `FQN` → `fqn` (evaluate), `supportsResourceAuth` → `supports_resource_auth` (casbin v1 + v2 authorizers), `isDefaultModel` / `isBuiltinPolicy` / `isPolicyExtended` / `isDefaultAdapter` (casbin enforcer), `kasInfo` → `kas_info`, `runMigrations` / `verifyConnection` (db), `prettyPrint` / `maxSizeMB` / `maxBackups` / `maxAgeDays` (otel), `Indexer` → `indexer`.

`SDKConfig.LogValue` in `pkg/config/config.go` also moves from loose key-value pairs to typed `slog.Group`/`slog.String`/`slog.Bool` attrs.

**nolintlint (9 removed)** — 2 stale `//nolint:sloglint // emoji` in `integration/main_test.go` and 7 `// preserve emoji usage` in `internal/fixtures/fixtures.go`. Six of those were reported unused outright. The seventh was genuinely suppressing something — but args-on-separate-lines, not emoji, so the stated reason was wrong. Rather than keep a misleading directive, the three `slog.Error` calls in `(*Fixtures).provision` are split one attr per line.

**goconst (17)** — constants extracted where the repeated literal has a real name:

- `entityresolution/multi-strategy/mapper.go` — `transformationCSVToArray` / `transformationArray` / `transformationString` / `transformationLowercase` / `transformationUppercase`, shared by `mapper.go` and `output_mapper.go`. Named `transformation*` rather than `transform*` to avoid colliding with the existing `(*OutputMapper).transformCSVToArray` method.
- `providers/{claims,ldap,sql}` — one `providerType*` const per package, used by both the provider and its mapper.
- `internal/security` — `pemTypePublicKey = "PUBLIC KEY"`, used by `standard_crypto.go`, `basic_manager.go` and `in_process_provider.go`.

**canonicalheader (1)** — `internal/auth/authn.go`: `r.Header.Values("Dpop")` → `r.Header.Values("DPoP")`. Cosmetic only: `Header.Values` canonicalizes through `textproto.CanonicalMIMEHeaderKey`, so the lookup is unchanged and there is no DPoP interop exposure.

**CodeQL follow-on — DPoP proofs are no longer logged verbatim.** Touching that line made CodeQL attribute a pre-existing `go/clear-text-logging` flow (2 high) to this PR: `dp` is a raw request header and both `WarnContext` calls in the failure path logged it with `slog.Any("dpop", dp)`. The same code is on `main` today — CodeQL only reports it here because the taint source line is in the diff — but rather than suppress it, the two call sites now log `slog.Int("dpop_proof_count", len(dp))`.

That keeps the diagnostic that actually matters (was a proof presented at all?) and drops attacker-controlled header content out of warn-level logs on every unauthenticated request, which was also a log-injection surface. No test asserts on the attribute, and `go test ./internal/auth/...` passes.

**staticcheck SA1019 (9)** — `//nolint:staticcheck` with a per-site reason:

- `authorization/authorization.go` — the v1 authorization API still returns the deprecated `Action.Value` oneof for clients that have not moved to `Action.Name`.
- `integration/keymanagement_test.go` — exercises the deprecated `Manager` field and `Name` identifier, which must keep validating until they're removed.
- `internal/server/memhttp/memhttp.go`, `internal/server/server.go` — `h2c.NewHandler` is deprecated in favour of `http.Server.Protocols`; that migration is a Go 1.24+ server rework and is tracked separately.

## Testing

- `golangci-lint run` over the affected packages — 0 findings, verified under both the tuned config from #3968 and `main`'s config, so merge order doesn't matter.
- `make fmt`
- `cd service && go test ./logger/audit/... -race` — pass. This is the guard for the audit change: the golden-JSON and reserved-path assertions confirm the emitted event schema is byte-identical.
- `cd service && go test ./... -race` — pass, other than pre-existing environmental failures unrelated to this change (`rttests` needs a platform on `:8080`; `integration` and `entityresolution/integration` need testcontainers, and both pass with the Docker socket configured).
- Confirmed zero files under `service/policy/` or `service/kas/` are touched, so this stays disjoint from #3977 and #3970.

## Related

#3965 (linter bump) · #3968 (config tuning) · #3969 · #3970 · #3971 · #3973 · #3974 · #3975 · #3977


[DSPX-4607]: https://virtru.atlassian.net/browse/DSPX-4607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- burndown-index -->
## DSPX-4607 burndown index

- #3965 — golangci-lint v2.13.2 bump (merged)
- #3968 — `.golangci.yaml` goconst tuning + `gomodguard_v2` migration (merged)
- Siblings: #3969 (`otdfctl`), #3970 (`service/kas`), #3971 (`lib/fixtures`), #3973 (`sdk`), #3974 (`examples`), #3975 (`tests-bdd`), #3977 (`service/policy`)

