### PR TITLE
fix(authz): reuse hierarchy and entity selector indexes

### DIFF
--- a/service/internal/access/v2/evaluate.go
+++ b/service/internal/access/v2/evaluate.go
@@ -37,6 +37,7 @@ func getResourceDecision(
 	action *policy.Action,
 	resource *authz.Resource,
 	namespacedPolicy bool,
+	hierarchies map[string]*hierarchyEntitlement,
 ) (*ResourceDecision, error) {
 	var (
 		resourceID                 = resource.GetEphemeralId()
@@ -140,7 +141,7 @@ func getResourceDecision(
 		return failure, nil
 	}
 
-	return evaluateResourceAttributeValues(ctx, l, resourceAttributeValues, resourceID, registeredResourceValueFQN, action, entitlements, accessibleAttributeValues, namespacedPolicy)
+	return evaluateResourceAttributeValues(ctx, l, resourceAttributeValues, resourceID, registeredResourceValueFQN, action, entitlements, accessibleAttributeValues, namespacedPolicy, hierarchies)
 }
 
 // evaluateResourceAttributeValues evaluates a list of attribute values against the action and entitlements
@@ -155,6 +156,7 @@ func evaluateResourceAttributeValues(
 	entitlements subjectmappingbuiltin.AttributeValueFQNsToActions,
 	accessibleAttributeValues map[string]*attrs.GetAttributeValuesByFqnsResponse_AttributeAndValue,
 	namespacedPolicy bool,
+	hierarchies map[string]*hierarchyEntitlement,
 ) (*ResourceDecision, error) {
 	// Group value FQNs by parent definition
 	definitionFqnToValueFqns := make(map[string][]string)
@@ -197,7 +199,7 @@ func evaluateResourceAttributeValues(
 			return nil, fmt.Errorf("%w: %s", ErrDefinitionNotFound, defFQN)
 		}
 
-		dataRuleResult, err := evaluateDefinition(ctx, l, entitlements, action, resourceValueFQNs, definition, namespacedPolicy)
+		dataRuleResult, err := evaluateDefinition(ctx, l, entitlements, action, resourceValueFQNs, definition, namespacedPolicy, hierarchies)
 		if err != nil {
 			return nil, errors.Join(ErrFailedEvaluation, err)
 		}
@@ -228,6 +230,7 @@ func evaluateDefinition(
 	resourceValueFQNs []string,
 	attrDefinition *policy.Attribute,
 	namespacedPolicy bool,
+	hierarchies map[string]*hierarchyEntitlement,
 ) (*DataRuleResult, error) {
 	var entitlementFailures []EntitlementFailure
 	namespaceFQN := attrDefinition.GetNamespace().GetFqn()
@@ -249,7 +252,7 @@ func evaluateDefinition(
 		entitlementFailures = anyOfRule(ctx, l, entitlements, action, resourceValueFQNs, namespaceFQN, namespacedPolicy)
 
 	case policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY:
-		entitlementFailures = hierarchyRule(ctx, l, entitlements, action, resourceValueFQNs, attrDefinition, namespaceFQN, namespacedPolicy)
+		entitlementFailures = hierarchyRule(ctx, l, entitlements, action, resourceValueFQNs, attrDefinition, namespaceFQN, namespacedPolicy, hierarchies[attrDefinition.GetFqn()])
 
 	case policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_UNSPECIFIED:
 		return nil, fmt.Errorf("%w: %s, rule: %s", ErrMissingRequiredSpecifiedRule, attrDefinition.GetFqn(), attrDefinition.GetRule().String())
@@ -382,6 +385,7 @@ func hierarchyRule(
 	attrDefinition *policy.Attribute,
 	requiredNamespaceFQN string,
 	namespacedPolicy bool,
+	prepared *hierarchyEntitlement,
 ) []EntitlementFailure {
 	// No resources to check
 	if len(resourceValueFQNs) == 0 {
@@ -391,11 +395,10 @@ func hierarchyRule(
 	actionName := action.GetName()
 	attrValues := attrDefinition.GetValues()
 
-	// Create a lookup map for the attribute value indices - O(n) where n is the number of values in the attribute
-	valueFQNToIndex := make(map[string]int, len(attrValues))
-	for idx, value := range attrValues {
-		valueFQNToIndex[value.GetFqn()] = idx
+	if prepared == nil {
+		prepared = newHierarchyEntitlement(ctx, l, attrDefinition, entitlements, action, requiredNamespaceFQN, namespacedPolicy, nil)
 	}
+	valueFQNToIndex := prepared.ranks
 
 	// Find the lowest indexed value FQN (highest in hierarchy) - O(m) where m is the number of resource values
 	lowestValueFQNIndex := len(attrValues)
@@ -405,28 +408,8 @@ func hierarchyRule(
 		}
 	}
 
-	// Check if the entitlements contain any values with index <= lowestValueFQNIndex
-	// This checks the requested value and any hierarchically higher values in a single pass - O(e) where e is entitlements count
-	for entitlementFQN, entitledActions := range entitlements {
-		// Check if this entitlement FQN has a valid index in the hierarchy
-		if idx, exists := valueFQNToIndex[entitlementFQN]; exists && idx <= lowestValueFQNIndex {
-			// Check if the required action is entitled
-			for _, entitledAction := range entitledActions {
-				if isRequestedActionMatch(ctx, l, action, requiredNamespaceFQN, entitledAction, namespacedPolicy) {
-					l.DebugContext(ctx, "hierarchy rule satisfied",
-						slog.Group("entitled_by_value",
-							slog.String("FQN", entitlementFQN),
-							slog.Int("index", idx),
-						),
-						slog.Group("resource_highest_hierarchy_value",
-							slog.String("FQN", attrValues[lowestValueFQNIndex].GetFqn()),
-							slog.Int("index", lowestValueFQNIndex),
-						),
-					)
-					return nil // Found an entitled action at or above the hierarchy level, no failures
-				}
-			}
-		}
+	if prepared.highest < len(attrValues) && prepared.highest <= lowestValueFQNIndex {
+		return nil
 	}
 
 	// The rule was not satisfied - collect failures - O(m) where m is the number of resource values

--- a/service/internal/access/v2/evaluate_test.go
+++ b/service/internal/access/v2/evaluate_test.go
@@ -649,7 +649,7 @@ func (s *EvaluateTestSuite) TestHierarchyRule() {
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
 			// Execute
-			failures := hierarchyRule(s.T().Context(), s.logger, tc.entitlements, s.action, tc.resourceValueFQNs, s.hierarchicalClassAttr, "", false)
+			failures := hierarchyRule(s.T().Context(), s.logger, tc.entitlements, s.action, tc.resourceValueFQNs, s.hierarchicalClassAttr, "", false, nil)
 
 			// Assert
 			if tc.expectedFailures {
@@ -729,7 +729,7 @@ func (s *EvaluateTestSuite) TestEvaluateDefinition() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			result, err := evaluateDefinition(s.T().Context(), s.logger, tc.entitlements, s.action, tc.resourceValues, tc.definition, false)
+			result, err := evaluateDefinition(s.T().Context(), s.logger, tc.entitlements, s.action, tc.resourceValues, tc.definition, false, nil)
 
 			if tc.expectError {
 				s.Require().Error(err)
@@ -913,7 +913,7 @@ func (s *EvaluateTestSuite) TestEvaluateDefinition_NamespacedPolicy() {
 
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
-			result, err := evaluateDefinition(s.T().Context(), s.logger, tc.entitlements, tc.requested, tc.resourceFQNs, tc.definition, tc.namespaced)
+			result, err := evaluateDefinition(s.T().Context(), s.logger, tc.entitlements, tc.requested, tc.resourceFQNs, tc.definition, tc.namespaced, nil)
 
 			if tc.expectErr != nil {
 				s.Require().Error(err)
@@ -1010,7 +1010,7 @@ func (s *EvaluateTestSuite) TestEvaluateResourceAttributeValues() {
 				s.action,
 				tc.entitlements,
 				s.accessibleAttrValues,
-				false,
+				false, nil,
 			)
 
 			if tc.expectError {
@@ -1266,7 +1266,7 @@ func (s *EvaluateTestSuite) TestGetResourceDecision() {
 				tc.entitlements,
 				s.action,
 				tc.resource,
-				tc.namespaced,
+				tc.namespaced, nil,
 			)
 
 			if tc.expectError {
@@ -1339,7 +1339,7 @@ func (s *EvaluateTestSuite) Test_getResourceDecision_MultiResources_GranularDeni
 				entitlements,
 				s.action,
 				tc.resource,
-				false,
+				false, nil,
 			)
 
 			s.Require().NoError(err, "Should not error for resource: %s", tc.name)
@@ -1376,7 +1376,7 @@ func (s *EvaluateTestSuite) Test_getResourceDecision_StrictMode_DeniesOnActionNa
 		entitlements,
 		actionRead,
 		resource,
-		true,
+		true, nil,
 	)
 
 	s.Require().NoError(err)
@@ -1430,7 +1430,7 @@ func (s *EvaluateTestSuite) Test_getResourceDecision_StrictMode_RegisteredResour
 		entitlements,
 		actionRead,
 		resource,
-		true,
+		true, nil,
 	)
 
 	s.Require().NoError(err)
@@ -1464,7 +1464,7 @@ func (s *EvaluateTestSuite) Test_getResourceDecision_RequestActionIDPrecedence()
 		entitlements,
 		&policy.Action{Id: "different-id", Name: actions.ActionNameRead},
 		resource,
-		true,
+		true, nil,
 	)
 
 	s.Require().NoError(err)
@@ -1528,7 +1528,7 @@ func (s *EvaluateTestSuite) Test_getResourceDecision_StrictMode_ErrorsOnAAVNames
 		entitlements,
 		actionRead,
 		resource,
-		true,
+		true, nil,
 	)
 
 	s.Require().Error(err)

--- a/service/internal/access/v2/hierarchy_benchmark_test.go
+++ b/service/internal/access/v2/hierarchy_benchmark_test.go
@@ -1,0 +1,49 @@
+package access
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+
+	authzV2 "github.com/opentdf/platform/protocol/go/authorization/v2"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/logger/audit"
+)
+
+func BenchmarkDecisionHierarchy(b *testing.B) {
+	for _, values := range []int{1000, 6000} {
+		b.Run(fmt.Sprintf("values=%d/resources=1000", values), func(b *testing.B) {
+			const def = "https://scale.example/attr/clearance"
+			attr := &policy.Attribute{Fqn: def, Rule: policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY, Values: make([]*policy.Value, values)}
+			for i := range attr.GetValues() {
+				attr.Values[i] = &policy.Value{Fqn: fmt.Sprintf("%s/value/%d", def, i)}
+			}
+			mappings := []*policy.SubjectMapping{{Id: "mapping", AttributeValue: attr.GetValues()[0], SubjectConditionSet: clientIDInConditionSet("abc"), Actions: []*policy.Action{{Name: "read"}}}}
+			log := slog.New(slog.DiscardHandler)
+			l := &logger.Logger{Logger: log, Audit: audit.CreateAuditLogger(*log)}
+			pdp, err := NewPolicyDecisionPoint(b.Context(), l, []*policy.Attribute{attr}, mappings, nil, false, false)
+			if err != nil {
+				b.Fatal(err)
+			}
+			resources := make([]*authzV2.Resource, 1000)
+			for i := range resources {
+				resources[i] = attrValueResource(attr.GetValues()[values-1].GetFqn())[0]
+				resources[i].EphemeralId = fmt.Sprintf("resource-%d", i)
+			}
+			representation := entityRepWithClientID("abc")
+			action := &policy.Action{Name: "read"}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				decision, _, err := pdp.GetDecision(b.Context(), representation, action, resources)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if !decision.AllPermitted || len(decision.Results) != len(resources) {
+					b.Fatal("unexpected decision")
+				}
+			}
+		})
+	}
+}

--- a/service/internal/access/v2/hierarchy_index.go
+++ b/service/internal/access/v2/hierarchy_index.go
@@ -1,0 +1,62 @@
+package access
+
+import (
+	"context"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	attrs "github.com/opentdf/platform/protocol/go/policy/attributes"
+	"github.com/opentdf/platform/service/internal/subjectmappingbuiltin"
+	"github.com/opentdf/platform/service/logger"
+)
+
+type hierarchyEntitlement struct {
+	ranks   map[string]int
+	highest int
+}
+
+func hierarchyRanks(definition *policy.Attribute) map[string]int {
+	ranks := make(map[string]int, len(definition.GetValues()))
+	for i, value := range definition.GetValues() {
+		ranks[value.GetFqn()] = i
+	}
+	return ranks
+}
+
+func newHierarchyEntitlement(ctx context.Context, l *logger.Logger, definition *policy.Attribute, entitlements subjectmappingbuiltin.AttributeValueFQNsToActions, action *policy.Action, namespace string, namespaced bool, ranks map[string]int) *hierarchyEntitlement {
+	if ranks == nil {
+		ranks = hierarchyRanks(definition)
+	}
+	prepared := &hierarchyEntitlement{ranks: ranks, highest: len(definition.GetValues())}
+	for fqn, actions := range entitlements {
+		rank, found := ranks[fqn]
+		if !found || rank >= prepared.highest {
+			continue
+		}
+		for _, entitledAction := range actions {
+			if isRequestedActionMatch(ctx, l, action, namespace, entitledAction, namespaced) {
+				prepared.highest = rank
+				break
+			}
+		}
+	}
+	return prepared
+}
+
+func (p *PolicyDecisionPoint) prepareHierarchyEntitlements(ctx context.Context, decisionable map[string]*attrs.GetAttributeValuesByFqnsResponse_AttributeAndValue, entitlements subjectmappingbuiltin.AttributeValueFQNsToActions, action *policy.Action) map[string]*hierarchyEntitlement {
+	var prepared map[string]*hierarchyEntitlement
+	for _, pair := range decisionable {
+		definition := pair.GetAttribute()
+		if definition.GetRule() != policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY {
+			continue
+		}
+		fqn := definition.GetFqn()
+		if _, exists := prepared[fqn]; exists {
+			continue
+		}
+		if prepared == nil {
+			prepared = make(map[string]*hierarchyEntitlement)
+		}
+		prepared[fqn] = newHierarchyEntitlement(ctx, p.logger, definition, entitlements, action, definition.GetNamespace().GetFqn(), p.namespacedPolicy, p.hierarchyRanksByDefinition[fqn])
+	}
+	return prepared
+}

--- a/service/internal/access/v2/hierarchy_index_test.go
+++ b/service/internal/access/v2/hierarchy_index_test.go
@@ -35,7 +35,7 @@ func TestHierarchyEntitlementsRemainDecisionScoped(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, tc.permit, decision.AllPermitted, "%s/%s", tc.client, tc.action)
 		for _, result := range decision.Results {
-				require.Equal(t, tc.permit, result.Entitled)
+			require.Equal(t, tc.permit, result.Entitled)
 		}
 	}
 }

--- a/service/internal/access/v2/hierarchy_index_test.go
+++ b/service/internal/access/v2/hierarchy_index_test.go
@@ -1,0 +1,41 @@
+package access
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/logger/audit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHierarchyEntitlementsRemainDecisionScoped(t *testing.T) {
+	const definition = "https://scale.example/attr/clearance"
+	high := &policy.Value{Fqn: definition + "/value/high"}
+	low := &policy.Value{Fqn: definition + "/value/low"}
+	attr := &policy.Attribute{Fqn: definition, Rule: policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY, Values: []*policy.Value{high, low}}
+	mapping := &policy.SubjectMapping{Id: "high-read", AttributeValue: high, SubjectConditionSet: clientIDInConditionSet("authorized"), Actions: []*policy.Action{{Name: "read"}}}
+	log := slog.New(slog.DiscardHandler)
+	l := &logger.Logger{Logger: log, Audit: audit.CreateAuditLogger(*log)}
+	pdp, err := NewPolicyDecisionPoint(t.Context(), l, []*policy.Attribute{attr}, []*policy.SubjectMapping{mapping}, nil, false, false)
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		client string
+		action string
+		permit bool
+	}{
+		{"authorized", "read", true},
+		{"authorized", "write", false},
+		{"unauthorized", "read", false},
+		{"authorized", "read", true},
+	} {
+		resources := append(attrValueResource(high.GetFqn()), attrValueResource(low.GetFqn())...)
+		decision, _, err := pdp.GetDecision(t.Context(), entityRepWithClientID(tc.client), &policy.Action{Name: tc.action}, resources)
+		require.NoError(t, err)
+		require.Equal(t, tc.permit, decision.AllPermitted, "%s/%s", tc.client, tc.action)
+		for _, result := range decision.Results {
+				require.Equal(t, tc.permit, result.Entitled)
+		}
+	}
+}

--- a/service/internal/access/v2/just_in_time_pdp.go
+++ b/service/internal/access/v2/just_in_time_pdp.go
@@ -438,6 +438,7 @@ func (p *JustInTimePDP) getMatchedSubjectMappings(
 			}
 			for _, item := range flattened.Items {
 				if _, ok := subjectPropertySet[item.Key]; !ok {
+					subjectPropertySet[item.Key] = struct{}{}
 					subjectProperties = append(subjectProperties, &policy.SubjectProperty{
 						ExternalSelectorValue: item.Key,
 					})

--- a/service/internal/access/v2/just_in_time_pdp_targeted_test.go
+++ b/service/internal/access/v2/just_in_time_pdp_targeted_test.go
@@ -382,3 +382,13 @@ func TestJITPDP_GetDecision_TargetedDenyOnUnknownFQN(t *testing.T) {
 	require.NotNil(t, decision)
 	assert.False(t, decision.AllPermitted)
 }
+
+func TestMatchedSubjectMappingsDeduplicatesSelectorsAcrossRepresentations(t *testing.T) {
+	fake := &fakeSubjectMappingClient{resp: &subjectmapping.MatchSubjectMappingsResponse{}}
+	pdp := &JustInTimePDP{sdk: &otdfSDK.SDK{SubjectMapping: fake}}
+	_, err := pdp.getMatchedSubjectMappings(t.Context(), []*entityresolutionV2.EntityRepresentation{entityRepWithClientID("one"), entityRepWithClientID("two")})
+	require.NoError(t, err)
+	require.Len(t, fake.requests, 1)
+	require.Len(t, fake.requests[0].GetSubjectProperties(), 1)
+	require.Equal(t, ".clientId", fake.requests[0].GetSubjectProperties()[0].GetExternalSelectorValue())
+}

--- a/service/internal/access/v2/pdp.go
+++ b/service/internal/access/v2/pdp.go
@@ -58,6 +58,7 @@ type EntitlementFailure struct {
 // PolicyDecisionPoint represents the Policy Decision Point component with all of policy passed in by the caller.
 // All decisions and entitlements are evaluated against the in-memory policy.
 type PolicyDecisionPoint struct {
+	hierarchyRanksByDefinition         map[string]map[string]int
 	logger                             *logger.Logger
 	allEntitleableAttributesByValueFQN map[string]*attrs.GetAttributeValuesByFqnsResponse_AttributeAndValue
 	allRegisteredResourceValuesByFQN   map[string]*policy.RegisteredResourceValue
@@ -137,12 +138,16 @@ func NewPolicyDecisionPoint(
 
 	// Build lookup maps to in-memory policy
 	allAttributesByDefinitionFQN := make(map[string]*policy.Attribute)
+	hierarchyRanksByDefinition := make(map[string]map[string]int)
 	allEntitleableAttributesByValueFQN := make(map[string]*attrs.GetAttributeValuesByFqnsResponse_AttributeAndValue)
 	for _, attr := range allAttributeDefinitions {
 		if err := validateAttribute(attr); err != nil {
 			return nil, fmt.Errorf("invalid attribute definition: %w", err)
 		}
 		allAttributesByDefinitionFQN[attr.GetFqn()] = attr
+		if attr.GetRule() == policy.AttributeRuleTypeEnum_ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY {
+			hierarchyRanksByDefinition[attr.GetFqn()] = hierarchyRanks(attr)
+		}
 
 		// Not every value may have a subject mapping and be entitleable, but a lookup must still be possible
 		for _, value := range attr.GetValues() {
@@ -235,6 +240,7 @@ func NewPolicyDecisionPoint(
 	}
 
 	pdp := &PolicyDecisionPoint{
+		hierarchyRanksByDefinition:         hierarchyRanksByDefinition,
 		logger:                             l,
 		allEntitleableAttributesByValueFQN: allEntitleableAttributesByValueFQN,
 		allRegisteredResourceValuesByFQN:   allRegisteredResourceValuesByFQN,
@@ -407,8 +413,9 @@ func (p *PolicyDecisionPoint) GetDecision(
 		Results:      make([]ResourceDecision, len(resources)),
 	}
 
+	hierarchies := p.prepareHierarchyEntitlements(ctx, decisionableAttributes, entitledFQNsToActions, action)
 	for idx, resource := range resources {
-		resourceDecision, err := getResourceDecision(ctx, l, decisionableAttributes, p.allRegisteredResourceValuesByFQN, entitledFQNsToActions, action, resource, p.namespacedPolicy)
+		resourceDecision, err := getResourceDecision(ctx, l, decisionableAttributes, p.allRegisteredResourceValuesByFQN, entitledFQNsToActions, action, resource, p.namespacedPolicy, hierarchies)
 		if err != nil || resourceDecision == nil {
 			return nil, nil, fmt.Errorf("error evaluating a decision on resource [%v]: %w", resource, err)
 		}
@@ -507,8 +514,9 @@ func (p *PolicyDecisionPoint) GetDecisionRegisteredResource(
 		Results:      make([]ResourceDecision, len(resources)),
 	}
 
+	hierarchies := p.prepareHierarchyEntitlements(ctx, decisionableAttributes, entitledFQNsToActions, action)
 	for idx, resource := range resources {
-		resourceDecision, err := getResourceDecision(ctx, l, decisionableAttributes, p.allRegisteredResourceValuesByFQN, entitledFQNsToActions, action, resource, p.namespacedPolicy)
+		resourceDecision, err := getResourceDecision(ctx, l, decisionableAttributes, p.allRegisteredResourceValuesByFQN, entitledFQNsToActions, action, resource, p.namespacedPolicy, hierarchies)
 		if err != nil || resourceDecision == nil {
 			return nil, nil, fmt.Errorf("error evaluating a decision on resource [%v]: %w", resource, err)
 		}

--- a/service/internal/subjectmappingbuiltin/selector_index.go
+++ b/service/internal/subjectmappingbuiltin/selector_index.go
@@ -1,0 +1,15 @@
+package subjectmappingbuiltin
+
+import "github.com/opentdf/platform/lib/flattening"
+
+type selectorIndex map[string][]interface{}
+
+func indexSelectors(entity flattening.Flattened) selectorIndex {
+	index := make(selectorIndex, len(entity.Items))
+	for _, item := range entity.Items {
+		index[item.Key] = append(index[item.Key], item.Value)
+	}
+	return index
+}
+
+func (i selectorIndex) lookup(selector string) []interface{} { return i[selector] }

--- a/service/internal/subjectmappingbuiltin/selector_index_test.go
+++ b/service/internal/subjectmappingbuiltin/selector_index_test.go
@@ -1,0 +1,28 @@
+package subjectmappingbuiltin
+
+import (
+	"testing"
+
+	"github.com/opentdf/platform/lib/flattening"
+	"github.com/opentdf/platform/protocol/go/policy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexedSelectorsPreserveConditionSemantics(t *testing.T) {
+	flattened, err := flattening.Flatten(map[string]interface{}{"roles": []interface{}{"reader", "admin"}, "active": true})
+	require.NoError(t, err)
+	indexed := indexSelectors(flattened)
+	for _, selector := range []string{".roles[]", ".roles[0]", ".active", ".missing"} {
+		for operator := range policy.SubjectMappingOperatorEnum_name {
+			condition := &policy.Condition{SubjectExternalSelectorValue: selector, Operator: policy.SubjectMappingOperatorEnum(operator), SubjectExternalValues: []string{"admin", "true"}}
+			expected, expectedError := EvaluateCondition(condition, flattened)
+			actual, actualError := evaluateCondition(condition, indexed.lookup(selector))
+			require.Equal(t, expected, actual)
+			if expectedError != nil {
+				require.EqualError(t, actualError, expectedError.Error())
+			} else {
+				require.NoError(t, actualError)
+			}
+		}
+	}
+}

--- a/service/internal/subjectmappingbuiltin/subject_mapping_builtin.go
+++ b/service/internal/subjectmappingbuiltin/subject_mapping_builtin.go
@@ -139,10 +139,14 @@ func EvaluateSubjectMappings(attributeMappings map[string]*attributes.GetAttribu
 }
 
 func EvaluateSubjectSet(subjectSet *policy.SubjectSet, entity flattening.Flattened) (bool, error) {
+	return evaluateSubjectSet(subjectSet, func(selector string) []interface{} { return flattening.GetFromFlattened(entity, selector) })
+}
+
+func evaluateSubjectSet(subjectSet *policy.SubjectSet, lookup func(string) []interface{}) (bool, error) {
 	// condition groups anded together
 	subjectSetConditionResult := true
 	for _, conditionGroup := range subjectSet.GetConditionGroups() {
-		conditionGroupResult, err := EvaluateConditionGroup(conditionGroup, entity)
+		conditionGroupResult, err := evaluateConditionGroup(conditionGroup, lookup)
 		if err != nil {
 			return false, err
 		}
@@ -158,6 +162,10 @@ func EvaluateSubjectSet(subjectSet *policy.SubjectSet, entity flattening.Flatten
 }
 
 func EvaluateConditionGroup(conditionGroup *policy.ConditionGroup, entity flattening.Flattened) (bool, error) {
+	return evaluateConditionGroup(conditionGroup, func(selector string) []interface{} { return flattening.GetFromFlattened(entity, selector) })
+}
+
+func evaluateConditionGroup(conditionGroup *policy.ConditionGroup, lookup func(string) []interface{}) (bool, error) {
 	// get boolean operator for condition group
 	var conditionGroupResult bool
 	switch conditionGroup.GetBooleanOperator() {
@@ -174,7 +182,7 @@ func EvaluateConditionGroup(conditionGroup *policy.ConditionGroup, entity flatte
 
 ConditionEval:
 	for _, condition := range conditionGroup.GetConditions() {
-		conditionResult, err := EvaluateCondition(condition, entity)
+		conditionResult, err := evaluateCondition(condition, lookup(condition.GetSubjectExternalSelectorValue()))
 		if err != nil {
 			return false, err
 		}
@@ -204,7 +212,10 @@ ConditionEval:
 }
 
 func EvaluateCondition(condition *policy.Condition, entity flattening.Flattened) (bool, error) {
-	mappedValues := flattening.GetFromFlattened(entity, condition.GetSubjectExternalSelectorValue())
+	return evaluateCondition(condition, flattening.GetFromFlattened(entity, condition.GetSubjectExternalSelectorValue()))
+}
+
+func evaluateCondition(condition *policy.Condition, mappedValues []interface{}) (bool, error) {
 	// slog.Debug("mapped values", "", mappedValues)
 	result := false
 	switch condition.GetOperator() {

--- a/service/internal/subjectmappingbuiltin/subject_mapping_builtin_actions.go
+++ b/service/internal/subjectmappingbuiltin/subject_mapping_builtin_actions.go
@@ -49,12 +49,13 @@ func EvaluateSubjectMappingsWithActions(
 			return nil, fmt.Errorf("failure to flatten entity in subject mapping builtin: %w", err)
 		}
 
+		selectors := indexSelectors(flattenedEntity)
 		for valueFQN, attributeAndValue := range resolveableAttributes {
 			// subject mapping results or-ed together
 			for _, subjectMapping := range attributeAndValue.GetValue().GetSubjectMappings() {
 				subjectMappingResult := true
 				for _, subjectSet := range subjectMapping.GetSubjectConditionSet().GetSubjectSets() {
-					subjectSetConditionResult, err := EvaluateSubjectSet(subjectSet, flattenedEntity)
+					subjectSetConditionResult, err := evaluateSubjectSet(subjectSet, selectors.lookup)
 					if err != nil {
 						return nil, err
 					}


### PR DESCRIPTION
### Proposed Changes

Hierarchy evaluation rebuilt the value-rank map and scanned entitlements for every resource. Build rank maps with the PDP and compute the highest matching entitlement once per definition and decision, including the registered-resource subject path.

Index flattened entity selectors once per entity during static subject-mapping evaluation. Also populate the existing selector deduplication set before querying matched subject mappings.

Layer 6 of 7 in the authorization performance stack. Review and merge from the bottom upward.

### Checklist

- [x] Added or updated unit or integration coverage appropriate to this layer
- [x] Ran focused verification for this layer
- [x] Documented behavior and validation limits below

### Testing Instructions

- Race tests passed for access v2, authorization v2, obligations, and subjectmappingbuiltin.
- Added coverage for repeated decisions with different subjects/actions and indexed selector behavior across operators, arrays, and missing selectors.
- `BenchmarkDecisionHierarchy`, three samples on Apple M4 Max, 1,000 resources: a 1,000-value hierarchy went from about 17.8ms to 0.81ms; a 6,000-value hierarchy went from about 97ms to 1.23ms. For the latter, allocated bytes fell from about 221MB to 2.28MB per decision. The benchmark excludes PDP construction and measures in-process evaluation.
- Run with `go test ./service/internal/access/v2 -run '^$' -bench BenchmarkDecisionHierarchy -benchtime=1s -count=3`.

Stack-wide validation:

- Focused race tests, the full verbose policy integration suite with the race detector, SDK README code-block tests, formatting, and service lint restricted to changes since the stack base passed with zero new issues.
- `make test` was attempted with Colima configured. The round-trip suite failed because its required platform server at `127.0.0.1:8080` was not running.
- `make lint` stopped because the configured Buf API token is invalid. Separate `make go-lint` reported existing repository issues; the formatting issue in the new hierarchy test was corrected.
- `make govulncheck` reported vulnerabilities in the existing dependencies and the installed Go 1.26.3 standard library. This stack changes no dependency versions.
- GitHub CI is still running. Keep this stack in draft pending review and CI results.
