### PR TITLE
fix(ers): multi_strat first match wins per category + bdd tests

### DIFF
--- a/service/entityresolution/integration/internal/chain_contract_tests.go
+++ b/service/entityresolution/integration/internal/chain_contract_tests.go
@@ -18,6 +18,11 @@ const (
 	expectedChainEntityCount = 2
 )
 
+// expectedChainCategories is the chain shape both implementations must produce per token.
+func expectedChainCategories() []string {
+	return []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"}
+}
+
 // ChainContractTestSuite holds implementation-agnostic multi-entity chain validation tests
 type ChainContractTestSuite struct {
 	TestCases []ContractTestCase
@@ -44,10 +49,10 @@ func NewChainContractTestSuite() *ChainContractTestSuite {
 					ChainValidation: []EntityChainValidationRule{
 						{
 							EphemeralID:               "chain-token-1",
-							EntityCount:               expectedChainEntityCount,                             // Both Keycloak and Multi-Strategy create 2 entities per token
-							EntityTypes:               []string{},                                           // Implementation-agnostic: don't specify entity types
-							EntityCategories:          []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"}, // Both must create these categories
-							RequireConsistentOrdering: false,                                                // Allow flexible ordering between implementations
+							EntityCount:               expectedChainEntityCount,  // Both Keycloak and Multi-Strategy create 2 entities per token
+							EntityTypes:               []string{},                // Implementation-agnostic: don't specify entity types
+							EntityCategories:          expectedChainCategories(), // Both must create these categories
+							RequireConsistentOrdering: false,                     // Allow flexible ordering between implementations
 						},
 					},
 				},
@@ -72,14 +77,14 @@ func NewChainContractTestSuite() *ChainContractTestSuite {
 							EphemeralID:               "chain-token-1",
 							EntityCount:               expectedChainEntityCount, // Both implementations create 2 entities per token
 							EntityTypes:               []string{},               // Implementation-agnostic
-							EntityCategories:          []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"},
+							EntityCategories:          expectedChainCategories(),
 							RequireConsistentOrdering: false,
 						},
 						{
 							EphemeralID:               "chain-token-2",
 							EntityCount:               expectedChainEntityCount, // Consistent behavior across tokens
 							EntityTypes:               []string{},               // Implementation-agnostic
-							EntityCategories:          []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"},
+							EntityCategories:          expectedChainCategories(),
 							RequireConsistentOrdering: false,
 						},
 					},
@@ -102,10 +107,10 @@ func NewChainContractTestSuite() *ChainContractTestSuite {
 					ChainValidation: []EntityChainValidationRule{
 						{
 							EphemeralID:               "category-test-token",
-							EntityCount:               expectedChainEntityCount,                             // Both implementations create multiple entities
-							EntityTypes:               []string{},                                           // Implementation-agnostic: entity types vary by implementation
-							EntityCategories:          []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"}, // Contract: both categories must exist
-							RequireConsistentOrdering: false,                                                // Allow implementation flexibility
+							EntityCount:               expectedChainEntityCount,  // Both implementations create multiple entities
+							EntityTypes:               []string{},                // Implementation-agnostic: entity types vary by implementation
+							EntityCategories:          expectedChainCategories(), // Contract: both categories must exist
+							RequireConsistentOrdering: false,                     // Allow implementation flexibility
 						},
 					},
 				},
@@ -129,7 +134,7 @@ func NewChainContractTestSuite() *ChainContractTestSuite {
 							EphemeralID:               "consistency-token",
 							EntityCount:               expectedChainEntityCount, // Consistent entity count across implementations
 							EntityTypes:               []string{},               // Implementation-specific entity types allowed
-							EntityCategories:          []string{"CATEGORY_ENVIRONMENT", "CATEGORY_SUBJECT"},
+							EntityCategories:          expectedChainCategories(),
 							RequireConsistentOrdering: false, // Behavioral contract, not implementation details
 						},
 					},

