### PR TITLE
fix(cli): restrict decrypted output permissions

### DIFF
--- a/otdfctl/cmd/tdf/decrypt.go
+++ b/otdfctl/cmd/tdf/decrypt.go
@@ -3,15 +3,17 @@ package tdf
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/opentdf/platform/lib/ocrypto"
 	"github.com/opentdf/platform/otdfctl/cmd/common"
 	"github.com/opentdf/platform/otdfctl/pkg/cli"
 	"github.com/opentdf/platform/otdfctl/pkg/man"
+	"github.com/opentdf/platform/otdfctl/pkg/streamio"
 	"github.com/opentdf/platform/otdfctl/pkg/utils"
 	"github.com/spf13/cobra"
 )
+
+const decryptedOutputFileMode = 0o600
 
 var (
 	assertionVerification string
@@ -84,13 +86,18 @@ func decryptRun(cmd *cobra.Command, args []string) {
 		return
 	}
 	// Here 'output' is the filename given with -o
-	f, err := os.Create(output)
+	f, err := streamio.NewOutputFile(output, decryptedOutputFileMode)
 	if err != nil {
 		cli.ExitWithError("Failed to write decrypted data to file", err)
 	}
-	defer f.Close()
+	defer f.Cleanup()
 	_, err = f.Write(decrypted.Bytes())
 	if err != nil {
+		f.Cleanup()
+		cli.ExitWithError("Failed to write decrypted data to file", err)
+	}
+	if err := f.Commit(); err != nil {
+		f.Cleanup()
 		cli.ExitWithError("Failed to write decrypted data to file", err)
 	}
 }

--- a/otdfctl/pkg/streamio/output.go
+++ b/otdfctl/pkg/streamio/output.go
@@ -10,12 +10,6 @@ import (
 // OutputFile that had already been committed or discarded.
 var ErrOutputFileFinished = errors.New("streamio: output file already committed or discarded")
 
-// outputFileMode is the permission Commit applies to the destination.
-// os.CreateTemp always creates the temp file with 0600; without an explicit
-// Chmod that would leak onto the destination regardless of the caller's
-// umask, so this matches the common default a plain os.Create would produce.
-const outputFileMode = 0o644
-
 // OutputFile writes to a temporary file alongside the destination and renames
 // it into place only once the write has succeeded, so an interrupted or failed
 // run leaves no partial output where a complete file is expected.
@@ -26,6 +20,7 @@ const outputFileMode = 0o644
 type OutputFile struct {
 	f        *os.File
 	path     string
+	mode     os.FileMode
 	finished bool
 }
 
@@ -33,12 +28,13 @@ type OutputFile struct {
 // A rename is only atomic within a single filesystem, so the temp file must
 // live beside the destination rather than in a shared temp directory —
 // Commit's os.Rename fails outright (EXDEV) if that invariant is broken.
-func NewOutputFile(path string) (*OutputFile, error) {
+// The destination receives mode after a successful commit.
+func NewOutputFile(path string, mode os.FileMode) (*OutputFile, error) {
 	f, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
 		return nil, err
 	}
-	return &OutputFile{f: f, path: path}, nil
+	return &OutputFile{f: f, path: path, mode: mode}, nil
 }
 
 func (o *OutputFile) Write(p []byte) (int, error) { return o.f.Write(p) }
@@ -58,7 +54,7 @@ func (o *OutputFile) Commit() error {
 	}
 	o.finished = true
 
-	if err := o.f.Chmod(outputFileMode); err != nil {
+	if err := o.f.Chmod(o.mode); err != nil {
 		o.f.Close()
 		os.Remove(o.f.Name())
 		return err

--- a/otdfctl/pkg/streamio/output_test.go
+++ b/otdfctl/pkg/streamio/output_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testOutputFileMode = 0o644
+
 func TestOutputFileCommitRenamesIntoPlace(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "out.tdf")
 
-	o, err := NewOutputFile(dest)
+	o, err := NewOutputFile(dest, testOutputFileMode)
 	require.NoError(t, err)
 
 	_, err = o.Write([]byte("payload"))
@@ -36,7 +38,7 @@ func TestOutputFileCleanupLeavesNoPartialOutput(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "out.tdf")
 
-	o, err := NewOutputFile(dest)
+	o, err := NewOutputFile(dest, testOutputFileMode)
 	require.NoError(t, err)
 	_, err = o.Write([]byte("partial"))
 	require.NoError(t, err)
@@ -53,7 +55,7 @@ func TestOutputFileCleanupAfterCommitIsNoop(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "out.tdf")
 
-	o, err := NewOutputFile(dest)
+	o, err := NewOutputFile(dest, testOutputFileMode)
 	require.NoError(t, err)
 	_, err = o.Write([]byte("payload"))
 	require.NoError(t, err)
@@ -72,7 +74,7 @@ func TestOutputFileTempIsSiblingOfDestination(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "out.tdf")
 
-	o, err := NewOutputFile(dest)
+	o, err := NewOutputFile(dest, testOutputFileMode)
 	require.NoError(t, err)
 	defer o.Cleanup()
 
@@ -86,7 +88,7 @@ func TestOutputFileCommitSetsReadableMode(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "out.tdf")
 
-	o, err := NewOutputFile(dest)
+	o, err := NewOutputFile(dest, testOutputFileMode)
 	require.NoError(t, err)
 	_, err = o.Write([]byte("payload"))
 	require.NoError(t, err)
@@ -94,15 +96,67 @@ func TestOutputFileCommitSetsReadableMode(t *testing.T) {
 
 	info, err := os.Stat(dest)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(outputFileMode), info.Mode().Perm(),
+	assert.Equal(t, os.FileMode(testOutputFileMode), info.Mode().Perm(),
 		"os.CreateTemp defaults to 0600; Commit must not leak that onto the destination")
+}
+
+func TestOutputFileCommitSetsRequestedMode(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "plaintext.txt")
+
+	o, err := NewOutputFile(dest, 0o600)
+	require.NoError(t, err)
+	_, err = o.Write([]byte("plaintext"))
+	require.NoError(t, err)
+	require.NoError(t, o.Commit())
+
+	info, err := os.Stat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestOutputFileCommitReplacesExistingFileWithRequestedMode(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "plaintext.txt")
+	require.NoError(t, os.WriteFile(dest, []byte("old"), 0o644))
+
+	o, err := NewOutputFile(dest, 0o600)
+	require.NoError(t, err)
+	_, err = o.Write([]byte("new"))
+	require.NoError(t, err)
+	require.NoError(t, o.Commit())
+
+	got, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
+	info, err := os.Stat(dest)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	assert.Empty(t, tempSiblings(t, dir, "plaintext.txt"))
+}
+
+func TestOutputFileCleanupPreservesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "plaintext.txt")
+	require.NoError(t, os.WriteFile(dest, []byte("original"), 0o600))
+
+	o, err := NewOutputFile(dest, 0o600)
+	require.NoError(t, err)
+	_, err = o.Write([]byte("partial"))
+	require.NoError(t, err)
+	o.Cleanup()
+
+	got, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(got))
+	assert.Empty(t, tempSiblings(t, dir, "plaintext.txt"))
 }
 
 func TestOutputFileCommitAfterCommitReturnsError(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "out.tdf")
 
