### PR TITLE
fix(core): omit DPoP proofs from failure logs

### DIFF
--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -536,7 +536,6 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 					ctxWithAuthX,
 					"unauthenticated",
 					slog.Any("error", err),
-					slog.Any("dpop", dp),
 				)
 				http.Error(w, "unauthenticated", http.StatusUnauthorized)
 				return
@@ -545,7 +544,6 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 				ctxWithAuthX,
 				"unauthenticated",
 				slog.Any("error", err),
-				slog.Any("dpop", dp),
 			)
 			http.Error(w, "unauthenticated", http.StatusUnauthorized)
 			return

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -536,6 +536,10 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 					ctxWithAuthX,
 					"unauthenticated",
 					slog.Any("error", err),
+					slog.String("request_method", r.Method),
+					slog.Int("dpop_proof_count", len(dp)),
+					slog.Bool("dpop_nonce_required", a.dpopNonceManager.requireNonce),
+					slog.Bool("dpop_strict_htu", a.strictDPoPHTU),
 				)
 				http.Error(w, "unauthenticated", http.StatusUnauthorized)
 				return
@@ -544,6 +548,10 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 				ctxWithAuthX,
 				"unauthenticated",
 				slog.Any("error", err),
+				slog.String("request_method", r.Method),
+				slog.Int("dpop_proof_count", len(dp)),
+				slog.Bool("dpop_nonce_required", a.dpopNonceManager.requireNonce),
+				slog.Bool("dpop_strict_htu", a.strictDPoPHTU),
 			)
 			http.Error(w, "unauthenticated", http.StatusUnauthorized)
 			return

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -1012,6 +1012,10 @@ func (s *AuthSuite) Test_MuxHandler_AuthenticationFailure_DoesNotLogDPoPProof() 
 	s.Equal(http.StatusUnauthorized, rec.Code)
 	s.Contains(logs.String(), `"level":"WARN"`)
 	s.Contains(logs.String(), "incorrect `htu` claim in DPoP JWT")
+	s.Contains(logs.String(), `"request_method":"POST"`)
+	s.Contains(logs.String(), `"dpop_proof_count":1`)
+	s.Contains(logs.String(), `"dpop_nonce_required":false`)
+	s.Contains(logs.String(), `"dpop_strict_htu":false`)
 	s.NotContains(logs.String(), "reusable-proof")
 }
 

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -994,6 +994,27 @@ func (s *AuthSuite) Test_MuxHandler_DPoPProofError_IssuesInvalidProofChallenge()
 	s.Empty(rec.Header().Get("DPoP-Nonce"))
 }
 
+func (s *AuthSuite) Test_MuxHandler_AuthenticationFailure_DoesNotLogDPoPProof() {
+	var logs bytes.Buffer
+	auth := s.newAuthDPoP(false)
+	auth.logger = &logger.Logger{Logger: slog.New(slog.NewJSONHandler(&logs, nil))}
+	auth._testCheckTokenFunc = func(ctx context.Context, _ []string, _ receiverInfo, _ []string) (jwt.Token, context.Context, error) {
+		return nil, ctx, &DPoPProofError{err: errors.New("incorrect `htu` claim in DPoP JWT")}
+	}
+
+	handler := auth.MuxHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, dpopChallengeRoute, nil)
+	req.Header.Set("Authorization", "DPoP access-token")
+	req.Header.Set("DPoP", "reusable-proof")
+	handler.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusUnauthorized, rec.Code)
+	s.Contains(logs.String(), `"level":"WARN"`)
+	s.Contains(logs.String(), "incorrect `htu` claim in DPoP JWT")
+	s.NotContains(logs.String(), "reusable-proof")
+}
+
 func (s *AuthSuite) Test_MuxHandler_DPoPProofError_IncludesNonceWhenRequired() {
 	auth := s.newAuthDPoP(true)
 	rec := s.muxAuthErrorRecorder(auth, &DPoPProofError{err: errors.New("DPoP proof replay detected")})


### PR DESCRIPTION
### Proposed Changes

Authentication failures in the raw HTTP handler wrote the complete DPoP proof header to warning logs. This removes the proof while preserving the warning level and validation reason. The warning retains bounded diagnostic context: request method, DPoP proof count, nonce requirement, and strict-HTU mode.

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

- `make fmt`
- `go test -race ./internal/auth/...` from `service/`
- `go test -run TestREADMECodeBlocks` from `sdk/`
- `make lint` stops at `buf lint` because the configured Buf API token is invalid.
- `make test` passes the changed auth package under the race detector, then fails in existing integration suites because Colima/Docker containers and the local round-trip server are unavailable.