--- a/service/entityresolution/integration/multistrategy_test.go
+++ b/service/entityresolution/integration/multistrategy_test.go
@@ -445,13 +445,13 @@ func TestMultiStrategyEntityResolutionV2(t *testing.T) {
 		Expected: internal.ContractExpected{
 			ChainValidation: []internal.EntityChainValidationRule{
 				{
-					EphemeralID:      "test-token-1",
-					EntityCount:      3,
-					EntityTypes:      []string{"claims", "claims", "claims"},
-					EntityCategories: []string{"CATEGORY_SUBJECT", "CATEGORY_SUBJECT", "CATEGORY_SUBJECT"},
+					EphemeralID: "test-token-1",
+					// All three configured strategies are entity_type: subject and all match this
+					// token. Only the first contributes: a chain carries one subject entity.
+					EntityCount:      1,
+					EntityTypes:      []string{"claims"},
+					EntityCategories: []string{"CATEGORY_SUBJECT"},
 					EntityRequiredFields: []map[string]interface{}{
-						{"username": "user123", "email": "user@example.com"},
-						{"client_id": "external-client"},
 						{"username": "user123", "email": "user@example.com"},
 					},
 					RequireConsistentOrdering: true,

--- a/service/entityresolution/multi-strategy/README.md
+++ b/service/entityresolution/multi-strategy/README.md
@@ -236,6 +236,21 @@ The failure strategy determines how Multi-Strategy ERS handles failures when exe
 - **Use Case**: When you want resilient failover with multiple fallback options
 - **Result**: Only fails if **all** matching strategies fail
 
+> **First match wins per entity category.** `ResolveEntity` returns the first strategy that
+> succeeds; the failure strategy only decides what happens when a strategy *fails*.
+>
+> `CreateEntityChainsFromTokens` applies the same rule per category, so a token's chain holds
+> at most one `subject` entity and at most one `environment` entity — the first match of each.
+> Later strategies of an already-filled category are skipped and never queried. To combine data
+> from several sources into one entity, merge them in a single strategy's `output_mapping`
+> rather than relying on strategy ordering.
+>
+> Authorization decisions discard `environment` entities, so claims emitted by an
+> `environment` strategy can never satisfy a subject mapping, and a token matching only
+> `environment` strategies produces a chain `GetDecision` rejects outright. Make sure a
+> `subject` strategy matches every token you expect to make decisions for, and emit anything
+> policy needs to match on from that `subject` strategy.
+
 ```yaml
 services:
   entityresolution:

--- a/service/entityresolution/multi-strategy/v2/registration.go
+++ b/service/entityresolution/multi-strategy/v2/registration.go
@@ -24,6 +24,10 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// chainCategoryCount is the number of entity categories a token chain can carry:
+// ENVIRONMENT and SUBJECT, one entity each.
+const chainCategoryCount = 2
+
 // ERSV2 implements the EntityResolutionServiceHandler for v2 multi-strategy resolution
 type ERSV2 struct {
 	ersV2.UnimplementedEntityResolutionServiceServer
@@ -228,7 +232,8 @@ func (ers *ERSV2) createEntityChainFromSingleTokenV2(ctx context.Context, token 
 		)
 	}
 
-	entities := make([]*entity.Entity, 0)
+	entities := make([]*entity.Entity, 0, chainCategoryCount)
+	resolvedCategories := make(map[entity.Entity_Category]bool, chainCategoryCount)
 	var lastError error
 	var attemptedStrategies []string
 
@@ -239,6 +244,18 @@ func (ers *ERSV2) createEntityChainFromSingleTokenV2(ctx context.Context, token 
 	}
 
 	for _, strategy := range strategies {
+		// First match wins per category: at most one ENVIRONMENT and one SUBJECT, like Keycloak.
+		// Avoids the multi-subject chains that make AND semantics unpredictable, without
+		// dropping the subject when an environment strategy is ordered first.
+		category := categoryForStrategy(strategy)
+		if resolvedCategories[category] {
+			ers.logger.DebugContext(ctx, "skipping strategy, category already resolved for token",
+				slog.String("token_id", token.GetEphemeralId()),
+				slog.String("strategy", strategy.Name),
+				slog.String("entity_category", category.String()))
+			continue
+		}
+
 		attemptedStrategies = append(attemptedStrategies, strategy.Name)
 
 		// Put JWT claims into context for providers to access
@@ -287,6 +304,7 @@ func (ers *ERSV2) createEntityChainFromSingleTokenV2(ctx context.Context, token 
 			return nil, err
 		}
 		entities = append(entities, entityV2)
+		resolvedCategories[category] = true
 
 		ers.logger.DebugContext(ctx, "successfully resolved entity for token",
 			slog.String("token_id", token.GetEphemeralId()),
@@ -294,13 +312,10 @@ func (ers *ERSV2) createEntityChainFromSingleTokenV2(ctx context.Context, token 
 			slog.String("entity_type", getEntityTypeStringV2(entityV2)),
 			slog.String("entity_category", entityV2.GetCategory().String()))
 
-		// ENHANCED: Continue trying additional strategies to build multi-entity chains (like Keycloak)
-		// This allows creating chains with multiple entities (e.g., ENVIRONMENT + SUBJECT)
-		// Only break if FailureStrategy is FailFast and we have at least one successful entity
-		if failureStrategy == types.FailureStrategyFailFast {
+		// Every category is filled, so no remaining strategy can contribute.
+		if len(resolvedCategories) == chainCategoryCount {
 			break
 		}
-		// With FailureStrategyContinue, we continue to try more strategies to build richer chains
 	}
 
 	// If no strategies succeeded
@@ -357,6 +372,15 @@ func (ers *ERSV2) createEntityForTokenChain(
 	)
 }
 
+// categoryForStrategy maps a strategy's configured entity_type onto the entity category it
+// produces. Only "environment" yields an ENVIRONMENT entity; everything else is a SUBJECT.
+func categoryForStrategy(strategy *types.MappingStrategy) entity.Entity_Category {
+	if strategy.EntityType == types.EntityTypeEnvironment {
+		return entity.Entity_CATEGORY_ENVIRONMENT
+	}
+	return entity.Entity_CATEGORY_SUBJECT
+}
+
 // createEntityFromResultV2 converts a multi-strategy EntityResult to a v2 entity.Entity.
 //
 // For token-derived entity chains, preserve the resolved claims directly in the chain so
@@ -369,10 +393,7 @@ func (ers *ERSV2) createEntityForTokenChain(
 // strategy ordering, and other deployment-specific ERS structure. Resolution metadata belongs
 // in observability or a dedicated out-of-band metadata channel, not in policy input.
 func (ers *ERSV2) createEntityFromResultV2(_ context.Context, result *types.EntityResult, strategy *types.MappingStrategy, tokenID string) (*entity.Entity, error) {
-	category := entity.Entity_CATEGORY_SUBJECT
-	if strategy.EntityType == types.EntityTypeEnvironment {
-		category = entity.Entity_CATEGORY_ENVIRONMENT
-	}
+	category := categoryForStrategy(strategy)
 
 	resultData, err := claimsToResultData(result.Claims)
 	if err != nil {

--- a/service/entityresolution/multi-strategy/v2/registration_test.go
+++ b/service/entityresolution/multi-strategy/v2/registration_test.go
@@ -361,3 +361,190 @@ func TestCreateEntityForTokenChainFailsClosedOnSerializationErrorWithContinue(t 
 	require.Equal(t, "token-1", inner.Context["token_id"])
 	require.Equal(t, "bad_subject", inner.Context["strategy"])
 }
+
+// firstMatchWinsConfig builds a config with two strategies that both match the test token:
+// an ENVIRONMENT strategy on "azp" followed by a SUBJECT strategy on "sub".
+func firstMatchWinsConfig(failureStrategy string, strategies ...types.MappingStrategy) types.MultiStrategyConfig {
+	return types.MultiStrategyConfig{
+		FailureStrategy: failureStrategy,
+		Providers: map[string]types.ProviderConfig{
+			"jwt": {Type: "claims", Connection: map[string]interface{}{}},
+		},
+		MappingStrategies: strategies,
+	}
+}
+
+func environmentStrategy() types.MappingStrategy {
+	return types.MappingStrategy{
+		Name:       "client_environment",
+		Provider:   "jwt",
+		EntityType: types.EntityTypeEnvironment,
+		Conditions: types.StrategyConditions{
+			JWTClaims: []types.JWTClaimCondition{{Claim: "azp", Operator: "exists"}},
+		},
+		OutputMapping: []types.OutputMapping{{SourceClaim: "azp", ClaimName: "client_id"}},
+	}
+}
+
+func subjectStrategy() types.MappingStrategy {
+	return types.MappingStrategy{
+		Name:       "user_subject",
+		Provider:   "jwt",
+		EntityType: types.EntityTypeSubject,
+		Conditions: types.StrategyConditions{
+			JWTClaims: []types.JWTClaimCondition{{Claim: "sub", Operator: "exists"}},
+		},
+		OutputMapping: []types.OutputMapping{{SourceClaim: "sub", ClaimName: "username"}},
+	}
+}
+
+// testTokenJWT is an unsigned-but-well-formed JWT carrying both "azp" and "sub", so every
+// strategy in firstMatchWinsConfig matches it.
+// Payload: {"sub":"alice","azp":"opentdf-sdk","iat":1600000000,"exp":4102444800}
+const testTokenJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+	"eyJzdWIiOiJhbGljZSIsImF6cCI6Im9wZW50ZGYtc2RrIiwiaWF0IjoxNjAwMDAwMDAwLCJleHAiOjQxMDI0NDQ4MDB9." +
+	"dGVzdHNpZ25hdHVyZQ"
+
+func chainForTestToken(t *testing.T, config types.MultiStrategyConfig) *entity.EntityChain {
+	t.Helper()
+
+	erService, err := NewERSV2(t.Context(), config, logger.CreateTestLogger())
+	require.NoError(t, err)
+
+	resp, err := erService.CreateEntityChainsFromTokens(t.Context(), connect.NewRequest(&ersV2.CreateEntityChainsFromTokensRequest{
+		Tokens: []*entity.Token{{EphemeralId: "token-1", Jwt: testTokenJWT}},
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.GetEntityChains(), 1)
+
+	return resp.Msg.GetEntityChains()[0]
+}
+
+func claimsOf(t *testing.T, resolved *entity.Entity) map[string]interface{} {
+	t.Helper()
+
+	require.NotNil(t, resolved.GetClaims())
+	var claimsStruct structpb.Struct
+	require.NoError(t, resolved.GetClaims().UnmarshalTo(&claimsStruct))
+	return claimsStruct.AsMap()
+}
+
+// secondSubjectStrategy is another subject strategy matching the same token, mapping a
+// different claim so tests can tell which of the two produced the chain's subject entity.
+func secondSubjectStrategy() types.MappingStrategy {
+	return types.MappingStrategy{
+		Name:       "user_subject_fallback",
+		Provider:   "jwt",
+		EntityType: types.EntityTypeSubject,
+		Conditions: types.StrategyConditions{
+			JWTClaims: []types.JWTClaimCondition{{Claim: "azp", Operator: "exists"}},
+		},
+		OutputMapping: []types.OutputMapping{{SourceClaim: "azp", ClaimName: "username"}},
+	}
+}
+
+func categoriesOf(chain *entity.EntityChain) []entity.Entity_Category {
+	categories := make([]entity.Entity_Category, 0, len(chain.GetEntities()))
+	for _, e := range chain.GetEntities() {
+		categories = append(categories, e.GetCategory())
+	}
+	return categories
+}
+
+func subjectEntity(t *testing.T, chain *entity.EntityChain) *entity.Entity {
+	t.Helper()
+
+	var found *entity.Entity
+	for _, e := range chain.GetEntities() {
+		if e.GetCategory() == entity.Entity_CATEGORY_SUBJECT {
+			require.Nil(t, found, "chain must not carry more than one subject entity")
+			found = e
+		}
+	}
+	require.NotNil(t, found, "chain must carry a subject entity")
+	return found
+}
+
+// TestCreateEntityChainsFromTokens_AtMostOneEntityPerCategory pins the chain contract: a
+// token yields at most one ENVIRONMENT and one SUBJECT entity, and within a category the
+// first matching strategy wins. Multiple subject entities are what made AND semantics
+// unpredictable; a missing subject entity breaks authz, which discards environment entities.
+func TestCreateEntityChainsFromTokens_AtMostOneEntityPerCategory(t *testing.T) {
+	tests := []struct {
+		name               string
+		failureStrategy    string
+		strategies         []types.MappingStrategy
+		expectedCategories []entity.Entity_Category
+		expectedUsername   string
+	}{
+		{
+			name:               "competing subject strategies collapse to the first",
+			failureStrategy:    types.FailureStrategyContinue,
+			strategies:         []types.MappingStrategy{subjectStrategy(), secondSubjectStrategy()},
+			expectedCategories: []entity.Entity_Category{entity.Entity_CATEGORY_SUBJECT},
+			expectedUsername:   "alice",
+		},
+		{
+			name:               "environment and subject strategies each contribute one entity",
+			failureStrategy:    types.FailureStrategyContinue,
+			strategies:         []types.MappingStrategy{environmentStrategy(), subjectStrategy()},
+			expectedCategories: []entity.Entity_Category{entity.Entity_CATEGORY_ENVIRONMENT, entity.Entity_CATEGORY_SUBJECT},
+			expectedUsername:   "alice",
+		},
+		{
+			name:               "chain follows strategy order",
+			failureStrategy:    types.FailureStrategyContinue,
+			strategies:         []types.MappingStrategy{subjectStrategy(), environmentStrategy()},
+			expectedCategories: []entity.Entity_Category{entity.Entity_CATEGORY_SUBJECT, entity.Entity_CATEGORY_ENVIRONMENT},
+			expectedUsername:   "alice",
+		},
+		{
+			name:               "a redundant subject strategy after a full chain is skipped",
+			failureStrategy:    types.FailureStrategyContinue,
+			strategies:         []types.MappingStrategy{environmentStrategy(), subjectStrategy(), secondSubjectStrategy()},
+			expectedCategories: []entity.Entity_Category{entity.Entity_CATEGORY_ENVIRONMENT, entity.Entity_CATEGORY_SUBJECT},
+			expectedUsername:   "alice",
+		},
+		{
+			name:               "fail-fast produces the same chain shape",
+			failureStrategy:    types.FailureStrategyFailFast,
+			strategies:         []types.MappingStrategy{environmentStrategy(), subjectStrategy()},
+			expectedCategories: []entity.Entity_Category{entity.Entity_CATEGORY_ENVIRONMENT, entity.Entity_CATEGORY_SUBJECT},
+			expectedUsername:   "alice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain := chainForTestToken(t, firstMatchWinsConfig(tt.failureStrategy, tt.strategies...))
+
+			require.Equal(t, tt.expectedCategories, categoriesOf(chain))
+			require.Equal(t, tt.expectedUsername, claimsOf(t, subjectEntity(t, chain))["username"],
+				"the first matching subject strategy must own the subject entity")
+		})
+	}
+}
+
+// TestCreateEntityChainsFromTokens_EnvironmentFirstStillResolvesSubject guards the ordering
+// regression: authz resolves decisions with skipEnvironmentEntities=true, so a chain built
+// from an environment-first config must still carry a subject or every decision errors out.
+func TestCreateEntityChainsFromTokens_EnvironmentFirstStillResolvesSubject(t *testing.T) {
+	chain := chainForTestToken(t, firstMatchWinsConfig(
+		types.FailureStrategyContinue, environmentStrategy(), subjectStrategy(),
+	))
+
+	require.Equal(t, "alice", claimsOf(t, subjectEntity(t, chain))["username"])
+}
+
+// TestCreateEntityChainsFromTokens_ContinueFallsThroughFailureToNextStrategy shows the one
+// thing "continue" does change: a failing strategy hands off to the next matching one.
+func TestCreateEntityChainsFromTokens_ContinueFallsThroughFailureToNextStrategy(t *testing.T) {
+	failing := environmentStrategy()
+	failing.Name = "missing_provider"
+	failing.Provider = "not-registered"
+
+	chain := chainForTestToken(t, firstMatchWinsConfig(types.FailureStrategyContinue, failing, subjectStrategy()))
+
+	require.Len(t, chain.GetEntities(), 1)
+	require.Equal(t, "alice", claimsOf(t, subjectEntity(t, chain))["username"])
+}

--- a/tests-bdd/features/ers-transformation-service.feature
+++ b/tests-bdd/features/ers-transformation-service.feature
@@ -1,0 +1,78 @@
+@ers-transformation-service @stateless
+Feature: Transformations through the ERS service path
+  Validate that output_mapping transformations (array, csv_to_array, lowercase)
+  work correctly through the full ERS service → gRPC → authorization pipeline,
+  not just at the unit test level.
+
+  Transformation unit tests exist in claims_mapper_test.go and ldap_mapper_test.go,
+  but no BDD feature exercises a transformation through the actual service path
+  where OutputMapper is called (service.go:269-271). This catches integration
+  issues between transformation output format and subject mapping evaluation.
+
+  This covers Jake's gap analysis row #5.
+
+  Background:
+    And an ERS configuration with mode "multi-strategy" and failure strategy "continue"
+    And an ERS provider "jwt_claims" of type "claims"
+    And an ERS mapping strategy "claims_with_array_transform" using provider "jwt_claims"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: userName
+            operator: exists
+      output_mapping:
+        - source_claim: department
+          claim_name: department
+          transformation: array
+        - source_claim: userName
+          claim_name: username
+      """
+    And a local platform with inline ERS configuration
+
+  Scenario: Array transformation — string claim transformed to array matches anyOf selector
+    Given I submit a request to create a namespace with name "xform-array.test" and reference id "ns_xa"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values                         |
+      | ns_xa        | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_xa" with an "or" operator with conditions:
+      | selector_value  | operator | values      |
+      | .department[]   | in       | engineering |
+    And a subject set referenced as "ss_xa" containing the condition groups "cg_xa"
+    And I send a request to create a subject condition set referenced as "scs_xa" containing subject sets "ss_xa"
+    And I send a request to create a subject mapping with:
+      | reference_id | attribute_value                                            | condition_set_name | standard actions | custom actions |
+      | sm_xa        | https://xform-array.test/attr/department/value/engineering | scs_xa             | read             |                |
+    Then the response should be successful
+    Given there is a claims subject entity referenced as "alice_xa" with claims:
+      """
+      {"userName":"alice","department":"engineering"}
+      """
+    When I send a decision request for entity chain "alice_xa" for "read" action on resource "https://xform-array.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response
+
+  Scenario: Array transformation — non-matching value gets DENY
+    Given I submit a request to create a namespace with name "xform-array-deny.test" and reference id "ns_xad"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values                         |
+      | ns_xad       | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_xad" with an "or" operator with conditions:
+      | selector_value  | operator | values      |
+      | .department[]   | in       | engineering |
+    And a subject set referenced as "ss_xad" containing the condition groups "cg_xad"
+    And I send a request to create a subject condition set referenced as "scs_xad" containing subject sets "ss_xad"
+    And I send a request to create a subject mapping with:
+      | reference_id | attribute_value                                                 | condition_set_name | standard actions | custom actions |
+      | sm_xad       | https://xform-array-deny.test/attr/department/value/engineering | scs_xad            | read             |                |
+    Then the response should be successful
+    Given there is a claims subject entity referenced as "bob_xad" with claims:
+      """
+      {"userName":"bob","department":"marketing"}
+      """
+    When I send a decision request for entity chain "bob_xad" for "read" action on resource "https://xform-array-deny.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "DENY" decision response
+

--- a/tests-bdd/features/ers-transformation-service.feature
+++ b/tests-bdd/features/ers-transformation-service.feature
@@ -9,8 +9,6 @@ Feature: Transformations through the ERS service path
   where OutputMapper is called (service.go:269-271). This catches integration
   issues between transformation output format and subject mapping evaluation.
 
-  This covers Jake's gap analysis row #5.
-
   Background:
     And an ERS configuration with mode "multi-strategy" and failure strategy "continue"
     And an ERS provider "jwt_claims" of type "claims"

--- a/tests-bdd/features/multi-strategy-ers-input-mapping-continue.feature
+++ b/tests-bdd/features/multi-strategy-ers-input-mapping-continue.feature
@@ -1,0 +1,71 @@
+@multi-strategy-ers-input-mapping-continue @stateless
+Feature: Multi-strategy ERS input_mapping required validation (continue)
+  When a required input_mapping claim is absent from the JWT and the failure
+  strategy is continue, the failing strategy is skipped and the next matching
+  strategy resolves the entity. This validates graceful degradation — the
+  claims fallback produces a PERMIT that fail-fast would have blocked.
+
+  Background:
+    Given an LDAP directory with test users
+
+  Scenario: Continue with missing required input_mapping claim falls through to claims
+    Given an ERS configuration with mode "multi-strategy" and failure strategy "continue"
+    And an ERS provider "jwt_claims" of type "claims"
+    And an ERS provider "ldap_directory" of type "ldap" connected to the LDAP directory
+    And an ERS mapping strategy "claims_fallback_cont" using provider "jwt_claims"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: userName
+            operator: exists
+      output_mapping:
+        - source_claim: userName
+          claim_name: username
+        - source_claim: department
+          claim_name: department
+      """
+    And an ERS mapping strategy "ldap_requires_employee_id_cont" using provider "ldap_directory"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: userName
+            operator: exists
+      ldap_search:
+        base_dn: "ou=users,dc=opentdf,dc=test"
+        filter: "(&(objectClass=inetOrgPerson)(uid={employee_id}))"
+        scope: subtree
+        attributes: ["uid", "mail", "departmentNumber"]
+      input_mapping:
+        - jwt_claim: employee_id
+          parameter: employee_id
+          required: true
+      output_mapping:
+        - source_attribute: departmentNumber
+          claim_name: department
+        - source_attribute: uid
+          claim_name: username
+      """
+    And a local platform with inline ERS configuration
+    Given I submit a request to create a namespace with name "req-continue.test" and reference id "ns_req_cont"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values                         |
+      | ns_req_cont  | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_req_cont" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_req_cont" containing the condition groups "cg_req_cont"
+    And I send a request to create a subject condition set referenced as "scs_req_cont" containing subject sets "ss_req_cont"
+    And I send a request to create a subject mapping with:
+      | reference_id | attribute_value                                              | condition_set_name | standard actions | custom actions |
+      | sm_req_cont  | https://req-continue.test/attr/department/value/engineering  | scs_req_cont       | read             |                |
+    Then the response should be successful
+    Given there is a claims subject entity referenced as "user_no_empid_cont" with claims:
+      """
+      {"userName":"alice","department":"engineering"}
+      """
+    When I send a decision request for entity chain "user_no_empid_cont" for "read" action on resource "https://req-continue.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response

--- a/tests-bdd/features/multi-strategy-ers-input-mapping-required.feature
+++ b/tests-bdd/features/multi-strategy-ers-input-mapping-required.feature
@@ -1,0 +1,70 @@
+@multi-strategy-ers-input-mapping-required @stateless
+Feature: Multi-strategy ERS input_mapping required validation (fail-fast)
+  When a required input_mapping claim is absent from the JWT and the failure
+  strategy is fail-fast, entity resolution fails immediately and the decision
+  is DENY — even when a later claims strategy would have matched.
+
+  Background:
+    Given an LDAP directory with test users
+
+  Scenario: Fail-fast with missing required input_mapping claim causes DENY
+    Given an ERS configuration with mode "multi-strategy" and failure strategy "fail-fast"
+    And an ERS provider "ldap_directory" of type "ldap" connected to the LDAP directory
+    And an ERS provider "jwt_claims" of type "claims"
+    And an ERS mapping strategy "ldap_requires_employee_id" using provider "ldap_directory"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: userName
+            operator: exists
+      ldap_search:
+        base_dn: "ou=users,dc=opentdf,dc=test"
+        filter: "(&(objectClass=inetOrgPerson)(uid={employee_id}))"
+        scope: subtree
+        attributes: ["uid", "mail", "departmentNumber"]
+      input_mapping:
+        - jwt_claim: employee_id
+          parameter: employee_id
+          required: true
+      output_mapping:
+        - source_attribute: departmentNumber
+          claim_name: department
+        - source_attribute: uid
+          claim_name: username
+      """
+    And an ERS mapping strategy "claims_fallback" using provider "jwt_claims"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: userName
+            operator: exists
+      output_mapping:
+        - source_claim: userName
+          claim_name: username
+        - source_claim: department
+          claim_name: department
+      """
+    And a local platform with inline ERS configuration
+    Given I submit a request to create a namespace with name "req-failfast.test" and reference id "ns_req_ff"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values                         |
+      | ns_req_ff    | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_req_ff" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_req_ff" containing the condition groups "cg_req_ff"
+    And I send a request to create a subject condition set referenced as "scs_req_ff" containing subject sets "ss_req_ff"
+    And I send a request to create a subject mapping with:
+      | reference_id | attribute_value                                             | condition_set_name | standard actions | custom actions |
+      | sm_req_ff    | https://req-failfast.test/attr/department/value/engineering | scs_req_ff         | read             |                |
+    Then the response should be successful
+    Given there is a claims subject entity referenced as "user_no_empid" with claims:
+      """
+      {"userName":"alice","department":"engineering"}
+      """
+    When I send a decision request for entity chain "user_no_empid" for "read" action on resource "https://req-failfast.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "DENY" decision response

--- a/tests-bdd/features/multi-strategy-ers-multi-success.feature
+++ b/tests-bdd/features/multi-strategy-ers-multi-success.feature
@@ -1,0 +1,113 @@
+@multi-strategy-ers-multi-success @stateless
+Feature: Multi-strategy chains hold one entity per category under continue
+  Per the multi-strategy ERS ADR, failure_strategy only controls error handling:
+    - "continue": try the next strategy if the current one fails
+    - "fail_fast": stop immediately on any failure
+  Neither mode adds a second entity of a category already resolved, so a chain holds at
+  most one subject and one environment entity.
+  See: adr/decisions/2025-07-31-multi-strategy-entity-resolution-service.md
+
+  All three strategies below match every token, so the chain holds the environment entity
+  from "client_environment" plus one subject entity from "claims_identity" — "ldap_department"
+  is skipped. Authorization discards environment entities, so only the subject's claims count.
+
+  Background:
+    Given an LDAP directory with test users
+    And a user exists with username "alice" and email "alice@opentdf.test" and the following attributes:
+      | name | value |
+    And an ERS configuration with mode "multi-strategy" and failure strategy "continue"
+    And an ERS provider "jwt_claims" of type "claims"
+    And an ERS provider "ldap_directory" of type "ldap" connected to the LDAP directory
+    # Ordered first on purpose: every Keycloak token carries azp, so an environment strategy
+    # always wins the race. This makes the scenarios below cover environment-first ordering —
+    # resolution that stopped at the first match outright would leave no subject entity and
+    # every decision would error instead of deciding.
+    And an ERS mapping strategy "client_environment" using provider "jwt_claims"
+      """
+      entity_type: environment
+      conditions:
+        jwt_claims:
+          - claim: azp
+            operator: exists
+      output_mapping:
+        - source_claim: azp
+          claim_name: client_id
+      """
+    And an ERS mapping strategy "claims_identity" using provider "jwt_claims"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: preferred_username
+            operator: exists
+      output_mapping:
+        - source_claim: preferred_username
+          claim_name: username
+      """
+    # Emits only "department", never "username" — the asymmetry the scenarios rely on.
+    And an ERS mapping strategy "ldap_department" using provider "ldap_directory"
+      """
+      entity_type: subject
+      conditions:
+        jwt_claims:
+          - claim: preferred_username
+            operator: exists
+      ldap_search:
+        base_dn: "ou=users,dc=opentdf,dc=test"
+        filter: "(&(objectClass=inetOrgPerson)(uid={username}))"
+        scope: subtree
+        attributes: ["uid", "departmentNumber"]
+      input_mapping:
+        - jwt_claim: preferred_username
+          parameter: username
+      output_mapping:
+        - source_attribute: departmentNumber
+          claim_name: department
+      """
+    And a local platform with inline ERS configuration
+
+  Scenario: First strategy succeeds — user entitled via first-match entity → PERMIT
+    Given I submit a request to create a namespace with name "multi-success.test" and reference id "ns_ms"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values                         |
+      | ns_ms        | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    # Regression guard: stopping at the first match regardless of category would leave only
+    # the environment entity (authz filters it away), and appending a second subject entity
+    # would add one with no .username for AND semantics to veto.
+    Given a condition group referenced as "cg_ms" with an "or" operator with conditions:
+      | selector_value | operator | values |
+      | .username      | in       | alice  |
+    And a subject set referenced as "ss_ms" containing the condition groups "cg_ms"
+    And I send a request to create a subject condition set referenced as "scs_ms" containing subject sets "ss_ms"
+    And I send a request to create a subject mapping with:
+      | reference_id | attribute_value                                             | condition_set_name | standard actions | custom actions |
+      | sm_ms        | https://multi-success.test/attr/department/value/engineering | scs_ms             | read             |                |
+    Then the response should be successful
+    Given a user access token for "alice" stored as "alice_token"
+    When I send a decision request for token "alice_token" for "read" action on resource "https://multi-success.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "PERMIT" decision response
+
+  Scenario: A later strategy that would supply the attribute never runs → DENY
+    # Alice is departmentNumber=engineering in LDAP, but "claims_identity" owns the subject
+    # entity and emits no .department. Also catches an implementation that merges claims.
+    # Fix in config: order the LDAP strategy first, or emit department from the winner.
+    Given I submit a request to create a namespace with name "and-semantics-gap.test" and reference id "ns_asg"
+    And I send a request to create an attribute with:
+      | namespace_id | name       | rule  | values                         |
+      | ns_asg       | department | anyOf | engineering,marketing,security |
+    Then the response should be successful
+    Given a condition group referenced as "cg_asg" with an "or" operator with conditions:
+      | selector_value | operator | values      |
+      | .department    | in       | engineering |
+    And a subject set referenced as "ss_asg" containing the condition groups "cg_asg"
+    And I send a request to create a subject condition set referenced as "scs_asg" containing subject sets "ss_asg"
+    And I send a request to create a subject mapping with:
+      | reference_id | attribute_value                                                  | condition_set_name | standard actions | custom actions |
+      | sm_asg       | https://and-semantics-gap.test/attr/department/value/engineering | scs_asg            | read             |                |
+    Then the response should be successful
+    Given a user access token for "alice" stored as "alice_and_token"
+    When I send a decision request for token "alice_and_token" for "read" action on resource "https://and-semantics-gap.test/attr/department/value/engineering"
+    Then the response should be successful
+    And I should get a "DENY" decision response


### PR DESCRIPTION
### Proposed Changes

* Multi-strategy entity resolution now keeps the first successful entity for each category and skips later strategies for already-resolved categories.
* Chain construction supports environment and subject entities while preventing duplicate entities within a category.
* Failure handling correctly falls through to fallback strategies when configured to continue.
* Added coverage for multi-strategy resolution, required and optional inputs, array transformations, and resulting permit/deny decisions.

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Multi-strategy entity resolution now keeps the first successful entity for each category and skips later strategies for already-resolved categories.
  - Chain construction supports environment and subject entities while preventing duplicate entities within a category.
  - Failure handling correctly falls through to fallback strategies when configured to continue.

- **Documentation**
  - Added guidance on strategy ordering, category resolution, output mappings, and authorization requirements.

- **Tests**
  - Added coverage for multi-strategy resolution, required and optional inputs, array transformations, and resulting permit/deny decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->