### PR TITLE
fix(core): DSPX-4694 honor reflection configuration

### DIFF
--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -231,6 +231,7 @@ type OpenTDFServer struct {
 	ConnectRPCInProcess *inProcessServer
 	ConnectRPC          *ConnectRPC
 	CacheManager        *cache.Manager
+	reflectionEnabled   bool
 
 	// To Deprecate: Use the TrustKeyIndex and TrustKeyManager instead
 	CryptoProvider *security.StandardCrypto
@@ -308,11 +309,12 @@ func NewOpenTDFServer(config Config, logger *logger.Logger, cacheManager *cache.
 	}
 
 	o := OpenTDFServer{
-		AuthN:        authN,
-		HTTPMux:      httpMux,
-		HTTPServer:   httpServer,
-		CacheManager: cacheManager,
-		ConnectRPC:   connectRPC,
+		AuthN:             authN,
+		HTTPMux:           httpMux,
+		HTTPServer:        httpServer,
+		CacheManager:      cacheManager,
+		ConnectRPC:        connectRPC,
+		reflectionEnabled: config.GRPC.ReflectionEnabled,
 		ConnectRPCInProcess: &inProcessServer{
 			logger:             logger.With("ipc_server", "true"),
 			srv:                memhttp.New(connectRPCIpc.Mux),
@@ -503,16 +505,7 @@ func newConnectRPC(c Config, authInts []connect.Interceptor, ints []connect.Inte
 }
 
 func (s OpenTDFServer) Start() error {
-	// Add reflection api to connect-rpc
-	reflector := grpcreflect.NewStaticReflector(
-		s.ConnectRPC.ServiceReflection...,
-	)
-
-	s.ConnectRPC.Mux.Handle(grpcreflect.NewHandlerV1(reflector))
-	s.ConnectRPC.Mux.Handle(grpcreflect.NewHandlerV1Alpha(reflector))
-
-	s.ConnectRPCInProcess.Mux.Handle(grpcreflect.NewHandlerV1(reflector))
-	s.ConnectRPCInProcess.Mux.Handle(grpcreflect.NewHandlerV1Alpha(reflector))
+	s.registerReflectionHandlers()
 
 	ln, err := s.openHTTPServerPort(context.Background())
 	if err != nil {
@@ -546,6 +539,21 @@ func (s OpenTDFServer) Stop() {
 	}
 
 	s.logger.Info("shutdown complete")
+}
+
+func (s OpenTDFServer) registerReflectionHandlers() {
+	// Add reflection api to connect-rpc
+	reflector := grpcreflect.NewStaticReflector(
+		s.ConnectRPC.ServiceReflection...,
+	)
+
+	if s.reflectionEnabled {
+		s.ConnectRPC.Mux.Handle(grpcreflect.NewHandlerV1(reflector))
+		s.ConnectRPC.Mux.Handle(grpcreflect.NewHandlerV1Alpha(reflector))
+	}
+
+	s.ConnectRPCInProcess.Mux.Handle(grpcreflect.NewHandlerV1(reflector))
+	s.ConnectRPCInProcess.Mux.Handle(grpcreflect.NewHandlerV1Alpha(reflector))
 }
 
 func (s inProcessServer) Conn() *sdk.ConnectRPCConnection {

--- a/service/internal/server/server.go
+++ b/service/internal/server/server.go
@@ -542,18 +542,17 @@ func (s OpenTDFServer) Stop() {
 }
 
 func (s OpenTDFServer) registerReflectionHandlers() {
+	if !s.reflectionEnabled {
+		return
+	}
+
 	// Add reflection api to connect-rpc
 	reflector := grpcreflect.NewStaticReflector(
 		s.ConnectRPC.ServiceReflection...,
 	)
 
-	if s.reflectionEnabled {
-		s.ConnectRPC.Mux.Handle(grpcreflect.NewHandlerV1(reflector))
-		s.ConnectRPC.Mux.Handle(grpcreflect.NewHandlerV1Alpha(reflector))
-	}
-
-	s.ConnectRPCInProcess.Mux.Handle(grpcreflect.NewHandlerV1(reflector))
-	s.ConnectRPCInProcess.Mux.Handle(grpcreflect.NewHandlerV1Alpha(reflector))
+	s.ConnectRPC.Mux.Handle(grpcreflect.NewHandlerV1(reflector))
+	s.ConnectRPC.Mux.Handle(grpcreflect.NewHandlerV1Alpha(reflector))
 }
 
 func (s inProcessServer) Conn() *sdk.ConnectRPCConnection {

--- a/service/internal/server/server_test.go
+++ b/service/internal/server/server_test.go
@@ -81,50 +81,43 @@ func TestMergeStringSlices(t *testing.T) {
 }
 
 func Test_OpenTDFServer_RegisterReflectionHandlers_Enabled_RegistersOnlyExternalHandlers(t *testing.T) {
-	reflectionPaths := []string{
-		"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
-		"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
-	}
+	server := newReflectionTestServer(t, true)
 
-	server, err := NewOpenTDFServer(Config{
-		GRPC: GRPCConfig{ReflectionEnabled: true},
-	}, logger.CreateTestLogger(), nil)
-	require.NoError(t, err)
-
-	server.registerReflectionHandlers()
-
-	for _, path := range reflectionPaths {
-		externalRequest := httptest.NewRequest(http.MethodPost, path, nil)
-		_, externalPattern := server.ConnectRPC.Mux.Handler(externalRequest)
-		assert.NotEmpty(t, externalPattern)
-
-		inProcessRequest := httptest.NewRequest(http.MethodPost, path, nil)
-		_, inProcessPattern := server.ConnectRPCInProcess.Mux.Handler(inProcessRequest)
-		assert.Empty(t, inProcessPattern)
-	}
+	assertReflectionHandlerRegistration(t, server.ConnectRPC.Mux, true)
+	assertReflectionHandlerRegistration(t, server.ConnectRPCInProcess.Mux, false)
 }
 
 func Test_OpenTDFServer_RegisterReflectionHandlers_Disabled_RegistersNoReflectionHandlers(t *testing.T) {
+	server := newReflectionTestServer(t, false)
+
+	assertReflectionHandlerRegistration(t, server.ConnectRPC.Mux, false)
+	assertReflectionHandlerRegistration(t, server.ConnectRPCInProcess.Mux, false)
+}
+
+func newReflectionTestServer(t *testing.T, reflectionEnabled bool) *OpenTDFServer {
+	t.Helper()
+
+	server, err := NewOpenTDFServer(Config{
+		GRPC: GRPCConfig{ReflectionEnabled: reflectionEnabled},
+	}, logger.CreateTestLogger(), nil)
+	require.NoError(t, err)
+
+	server.registerReflectionHandlers()
+	return server
+}
+
+func assertReflectionHandlerRegistration(t *testing.T, mux *http.ServeMux, wantRegistered bool) {
+	t.Helper()
+
 	reflectionPaths := []string{
 		"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
 		"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
 	}
 
-	server, err := NewOpenTDFServer(Config{
-		GRPC: GRPCConfig{ReflectionEnabled: false},
-	}, logger.CreateTestLogger(), nil)
-	require.NoError(t, err)
-
-	server.registerReflectionHandlers()
-
 	for _, path := range reflectionPaths {
-		externalRequest := httptest.NewRequest(http.MethodPost, path, nil)
-		_, externalPattern := server.ConnectRPC.Mux.Handler(externalRequest)
-		assert.Empty(t, externalPattern)
-
-		inProcessRequest := httptest.NewRequest(http.MethodPost, path, nil)
-		_, inProcessPattern := server.ConnectRPCInProcess.Mux.Handler(inProcessRequest)
-		assert.Empty(t, inProcessPattern)
+		request := httptest.NewRequest(http.MethodPost, path, nil)
+		_, pattern := mux.Handler(request)
+		assert.Equal(t, wantRegistered, pattern != "", "unexpected registration for %s", path)
 	}
 }
 

--- a/service/internal/server/server_test.go
+++ b/service/internal/server/server_test.go
@@ -80,6 +80,55 @@ func TestMergeStringSlices(t *testing.T) {
 	}
 }
 
+func Test_OpenTDFServer_RegisterReflectionHandlers(t *testing.T) {
+	tests := []struct {
+		name                       string
+		reflectionEnabled          bool
+		expectExternalRegistration bool
+	}{
+		{
+			name:                       "Enabled_RegistersExternalAndInProcessHandlers",
+			reflectionEnabled:          true,
+			expectExternalRegistration: true,
+		},
+		{
+			name:                       "Disabled_RegistersOnlyInProcessHandlers",
+			reflectionEnabled:          false,
+			expectExternalRegistration: false,
+		},
+	}
+
+	reflectionPaths := []string{
+		"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
+		"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, err := NewOpenTDFServer(Config{
+				GRPC: GRPCConfig{ReflectionEnabled: tt.reflectionEnabled},
+			}, logger.CreateTestLogger(), nil)
+			require.NoError(t, err)
+
+			server.registerReflectionHandlers()
+
+			for _, path := range reflectionPaths {
+				externalRequest := httptest.NewRequest(http.MethodPost, path, nil)
+				_, externalPattern := server.ConnectRPC.Mux.Handler(externalRequest)
+				if tt.expectExternalRegistration {
+					assert.NotEmpty(t, externalPattern)
+				} else {
+					assert.Empty(t, externalPattern)
+				}
+
+				inProcessRequest := httptest.NewRequest(http.MethodPost, path, nil)
+				_, inProcessPattern := server.ConnectRPCInProcess.Mux.Handler(inProcessRequest)
+				assert.NotEmpty(t, inProcessPattern)
+			}
+		})
+	}
+}
+
 func TestCORSConfig_EffectiveMethods(t *testing.T) {
 	tests := []struct {
 		name string

--- a/service/internal/server/server_test.go
+++ b/service/internal/server/server_test.go
@@ -80,52 +80,51 @@ func TestMergeStringSlices(t *testing.T) {
 	}
 }
 
-func Test_OpenTDFServer_RegisterReflectionHandlers(t *testing.T) {
-	tests := []struct {
-		name                       string
-		reflectionEnabled          bool
-		expectExternalRegistration bool
-	}{
-		{
-			name:                       "Enabled_RegistersOnlyExternalHandlers",
-			reflectionEnabled:          true,
-			expectExternalRegistration: true,
-		},
-		{
-			name:                       "Disabled_RegistersNoReflectionHandlers",
-			reflectionEnabled:          false,
-			expectExternalRegistration: false,
-		},
-	}
-
+func Test_OpenTDFServer_RegisterReflectionHandlers_Enabled_RegistersOnlyExternalHandlers(t *testing.T) {
 	reflectionPaths := []string{
 		"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
 		"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			server, err := NewOpenTDFServer(Config{
-				GRPC: GRPCConfig{ReflectionEnabled: tt.reflectionEnabled},
-			}, logger.CreateTestLogger(), nil)
-			require.NoError(t, err)
+	server, err := NewOpenTDFServer(Config{
+		GRPC: GRPCConfig{ReflectionEnabled: true},
+	}, logger.CreateTestLogger(), nil)
+	require.NoError(t, err)
 
-			server.registerReflectionHandlers()
+	server.registerReflectionHandlers()
 
-			for _, path := range reflectionPaths {
-				externalRequest := httptest.NewRequest(http.MethodPost, path, nil)
-				_, externalPattern := server.ConnectRPC.Mux.Handler(externalRequest)
-				if tt.expectExternalRegistration {
-					assert.NotEmpty(t, externalPattern)
-				} else {
-					assert.Empty(t, externalPattern)
-				}
+	for _, path := range reflectionPaths {
+		externalRequest := httptest.NewRequest(http.MethodPost, path, nil)
+		_, externalPattern := server.ConnectRPC.Mux.Handler(externalRequest)
+		assert.NotEmpty(t, externalPattern)
 
-				inProcessRequest := httptest.NewRequest(http.MethodPost, path, nil)
-				_, inProcessPattern := server.ConnectRPCInProcess.Mux.Handler(inProcessRequest)
-				assert.Empty(t, inProcessPattern)
-			}
-		})
+		inProcessRequest := httptest.NewRequest(http.MethodPost, path, nil)
+		_, inProcessPattern := server.ConnectRPCInProcess.Mux.Handler(inProcessRequest)
+		assert.Empty(t, inProcessPattern)
+	}
+}
+
+func Test_OpenTDFServer_RegisterReflectionHandlers_Disabled_RegistersNoReflectionHandlers(t *testing.T) {
+	reflectionPaths := []string{
+		"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
+		"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+	}
+
+	server, err := NewOpenTDFServer(Config{
+		GRPC: GRPCConfig{ReflectionEnabled: false},
+	}, logger.CreateTestLogger(), nil)
+	require.NoError(t, err)
+
+	server.registerReflectionHandlers()
+
+	for _, path := range reflectionPaths {
+		externalRequest := httptest.NewRequest(http.MethodPost, path, nil)
+		_, externalPattern := server.ConnectRPC.Mux.Handler(externalRequest)
+		assert.Empty(t, externalPattern)
+
+		inProcessRequest := httptest.NewRequest(http.MethodPost, path, nil)
+		_, inProcessPattern := server.ConnectRPCInProcess.Mux.Handler(inProcessRequest)
+		assert.Empty(t, inProcessPattern)
 	}
 }
 

--- a/service/internal/server/server_test.go
+++ b/service/internal/server/server_test.go
@@ -87,12 +87,12 @@ func Test_OpenTDFServer_RegisterReflectionHandlers(t *testing.T) {
 		expectExternalRegistration bool
 	}{
 		{
-			name:                       "Enabled_RegistersExternalAndInProcessHandlers",
+			name:                       "Enabled_RegistersOnlyExternalHandlers",
 			reflectionEnabled:          true,
 			expectExternalRegistration: true,
 		},
 		{
-			name:                       "Disabled_RegistersOnlyInProcessHandlers",
+			name:                       "Disabled_RegistersNoReflectionHandlers",
 			reflectionEnabled:          false,
 			expectExternalRegistration: false,
 		},
@@ -123,7 +123,7 @@ func Test_OpenTDFServer_RegisterReflectionHandlers(t *testing.T) {
 
 				inProcessRequest := httptest.NewRequest(http.MethodPost, path, nil)
 				_, inProcessPattern := server.ConnectRPCInProcess.Mux.Handler(inProcessRequest)
-				assert.NotEmpty(t, inProcessPattern)
+				assert.Empty(t, inProcessPattern)
 			}
 		})
 	}


### PR DESCRIPTION
Honors `server.grpc.reflectionEnabled` for external handlers and omits reflection from the in-process mux.

Tested: `make test HAND_MODS=service/internal/server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * gRPC reflection is now registered only when explicitly enabled.
  * Reflection handlers are no longer registered on the in-process server.

* **Bug Fixes**
  * Prevents unintended exposure of reflection endpoints when reflection is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->