### PR TITLE
fix(ers): DSPX-4595 limit multi-strategy token chains to one entity per category

### DIFF
--- a/service/entityresolution/integration/internal/chain_contract_tests.go
+++ b/service/entityresolution/integration/internal/chain_contract_tests.go
@@ -18,6 +18,11 @@ const (
 	expectedChainEntityCount = 2
 )
 
+// expectedChainCategories is the chain shape both implementations must produce per token.
+func expectedChainCategories() []string {
+	return []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"}
+}
+
 // ChainContractTestSuite holds implementation-agnostic multi-entity chain validation tests
 type ChainContractTestSuite struct {
 	TestCases []ContractTestCase
@@ -44,10 +49,10 @@ func NewChainContractTestSuite() *ChainContractTestSuite {
 					ChainValidation: []EntityChainValidationRule{
 						{
 							EphemeralID:               "chain-token-1",
-							EntityCount:               expectedChainEntityCount,                             // Both Keycloak and Multi-Strategy create 2 entities per token
-							EntityTypes:               []string{},                                           // Implementation-agnostic: don't specify entity types
-							EntityCategories:          []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"}, // Both must create these categories
-							RequireConsistentOrdering: false,                                                // Allow flexible ordering between implementations
+							EntityCount:               expectedChainEntityCount,  // Both Keycloak and Multi-Strategy create 2 entities per token
+							EntityTypes:               []string{},                // Implementation-agnostic: don't specify entity types
+							EntityCategories:          expectedChainCategories(), // Both must create these categories
+							RequireConsistentOrdering: false,                     // Allow flexible ordering between implementations
 						},
 					},
 				},
@@ -72,14 +77,14 @@ func NewChainContractTestSuite() *ChainContractTestSuite {
 							EphemeralID:               "chain-token-1",
 							EntityCount:               expectedChainEntityCount, // Both implementations create 2 entities per token
 							EntityTypes:               []string{},               // Implementation-agnostic
-							EntityCategories:          []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"},
+							EntityCategories:          expectedChainCategories(),
 							RequireConsistentOrdering: false,
 						},
 						{
 							EphemeralID:               "chain-token-2",
 							EntityCount:               expectedChainEntityCount, // Consistent behavior across tokens
 							EntityTypes:               []string{},               // Implementation-agnostic
-							EntityCategories:          []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"},
+							EntityCategories:          expectedChainCategories(),
 							RequireConsistentOrdering: false,
 						},
 					},
@@ -102,10 +107,10 @@ func NewChainContractTestSuite() *ChainContractTestSuite {
 					ChainValidation: []EntityChainValidationRule{
 						{
 							EphemeralID:               "category-test-token",
-							EntityCount:               expectedChainEntityCount,                             // Both implementations create multiple entities
-							EntityTypes:               []string{},                                           // Implementation-agnostic: entity types vary by implementation
-							EntityCategories:          []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"}, // Contract: both categories must exist
-							RequireConsistentOrdering: false,                                                // Allow implementation flexibility
+							EntityCount:               expectedChainEntityCount,  // Both implementations create multiple entities
+							EntityTypes:               []string{},                // Implementation-agnostic: entity types vary by implementation
+							EntityCategories:          expectedChainCategories(), // Contract: both categories must exist
+							RequireConsistentOrdering: false,                     // Allow implementation flexibility
 						},
 					},
 				},
@@ -129,7 +134,7 @@ func NewChainContractTestSuite() *ChainContractTestSuite {
 							EphemeralID:               "consistency-token",
 							EntityCount:               expectedChainEntityCount, // Consistent entity count across implementations
 							EntityTypes:               []string{},               // Implementation-specific entity types allowed
-							EntityCategories:          []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"},
+							EntityCategories:          expectedChainCategories(),
 							RequireConsistentOrdering: false, // Behavioral contract, not implementation details
 						},
 					},

