### PR TITLE
fix(authz): bound retries for missing attribute values

### DIFF
--- a/service/internal/access/v2/entitleable.go
+++ b/service/internal/access/v2/entitleable.go
@@ -149,37 +149,48 @@ func fetchEntitleableAttributes(
 		return resp, false, nil
 	}
 
-	// processBatch resolves a batch, falling back to per-FQN resolution on a batch NotFound. The
-	// server rejects the whole batch with NotFound if any requested FQN does not exist, so the retry
-	// keeps the values that DO exist and skips the missing ones (denied per-resource downstream). This
-	// preserves valid decisions in a multi-resource request that also references an unknown FQN.
-	processBatch := func(batch []string) error {
-		resp, err := getBatch(batch)
-		if err == nil {
-			return process(resp, batch)
-		}
-		if connect.CodeOf(err) != connect.CodeNotFound {
-			return fmt.Errorf("failed to get entitleable attributes by fqns: %w", err)
-		}
-		for _, fqn := range batch {
-			single, skip, ferr := fetchOne(fqn)
-			if ferr != nil {
-				return ferr
-			}
-			if skip {
-				continue
-			}
-			if perr := process(single, []string{fqn}); perr != nil {
-				return perr
-			}
-		}
-		return nil
-	}
-
+	// Split sparse misses breadth-first so valid subsets are retained in batches.
+	// Bound failed batch probes before reverting to single-value lookups when many
+	// values are missing. This keeps dense misses close to the original call count.
+	const maxFailedBatchProbes = 8
 	for start := 0; start < len(normalizedFQNs); start += maxEntitleableFQNsPerRequest {
 		end := min(start+maxEntitleableFQNsPerRequest, len(normalizedFQNs))
-		if err := processBatch(normalizedFQNs[start:end]); err != nil {
-			return nil, nil, err
+		pending := [][]string{normalizedFQNs[start:end]}
+		failedProbes := 0
+		for len(pending) > 0 {
+			batch := pending[0]
+			pending = pending[1:]
+			if failedProbes >= maxFailedBatchProbes && len(batch) > 1 {
+				for _, fqn := range batch {
+					single, skip, err := fetchOne(fqn)
+					if err != nil {
+						return nil, nil, err
+					}
+					if skip {
+						continue
+					}
+					if err := process(single, []string{fqn}); err != nil {
+						return nil, nil, err
+					}
+				}
+				continue
+			}
+			resp, err := getBatch(batch)
+			if err == nil {
+				if err := process(resp, batch); err != nil {
+					return nil, nil, err
+				}
+				continue
+			}
+			if connect.CodeOf(err) != connect.CodeNotFound {
+				return nil, nil, fmt.Errorf("failed to get entitleable attributes by fqns: %w", err)
+			}
+			if len(batch) == 1 {
+				continue
+			}
+			failedProbes++
+			middle := len(batch) / 2
+			pending = append(pending, batch[:middle], batch[middle:])
 		}
 	}
 

--- a/service/internal/access/v2/entitleable.go
+++ b/service/internal/access/v2/entitleable.go
@@ -153,6 +153,7 @@ func fetchEntitleableAttributes(
 	// Bound failed batch probes before reverting to single-value lookups when many
 	// values are missing. This keeps dense misses close to the original call count.
 	const maxFailedBatchProbes = 8
+	const splitDivisor = 2
 	for start := 0; start < len(normalizedFQNs); start += maxEntitleableFQNsPerRequest {
 		end := min(start+maxEntitleableFQNsPerRequest, len(normalizedFQNs))
 		pending := [][]string{normalizedFQNs[start:end]}
@@ -189,7 +190,7 @@ func fetchEntitleableAttributes(
 				continue
 			}
 			failedProbes++
-			middle := len(batch) / 2
+			middle := len(batch) / splitDivisor
 			pending = append(pending, batch[:middle], batch[middle:])
 		}
 	}

--- a/service/internal/access/v2/entitleable_batch_test.go
+++ b/service/internal/access/v2/entitleable_batch_test.go
@@ -1,0 +1,63 @@
+package access
+
+import (
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/opentdf/platform/protocol/go/policy"
+	attrs "github.com/opentdf/platform/protocol/go/policy/attributes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntitleableBatchSplitsSparseMisses(t *testing.T) {
+	const definition = "https://scale.example/attr/department"
+	const total = 250
+	for _, missing := range []int{-1, 0, total - 1, total} {
+		t.Run(fmt.Sprintf("missing-%d", missing), func(t *testing.T) {
+			fqns := make([]string, total)
+			for i := range fqns {
+				fqns[i] = fmt.Sprintf("%s/value/%d", definition, i)
+			}
+			fake := &fakeAttributesClient{respFunc: func(req *attrs.GetEntitleableAttributesByFqnsRequest) (*attrs.GetEntitleableAttributesByFqnsResponse, error) {
+				for _, fqn := range req.GetFqns() {
+					if missing == total || (missing >= 0 && fqn == fqns[missing]) {
+						return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("missing value"))
+					}
+				}
+				resp := &attrs.GetEntitleableAttributesByFqnsResponse{
+					Definitions:              map[string]*attrs.GetEntitleableAttributesByFqnsResponse_EntitleableDefinition{definition: {Rule: policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF}},
+					FqnEntitleableAttributes: make(map[string]*attrs.GetEntitleableAttributesByFqnsResponse_EntitleableAttribute),
+				}
+				for _, fqn := range req.GetFqns() {
+					resp.FqnEntitleableAttributes[fqn] = &attrs.GetEntitleableAttributesByFqnsResponse_EntitleableAttribute{DefinitionFqn: definition, Value: &attrs.GetEntitleableAttributesByFqnsResponse_EntitleableValue{ValueId: fqn, Fqn: fqn}}
+				}
+				return resp, nil
+			}}
+			definitions, _, err := fetchEntitleableAttributes(t.Context(), newSDKWithAttributes(fake), fqns)
+			require.NoError(t, err)
+			switch missing {
+			case -1:
+				require.Len(t, fake.requests, 1)
+				require.Len(t, definitions[0].GetValues(), total)
+			case total:
+				require.Empty(t, definitions)
+				require.LessOrEqual(t, len(fake.requests), total+8)
+			default:
+				require.Len(t, definitions, 1)
+				require.Len(t, definitions[0].GetValues(), total-1)
+				require.LessOrEqual(t, len(fake.requests), 17)
+			}
+		})
+	}
+}
+
+func TestEntitleableBatchDoesNotRetryOtherFailures(t *testing.T) {
+	expected := connect.NewError(connect.CodeUnavailable, fmt.Errorf("policy unavailable"))
+	fake := &fakeAttributesClient{respFunc: func(*attrs.GetEntitleableAttributesByFqnsRequest) (*attrs.GetEntitleableAttributesByFqnsResponse, error) {
+		return nil, expected
+	}}
+	_, _, err := fetchEntitleableAttributes(t.Context(), newSDKWithAttributes(fake), []string{"https://scale.example/attr/a/value/one", "https://scale.example/attr/a/value/two"})
+	require.ErrorIs(t, err, expected)
+	require.Len(t, fake.requests, 1)
+}

