### PR TITLE
feat(sdk,cli): settable segment and root integrity algorithms (DSPX-4736)

### DIFF
--- a/otdfctl/cmd/tdf/encrypt.go
+++ b/otdfctl/cmd/tdf/encrypt.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/otdfctl/cmd/common"
 	"github.com/opentdf/platform/otdfctl/pkg/cli"
+	"github.com/opentdf/platform/otdfctl/pkg/handlers"
 	"github.com/opentdf/platform/otdfctl/pkg/man"
 	"github.com/opentdf/platform/otdfctl/pkg/utils"
 	"github.com/spf13/cobra"
@@ -26,6 +27,17 @@ var (
 
 func encryptRun(cmd *cobra.Command, args []string) {
 	c := cli.New(cmd, args, cli.WithPrintJSON())
+
+	// Validate the integrity cli arguments first, to fail fast and with
+	// helpful comments on invalid configurations or misspellings.
+	integrityAlgorithms := handlers.IntegrityAlgorithms{
+		Root:    c.Flags.GetOptionalString("root-integrity-algorithm"),
+		Segment: c.Flags.GetOptionalString("segment-integrity-algorithm"),
+	}
+	if err := integrityAlgorithms.Validate(); err != nil {
+		cli.ExitWithError("Invalid integrity algorithm", err)
+	}
+
 	h := common.NewHandler(c)
 	defer h.Close()
 
@@ -116,6 +128,7 @@ func encryptRun(cmd *cobra.Command, args []string) {
 		assertions,
 		wrappingKeyAlgorithm,
 		targetMode,
+		integrityAlgorithms,
 	)
 	if err != nil {
 		cli.ExitWithError("Failed to encrypt", err)
@@ -190,6 +203,16 @@ func InitEncryptCommand() {
 		encryptDoc.GetDocFlag("target-mode").Name,
 		encryptDoc.GetDocFlag("target-mode").Default,
 		encryptDoc.GetDocFlag("target-mode").Description,
+	)
+	encryptDoc.Flags().String(
+		encryptDoc.GetDocFlag("root-integrity-algorithm").Name,
+		encryptDoc.GetDocFlag("root-integrity-algorithm").Default,
+		encryptDoc.GetDocFlag("root-integrity-algorithm").Description,
+	)
+	encryptDoc.Flags().String(
+		encryptDoc.GetDocFlag("segment-integrity-algorithm").Name,
+		encryptDoc.GetDocFlag("segment-integrity-algorithm").Default,
+		encryptDoc.GetDocFlag("segment-integrity-algorithm").Description,
 	)
 	encryptDoc.GroupID = TDF
 }

--- a/otdfctl/docs/man/encrypt/_index.md
+++ b/otdfctl/docs/man/encrypt/_index.md
@@ -24,7 +24,6 @@ command:
         The algorithm used for the TDF's root signature. Only hs256 is supported; gmac is rejected.
       enum:
         - hs256
-        - gmac
       default: hs256
     - name: segment-integrity-algorithm
       description: >

--- a/otdfctl/docs/man/encrypt/_index.md
+++ b/otdfctl/docs/man/encrypt/_index.md
@@ -112,12 +112,7 @@ ciphertext; `hs256` recomputes an HMAC-SHA256 over the same bytes.
 
 `--root-integrity-algorithm` (default `hs256`) selects how the root signature
 over the aggregate of those segment hashes is computed. **Only `hs256` is
-supported.** The aggregate hash never passes through AES-GCM, so there is no
-tag to read back out and `gmac` would authenticate nothing — it degenerates
-into a copy of the last segment hash, which anyone who can edit the manifest
-can rewrite. Passing `--root-integrity-algorithm gmac` fails with
-`unsupported root integrity algorithm`, and decrypting a TDF whose manifest
-declares a GMAC root is refused for the same reason.
+supported.**```
 
 ```shell
 # HS256 segment hashes instead of the default GMAC

--- a/otdfctl/docs/man/encrypt/_index.md
+++ b/otdfctl/docs/man/encrypt/_index.md
@@ -19,6 +19,20 @@ command:
         - ec:secp384r1
         - ec:secp521r1
       default: rsa:2048  
+    - name: root-integrity-algorithm
+      description: >
+        The algorithm used for the TDF's root signature. Only hs256 is supported; gmac is rejected.
+      enum:
+        - hs256
+        - gmac
+      default: hs256
+    - name: segment-integrity-algorithm
+      description: >
+        The algorithm used to compute each payload segment's integrity hash.
+      enum:
+        - hs256
+        - gmac
+      default: gmac
     - name: mime-type
       description: The MIME type of the input data. If not provided, the MIME type is inferred from the input data.
     - name: tdf-type
@@ -86,6 +100,29 @@ Example
 # Encrypt a file using the ec:secp256r1 algorithm for the wrapping key
 # EXPERIMENTAL
 otdfctl encrypt hello.txt --wrapping-key-algorithm ec:secp256r1 --out hello.txt.tdf
+```
+
+## Integrity Algorithms
+
+A ZTDF carries two kinds of integrity value, and they are not interchangeable.
+
+`--segment-integrity-algorithm` (default `gmac`) selects how each payload
+segment's hash is computed. Both values are supported. `gmac` reads out the
+AES-GCM authentication tag the cipher already produced over that segment's
+ciphertext; `hs256` recomputes an HMAC-SHA256 over the same bytes.
+
+`--root-integrity-algorithm` (default `hs256`) selects how the root signature
+over the aggregate of those segment hashes is computed. **Only `hs256` is
+supported.** The aggregate hash never passes through AES-GCM, so there is no
+tag to read back out and `gmac` would authenticate nothing — it degenerates
+into a copy of the last segment hash, which anyone who can edit the manifest
+can rewrite. Passing `--root-integrity-algorithm gmac` fails with
+`unsupported root integrity algorithm`, and decrypting a TDF whose manifest
+declares a GMAC root is refused for the same reason.
+
+```shell
+# HS256 segment hashes instead of the default GMAC
+otdfctl encrypt hello.txt --out hello.txt.tdf --segment-integrity-algorithm hs256
 ```
 
 ## Attributes

--- a/otdfctl/pkg/handlers/tdf.go
+++ b/otdfctl/pkg/handlers/tdf.go
@@ -38,6 +38,74 @@ type TDFInspect struct {
 	UnencryptedMetadata []byte
 }
 
+// IntegrityAlgorithms carries the segment and root integrity algorithm names as
+// they arrived from the CLI, so the flags can be validated before any work is
+// done and mapped onto SDK options in one place.
+type IntegrityAlgorithms struct {
+	Root    string
+	Segment string
+}
+
+// Validate reports whether both algorithm names are usable, without needing a
+// platform connection or any input data.
+//
+// It applies the options to a throwaway config rather than re-stating the rule,
+// so the SDK stays the single source of truth for which algorithms are allowed
+// where.
+func (a IntegrityAlgorithms) Validate() error {
+	opts, err := a.tdfOptions()
+	if err != nil {
+		return err
+	}
+	var cfg sdk.TDFConfig
+	for _, opt := range opts {
+		if err := opt(&cfg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// tdfOptions maps the requested algorithm names onto SDK options. Names are
+// matched case-insensitively; an empty name leaves the SDK default in place
+// (HS256 root, GMAC segments).
+//
+// The root option is where `gmac` is refused: the SDK returns
+// ErrUnsupportedRootIntegrityAlgorithm, whose message carries the literal
+// "unsupported root integrity algorithm" that callers grep for.
+func (a IntegrityAlgorithms) tdfOptions() ([]sdk.TDFOption, error) {
+	var opts []sdk.TDFOption
+
+	if a.Segment != "" {
+		alg, err := parseIntegrityAlgorithm(a.Segment)
+		if err != nil {
+			return nil, fmt.Errorf("segment integrity algorithm: %w", err)
+		}
+		opts = append(opts, sdk.WithSegmentIntegrityAlgorithm(alg))
+	}
+
+	if a.Root != "" {
+		alg, err := parseIntegrityAlgorithm(a.Root)
+		if err != nil {
+			return nil, fmt.Errorf("root integrity algorithm: %w", err)
+		}
+		opts = append(opts, sdk.WithRootIntegrityAlgorithm(alg))
+	}
+
+	return opts, nil
+}
+
+func parseIntegrityAlgorithm(name string) (sdk.IntegrityAlgorithm, error) {
+	switch strings.ToLower(name) {
+	case "hs256":
+		return sdk.HS256, nil
+	case "gmac":
+		return sdk.GMAC, nil
+	default:
+		return 0, fmt.Errorf("unrecognized algorithm %q, expected one of: hs256, gmac", name)
+	}
+}
+
 func (h Handler) EncryptBytes(
 	tdfType string,
 	unencrypted []byte,
@@ -47,6 +115,7 @@ func (h Handler) EncryptBytes(
 	assertions string,
 	wrappingKeyAlgorithm ocrypto.KeyType,
 	targetMode string,
+	integrityAlgorithms IntegrityAlgorithms,
 ) (*bytes.Buffer, error) {
 	var encrypted []byte
 	enc := bytes.NewBuffer(encrypted)
@@ -62,6 +131,12 @@ func (h Handler) EncryptBytes(
 			sdk.WithMimeType(mimeType),
 			sdk.WithWrappingKeyAlg(wrappingKeyAlgorithm), //nolint:staticcheck // SDK option is deprecated but no replacement is available in this SDK version.
 		}
+
+		integrityOpts, err := integrityAlgorithms.tdfOptions()
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, integrityOpts...)
 
 		var assertionConfigs []sdk.AssertionConfig
 		//nolint:nestif // nested its mainly for error catching and handling case of string vs file
@@ -94,7 +169,7 @@ func (h Handler) EncryptBytes(
 			opts = append(opts, sdk.WithTargetMode(targetMode))
 		}
 
-		_, err := h.sdk.CreateTDF(enc, bytes.NewReader(unencrypted), opts...)
+		_, err = h.sdk.CreateTDF(enc, bytes.NewReader(unencrypted), opts...)
 		return enc, err
 	default:
 		return nil, errors.New("unknown TDF type")

--- a/otdfctl/pkg/handlers/tdf_test.go
+++ b/otdfctl/pkg/handlers/tdf_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/opentdf/platform/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The two integrity flags are deliberately asymmetric: segments accept either
+// algorithm because a GMAC segment hash really is the AES-GCM tag over that
+// segment's ciphertext, while the root signature covers the aggregate hash,
+// which the AEAD never touched, so only HS256 authenticates anything there.
+func TestIntegrityAlgorithmsValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		algs    IntegrityAlgorithms
+		wantErr string
+	}{
+		{name: "defaults/unset"},
+		{name: "root hs256", algs: IntegrityAlgorithms{Root: "hs256"}},
+		{name: "root HS256 uppercase", algs: IntegrityAlgorithms{Root: "HS256"}},
+		{name: "segment gmac", algs: IntegrityAlgorithms{Segment: "gmac"}},
+		{name: "segment hs256", algs: IntegrityAlgorithms{Segment: "hs256"}},
+		{name: "segment GMAC uppercase", algs: IntegrityAlgorithms{Segment: "GMAC"}},
+		{name: "both", algs: IntegrityAlgorithms{Root: "hs256", Segment: "hs256"}},
+
+		// xtest greps stderr for this exact lowercase substring.
+		{
+			name:    "root gmac",
+			algs:    IntegrityAlgorithms{Root: "gmac"},
+			wantErr: "unsupported root integrity algorithm",
+		},
+		{
+			name:    "root GMAC uppercase",
+			algs:    IntegrityAlgorithms{Root: "GMAC"},
+			wantErr: "unsupported root integrity algorithm",
+		},
+		{
+			name:    "root GMac mixed case",
+			algs:    IntegrityAlgorithms{Root: "GMac"},
+			wantErr: "unsupported root integrity algorithm",
+		},
+		{
+			name:    "root unknown",
+			algs:    IntegrityAlgorithms{Root: "hs512"},
+			wantErr: `unrecognized algorithm "hs512"`,
+		},
+		{
+			name:    "segment unknown",
+			algs:    IntegrityAlgorithms{Segment: "sha1"},
+			wantErr: `unrecognized algorithm "sha1"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.algs.Validate()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+
+	require.ErrorIs(t, IntegrityAlgorithms{Root: "gmac"}.Validate(), sdk.ErrUnsupportedRootIntegrityAlgorithm)
+}
+
+// An unset flag must not add an option at all, so the SDK defaults (HS256 root,
+// GMAC segments) stay in force.
+func TestIntegrityAlgorithmsOptions(t *testing.T) {
+	opts, err := IntegrityAlgorithms{}.tdfOptions()
+	require.NoError(t, err)
+	assert.Empty(t, opts)
+
+	opts, err = IntegrityAlgorithms{Root: "hs256", Segment: "gmac"}.tdfOptions()
+	require.NoError(t, err)
+	assert.Len(t, opts, 2)
+}

--- a/sdk/experimental/tdf/doc.go
+++ b/sdk/experimental/tdf/doc.go
@@ -97,7 +97,8 @@
 //
 //   - Custom cryptographic assertions with JWT-based integrity
 //   - Encrypted metadata storage within key access objects
-//   - Multiple integrity algorithm support (HS256, GMAC)
+//   - Multiple segment integrity algorithms (HS256, GMAC); the root signature
+//     is always HS256
 //   - ZIP64 format support for large files
 //   - Memory-optimized segment processing
 //

--- a/sdk/experimental/tdf/example_test.go
+++ b/sdk/experimental/tdf/example_test.go
@@ -60,8 +60,9 @@ func ExampleWriter() {
 func ExampleWriter_withAttributes() {
 	ctx := context.Background()
 
-	// Create writer with custom integrity algorithm
-	writer, err := tdf.NewWriter(ctx, tdf.WithIntegrityAlgorithm(tdf.GMAC))
+	// Create writer with custom integrity algorithm. GMAC is available for
+	// segments only; the root signature is always HS256.
+	writer, err := tdf.NewWriter(ctx, tdf.WithSegmentIntegrityAlgorithm(tdf.GMAC))
 	if err != nil {
 		log.Println(err)
 		return

--- a/sdk/experimental/tdf/manifest.go
+++ b/sdk/experimental/tdf/manifest.go
@@ -3,8 +3,8 @@
 package tdf
 
 import (
-	"encoding/hex"
 	"errors"
+	"fmt"
 
 	"github.com/opentdf/platform/lib/ocrypto"
 )
@@ -103,20 +103,52 @@ type EncryptedMetadata struct {
 	Iv     string `json:"iv"`
 }
 
-func calculateSignature(data []byte, secret []byte, alg IntegrityAlgorithm, isLegacyTDF bool) (string, error) {
-	if alg == HS256 {
-		hmac := ocrypto.CalculateSHA256Hmac(secret, data)
-		if isLegacyTDF {
-			return hex.EncodeToString(hmac), nil
-		}
-		return string(hmac), nil
-	}
-	if kGMACPayloadLength > len(data) {
+// ErrUnsupportedRootIntegrityAlgorithm rejects any root signature algorithm
+// other than HS256. See the stable SDK's error of the same name for the full
+// rationale: the root signature covers the aggregate hash, which AES-GCM never
+// processed, so there is no tag to read back out and a "GMAC" root
+// authenticates nothing.
+var ErrUnsupportedRootIntegrityAlgorithm = errors.New("tdf: unsupported root integrity algorithm")
+
+// hmacIntegrity computes an HMAC-SHA256 over data, keyed by the DEK.
+//
+// Unlike the stable SDK's namesake there is no legacy hex-encoding branch: this
+// package only ever writes current-format TDFs, so the digest goes straight to
+// the caller's base64.
+func hmacIntegrity(data, key []byte) string {
+	return string(ocrypto.CalculateSHA256Hmac(key, data))
+}
+
+// readAEADTag returns the trailing authentication tag of an AES-GCM ciphertext.
+//
+// PRECONDITION: ciphertext must be exactly the bytes AES-GCM sealed under the
+// DEK. Only then are the trailing kGMACPayloadLength bytes the tag the cipher
+// already computed over them; over anything else the same rule just copies the
+// input's own last 16 bytes and authenticates nothing. Reachable only from
+// segmentIntegrity, whose argument is by construction a segment ciphertext.
+func readAEADTag(ciphertext []byte) (string, error) {
+	if kGMACPayloadLength > len(ciphertext) {
 		return "", errors.New("fail to create gmac signature")
 	}
 
-	if isLegacyTDF {
-		return hex.EncodeToString(data[len(data)-kGMACPayloadLength:]), nil
+	return string(ciphertext[len(ciphertext)-kGMACPayloadLength:]), nil
+}
+
+// segmentIntegrity computes a segment's integrity value over its AES-GCM
+// ciphertext. Both algorithms are legitimate here: GMAC reads out the AEAD tag
+// covering exactly these bytes, HS256 recomputes an HMAC over them.
+func segmentIntegrity(ciphertext, key []byte, alg IntegrityAlgorithm) (string, error) {
+	if alg == HS256 {
+		return hmacIntegrity(ciphertext, key), nil
 	}
-	return string(data[len(data)-kGMACPayloadLength:]), nil
+	return readAEADTag(ciphertext)
+}
+
+// rootIntegrity computes the root signature over the aggregate hash. HS256
+// only; see ErrUnsupportedRootIntegrityAlgorithm.
+func rootIntegrity(aggregateHash, key []byte, alg IntegrityAlgorithm) (string, error) {
+	if alg != HS256 {
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedRootIntegrityAlgorithm, alg)
+	}
+	return hmacIntegrity(aggregateHash, key), nil
 }

--- a/sdk/experimental/tdf/manifest_test.go
+++ b/sdk/experimental/tdf/manifest_test.go
@@ -1,0 +1,81 @@
+// Experimental: This package is EXPERIMENTAL and may change or be removed at any time
+
+package tdf
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/opentdf/platform/lib/ocrypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This package used to be the only public API in any OpenTDF SDK that could
+// write a GMAC root signature. The root signature covers the aggregate hash,
+// which AES-GCM never processes, so "GMAC" there is not a tag read back out of
+// the AEAD -- it is a copy of the last segment hash, computed without the key
+// and forgeable by anyone who can edit the manifest.
+func TestRootIntegrityRejectsGMAC(t *testing.T) {
+	key := make([]byte, kKeySize)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+
+	aggregate := make([]byte, kGMACPayloadLength*4)
+	_, err = rand.Read(aggregate)
+	require.NoError(t, err)
+
+	_, err = rootIntegrity(aggregate, key, GMAC)
+	require.ErrorIs(t, err, ErrUnsupportedRootIntegrityAlgorithm)
+
+	sig, err := rootIntegrity(aggregate, key, HS256)
+	require.NoError(t, err)
+	assert.Equal(t, string(ocrypto.CalculateSHA256Hmac(key, aggregate)), sig)
+}
+
+// Segments keep both algorithms: their input is ciphertext the AEAD produced,
+// so the trailing bytes really are the tag it computed under the DEK.
+func TestSegmentIntegrityKeepsGMAC(t *testing.T) {
+	key := make([]byte, kKeySize)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+
+	ciphertext := make([]byte, kGMACPayloadLength*4)
+	_, err = rand.Read(ciphertext)
+	require.NoError(t, err)
+
+	tag, err := segmentIntegrity(ciphertext, key, GMAC)
+	require.NoError(t, err)
+	assert.Equal(t, string(ciphertext[len(ciphertext)-kGMACPayloadLength:]), tag)
+
+	hmacSig, err := segmentIntegrity(ciphertext, key, HS256)
+	require.NoError(t, err)
+	assert.Equal(t, string(ocrypto.CalculateSHA256Hmac(key, ciphertext)), hmacSig)
+
+	// A ciphertext shorter than the tag has no tag to return.
+	_, err = segmentIntegrity(ciphertext[:kGMACPayloadLength-1], key, GMAC)
+	require.Error(t, err)
+}
+
+// The writer must refuse the configuration outright rather than emit a file a
+// conforming reader would then have to reject.
+func TestNewWriterRejectsGMACRoot(t *testing.T) {
+	ctx := t.Context()
+
+	_, err := NewWriter(ctx, WithIntegrityAlgorithm(GMAC))
+	require.ErrorIs(t, err, ErrUnsupportedRootIntegrityAlgorithm)
+
+	_, err = NewWriter(ctx, WithIntegrityAlgorithm(IntegrityAlgorithm(99)))
+	require.ErrorIs(t, err, ErrUnsupportedRootIntegrityAlgorithm)
+
+	// Segments are unaffected.
+	for _, alg := range []IntegrityAlgorithm{HS256, GMAC} {
+		w, err := NewWriter(ctx, WithSegmentIntegrityAlgorithm(alg))
+		require.NoError(t, err)
+		assert.Equal(t, alg, w.segmentIntegrityAlgorithm)
+		assert.Equal(t, IntegrityAlgorithm(HS256), w.integrityAlgorithm)
+	}
+
+	_, err = NewWriter(ctx, WithSegmentIntegrityAlgorithm(IntegrityAlgorithm(99)))
+	require.Error(t, err)
+}

--- a/sdk/experimental/tdf/options.go
+++ b/sdk/experimental/tdf/options.go
@@ -77,7 +77,7 @@ type ReaderConfig struct {
 //
 // Example usage:
 //
-//	writer, err := NewWriter(ctx, WithIntegrityAlgorithm(GMAC))
+//	writer, err := NewWriter(ctx, WithSegmentIntegrityAlgorithm(GMAC))
 //	finalBytes, manifest, err := writer.Finalize(ctx, WithPayloadMimeType("text/plain"))
 type Option[T any] func(T)
 
@@ -86,13 +86,16 @@ type Option[T any] func(T)
 // The root integrity algorithm is used to generate a signature over all segment hashes,
 // providing verification that the complete TDF has not been tampered with.
 //
-// Algorithm options:
-//   - HS256: HMAC-SHA256 (default) - widely supported, secure
-//   - GMAC: Galois Message Authentication Code - faster with hardware acceleration
+// HS256 (the default) is the only supported value. GMAC is rejected: NewWriter
+// returns ErrUnsupportedRootIntegrityAlgorithm. The root signature covers the
+// aggregate hash, which AES-GCM never processed, so a GMAC root has no tag to
+// read back out -- it degenerates into a copy of the last segment hash and
+// authenticates nothing. Validation happens in NewWriter rather than here
+// because Option cannot return an error.
 //
 // Example:
 //
-//	writer, err := NewWriter(ctx, WithIntegrityAlgorithm(GMAC))
+//	writer, err := NewWriter(ctx, WithIntegrityAlgorithm(HS256))
 func WithIntegrityAlgorithm(algo IntegrityAlgorithm) Option[*WriterConfig] {
 	return func(c *WriterConfig) {
 		c.integrityAlgorithm = algo
@@ -106,17 +109,17 @@ func WithIntegrityAlgorithm(algo IntegrityAlgorithm) Option[*WriterConfig] {
 // complete file. This is particularly useful for streaming scenarios where
 // segments may be processed independently.
 //
-// The segment algorithm can differ from the root algorithm to optimize for
-// different processing patterns:
-//   - Use GMAC for segments if processing many small segments (better performance)
-//   - Use HS256 for root signature for broader compatibility
+// Both HS256 and GMAC are valid here, and the segment algorithm can differ from
+// the root algorithm. GMAC is sound for segments -- unlike at the root, the
+// input is ciphertext AES-GCM produced, so the trailing bytes really are the
+// tag it computed under the DEK.
 //
 // Example:
 //
 //	// Fast segment processing with compatible root signature
 //	writer, err := NewWriter(ctx,
 //		WithSegmentIntegrityAlgorithm(GMAC),  // Fast segment hashing
-//		WithIntegrityAlgorithm(HS256),        // Compatible root signature
+//		WithIntegrityAlgorithm(HS256),        // Only supported root signature
 //	)
 func WithSegmentIntegrityAlgorithm(algo IntegrityAlgorithm) Option[*WriterConfig] {
 	return func(c *WriterConfig) {

--- a/sdk/experimental/tdf/writer.go
+++ b/sdk/experimental/tdf/writer.go
@@ -132,13 +132,15 @@ type Writer struct {
 //   - Memory-efficient segment processing
 //
 // Configuration options can be provided to customize:
-//   - Integrity algorithm selection (HS256, GMAC)
-//   - Segment integrity algorithm (independent of root algorithm)
+//   - Segment integrity algorithm (HS256 or GMAC)
+//   - Root integrity algorithm (HS256 only)
 //
 // The writer generates a unique Data Encryption Key (DEK) and initializes
 // the underlying archive writer for ZIP structure management.
 //
 // Returns an error if:
+//   - The requested root integrity algorithm is not HS256
+//     (ErrUnsupportedRootIntegrityAlgorithm)
 //   - DEK generation fails (cryptographic entropy issues)
 //   - AES-GCM cipher initialization fails (invalid key)
 //   - Archive writer creation fails (resource constraints)
@@ -150,8 +152,8 @@ type Writer struct {
 //
 //	// Custom integrity algorithms
 //	writer, err := NewWriter(ctx,
-//		WithIntegrityAlgorithm(GMAC),
-//		WithSegmentIntegrityAlgorithm(HS256),
+//		WithIntegrityAlgorithm(HS256),
+//		WithSegmentIntegrityAlgorithm(GMAC),
 //	)
 func NewWriter(_ context.Context, opts ...Option[*WriterConfig]) (*Writer, error) {
 	// Initialize Config
@@ -162,6 +164,15 @@ func NewWriter(_ context.Context, opts ...Option[*WriterConfig]) (*Writer, error
 
 	for _, opt := range opts {
 		opt(config)
+	}
+
+	if config.integrityAlgorithm != HS256 {
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedRootIntegrityAlgorithm, config.integrityAlgorithm)
+	}
+	switch config.segmentIntegrityAlgorithm {
+	case HS256, GMAC:
+	default:
+		return nil, fmt.Errorf("tdf: unsupported segment integrity algorithm: %s", config.segmentIntegrityAlgorithm)
 	}
 
 	// Initialize archive writer - start with 1 segment and expand dynamically
@@ -264,7 +275,7 @@ func (w *Writer) WriteSegment(ctx context.Context, index int, data []byte) (*Seg
 	if err != nil {
 		return nil, err
 	}
-	segmentSig, err := calculateSignature(segmentCipher, w.dek, w.segmentIntegrityAlgorithm, false) // Don't ever hex encode new tdf's
+	segmentSig, err := segmentIntegrity(segmentCipher, w.dek, w.segmentIntegrityAlgorithm)
 	if err != nil {
 		return nil, err
 	}
@@ -565,7 +576,7 @@ func (w *Writer) getManifest(ctx context.Context, cfg *WriterFinalizeConfig) (*M
 		return nil, 0, 0, errors.New("empty segment hash")
 	}
 
-	rootSignature, err := calculateSignature(aggregateHash.Bytes(), w.dek, w.integrityAlgorithm, false)
+	rootSignature, err := rootIntegrity(aggregateHash.Bytes(), w.dek, w.integrityAlgorithm)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/sdk/tdf_config.go
+++ b/sdk/tdf_config.go
@@ -194,6 +194,35 @@ func WithSegmentSize(size int64) TDFOption {
 	}
 }
 
+// WithSegmentIntegrityAlgorithm returns an Option that sets the algorithm used
+// to compute each segment's integrity value. Both HS256 and GMAC are supported;
+// the default is GMAC, which reads out the AES-GCM tag the cipher already
+// produced over that segment's ciphertext.
+func WithSegmentIntegrityAlgorithm(alg IntegrityAlgorithm) TDFOption {
+	return func(c *TDFConfig) error {
+		switch alg {
+		case HS256, GMAC:
+			c.segmentIntegrityAlgorithm = alg
+			return nil
+		default:
+			return fmt.Errorf("unsupported segment integrity algorithm: %d", alg)
+		}
+	}
+}
+
+// WithRootIntegrityAlgorithm returns an Option that sets the algorithm used for
+// the TDF's root signature. HS256 is the only supported value and the default;
+// any other value fails with ErrUnsupportedRootIntegrityAlgorithm.
+func WithRootIntegrityAlgorithm(alg IntegrityAlgorithm) TDFOption {
+	return func(c *TDFConfig) error {
+		if alg != HS256 {
+			return fmt.Errorf("%w: %s", ErrUnsupportedRootIntegrityAlgorithm, integrityAlgorithmString(alg))
+		}
+		c.integrityAlgorithm = alg
+		return nil
+	}
+}
+
 // WithDefaultAssertion returns an Option that adds a default assertion to the TDF.
 func WithSystemMetadataAssertion() TDFOption {
 	return func(c *TDFConfig) error {

--- a/sdk/tdferrors.go
+++ b/sdk/tdferrors.go
@@ -23,6 +23,10 @@ var (
 	ErrRootSignatureFailure    = fmt.Errorf("[%w] tdf: issue verifying root signature", ErrTampered)
 	ErrRewrapBadRequest        = fmt.Errorf("[%w] tdf: rewrap request 400", ErrTampered)
 
+	// ErrUnsupportedRootIntegrityAlgorithm rejects any root signature algorithm
+	// other than HS256, on both the write and the read path.
+	ErrUnsupportedRootIntegrityAlgorithm = errors.New("tdf: unsupported root integrity algorithm")
+
 	// kasGenericBadRequest is the substring the SDK looks for in serialized
 	// KAS 400 errors to identify potential tamper. KAS uses the generic message
 	// "bad request" for errors involving secret key material (policy binding,


### PR DESCRIPTION
### Proposed Changes

Adds explicit controls for the two integrity algorithms a ZTDF writer picks, and makes an unsupported choice fail loudly instead of being silently coerced.

The asymmetry is the point:

| | allowed | why |
|---|---|---|
| **segment** | `HS256`, `GMAC` | a segment hash is computed over ciphertext AES-GCM actually produced, so "GMAC" means reading back a real tag |
| **root** | `HS256` only | the root signature covers the aggregate hash, which never passes through AES-GCM — there is no tag to read out, so GMAC would authenticate nothing |

**`sdk`**
* `WithSegmentIntegrityAlgorithm(HS256|GMAC)`
* `WithRootIntegrityAlgorithm(HS256)` — anything else returns the new `ErrUnsupportedRootIntegrityAlgorithm`. The option exists so callers can state the choice explicitly and a CLI can surface the refusal, not to widen it.
* The same split in `sdk/experimental/tdf`, where `NewWriter` validates eagerly because `Option[T]` cannot return an error.

**`otdfctl`**
* `encrypt --segment-integrity-algorithm` and `--root-integrity-algorithm`, validated *before* the handler is constructed, so an invalid value fails offline as a config error rather than after a KAS round trip.
* Documented in `docs/man/encrypt/_index.md` with enum values — which is also what the cross-SDK xtest feature detectors grep for, so merging this flips the `integrity_algs` / `gmac_root_rejected` gates on and stops those cells from silently skipping.

### Scope

This is the **control surface** for evaluating DSPX-4703, deliberately separated from the fix. It changes what a writer may *choose*; it does not change how a manifest that already declares a GMAC root is verified on **read**. That is the stacked follow-up, opentdf/platform PR for DSPX-4703.

Splitting it this way means the xtest exploit cases can be run against this branch to get a live, reproducible "before" baseline, then against the fix branch to watch them go red → green.

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation

### Testing Instructions

```bash
cd sdk     && go test ./...
cd otdfctl && go test ./pkg/handlers/...
```

Both were also run with this commit as `HEAD` and the DSPX-4703 fix commit entirely absent, to confirm the branch stands alone.

Manual check that the refusal is offline (no platform needed):

```bash
otdfctl encrypt --root-integrity-algorithm gmac ./somefile
# => unsupported root integrity algorithm: gmac
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encryption options for selecting root and segment integrity algorithms.
  * Segment integrity now supports HS256 and GMAC.
  * Added SDK configuration options for root and segment integrity algorithms.

* **Bug Fixes**
  * Root signatures accept only HS256, with unsupported configurations rejected early.
  * Improved validation and error reporting for unsupported algorithm settings.

* **Documentation**
  * Updated CLI and SDK documentation and examples for separate integrity algorithm settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Cross-SDK coverage lives in opentdf/tests#594.