--- a/service/entityresolution/integration/multistrategy_test.go
+++ b/service/entityresolution/integration/multistrategy_test.go
@@ -445,13 +445,13 @@ func TestMultiStrategyEntityResolutionV2(t *testing.T) {
 		Expected: internal.ContractExpected{
 			ChainValidation: []internal.EntityChainValidationRule{
 				{
-					EphemeralID:      "test-token-1",
-					EntityCount:      3,
-					EntityTypes:      []string{"claims", "claims", "claims"},
-					EntityCategories: []string{"CATEGORY_SUBJECT", "CATEGORY_SUBJECT", "CATEGORY_SUBJECT"},
+					EphemeralID: "test-token-1",
+					// All three configured strategies are entity_type: subject and all match this
+					// token. Only the first contributes: a chain carries one subject entity.
+					EntityCount:      1,
+					EntityTypes:      []string{"claims"},
+					EntityCategories: []string{"CATEGORY_SUBJECT"},
 					EntityRequiredFields: []map[string]interface{}{
-						{"username": "user123", "email": "user@example.com"},
-						{"client_id": "external-client"},
 						{"username": "user123", "email": "user@example.com"},
 					},
 					RequireConsistentOrdering: true,

--- a/service/entityresolution/multi-strategy/README.md
+++ b/service/entityresolution/multi-strategy/README.md
@@ -236,6 +236,21 @@ The failure strategy determines how Multi-Strategy ERS handles failures when exe
 - **Use Case**: When you want resilient failover with multiple fallback options
 - **Result**: Only fails if **all** matching strategies fail
 
+> **First match wins per entity category.** `ResolveEntity` returns the first strategy that
+> succeeds; the failure strategy only decides what happens when a strategy *fails*.
+>
+> `CreateEntityChainsFromTokens` applies the same rule per category, so a token's chain holds
+> at most one `subject` entity and at most one `environment` entity — the first match of each.
+> Later strategies of an already-filled category are skipped and never queried. To combine data
+> from several sources into one entity, merge them in a single strategy's `output_mapping`
+> rather than relying on strategy ordering.
+>
+> Authorization decisions discard `environment` entities, so claims emitted by an
+> `environment` strategy can never satisfy a subject mapping, and a token matching only
+> `environment` strategies produces a chain `GetDecision` rejects outright. Make sure a
+> `subject` strategy matches every token you expect to make decisions for, and emit anything
+> policy needs to match on from that `subject` strategy.
+
 ```yaml
 services:
   entityresolution:

--- a/service/entityresolution/multi-strategy/v2/registration.go
+++ b/service/entityresolution/multi-strategy/v2/registration.go
@@ -24,6 +24,10 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// chainCategoryCount is the number of entity categories a token chain can carry:
+// ENVIRONMENT and SUBJECT, one entity each.
+const chainCategoryCount = 2
+
 // ERSV2 implements the EntityResolutionServiceHandler for v2 multi-strategy resolution
 type ERSV2 struct {
 	ersV2.UnimplementedEntityResolutionServiceServer
@@ -228,7 +232,8 @@ func (ers *ERSV2) createEntityChainFromSingleTokenV2(ctx context.Context, token 
 		)
 	}
 
-	entities := make([]*entity.Entity, 0)
+	entities := make([]*entity.Entity, 0, chainCategoryCount)
+	resolvedCategories := make(map[entity.Entity_Category]bool, chainCategoryCount)
 	var lastError error
 	var attemptedStrategies []string
 
@@ -239,6 +244,18 @@ func (ers *ERSV2) createEntityChainFromSingleTokenV2(ctx context.Context, token 
 	}
 
 	for _, strategy := range strategies {
+		// First match wins per category: at most one ENVIRONMENT and one SUBJECT, like Keycloak.
+		// Avoids the multi-subject chains that make AND semantics unpredictable, without
+		// dropping the subject when an environment strategy is ordered first.
+		category := categoryForStrategy(strategy)
+		if resolvedCategories[category] {
+			ers.logger.DebugContext(ctx, "skipping strategy, category already resolved for token",
+				slog.String("token_id", token.GetEphemeralId()),
+				slog.String("strategy", strategy.Name),
+				slog.String("entity_category", category.String()))
+			continue
+		}
+
 		attemptedStrategies = append(attemptedStrategies, strategy.Name)
 
 		// Put JWT claims into context for providers to access
@@ -287,6 +304,7 @@ func (ers *ERSV2) createEntityChainFromSingleTokenV2(ctx context.Context, token 
 			return nil, err
 		}
 		entities = append(entities, entityV2)
+		resolvedCategories[category] = true
 
 		ers.logger.DebugContext(ctx, "successfully resolved entity for token",
 			slog.String("token_id", token.GetEphemeralId()),
@@ -294,13 +312,10 @@ func (ers *ERSV2) createEntityChainFromSingleTokenV2(ctx context.Context, token 
 			slog.String("entity_type", getEntityTypeStringV2(entityV2)),
 			slog.String("entity_category", entityV2.GetCategory().String()))
 
-		// ENHANCED: Continue trying additional strategies to build multi-entity chains (like Keycloak)
-		// This allows creating chains with multiple entities (e.g., ENVIRONMENT + SUBJECT)
-		// Only break if FailureStrategy is FailFast and we have at least one successful entity
-		if failureStrategy == types.FailureStrategyFailFast {
+		// Every category is filled, so no remaining strategy can contribute.
+		if len(resolvedCategories) == chainCategoryCount {
 			break
 		}
-		// With FailureStrategyContinue, we continue to try more strategies to build richer chains
 	}
 
 	// If no strategies succeeded
@@ -357,6 +372,15 @@ func (ers *ERSV2) createEntityForTokenChain(
 	)
 }
 
+// categoryForStrategy maps a strategy's configured entity_type onto the entity category it
+// produces. Only "environment" yields an ENVIRONMENT entity; everything else is a SUBJECT.
+func categoryForStrategy(strategy *types.MappingStrategy) entity.Entity_Category {
+	if strategy.EntityType == types.EntityTypeEnvironment {
+		return entity.Entity_CATEGORY_ENVIRONMENT
+	}
+	return entity.Entity_CATEGORY_SUBJECT
+}
+
 // createEntityFromResultV2 converts a multi-strategy EntityResult to a v2 entity.Entity.
 //
 // For token-derived entity chains, preserve the resolved claims directly in the chain so
@@ -369,10 +393,7 @@ func (ers *ERSV2) createEntityForTokenChain(
 // strategy ordering, and other deployment-specific ERS structure. Resolution metadata belongs
 // in observability or a dedicated out-of-band metadata channel, not in policy input.
 func (ers *ERSV2) createEntityFromResultV2(_ context.Context, result *types.EntityResult, strategy *types.MappingStrategy, tokenID string) (*entity.Entity, error) {
-	category := entity.Entity_CATEGORY_SUBJECT
-	if strategy.EntityType == types.EntityTypeEnvironment {
-		category = entity.Entity_CATEGORY_ENVIRONMENT
-	}
+	category := categoryForStrategy(strategy)
 
 	resultData, err := claimsToResultData(result.Claims)
 	if err != nil {

--- a/service/entityresolution/multi-strategy/v2/registration_test.go
+++ b/service/entityresolution/multi-strategy/v2/registration_test.go
@@ -361,3 +361,190 @@ func TestCreateEntityForTokenChainFailsClosedOnSerializationErrorWithContinue(t 
 	require.Equal(t, "token-1", inner.Context["token_id"])
 	require.Equal(t, "bad_subject", inner.Context["strategy"])
 }
+
+// firstMatchWinsConfig builds a config with two strategies that both match the test token:
+// an ENVIRONMENT strategy on "azp" followed by a SUBJECT strategy on "sub".
+func firstMatchWinsConfig(failureStrategy string, strategies ...types.MappingStrategy) types.MultiStrategyConfig {
+	return types.MultiStrategyConfig{
+		FailureStrategy: failureStrategy,
+		Providers: map[string]types.ProviderConfig{
+			"jwt": {Type: "claims", Connection: map[string]interface{}{}},
+		},
+		MappingStrategies: strategies,
+	}
+}
+
+func environmentStrategy() types.MappingStrategy {
+	return types.MappingStrategy{
+		Name:       "client_environment",
+		Provider:   "jwt",
+		EntityType: types.EntityTypeEnvironment,
+		Conditions: types.StrategyConditions{
+			JWTClaims: []types.JWTClaimCondition{{Claim: "azp", Operator: "exists"}},
+		},
+		OutputMapping: []types.OutputMapping{{SourceClaim: "azp", ClaimName: "client_id"}},
+	}
+}
+
+func subjectStrategy() types.MappingStrategy {
+	return types.MappingStrategy{
+		Name:       "user_subject",
+		Provider:   "jwt",
+		EntityType: types.EntityTypeSubject,
+		Conditions: types.StrategyConditions{
+			JWTClaims: []types.JWTClaimCondition{{Claim: "sub", Operator: "exists"}},
+		},
+		OutputMapping: []types.OutputMapping{{SourceClaim: "sub", ClaimName: "username"}},
+	}
+}
+
+// testTokenJWT is an unsigned-but-well-formed JWT carrying both "azp" and "sub", so every
+// strategy in firstMatchWinsConfig matches it.
+// Payload: {"sub":"alice","azp":"opentdf-sdk","iat":1600000000,"exp":4102444800}
+const testTokenJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+	"eyJzdWIiOiJhbGljZSIsImF6cCI6Im9wZW50ZGYtc2RrIiwiaWF0IjoxNjAwMDAwMDAwLCJleHAiOjQxMDI0NDQ4MDB9." +
+	"dGVzdHNpZ25hdHVyZQ"
+
+func chainForTestToken(t *testing.T, config types.MultiStrategyConfig) *entity.EntityChain {
+	t.Helper()
+
+	erService, err := NewERSV2(t.Context(), config, logger.CreateTestLogger())
+	require.NoError(t, err)
+
+	resp, err := erService.CreateEntityChainsFromTokens(t.Context(), connect.NewRequest(&ersV2.CreateEntityChainsFromTokensRequest{
+		Tokens: []*entity.Token{{EphemeralId: "token-1", Jwt: testTokenJWT}},
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.GetEntityChains(), 1)
+
+	return resp.Msg.GetEntityChains()[0]
+}
+
+func claimsOf(t *testing.T, resolved *entity.Entity) map[string]interface{} {
+	t.Helper()
+
+	require.NotNil(t, resolved.GetClaims())
+	var claimsStruct structpb.Struct
+	require.NoError(t, resolved.GetClaims().UnmarshalTo(&claimsStruct))
+	return claimsStruct.AsMap()
+}
+
+// secondSubjectStrategy is another subject strategy matching the same token, mapping a
+// different claim so tests can tell which of the two produced the chain's subject entity.
+func secondSubjectStrategy() types.MappingStrategy {
+	return types.MappingStrategy{
+		Name:       "user_subject_fallback",
+		Provider:   "jwt",
+		EntityType: types.EntityTypeSubject,
+		Conditions: types.StrategyConditions{
+			JWTClaims: []types.JWTClaimCondition{{Claim: "azp", Operator: "exists"}},
+		},
+		OutputMapping: []types.OutputMapping{{SourceClaim: "azp", ClaimName: "username"}},
+	}
+}
+
+func categoriesOf(chain *entity.EntityChain) []entity.Entity_Category {
+	categories := make([]entity.Entity_Category, 0, len(chain.GetEntities()))
+	for _, e := range chain.GetEntities() {
+		categories = append(categories, e.GetCategory())
+	}
+	return categories
+}
+
+func subjectEntity(t *testing.T, chain *entity.EntityChain) *entity.Entity {
+	t.Helper()
+
+	var found *entity.Entity
+	for _, e := range chain.GetEntities() {
+		if e.GetCategory() == entity.Entity_CATEGORY_SUBJECT {
+			require.Nil(t, found, "chain must not carry more than one subject entity")
+			found = e
+		}
+	}
+	require.NotNil(t, found, "chain must carry a subject entity")
+	return found
+}
+
+// TestCreateEntityChainsFromTokens_AtMostOneEntityPerCategory pins the chain contract: a
+// token yields at most one ENVIRONMENT and one SUBJECT entity, and within a category the
+// first matching strategy wins. Multiple subject entities are what made AND semantics
+// unpredictable; a missing subject entity breaks authz, which discards environment entities.
+func TestCreateEntityChainsFromTokens_AtMostOneEntityPerCategory(t *testing.T) {
+	tests := []struct {
+		name               string
+		failureStrategy    string
+		strategies         []types.MappingStrategy
+		expectedCategories []entity.Entity_Category
+		expectedUsername   string
+	}{
+		{
+			name:               "competing subject strategies collapse to the first",
+			failureStrategy:    types.FailureStrategyContinue,
+			strategies:         []types.MappingStrategy{subjectStrategy(), secondSubjectStrategy()},
+			expectedCategories: []entity.Entity_Category{entity.Entity_CATEGORY_SUBJECT},
+			expectedUsername:   "alice",
+		},
+		{
+			name:               "environment and subject strategies each contribute one entity",
+			failureStrategy:    types.FailureStrategyContinue,
+			strategies:         []types.MappingStrategy{environmentStrategy(), subjectStrategy()},
+			expectedCategories: []entity.Entity_Category{entity.Entity_CATEGORY_ENVIRONMENT, entity.Entity_CATEGORY_SUBJECT},
+			expectedUsername:   "alice",
+		},
+		{
+			name:               "chain follows strategy order",
+			failureStrategy:    types.FailureStrategyContinue,
+			strategies:         []types.MappingStrategy{subjectStrategy(), environmentStrategy()},
+			expectedCategories: []entity.Entity_Category{entity.Entity_CATEGORY_SUBJECT, entity.Entity_CATEGORY_ENVIRONMENT},
+			expectedUsername:   "alice",
+		},
+		{
+			name:               "a redundant subject strategy after a full chain is skipped",
+			failureStrategy:    types.FailureStrategyContinue,
+			strategies:         []types.MappingStrategy{environmentStrategy(), subjectStrategy(), secondSubjectStrategy()},
+			expectedCategories: []entity.Entity_Category{entity.Entity_CATEGORY_ENVIRONMENT, entity.Entity_CATEGORY_SUBJECT},
+			expectedUsername:   "alice",
+		},
+		{
+			name:               "fail-fast produces the same chain shape",
+			failureStrategy:    types.FailureStrategyFailFast,
+			strategies:         []types.MappingStrategy{environmentStrategy(), subjectStrategy()},
+			expectedCategories: []entity.Entity_Category{entity.Entity_CATEGORY_ENVIRONMENT, entity.Entity_CATEGORY_SUBJECT},
+			expectedUsername:   "alice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain := chainForTestToken(t, firstMatchWinsConfig(tt.failureStrategy, tt.strategies...))
+
+			require.Equal(t, tt.expectedCategories, categoriesOf(chain))
+			require.Equal(t, tt.expectedUsername, claimsOf(t, subjectEntity(t, chain))["username"],
+				"the first matching subject strategy must own the subject entity")
+		})
+	}
+}
+
+// TestCreateEntityChainsFromTokens_EnvironmentFirstStillResolvesSubject guards the ordering
+// regression: authz resolves decisions with skipEnvironmentEntities=true, so a chain built
+// from an environment-first config must still carry a subject or every decision errors out.
+func TestCreateEntityChainsFromTokens_EnvironmentFirstStillResolvesSubject(t *testing.T) {
+	chain := chainForTestToken(t, firstMatchWinsConfig(
+		types.FailureStrategyContinue, environmentStrategy(), subjectStrategy(),
+	))
+
+	require.Equal(t, "alice", claimsOf(t, subjectEntity(t, chain))["username"])
+}
+
+// TestCreateEntityChainsFromTokens_ContinueFallsThroughFailureToNextStrategy shows the one
+// thing "continue" does change: a failing strategy hands off to the next matching one.
+func TestCreateEntityChainsFromTokens_ContinueFallsThroughFailureToNextStrategy(t *testing.T) {
+	failing := environmentStrategy()
+	failing.Name = "missing_provider"
+	failing.Provider = "not-registered"
+
+	chain := chainForTestToken(t, firstMatchWinsConfig(types.FailureStrategyContinue, failing, subjectStrategy()))
+
+	require.Len(t, chain.GetEntities(), 1)
+	require.Equal(t, "alice", claimsOf(t, subjectEntity(t, chain))["username"])
+}


### PR DESCRIPTION
## Summary

- `CreateEntityChainsFromTokens` with `failure_strategy: continue` accumulated multiple subject entities when several strategies matched the same token. This broke AND semantics — a second entity with fewer claims could veto the richer one, causing unexpected DENY decisions.
- Fix: track resolved categories (ENVIRONMENT, SUBJECT) and skip strategies whose category is already filled. First matching strategy per category wins, matching the Keycloak ERS contract.
- `continue` still works for error handling: if a strategy *fails*, the next matching one is tried.

## Bug details

**Root cause:** The loop in `createEntityChainFromSingleTokenV2` only broke on success under `fail-fast`. Under `continue`, it fell through to the next strategy even after a success, appending entities.

**ADR reference:** The [multi-strategy ADR](https://github.com/opentdf/platform/blob/main/adr/decisions/2025-07-31-multi-strategy-entity-resolution-service.md#strategy-configuration-properties) is explicit: on success, return result immediately — `failure_strategy` controls what happens on *failure* only.

## Repro steps (before fix)

1. Configure 2+ subject strategies that both match a token (e.g. both have `conditions: jwt_claims: [{claim: sub, operator: exists}]`)
2. Set `failure_strategy: continue`
3. Call `CreateEntityChainsFromTokens` with a JWT that matches both strategies
4. **Bug:** Chain contains multiple subject entities (one per matching strategy)
5. A subject mapping that matches strategy 1's claims but not strategy 2's → **DENY** (strategy 2's entity vetoes via AND semantics)

**After fix:** Chain contains exactly one subject entity from the first matching strategy. Second strategy is skipped.

## Changes

| File | Change |
|------|--------|
| `v2/registration.go` | Add `resolvedCategories` map + `categoryForStrategy()` helper. Skip strategies whose category is already filled. Break when all categories resolved. |
| `v2/registration_test.go` | 7 new unit tests: competing subjects collapse, env+subject each contribute, strategy order, redundant skip, fail-fast parity, env-first regression, continue fallthrough |
| `integration/multistrategy_test.go` | Fix expected entity count 3→1 for all-subject-strategies test case |
| `integration/internal/chain_contract_tests.go` | Extract `expectedChainCategories()` to deduplicate |
| `README.md` | Document first-match-wins semantics, environment entity handling in authz |

## Test plan

- [x] Unit tests pass: `go test ./service/entityresolution/multi-strategy/v2/ -run TestCreateEntityChainsFromTokens` (7 tests)
- [x] Integration tests pass: `go test ./service/entityresolution/integration/ -run TestMultiStrategy`
- [ ] CI: Cucumber BDD, xtest (Go/Java/JS SDK)
- [ ] Review by multi-strategy ERS developer (Chris Reed / JP / Ryan Schumacher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Entity chains now include at most one environment entity and one subject entity.
  * The first successful strategy for each entity category is used; later strategies are skipped.
  * Subject entities remain available even when environment resolution occurs first.
  * Authorization decisions continue to reject tokens that resolve only to environment entities.

* **Documentation**
  * Clarified strategy selection and fallback behavior for `continue` failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->