--- a/service/internal/access/v2/entitleable_batch_test.go
+++ b/service/internal/access/v2/entitleable_batch_test.go
@@ -1,6 +1,7 @@
 package access
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestEntitleableBatchSplitsSparseMisses(t *testing.T) {
 			fake := &fakeAttributesClient{respFunc: func(req *attrs.GetEntitleableAttributesByFqnsRequest) (*attrs.GetEntitleableAttributesByFqnsResponse, error) {
 				for _, fqn := range req.GetFqns() {
 					if missing == total || (missing >= 0 && fqn == fqns[missing]) {
-						return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("missing value"))
+						return nil, connect.NewError(connect.CodeNotFound, errors.New("missing value"))
 					}
 				}
 				resp := &attrs.GetEntitleableAttributesByFqnsResponse{
@@ -53,7 +54,7 @@ func TestEntitleableBatchSplitsSparseMisses(t *testing.T) {
 }
 
 func TestEntitleableBatchDoesNotRetryOtherFailures(t *testing.T) {
-	expected := connect.NewError(connect.CodeUnavailable, fmt.Errorf("policy unavailable"))
+	expected := connect.NewError(connect.CodeUnavailable, errors.New("policy unavailable"))
 	fake := &fakeAttributesClient{respFunc: func(*attrs.GetEntitleableAttributesByFqnsRequest) (*attrs.GetEntitleableAttributesByFqnsResponse, error) {
 		return nil, expected
 	}}


### PR DESCRIPTION
### Proposed Changes

A single unknown FQN turned a 250-value lookup into 251 SDK calls. Split failed batches breadth-first, retain successful sub-batches, and skip missing singleton values while preserving per-resource denial behavior.

Limit failed batch probes to eight before falling back to singleton lookups. Sparse misses improve substantially; an all-missing batch is bounded at 258 calls versus the previous 251. Errors other than NotFound are returned without retries.

Layer 4 of 7 in the authorization performance stack. Review and merge from the bottom upward.

### Checklist

- [x] Added or updated unit or integration coverage appropriate to this layer
- [x] Ran focused verification for this layer
- [x] Documented behavior and validation limits below

### Testing Instructions

- Tests verify all-known values, first/last missing values, all-missing values, and unavailable-policy errors.
- One missing value in a batch of 250 now uses at most 17 calls, verified by SDK call counters.
- Focused access v2 race tests passed.

Stack-wide validation:

- Focused race tests, the full verbose policy integration suite with the race detector, SDK README code-block tests, formatting, and service lint restricted to changes since the stack base passed with zero new issues.
- `make test` was attempted with Colima configured. The round-trip suite failed because its required platform server at `127.0.0.1:8080` was not running.
- `make lint` stopped because the configured Buf API token is invalid. Separate `make go-lint` reported existing repository issues; the formatting issue in the new hierarchy test was corrected.
- `make govulncheck` reported vulnerabilities in the existing dependencies and the installed Go 1.26.3 standard library. This stack changes no dependency versions.
- GitHub CI is still running. Keep this stack in draft pending review and CI results.
