### PR TITLE
chore(ci): DSPX-4752 test tracing schema compatibility

### DIFF
--- a/service/tracing/otel_test.go
+++ b/service/tracing/otel_test.go
@@ -1,0 +1,23 @@
+package tracing
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_InitTracer_CompatibleResourceSchemas_Succeeds(t *testing.T) {
+	shutdown, err := InitTracer(context.Background(), Config{
+		Enabled: true,
+		Provider: ProviderConfig{
+			Name: ProviderFile,
+			File: &FileConfig{Path: filepath.Join(t.TempDir(), "traces.json")},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+
+	shutdown()
+}

--- a/service/tracing/otel_test.go
+++ b/service/tracing/otel_test.go
@@ -9,8 +9,11 @@ import (
 )
 
 func Test_InitTracer_CompatibleResourceSchemas_Succeeds(t *testing.T) {
-	// The file exporter keeps the test hermetic while exercising the same enabled
-	// tracing path used by OTLP, including creation and merging of OTel resources.
+	// resource.Default uses the schema from go.opentelemetry.io/otel/sdk, while
+	// InitTracer's base resource uses the versioned go.opentelemetry.io/otel/semconv
+	// import. If they drift, such as SDK schema 1.41.0 with semconv schema 1.26.0,
+	// InitTracer returns "conflicting Schema URL" and require.NoError fails.
+	// The file exporter avoids needing a collector; all exporters use this merge.
 	shutdown, err := InitTracer(context.Background(), Config{
 		Enabled: true,
 		Provider: ProviderConfig{
@@ -18,8 +21,6 @@ func Test_InitTracer_CompatibleResourceSchemas_Succeeds(t *testing.T) {
 			File: &FileConfig{Path: filepath.Join(t.TempDir(), "traces.json")},
 		},
 	})
-	// InitTracer returns an error here when the SDK default resource schema and
-	// the semantic-conventions schema selected by the module graph do not match.
 	require.NoError(t, err)
 	require.NotNil(t, shutdown)
 

--- a/service/tracing/otel_test.go
+++ b/service/tracing/otel_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func Test_InitTracer_CompatibleResourceSchemas_Succeeds(t *testing.T) {
+	// The file exporter keeps the test hermetic while exercising the same enabled
+	// tracing path used by OTLP, including creation and merging of OTel resources.
 	shutdown, err := InitTracer(context.Background(), Config{
 		Enabled: true,
 		Provider: ProviderConfig{
@@ -16,6 +18,8 @@ func Test_InitTracer_CompatibleResourceSchemas_Succeeds(t *testing.T) {
 			File: &FileConfig{Path: filepath.Join(t.TempDir(), "traces.json")},
 		},
 	})
+	// InitTracer returns an error here when the SDK default resource schema and
+	// the semantic-conventions schema selected by the module graph do not match.
 	require.NoError(t, err)
 	require.NotNil(t, shutdown)
 


### PR DESCRIPTION
## Summary

Add regression coverage that initializes tracing and exercises OpenTelemetry resource schema merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that tracer initialization succeeds with compatible resource schemas.
  * Confirmed initialization returns a usable shutdown function without requiring an external collector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->