-	o, err := NewOutputFile(dest)
+	o, err := NewOutputFile(dest, testOutputFileMode)
 	require.NoError(t, err)
 	_, err = o.Write([]byte("payload"))
 	require.NoError(t, err)
@@ -119,7 +173,7 @@ func TestOutputFileCommitAfterCleanupReturnsError(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "out.tdf")
 
-	o, err := NewOutputFile(dest)
+	o, err := NewOutputFile(dest, testOutputFileMode)
 	require.NoError(t, err)
 	_, err = o.Write([]byte("payload"))
 	require.NoError(t, err)


### PR DESCRIPTION
### Proposed Changes

- Create decrypted CLI output through the atomic output helper with mode `0600`.
- Require output-helper callers to choose the destination mode explicitly.
- Preserve an existing destination when a write fails and add regression coverage for new and existing files.

Fixes [DSPX-4696](https://virtru.atlassian.net/browse/DSPX-4696).

### Checklist

- [x] I have added or updated unit tests
- [ ] I have added or updated integration tests (not needed for this file-mode change)
- [ ] I have added or updated documentation (no user-facing command behavior changed)

### Testing Instructions

Passed:

```shell
cd otdfctl
go test ./... -race
golangci-lint run --max-same-issues 0 --max-issues-per-linter 0 --timeout 10m

cd ../sdk
go test -run 'TestREADMECodeBlocks|TestDecryptBytes_InvalidCiphertext'
```

Repository-wide checks attempted:

- `make lint` stops at `buf lint service` because the configured Buf API token is invalid.
- `make test` reaches unrelated integration suites, then fails because Colima/Docker, Keycloak, and the local platform service are unavailable.


[DSPX-4696]: https://virtru.atlassian.net/browse/DSPX-4696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Decrypted output files are now restricted to the creating user by default, reducing the risk of unauthorized access.

- **Reliability**
  - Decryption output is written more safely, helping prevent incomplete files from replacing existing results.
  - Existing destination files remain intact when cleanup or writing fails.
  - Successful output replacement now applies the requested file permissions consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->