### PR TITLE
fix(authz): keep shared policy values immutable

### DIFF
--- a/service/internal/access/v2/pdp.go
+++ b/service/internal/access/v2/pdp.go
@@ -16,6 +16,7 @@ import (
 	attrs "github.com/opentdf/platform/protocol/go/policy/attributes"
 	"github.com/opentdf/platform/service/internal/subjectmappingbuiltin"
 	"github.com/opentdf/platform/service/logger"
+	"google.golang.org/protobuf/proto"
 )
 
 // Decision represents the overall access decision for an entity.
@@ -140,7 +141,7 @@ func NewPolicyDecisionPoint(
 		// Not every value may have a subject mapping and be entitleable, but a lookup must still be possible
 		for _, value := range attr.GetValues() {
 			mapped := &attrs.GetAttributeValuesByFqnsResponse_AttributeAndValue{
-				Value:     value,
+				Value:     proto.CloneOf(value),
 				Attribute: attr,
 			}
 			allEntitleableAttributesByValueFQN[value.GetFqn()] = mapped
@@ -181,6 +182,7 @@ func NewPolicyDecisionPoint(
 		if err != nil {
 			return nil, fmt.Errorf("failed to get attribute definition: %w", err)
 		}
+		mappedValue = proto.CloneOf(mappedValue)
 		mappedValue.SubjectMappings = []*policy.SubjectMapping{sm}
 		mapped := &attrs.GetAttributeValuesByFqnsResponse_AttributeAndValue{
 			Value:     mappedValue,

--- a/service/internal/access/v2/pdp_immutable_test.go
+++ b/service/internal/access/v2/pdp_immutable_test.go
@@ -1,0 +1,52 @@
+package access
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/service/logger"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestPolicyConstructionDoesNotMutateSharedValues(t *testing.T) {
+	const definitionFQN = "https://scale.example/attr/department"
+	value := &policy.Value{Fqn: definitionFQN + "/value/engineering"}
+	attr := &policy.Attribute{Fqn: definitionFQN, Rule: policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF, Values: []*policy.Value{value}}
+	// The second mapping exercises values absent from the definition's value list.
+	mappings := []*policy.SubjectMapping{
+		{Id: "existing", AttributeValue: value, Actions: []*policy.Action{{Name: "read"}}},
+		{Id: "additional", AttributeValue: &policy.Value{Fqn: definitionFQN + "/value/sales"}, Actions: []*policy.Action{{Name: "read"}}},
+	}
+	originalAttribute := proto.CloneOf(attr)
+	originalMapping := proto.CloneOf(mappings[1])
+	log := &logger.Logger{Logger: slog.New(slog.DiscardHandler)}
+	ctx := t.Context()
+	const constructions = 16
+	results := make(chan *PolicyDecisionPoint, constructions)
+	errors := make(chan error, constructions)
+	var workers sync.WaitGroup
+	for range constructions {
+		workers.Go(func() {
+			pdp, err := NewPolicyDecisionPoint(ctx, log, []*policy.Attribute{attr}, mappings, nil, true, false)
+			results <- pdp
+			errors <- err
+		})
+	}
+	workers.Wait()
+	close(results)
+	close(errors)
+	for err := range errors {
+		require.NoError(t, err)
+	}
+	for pdp := range results {
+		for _, mapping := range mappings {
+			got := pdp.allEntitleableAttributesByValueFQN[mapping.GetAttributeValue().GetFqn()]
+			require.Len(t, got.GetValue().GetSubjectMappings(), 1)
+		}
+	}
+	require.True(t, proto.Equal(originalAttribute, attr))
+	require.True(t, proto.Equal(originalMapping, mappings[1]))
+}


### PR DESCRIPTION
### Proposed Changes

Constructing a PDP appended subject mappings directly to policy values supplied by the caller. Reusing those values accumulated mappings across constructions and allowed concurrent constructors to mutate shared state.

Clone values before attaching mappings, including values introduced by a subject mapping. This makes shared policy snapshots safe for the next layer.

Layer 2 of 7 in the authorization performance stack. Review and merge from the bottom upward.

### Checklist

- [x] Added or updated unit or integration coverage appropriate to this layer
- [x] Ran focused verification for this layer
- [x] Documented behavior and validation limits below

### Testing Instructions

- Added a regression test constructing 16 PDPs concurrently from the same policy objects. Every PDP has exactly one copy of each mapping, and the original protobufs remain unchanged.
- Authorization v2 and access v2 race tests passed.

Stack-wide validation:

- Focused race tests, the full verbose policy integration suite with the race detector, SDK README code-block tests, formatting, and service lint restricted to changes since the stack base passed with zero new issues.
- `make test` was attempted with Colima configured. The round-trip suite failed because its required platform server at `127.0.0.1:8080` was not running.
- `make lint` stopped because the configured Buf API token is invalid. Separate `make go-lint` reported existing repository issues; the formatting issue in the new hierarchy test was corrected.
- `make govulncheck` reported vulnerabilities in the existing dependencies and the installed Go 1.26.3 standard library. This stack changes no dependency versions.
- GitHub CI is still running. Keep this stack in draft pending review and CI results.
