### PR TITLE
fix(cli): reject extra inspect args and add stdin BATS coverage

### DIFF
--- a/otdfctl/cmd/tdf/inspect.go
+++ b/otdfctl/cmd/tdf/inspect.go
@@ -106,6 +106,7 @@ func inspectRun(cmd *cobra.Command, args []string) {
 
 func InitInspectCommand() {
 	inspectDoc.GroupID = TDF
+	inspectDoc.Args = cobra.MaximumNArgs(1)
 
 	inspectDoc.PreRun = func(cmd *cobra.Command, args []string) {
 		// Set the json flag to true since we only support json output

--- a/otdfctl/e2e/encrypt-decrypt.bats
+++ b/otdfctl/e2e/encrypt-decrypt.bats
@@ -103,6 +103,20 @@ teardown_file(){
   ./otdfctl decrypt --host $HOST --tls-no-verify $DEBUG_LEVEL $WITH_CREDS $OUTFILE_TXT | grep "$SECRET_TEXT"
 }
 
+@test "inspect TDF3, one attribute, stdin" {
+  echo $SECRET_TEXT | ./otdfctl encrypt -o $OUT_TXT --host $HOST --tls-no-verify $DEBUG_LEVEL $WITH_CREDS -a $FQN
+
+  inspect_output=$(cat $OUTFILE_TXT | ./otdfctl --host $HOST --tls-no-verify $WITH_CREDS inspect)
+  assert_equal "$(echo "$inspect_output" | jq -r '.manifest.encryptionInformation.keyAccess | length')" "1"
+}
+
+@test "inspect rejects extra positional arguments" {
+  echo $SECRET_TEXT | ./otdfctl encrypt -o $OUT_TXT --host $HOST --tls-no-verify $DEBUG_LEVEL $WITH_CREDS -a $FQN
+
+  run sh -c "./otdfctl --host $HOST --tls-no-verify $WITH_CREDS inspect $OUTFILE_TXT extra-arg"
+  assert_failure
+}
+
 @test "allow traversal with mapped key uses definition when value missing" {
   local attr_name="attr-allow-traversal-${RANDOM}"
   local kas_name="kas-allow-traversal-${RANDOM}"


### PR DESCRIPTION
Follow-up to review feedback on #3937 (`chore(cli): move streaming IO helpers into pkg`, merged into `main`).

## Changes

- `otdfctl/cmd/tdf/inspect.go`: `inspectDoc.Args = cobra.MaximumNArgs(1)`, so `otdfctl inspect a.tdf b.tdf` now errors instead of silently ignoring `b.tdf`.
- `otdfctl/e2e/encrypt-decrypt.bats`: added a test piping a TDF into `inspect` via stdin, and a test asserting extra positional args now fail.

## Not changed

`TestOpenSeekableSpoolsNonSeekableNamedFile` in `otdfctl/pkg/streamio/input_test.go` was also flagged (uses `syscall.Mkfifo`, not portable to Windows) — it already guards with a `runtime.GOOS == "windows"` skip, so no change was needed. Verified by running the test.

## Testing

- `go build ./...` / `go vet ./...` — pass
- `golangci-lint run ./otdfctl/cmd/tdf/...` — 0 issues
- `bats --count e2e/encrypt-decrypt.bats` — parses, 19 tests (up from 17)
- Manually verified `otdfctl inspect a.tdf b.tdf` now errors with `accepts at most 1 arg(s), received 2`

Note: `encrypt-decrypt.bats` has a pre-existing file-level `skip` in `setup_file` (unrelated: namespaced subject-mapping API dependency), so the new BATS tests won't run in CI until that skip is lifted, same as all other tests in that file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The `inspect` command now rejects requests containing more than one positional argument, providing clearer command-line validation.

- **Tests**
  - Added coverage confirming that valid TDF3 input reports the expected key-access entry.
  - Added coverage confirming that extra positional arguments result in a command failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->