### PR TITLE
fix(core): DSPX-4692 omit rejected credentials from logs

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -1231,7 +1231,7 @@ func (a *Authentication) checkToken(ctx context.Context, authHeader []string, dp
 		tokenRaw = strings.TrimPrefix(authHeader[0], "Bearer ")
 		authScheme = "Bearer"
 	default:
-		a.logger.WarnContext(ctx, "failed to validate authentication header: not of type bearer or dpop", slog.String("header", authHeader[0]))
+		a.logger.WarnContext(ctx, "failed to validate authentication header: not of type bearer or dpop")
 		return nil, nil, errors.New("not of type bearer or dpop")
 	}
 

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/rand"
@@ -1039,9 +1040,23 @@ func (s *AuthSuite) Test_ConnectAuthNInterceptor_DPoPNonceError_IssuesUseNonceCh
 }
 
 func (s *AuthSuite) Test_CheckToken_When_Authorization_Header_Invalid_Expect_Error() {
-	_, _, err := s.auth.checkToken(context.Background(), []string{"BPOP "}, receiverInfo{}, nil)
-	s.Require().Error(err)
-	s.Equal("not of type bearer or dpop", err.Error())
+	for _, authHeader := range []string{
+		"bearer reusable-credential",
+		"BPOP reusable-credential",
+	} {
+		s.Run(authHeader, func() {
+			var logs bytes.Buffer
+			auth := *s.auth
+			auth.logger = &logger.Logger{Logger: slog.New(slog.NewJSONHandler(&logs, nil))}
+
+			_, _, err := auth.checkToken(context.Background(), []string{authHeader}, receiverInfo{}, nil)
+
+			s.Require().Error(err)
+			s.Equal("not of type bearer or dpop", err.Error())
+			s.Contains(logs.String(), "failed to validate authentication header: not of type bearer or dpop")
+			s.NotContains(logs.String(), "reusable-credential")
+		})
+	}
 }
 
 func (s *AuthSuite) Test_CheckToken_When_Missing_Issuer_Expect_Error() {

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -1039,7 +1039,7 @@ func (s *AuthSuite) Test_ConnectAuthNInterceptor_DPoPNonceError_IssuesUseNonceCh
 	s.NotEmpty(connectErr.Meta().Get("DPoP-Nonce"))
 }
 
-func (s *AuthSuite) Test_CheckToken_When_Authorization_Header_Invalid_Expect_Error() {
+func (s *AuthSuite) Test_CheckToken_When_Authorization_Header_Invalid_Does_Not_Log_Credential() {
 	for _, tc := range []struct {
 		name       string
 		authHeader string

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -1044,8 +1044,10 @@ func (s *AuthSuite) Test_CheckToken_When_Authorization_Header_Invalid_Expect_Err
 		name       string
 		authHeader string
 	}{
-		{name: "mixed-case scheme", authHeader: "bearer reusable-credential"},
-		{name: "missing scheme separator", authHeader: "Bearerreusable-credential"},
+		{name: "mixed-case bearer scheme", authHeader: "bearer reusable-credential"},
+		{name: "bearer missing scheme separator", authHeader: "Bearerreusable-credential"},
+		{name: "mixed-case dpop scheme", authHeader: "dpop reusable-credential"},
+		{name: "dpop missing scheme separator", authHeader: "DPoPreusable-credential"},
 	} {
 		s.Run(tc.name, func() {
 			var logs bytes.Buffer

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -1040,16 +1040,19 @@ func (s *AuthSuite) Test_ConnectAuthNInterceptor_DPoPNonceError_IssuesUseNonceCh
 }
 
 func (s *AuthSuite) Test_CheckToken_When_Authorization_Header_Invalid_Expect_Error() {
-	for _, authHeader := range []string{
-		"bearer reusable-credential",
-		"BPOP reusable-credential",
+	for _, tc := range []struct {
+		name       string
+		authHeader string
+	}{
+		{name: "mixed-case scheme", authHeader: "bearer reusable-credential"},
+		{name: "missing scheme separator", authHeader: "Bearerreusable-credential"},
 	} {
-		s.Run(authHeader, func() {
+		s.Run(tc.name, func() {
 			var logs bytes.Buffer
 			auth := *s.auth
 			auth.logger = &logger.Logger{Logger: slog.New(slog.NewJSONHandler(&logs, nil))}
 
-			_, _, err := auth.checkToken(context.Background(), []string{authHeader}, receiverInfo{}, nil)
+			_, _, err := auth.checkToken(context.Background(), []string{tc.authHeader}, receiverInfo{}, nil)
 
 			s.Require().Error(err)
 			s.Equal("not of type bearer or dpop", err.Error())

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -1039,6 +1039,12 @@ func (s *AuthSuite) Test_ConnectAuthNInterceptor_DPoPNonceError_IssuesUseNonceCh
 	s.NotEmpty(connectErr.Meta().Get("DPoP-Nonce"))
 }
 
+func (s *AuthSuite) Test_CheckToken_When_Authorization_Header_Invalid_Expect_Error() {
+	_, _, err := s.auth.checkToken(context.Background(), []string{"DPOP "}, receiverInfo{}, nil)
+	s.Require().Error(err)
+	s.Equal("not of type bearer or dpop", err.Error())
+}
+
 func (s *AuthSuite) Test_CheckToken_When_Authorization_Header_Invalid_Does_Not_Log_Credential() {
 	for _, tc := range []struct {
 		name       string


### PR DESCRIPTION
### Proposed Changes

* Stop attaching rejected Authorization header values to authentication warning logs.
* Add regression coverage for mixed-case and malformed schemes, preserving rejection behavior while asserting credentials are absent from logs.

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (not applicable)
- [ ] I have added or updated documentation (not applicable)

### Testing Instructions

* `make fmt`
* `cd service && go test ./internal/auth -race -count=1`
* `cd service && golangci-lint run -c ../.golangci.yaml --new-from-rev=HEAD ./internal/auth/...`
* `cd sdk && go test -run TestREADMECodeBlocks`
* `git diff --check`

Repository-wide checks were also attempted:

* `make lint` stops at `buf lint` because the configured Buf API token is invalid.
* `make go-lint govulncheck` stops in `go-lint` on existing findings outside this change.
* `make test` reaches and passes `service/internal/auth`, but fails in existing integration suites because Colima cannot start test containers and no platform is listening on `localhost:8080`.

Jira: [DSPX-4692](https://virtru.atlassian.net/browse/DSPX-4692)


[DSPX-4692]: https://virtru.atlassian.net/browse/DSPX-4692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